### PR TITLE
Add Example DSL

### DIFF
--- a/design/api.go
+++ b/design/api.go
@@ -372,15 +372,20 @@ func (a *APIDefinition) IterateUserTypes(it UserTypeIterator) error {
 	return nil
 }
 
-// Example returns a random value for the given data type.
+// GenerateExample returns a random value for the given data type.
 // If the data type has validations then the example value validates them.
-// Example returns the same random value for a given api name (the random
-// generator is seeded after the api name).
-func (a *APIDefinition) Example(dt DataType) interface{} {
+// GenerateExample returns the same random value for a given api name
+// (the random generator is seeded after the api name).
+func (a *APIDefinition) GenerateExample(dt DataType) interface{} {
+	return dt.GenerateExample(a.RandomGenerator())
+}
+
+// RandomGenerator is seeded after the api name. It's used to generate examples in the most cases.
+func (a *APIDefinition) RandomGenerator() *RandomGenerator {
 	if a.rand == nil {
 		a.rand = NewRandomGenerator(a.Name)
 	}
-	return dt.Example(a.rand)
+	return a.rand
 }
 
 // MediaTypeWithIdentifier returns the media type with a matching

--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -216,6 +216,17 @@ func Default(def interface{}) {
 	}
 }
 
+// Example sets the example of an attribute to be used for the documentation. If not given,
+// a random value will be automatically generated. User can use `Example(None)` to leave it blank.
+func Example(exp interface{}) {
+	if a, ok := attributeDefinition(true); ok {
+		if pass := a.SetExample(exp); !pass {
+			dslengine.ReportError("example value %#v is incompatible with attribute of type %s",
+				exp, a.Type.Name())
+		}
+	}
+}
+
 // Enum adds a "enum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor76.
 func Enum(val ...interface{}) {

--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -216,14 +216,21 @@ func Default(def interface{}) {
 	}
 }
 
-// Example sets the example of an attribute to be used for the documentation. If not given,
-// a random value will be automatically generated. User can use `Example(None)` to leave it blank.
+// Example sets the example of an attribute to be used for the documentation.
 func Example(exp interface{}) {
 	if a, ok := attributeDefinition(true); ok {
 		if pass := a.SetExample(exp); !pass {
 			dslengine.ReportError("example value %#v is incompatible with attribute of type %s",
 				exp, a.Type.Name())
 		}
+	}
+}
+
+// NoExample sets the example of an attribute to be blank for the documentation. It is used when
+// users don't want any custom or auto-generated example
+func NoExample() {
+	if a, ok := attributeDefinition(true); ok {
+		a.SetExample(nil)
 	}
 }
 

--- a/design/apidsl/media_type_test.go
+++ b/design/apidsl/media_type_test.go
@@ -489,7 +489,7 @@ var _ = Describe("Example", func() {
 			Ω(attr.Example).ShouldNot(BeNil())
 			attrChildren, pass := attr.Example.([]interface{})
 			Ω(pass).Should(BeTrue())
-			Ω(len(attrChildren)).Should(BeNumerically(">", 1))
+			Ω(len(attrChildren)).Should(BeNumerically(">", 0))
 			attrChild, pass := attrChildren[0].(map[string]interface{})
 			Ω(pass).Should(BeTrue())
 			Ω(attrChild["test1"]).ShouldNot(Equal(cexample))

--- a/design/example.go
+++ b/design/example.go
@@ -86,7 +86,6 @@ func (eg *exampleGenerator) hasLengthValidation() bool {
 }
 
 // generateValidatedLengthExample generates a random size array of examples based on what's given.
-// generateValidatedLengthExample returns false when the example cannot be determined.
 func (eg *exampleGenerator) generateValidatedLengthExample() interface{} {
 	minlength, maxlength := math.Inf(1), math.Inf(-1)
 	for _, v := range eg.a.Validations {
@@ -109,7 +108,7 @@ func (eg *exampleGenerator) generateValidatedLengthExample() interface{} {
 	} else if minlength == maxlength {
 		count = int(minlength)
 	} else {
-		panic("Validation: Minimum > Maximum")
+		panic("Validation: MinLength > MaxLength")
 	}
 	if !eg.a.Type.IsArray() {
 		return eg.r.faker.Characters(count)
@@ -174,7 +173,7 @@ func (eg *exampleGenerator) generateFormatExample() interface{} {
 			}[actual.Format]; ok {
 				return res
 			}
-			panic("Validation: unknown format:" + actual.Format) // bug
+			panic("Validation: unknown format '" + actual.Format + "'") // bug
 		}
 	}
 	return nil

--- a/design/example.go
+++ b/design/example.go
@@ -1,0 +1,228 @@
+package design
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"time"
+
+	"github.com/goadesign/goa/dslengine"
+	regen "github.com/zach-klippenstein/goregen"
+)
+
+// exampleGenerator generates a random example based on the given validations on the definition.
+type exampleGenerator struct {
+	a *AttributeDefinition
+	r *RandomGenerator
+}
+
+// newExampleGenerator returns an example generator that uses the given random generator.
+func newExampleGenerator(a *AttributeDefinition, r *RandomGenerator) *exampleGenerator {
+	return &exampleGenerator{a, r}
+}
+
+// generate generates a random value based on the given validations.
+func (eg *exampleGenerator) generate() interface{} {
+	// Randomize array length first, since that's from higher level
+	if eg.hasLengthValidation() {
+		return eg.generateValidatedLengthExample()
+	}
+	// Enum should dominate, because the potential "examples" are fixed
+	if eg.hasEnumValidation() {
+		return eg.generateValidatedEnumExample()
+	}
+	// loop until a satisified example is generated
+	hasFormat := eg.hasFormatValidation()
+	for {
+		var example interface{}
+		// Format comes first, since it initiates the example
+		if hasFormat {
+			example = eg.generateFormatExample()
+		}
+		// now validate with the rest of matchers; if not satisified, redo
+		failed := false
+		for _, v := range eg.a.Validations {
+			switch actual := v.(type) {
+			case *dslengine.PatternValidationDefinition:
+				if example == nil {
+					example = eg.generateValidatedPatternExample(actual.Pattern)
+				} else if !eg.checkPatternValidation(example, actual.Pattern) {
+					failed = true
+				}
+			case *dslengine.MinimumValidationDefinition:
+				if example == nil {
+					example = eg.generateValidatedMinValueExample(actual.Min)
+				} else if !eg.checkMinValueValidation(example, actual.Min) {
+					failed = true
+				}
+			case *dslengine.MaximumValidationDefinition:
+				if example == nil {
+					example = eg.generateValidatedMaxValueExample(actual.Max)
+				} else if !eg.checkMaxValueValidation(example, actual.Max) {
+					failed = true
+				}
+			}
+			if failed {
+				break
+			}
+		}
+		if !failed {
+			return example
+		}
+	}
+	return nil
+}
+
+func (eg *exampleGenerator) hasLengthValidation() bool {
+	for _, v := range eg.a.Validations {
+		switch v.(type) {
+		case *dslengine.MinLengthValidationDefinition:
+			return true
+		case *dslengine.MaxLengthValidationDefinition:
+			return true
+		}
+	}
+	return false
+}
+
+// generateValidatedLengthExample generates a random size array of examples based on what's given.
+// generateValidatedLengthExample returns false when the example cannot be determined.
+func (eg *exampleGenerator) generateValidatedLengthExample() interface{} {
+	minlength, maxlength := math.Inf(1), math.Inf(-1)
+	for _, v := range eg.a.Validations {
+		switch actual := v.(type) {
+		case *dslengine.MinLengthValidationDefinition:
+			minlength = math.Min(minlength, float64(actual.MinLength))
+			maxlength = math.Max(maxlength, float64(actual.MinLength))
+		case *dslengine.MaxLengthValidationDefinition:
+			minlength = math.Min(minlength, float64(actual.MaxLength))
+			maxlength = math.Max(maxlength, float64(actual.MaxLength))
+		}
+	}
+	count := 0
+	if math.IsInf(minlength, 1) {
+		count = int(maxlength) - (eg.r.Int() % 3)
+	} else if math.IsInf(maxlength, -1) {
+		count = int(minlength) + (eg.r.Int() % 3)
+	} else if minlength < maxlength {
+		count = int(minlength) + (eg.r.Int() % int(maxlength-minlength))
+	} else if minlength == maxlength {
+		count = int(minlength)
+	} else {
+		panic("Validation: Minimum > Maximum")
+	}
+	if !eg.a.Type.IsArray() {
+		return eg.r.faker.Characters(count)
+	}
+	res := make([]interface{}, count)
+	for i := 0; i < count; i++ {
+		res[i] = eg.a.Type.ToArray().ElemType.GenerateExample(eg.r)
+	}
+	return res
+}
+
+func (eg *exampleGenerator) hasEnumValidation() bool {
+	for _, v := range eg.a.Validations {
+		if _, ok := v.(*dslengine.EnumValidationDefinition); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// generateValidatedEnumExample returns a random selected enum value,
+func (eg *exampleGenerator) generateValidatedEnumExample() interface{} {
+	for _, v := range eg.a.Validations {
+		if actual, ok := v.(*dslengine.EnumValidationDefinition); ok {
+			count := len(actual.Values)
+			i := eg.r.Int() % count
+			return actual.Values[i]
+		}
+	}
+	return nil
+}
+
+func (eg *exampleGenerator) hasFormatValidation() bool {
+	for _, v := range eg.a.Validations {
+		if _, ok := v.(*dslengine.FormatValidationDefinition); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// generateFormatExample returns a random example based on the format the user asks.
+func (eg *exampleGenerator) generateFormatExample() interface{} {
+	for _, v := range eg.a.Validations {
+		if actual, ok := v.(*dslengine.FormatValidationDefinition); ok {
+			if res, ok := map[string]interface{}{
+				"email":     eg.r.faker.Email(),
+				"hostname":  eg.r.faker.DomainName() + "." + eg.r.faker.DomainSuffix(),
+				"date-time": time.Now().Format(time.RFC3339),
+				"ipv4":      eg.r.faker.IPv4Address().String(),
+				"ipv6":      eg.r.faker.IPv6Address().String(),
+				"uri":       eg.r.faker.URL(),
+				"mac": func() string {
+					res, err := regen.Generate(`([0-9A-F]{2}-){5}[0-9A-F]{2}`)
+					if err != nil {
+						return "12-34-56-78-9A-BC"
+					}
+					return res
+				}(),
+				"cidr":   "192.168.100.14/24",
+				"regexp": eg.r.faker.Characters(3) + ".*",
+			}[actual.Format]; ok {
+				return res
+			}
+			panic("Validation: unknown format:" + actual.Format) // bug
+		}
+	}
+	return nil
+}
+
+func (eg *exampleGenerator) checkPatternValidation(example interface{}, pattern string) bool {
+	if re, err := regexp.Compile(pattern); err == nil {
+		return re.MatchString(fmt.Sprint(example))
+	}
+	return false
+}
+
+func (eg *exampleGenerator) generateValidatedPatternExample(pattern string) interface{} {
+	example, err := regen.Generate(pattern)
+	if err != nil {
+		return eg.r.faker.Name()
+	}
+	return example
+}
+
+func (eg *exampleGenerator) checkMinValueValidation(example interface{}, min float64) bool {
+	if v, ok := example.(int); ok && float64(v) < min {
+		return false
+	} else if v, ok := example.(float64); ok && v < min {
+		return false
+	}
+	return true
+}
+
+func (eg *exampleGenerator) generateValidatedMinValueExample(min float64) interface{} {
+	if eg.a.Type.Kind() == IntegerKind {
+		return int(min) + eg.r.Int()%int(min)
+	}
+	return min + eg.r.Float64()*min
+}
+
+func (eg *exampleGenerator) checkMaxValueValidation(example interface{}, max float64) bool {
+	if v, ok := example.(int); ok && float64(v) > max {
+		return false
+	} else if v, ok := example.(float64); ok && v > max {
+		return false
+	}
+	return true
+}
+
+func (eg *exampleGenerator) generateValidatedMaxValueExample(max float64) interface{} {
+	if eg.a.Type.Kind() == IntegerKind {
+		return eg.r.Int() % int(max)
+	}
+	return eg.r.Float64() * max
+}

--- a/design/random.go
+++ b/design/random.go
@@ -39,7 +39,7 @@ func NewRandomGenerator(seed string) *RandomGenerator {
 
 // Int produces a random integer.
 func (r *RandomGenerator) Int() int {
-	return r.rand.Int() % 1000
+	return r.rand.Int()
 }
 
 // String produces a random string.

--- a/design/types.go
+++ b/design/types.go
@@ -133,8 +133,6 @@ const (
 	UserTypeKind
 	// MediaTypeKind represents a media type.
 	MediaTypeKind
-	// NoneKind represents a nil
-	NoneKind
 )
 
 const (
@@ -156,9 +154,6 @@ const (
 
 	// Any is the type for an arbitrary JSON value (interface{} in Go).
 	Any = Primitive(AnyKind)
-
-	// None is the type to ignore some value
-	None = Primitive(NoneKind)
 )
 
 // DataType implementation
@@ -181,8 +176,6 @@ func (p Primitive) Name() string {
 		return "date"
 	case Any:
 		return "any"
-	case None:
-		return ""
 	default:
 		panic("unknown primitive type") // bug
 	}

--- a/design/types.go
+++ b/design/types.go
@@ -52,9 +52,9 @@ type (
 		// IsCompatible checks whether val has a Go type that is
 		// compatible with the data type.
 		IsCompatible(val interface{}) bool
-		// Example returns a random value for the given data type.
+		// GenerateExample returns a random value for the given data type.
 		// If the data type has validations then the example value validates them.
-		Example(r *RandomGenerator) interface{}
+		GenerateExample(r *RandomGenerator) interface{}
 	}
 
 	// DataStructure is the interface implemented by all data structure types.
@@ -133,6 +133,8 @@ const (
 	UserTypeKind
 	// MediaTypeKind represents a media type.
 	MediaTypeKind
+	// NoneKind represents a nil
+	NoneKind
 )
 
 const (
@@ -154,6 +156,9 @@ const (
 
 	// Any is the type for an arbitrary JSON value (interface{} in Go).
 	Any = Primitive(AnyKind)
+
+	// None is the type to ignore some value
+	None = Primitive(NoneKind)
 )
 
 // DataType implementation
@@ -176,6 +181,8 @@ func (p Primitive) Name() string {
 		return "date"
 	case Any:
 		return "any"
+	case None:
+		return ""
 	default:
 		panic("unknown primitive type") // bug
 	}
@@ -260,8 +267,8 @@ func (p Primitive) IsCompatible(val interface{}) (ok bool) {
 	return
 }
 
-// Example returns an instance of the given data type.
-func (p Primitive) Example(r *RandomGenerator) interface{} {
+// GenerateExample returns an instance of the given data type.
+func (p Primitive) GenerateExample(r *RandomGenerator) interface{} {
 	switch p {
 	case Boolean:
 		return r.Bool()
@@ -313,12 +320,12 @@ func (a *Array) IsCompatible(val interface{}) bool {
 	return k == reflect.Array || k == reflect.Slice
 }
 
-// Example produces a random array value.
-func (a *Array) Example(r *RandomGenerator) interface{} {
+// GenerateExample produces a random array value.
+func (a *Array) GenerateExample(r *RandomGenerator) interface{} {
 	count := r.Int()%3 + 1
 	res := make([]interface{}, count)
 	for i := 0; i < count; i++ {
-		res[i] = a.ElemType.Type.Example(r)
+		res[i] = a.ElemType.Type.GenerateExample(r)
 	}
 	return res
 }
@@ -363,11 +370,11 @@ func (o Object) IsCompatible(val interface{}) bool {
 	return k == reflect.Map || k == reflect.Struct
 }
 
-// Example returns a random value of the object.
-func (o Object) Example(r *RandomGenerator) interface{} {
+// GenerateExample returns a random value of the object.
+func (o Object) GenerateExample(r *RandomGenerator) interface{} {
 	res := make(map[string]interface{})
 	for n, att := range o {
-		res[n] = att.Type.Example(r)
+		res[n] = att.Type.GenerateExample(r)
 	}
 	return res
 }
@@ -405,12 +412,12 @@ func (h *Hash) IsCompatible(val interface{}) bool {
 	return k == reflect.Map
 }
 
-// Example returns a random hash value.
-func (h *Hash) Example(r *RandomGenerator) interface{} {
+// GenerateExample returns a random hash value.
+func (h *Hash) GenerateExample(r *RandomGenerator) interface{} {
 	count := r.Int()%3 + 1
 	res := make(map[interface{}]interface{})
 	for i := 0; i < count; i++ {
-		res[h.KeyType.Type.Example(r)] = h.ElemType.Type.Example(r)
+		res[h.KeyType.Type.GenerateExample(r)] = h.ElemType.Type.GenerateExample(r)
 	}
 	return res
 }
@@ -509,6 +516,8 @@ func (u *UserTypeDefinition) Finalize() {
 			u.AttributeDefinition.Inherit(bat)
 		}
 	}
+
+	u.finalizeExample(nil)
 }
 
 // NewMediaTypeDefinition creates a media type definition but does not

--- a/goagen/gen_js/generator.go
+++ b/goagen/gen_js/generator.go
@@ -122,7 +122,7 @@ func (g *Generator) generateIndexHTML(htmlFile string, api *design.APIDefinition
 		for i, n := range argNames {
 			q := query[n].Type.ToArray().ElemType
 			// below works because we deal with simple types in query strings
-			argValues[i] = fmt.Sprintf("%v", api.Example(q.Type))
+			argValues[i] = fmt.Sprintf("%v", q.GenerateExample(api.RandomGenerator()))
 		}
 		args = strings.Join(argValues, ", ")
 	}
@@ -132,7 +132,11 @@ func (g *Generator) generateIndexHTML(htmlFile string, api *design.APIDefinition
 		pathVars := exampleAction.AllParams().Type.ToObject()
 		pathValues := make([]interface{}, len(pathParams))
 		for i, n := range pathParams {
-			pathValues[i] = api.Example(pathVars[n].Type)
+			if pathVars[n].Example == nil {
+				pathValues[i] = pathVars[n].GenerateExample(api.RandomGenerator())
+			} else {
+				pathValues[i] = fmt.Sprintf("%v", pathVars[n].Example)
+			}
 		}
 		format := design.WildcardRegex.ReplaceAllLiteralString(examplePath, "/%v")
 		examplePath = fmt.Sprintf(format, pathValues...)

--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -23,6 +23,7 @@ type (
 		Definitions  map[string]*JSONSchema `json:"definitions,omitempty"`
 		Description  string                 `json:"description,omitempty"`
 		DefaultValue interface{}            `json:"defaultValue,omitempty"`
+		Example      interface{}            `json:"example,omitempty"`
 
 		// Hyper schema
 		Media     *JSONMedia  `json:"media,omitempty"`
@@ -380,6 +381,7 @@ func buildAttributeSchema(api *design.APIDefinition, s *JSONSchema, at *design.A
 	s.Merge(TypeSchema(api, at.Type))
 	s.DefaultValue = at.DefaultValue
 	s.Description = at.Description
+	s.Example = at.Example
 	for _, val := range at.Validations {
 		switch actual := val.(type) {
 		case *dslengine.EnumValidationDefinition:

--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -110,8 +110,8 @@ type (
 		// Required determines whether this parameter is mandatory.
 		Required bool `json:"required"`
 		// Schema defining the type used for the body parameter, only if "in" is body
-
 		Schema *genschema.JSONSchema `json:"schema,omitempty"`
+
 		// properties below only apply if "in" is not body
 
 		//  Type of the parameter. Since the parameter is not located at the request body,


### PR DESCRIPTION
Add Example DSL to allow users define their custom example, so goa can generate swagger specs with examples. If not given, goa will automatically generate a random value for the users.