### PR TITLE
Add integration tests to generate and build code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ examples/cellar/client/cellar-cli/cellar-cli
 goagen/goagen
 **/autogen
 vendor
+_integration_tests/*/**/*.*

--- a/_integration_tests/integration_test.go
+++ b/_integration_tests/integration_test.go
@@ -1,0 +1,47 @@
+package tests
+
+import (
+	"fmt"
+	"go/build"
+	"os/exec"
+	"path"
+	"testing"
+)
+
+func TestBootstrapReadme(t *testing.T) {
+	if err := goagen("./readme", "bootstrap", "-d", "github.com/goadesign/goa/_integration_tests/readme/design"); err != nil {
+		t.Error(err.Error())
+	}
+	if err := gobuild("./readme"); err != nil {
+		t.Error(err.Error())
+	}
+}
+
+func goagen(dir, command string, args ...string) error {
+	pkg, err := build.Import("github.com/goadesign/goa/goagen", "", 0)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("go", "run")
+	for _, f := range pkg.GoFiles {
+		cmd.Args = append(cmd.Args, path.Join(pkg.Dir, f))
+	}
+	cmd.Dir = dir
+	cmd.Args = append(cmd.Args, command)
+	cmd.Args = append(cmd.Args, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s\n%s", err.Error(), out)
+	}
+	return nil
+}
+
+func gobuild(dir string) error {
+	cmd := exec.Command("go", "build", "./...")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s\n%s", err.Error(), out)
+	}
+	return nil
+}

--- a/_integration_tests/readme/design/design.go
+++ b/_integration_tests/readme/design/design.go
@@ -1,0 +1,26 @@
+package design
+
+import (
+	. "github.com/goadesign/goa/design"
+	. "github.com/goadesign/goa/design/dsl"
+)
+
+var _ = API("adder", func() {
+	Title("The adder API")
+	Description("A teaser for goa")
+	Host("localhost:8080")
+	Scheme("http")
+})
+
+var _ = Resource("operands", func() {
+	Action("add", func() {
+		Routing(GET("add/:left/:right"))
+		Description("add returns the sum of the left and right parameters in the response body")
+		Params(func() {
+			Param("left", Integer, "Left operand")
+			Param("right", Integer, "Right operand")
+		})
+		Response(OK, "plain/text")
+	})
+
+})


### PR DESCRIPTION
These tests would be aimed at finding generating code or with generated code.

e.g: right now the example in README generates invalid code:
```
--- FAIL: TestBootstrapReadme (4.59s)
        integration_test.go:16: exit status 2
                # github.com/goadesign/goa/_integration_tests/readme
                ./main.go:20: cannot use service (type "github.com/goadesign/goa".Service) as type "github.com/raphael/goa".Service in argument to NewOperandsController:
                        "github.com/goadesign/goa".Service does not implement "github.com/raphael/goa".Service (wrong type for ErrorHandler method)
                                have ErrorHandler() "github.com/goadesign/goa".ErrorHandler
                                want ErrorHandler() "github.com/raphael/goa".ErrorHandler
                ./operands.go:15: cannot use OperandsController literal (type *OperandsController) as type app.OperandsController in return argument:
                        *OperandsController does not implement app.OperandsController (missing Crit method)

FAIL
FAIL    github.com/goadesign/goa/_integration_tests     4.598s
```

How to run the tests:
`go test ./_integration_tests`

