### PR TITLE
Update to match middleware move

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DEPEND=\
 	github.com/PuerkitoBio/purell \
 	github.com/asaskevich/govalidator \
 	github.com/go-swagger/go-swagger \
-	github.com/goadesign/middleware/middleware \
+	github.com/goadesign/middleware \
 	github.com/golang/gddo/httputil \
 	github.com/golang/lint/golint \
 	github.com/onsi/gomega \

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -96,7 +96,7 @@ func (g *Generator) Generate(api *design.APIDefinition) (_ []string, err error) 
 		swaggerPkg := path.Join(outPkg, "swagger")
 		imports := []*codegen.ImportSpec{
 			codegen.SimpleImport("github.com/goadesign/goa"),
-			codegen.SimpleImport("github.com/goadesign/middleware/middleware"),
+			codegen.SimpleImport("github.com/goadesign/middleware"),
 			codegen.SimpleImport(appPkg),
 			codegen.SimpleImport(swaggerPkg),
 			codegen.NewImport("log", "gopkg.in/inconshreveable/log15.v2"),

--- a/service_test.go
+++ b/service_test.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 
 	"github.com/goadesign/goa"
-	"github.com/goadesign/middleware/middleware"
+	"github.com/goadesign/middleware"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
Middleware is now `github.com/goadesign/middleware` instead of `github.com/goadesign/middleware/middleware`.