### PR TITLE
Add more Travis CI options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: go
 go:
-- 1.4
-- 1.5
+- 1.4.3
+- 1.5.3
 - tip
+matrix:
+  allow_failures:
+    - go: tip
 sudo: false
 install:
 - go get -v ./...


### PR DESCRIPTION
- Use the latest releases of go 1.4 and 1.5.
- Enable OSX builds.
- Allow go tip builds to fail.