### PR TITLE
Don't call Validate() if there is no Validate() function on a payload

### DIFF
--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -384,11 +384,13 @@ func (ctx *{{$ctx.Name}}) {{goify .Name true}}({{/*
 	payloadT = `{{$payload := .Payload}}// {{gotypename .Payload nil 0}} is the {{.ResourceName}} {{.ActionName}} action payload.
 type {{gotypename .Payload nil 1}} {{gotypedef .Payload .Versioned .DefaultPkg 0 false}}
 
-{{$validation := recursiveValidate .Payload.AttributeDefinition false false "payload" "raw" 1}}{{if $validation}}// Validate runs the validation rules defined in the design.
+{{$validation := recursiveValidate .Payload.AttributeDefinition false false "payload" "raw" 1}}
+// Validate runs the validation rules defined in the design.
 func (payload {{gotyperef .Payload .Payload.AllRequired 0}}) Validate() (err error) {
-{{$validation}}
+{{if $validation}}{{$validation}}
+{{end}}
        return
-}{{end}}
+}
 `
 	// ctrlT generates the controller interface for a given resource.
 	// template input: *ControllerTemplateData

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -427,12 +427,10 @@ func {{.Unmarshal}}(ctx *goa.Context) error {
 	payload := &{{gotypename .Payload nil 1}}{}
 	if err := ctx.Service().DecodeRequest(ctx, payload); err != nil {
 		return err
-	}
-	
-{{$validation := recursiveValidate .Payload.AttributeDefinition false false "payload" "raw" 1}}{{if $validation}}if err := payload.Validate(); err != nil {
+	}{{$validation := recursiveValidate .Payload.AttributeDefinition false false "payload" "raw" 1}}{{if $validation}}
+	if err := payload.Validate(); err != nil {
 		return err
-	}
-	{{end}}
+	}{{end}}
 	ctx.SetPayload(payload)
 	return nil
 }

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -384,13 +384,11 @@ func (ctx *{{$ctx.Name}}) {{goify .Name true}}({{/*
 	payloadT = `{{$payload := .Payload}}// {{gotypename .Payload nil 0}} is the {{.ResourceName}} {{.ActionName}} action payload.
 type {{gotypename .Payload nil 1}} {{gotypedef .Payload .Versioned .DefaultPkg 0 false}}
 
-{{$validation := recursiveValidate .Payload.AttributeDefinition false false "payload" "raw" 1}}
-// Validate runs the validation rules defined in the design.
+{{$validation := recursiveValidate .Payload.AttributeDefinition false false "payload" "raw" 1}}{{if $validation}}// Validate runs the validation rules defined in the design.
 func (payload {{gotyperef .Payload .Payload.AllRequired 0}}) Validate() (err error) {
-{{if $validation}}{{$validation}}
-{{end}}
+{{$validation}}
        return
-}
+}{{end}}
 `
 	// ctrlT generates the controller interface for a given resource.
 	// template input: *ControllerTemplateData
@@ -430,9 +428,11 @@ func {{.Unmarshal}}(ctx *goa.Context) error {
 	if err := ctx.Service().DecodeRequest(ctx, payload); err != nil {
 		return err
 	}
-	if err := payload.Validate(); err != nil {
+	
+{{$validation := recursiveValidate .Payload.AttributeDefinition false false "payload" "raw" 1}}{{if $validation}}if err := payload.Validate(); err != nil {
 		return err
 	}
+	{{end}}
 	ctx.SetPayload(payload)
 	return nil
 }


### PR DESCRIPTION
If a payload has no required fields or other validation triggers a Validate() function is not generated.  The controllers don't  have this check.  This fix generates a Validate() function even if there are no validations, and simply returns a nil error.

{EDIT} Instead this change doesn't test Validate() if it shouldn't.