### PR TITLE
Fixes #268: avoid direct manipulation of dslengine's state

### DIFF
--- a/design/apidsl/attribute_test.go
+++ b/design/apidsl/attribute_test.go
@@ -41,7 +41,7 @@ var _ = Describe("ContainerDefinition", func() {
 		InitDesign()
 		att = &AttributeDefinition{Type: Object{}}
 		t := &TestCD{AttributeDefinition: att}
-		dslengine.Roots = append(dslengine.Roots, t)
+		dslengine.Register(t)
 	})
 
 	JustBeforeEach(func() {
@@ -50,7 +50,14 @@ var _ = Describe("ContainerDefinition", func() {
 	})
 
 	It("contains attributes", func() {
-		Ω(dslengine.Roots[1].(*TestCD).Attribute()).Should(Equal(att))
+		var t *TestCD
+		dslengine.Roots().IterateRoots(func(root dslengine.Root) error {
+			if r, ok := root.(*TestCD); ok {
+				t = r
+			}
+			return nil
+		})
+		Ω(t.Attribute()).Should(Equal(att))
 	})
 })
 

--- a/design/apidsl/init.go
+++ b/design/apidsl/init.go
@@ -93,6 +93,6 @@ func InitDesign() {
 
 	// Initialize package variables
 	design.Design = api
-	dslengine.Roots = []dslengine.Root{api}
+	dslengine.Register(api)
 	design.GeneratedMediaTypes = nil
 }

--- a/design/apidsl/media_type.go
+++ b/design/apidsl/media_type.go
@@ -325,7 +325,7 @@ func Link(name string, view ...string) {
 func CollectionOf(v interface{}, apidsl ...func()) *design.MediaTypeDefinition {
 	if design.GeneratedMediaTypes == nil {
 		design.GeneratedMediaTypes = make(design.MediaTypeRoot)
-		dslengine.Roots = append(dslengine.Roots, design.GeneratedMediaTypes)
+		dslengine.Register(design.GeneratedMediaTypes)
 	}
 	var m *design.MediaTypeDefinition
 	var ok bool

--- a/design/root_definitions.go
+++ b/design/root_definitions.go
@@ -1,0 +1,30 @@
+package design
+
+import (
+	"errors"
+
+	"github.com/goadesign/goa/dslengine"
+)
+
+// FindAPIDefinition iterates over the RootDefinitions to find the registered
+// APIDefinition.
+// It will return an error if there's more than one APIDefinition registered or
+// no APIDefinition could be found.
+func FindAPIDefinition(roots dslengine.RootDefinitions) (*APIDefinition, error) {
+	var api *APIDefinition
+	err := roots.IterateRoots(func(root dslengine.Root) error {
+		if def, ok := root.(*APIDefinition); ok && api == nil {
+			api = def
+		} else if ok {
+			return errors.New("encountered more than one APIDefinition registered")
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if api == nil {
+		return nil, errors.New("no APIDefinition registered in the API design")
+	}
+	return api, nil
+}

--- a/design/types.go
+++ b/design/types.go
@@ -549,7 +549,7 @@ func (m *MediaTypeDefinition) ComputeViews() map[string]*ViewDefinition {
 func (m *MediaTypeDefinition) Project(view string) (p *MediaTypeDefinition, links *UserTypeDefinition, err error) {
 	if GeneratedMediaTypes == nil {
 		GeneratedMediaTypes = make(MediaTypeRoot)
-		dslengine.Roots = append(dslengine.Roots, GeneratedMediaTypes)
+		dslengine.Register(GeneratedMediaTypes)
 	}
 	if _, ok := m.Views[view]; !ok {
 		return nil, nil, fmt.Errorf("unknown view %#v", view)

--- a/dslengine/definitions.go
+++ b/dslengine/definitions.go
@@ -15,13 +15,25 @@ type (
 	// corresponding behaviors during DSL execution.
 	DefinitionSet []Definition
 
-	// Root is the interface implemented by the DSL root objects held by the Roots variable.
-	// These objects contains all the definition sets created by the DSL and can be passed to
-	// the dsl for execution.
+	// Root is the interface implemented by the DSL root objects held by
+	// RootDefinitions.
+	// These objects contains all the definition sets created by the DSL and can
+	// be passed to the dsl for execution.
 	Root interface {
-		// IterateSets calls the given iterator passing in each definition set sorted in
-		// execution order.
+		// IterateSets calls the given iterator passing in each definition set
+		// sorted in execution order.
 		IterateSets(SetIterator)
+	}
+
+	// RootDefinitions is the interface for the object containging all the Roots
+	// registered by DSLs and can be passed to the dsl for execution.
+	RootDefinitions interface {
+		// Register a new root into the list of definitions.
+		Register(Root)
+		// IterateRoots takes a handler function that will be called with each of the
+		// registered Roots. If the handler returns an error the walk will be
+		// stopped and the error will be returned by IterateRoots.
+		IterateRoots(func(Root) error) error
 	}
 
 	// Validate is the interface implemented by definitions that can be validated.

--- a/dslengine/roots.go
+++ b/dslengine/roots.go
@@ -1,0 +1,44 @@
+package dslengine
+
+// Roots returns the default RootDefinitions for dslengine
+func Roots() RootDefinitions {
+	return roots
+}
+
+func init() {
+	roots = &rootDefinitions{}
+}
+
+// NewRootDefinitions returns a new RootDefinitions with the added given roots
+// pre-registered.
+// It is useful when testing generators.
+func NewRootDefinitions(roots ...Root) RootDefinitions {
+	r := &rootDefinitions{}
+	for _, root := range roots {
+		r.Register(root)
+	}
+	return r
+}
+
+// rootDefinitions implements the RootDefinitions interface
+type rootDefinitions struct {
+	roots []Root
+}
+
+func (defs *rootDefinitions) Register(r Root) {
+	defs.roots = append(defs.roots, r)
+}
+
+// Register adds a Root to the default RootDefinitions returned by Roots
+func Register(r Root) {
+	Roots().Register(r)
+}
+
+func (defs *rootDefinitions) IterateRoots(fn func(Root) error) error {
+	for _, r := range defs.roots {
+		if err := fn(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/utils"
 	"github.com/spf13/cobra"
@@ -19,8 +20,11 @@ type Generator struct {
 }
 
 // Generate is the generator entry point called by the meta generator.
-func Generate(roots []interface{}) (files []string, err error) {
-	api := roots[0].(*design.APIDefinition)
+func Generate(roots dslengine.RootDefinitions) (files []string, err error) {
+	api, err := design.FindAPIDefinition(roots)
+	if err != nil {
+		return nil, err
+	}
 	g := new(Generator)
 	root := &cobra.Command{
 		Use:   "goagen",

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Generate", func() {
 	})
 
 	JustBeforeEach(func() {
-		files, genErr = genapp.Generate([]interface{}{design.Design})
+		files, genErr = genapp.Generate(dslengine.NewRootDefinitions(design.Design))
 	})
 
 	AfterEach(func() {

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/utils"
 	"github.com/spf13/cobra"
@@ -22,8 +23,11 @@ type Generator struct {
 }
 
 // Generate is the generator entry point called by the meta generator.
-func Generate(roots []interface{}) (files []string, err error) {
-	api := roots[0].(*design.APIDefinition)
+func Generate(roots dslengine.RootDefinitions) (files []string, err error) {
+	api, err := design.FindAPIDefinition(roots)
+	if err != nil {
+		return nil, err
+	}
 	g := new(Generator)
 	root := &cobra.Command{
 		Use:   "goagen",

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_client"
 	. "github.com/onsi/ginkgo"
@@ -34,7 +35,7 @@ var _ = Describe("Generate", func() {
 	})
 
 	JustBeforeEach(func() {
-		files, genErr = genclient.Generate([]interface{}{design.Design})
+		files, genErr = genclient.Generate(dslengine.NewRootDefinitions(design.Design))
 	})
 
 	AfterEach(func() {

--- a/goagen/gen_gen/command_test.go
+++ b/goagen/gen_gen/command_test.go
@@ -77,7 +77,7 @@ var _ = Describe("RegisterFlags", func() {
 
 const dummyGenSrc = `package dummy
 
-func Generate(roots []interface{}) ([]string, error) {
+func Generate(roots dslengine.RootDefinitions) ([]string, error) {
 	return []string{"worked"}, nil
 }
 `

--- a/goagen/gen_js/generator.go
+++ b/goagen/gen_js/generator.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/utils"
 	"github.com/spf13/cobra"
@@ -22,8 +23,11 @@ type Generator struct {
 }
 
 // Generate is the generator entry point called by the meta generator.
-func Generate(roots []interface{}) (files []string, err error) {
-	api := roots[0].(*design.APIDefinition)
+func Generate(roots dslengine.RootDefinitions) (files []string, err error) {
+	api, err := design.FindAPIDefinition(roots)
+	if err != nil {
+		return nil, err
+	}
 	g := new(Generator)
 	root := &cobra.Command{
 		Use:   "goagen",

--- a/goagen/gen_js/generator_test.go
+++ b/goagen/gen_js/generator_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_js"
 	. "github.com/onsi/ginkgo"
@@ -33,7 +34,7 @@ var _ = Describe("Generate", func() {
 	})
 
 	JustBeforeEach(func() {
-		files, genErr = genjs.Generate([]interface{}{design.Design})
+		files, genErr = genjs.Generate(dslengine.NewRootDefinitions(design.Design))
 	})
 
 	AfterEach(func() {

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/utils"
 	"github.com/spf13/cobra"
@@ -22,8 +23,11 @@ type Generator struct {
 }
 
 // Generate is the generator entry point called by the meta generator.
-func Generate(roots []interface{}) (files []string, err error) {
-	api := roots[0].(*design.APIDefinition)
+func Generate(roots dslengine.RootDefinitions) (files []string, err error) {
+	api, err := design.FindAPIDefinition(roots)
+	if err != nil {
+		return nil, err
+	}
 	g := new(Generator)
 	root := &cobra.Command{
 		Use:   "goagen",

--- a/goagen/gen_main/generator_test.go
+++ b/goagen/gen_main/generator_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_main"
 	. "github.com/onsi/ginkgo"
@@ -34,7 +35,7 @@ var _ = Describe("Generate", func() {
 	})
 
 	JustBeforeEach(func() {
-		files, genErr = genmain.Generate([]interface{}{design.Design})
+		files, genErr = genmain.Generate(dslengine.NewRootDefinitions(design.Design))
 	})
 
 	AfterEach(func() {

--- a/goagen/gen_schema/generator.go
+++ b/goagen/gen_schema/generator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/utils"
 	"github.com/spf13/cobra"
@@ -18,8 +19,11 @@ type Generator struct {
 }
 
 // Generate is the generator entry point called by the meta generator.
-func Generate(roots []interface{}) (files []string, err error) {
-	api := roots[0].(*design.APIDefinition)
+func Generate(roots dslengine.RootDefinitions) (files []string, err error) {
+	api, err := design.FindAPIDefinition(roots)
+	if err != nil {
+		return nil, err
+	}
 	g := new(Generator)
 	root := &cobra.Command{
 		Use:   "goagen",

--- a/goagen/gen_schema/generator_test.go
+++ b/goagen/gen_schema/generator_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_schema"
 	. "github.com/onsi/ginkgo"
@@ -30,7 +31,7 @@ var _ = Describe("Generate", func() {
 	})
 
 	JustBeforeEach(func() {
-		files, genErr = genschema.Generate([]interface{}{design.Design})
+		files, genErr = genschema.Generate(dslengine.NewRootDefinitions(design.Design))
 	})
 
 	AfterEach(func() {

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/utils"
 	"github.com/spf13/cobra"
@@ -17,8 +18,11 @@ import (
 type Generator struct{}
 
 // Generate is the generator entry point called by the meta generator.
-func Generate(roots []interface{}) (files []string, err error) {
-	api := roots[0].(*design.APIDefinition)
+func Generate(roots dslengine.RootDefinitions) (files []string, err error) {
+	api, err := design.FindAPIDefinition(roots)
+	if err != nil {
+		return nil, err
+	}
 	g := new(Generator)
 	root := &cobra.Command{
 		Use:   "goagen",

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -19,10 +19,7 @@ type Generator struct {
 	// Genfunc contains the name of the generator entry point function.
 	// The function signature must be:
 	//
-	// func <Genfunc>(api *design.APIDefinition) ([]string, error)
-	//
-	// where "api" contains the DSL generated metadata and the returned
-	// string array lists the generated filenames.
+	// func <Genfunc>(dslengine.RootDefinitions) ([]string, error)
 	Genfunc string
 
 	// Imports list the imports that are specific for that generator that
@@ -181,12 +178,7 @@ func main() {
 	// Now run the secondary DSLs
 	failOnError(dslengine.Run())
 
-	// Now take the results and call the generator with it
-	roots := make([]interface{}, len(dslengine.Roots))
-	for i, r := range dslengine.Roots {
-		roots[i] = r
-	}
-	files, err := {{.Genfunc}}(roots)
+	files, err := {{.Genfunc}}(dslengine.Roots())
 	failOnError(err)
 
 	// We're done

--- a/goagen/meta/generator_test.go
+++ b/goagen/meta/generator_test.go
@@ -255,7 +255,8 @@ invalid go code
 `
 
 	panickySource = `package foo
-func Generate(roots []interface{}) ([]string, error) {
+import "github.com/goadesign/goa/dslengine"
+func Generate(roots dslengine.RootDefinitions) ([]string, error) {
 	return nil, nil
 }
 
@@ -263,14 +264,16 @@ func init() { panic("kaboom") }
 `
 
 	validSource = `package foo
-func Generate(roots []interface{}) ([]string, error) {
+import "github.com/goadesign/goa/dslengine"
+func Generate(roots dslengine.RootDefinitions) ([]string, error) {
 	return nil, nil
 }
 `
 
 	validSourceTmpl = `package foo
 import "fmt"
-func Generate(roots []interface{}) ([]string, error) {
+import "github.com/goadesign/goa/dslengine"
+func Generate(roots dslengine.RootDefinitions) ([]string, error) {
 	{{range .}}fmt.Println("{{.}}")
 	{{end}}
 	return nil, nil


### PR DESCRIPTION
These modifications fix issue #268.

Code builds and integration tests pass. However, unit tests are broken due to the fact they relied on  the exported state to reset the state of `dslengine` between tests.

`apidsl` contains a `InitDesign` method which was used to reset the state of `dslengine.Roots` with a new `APIDefinition`. This method is called in `apidsl.init()` and in tests from the rest of the packages[1].

To properly fix these tests would require a bigger refactor.

My suggestion would be:

 - Move all the package state from `dslengine` into a self-contained struct. e.g: `type engine struct {...}`
 - Change all functions like `Run` to methods working on `engine`.
 - Have `dslengine.init` initialise a package variable `DefaultEngine`
 - Package level functions like `Run` call the methods on `DefaultEngine`
 - Export a `NewEngine` function that can return a clean engine state for the tests to work on.
 - Remove `apidsl.InitDesign` and export a `NewDesign` function instead.

This pattern is used in the stdlib. e.g: `log` and `net/http` packages.



---
[1] - Places where `apidsl.InitDesign()` was used to reset the state of `dslengine`
```go
./design/apidsl/action_test.go:		InitDesign()
./design/apidsl/action_test.go:			InitDesign()
./design/apidsl/action_test.go:			InitDesign()
./design/apidsl/action_test.go:			InitDesign()
./design/apidsl/api_test.go:		InitDesign()
./design/apidsl/attribute_test.go:		InitDesign()
./design/apidsl/attribute_test.go:		InitDesign()
./design/apidsl/init.go:// Call InitDesign by default.
./design/apidsl/init.go:	InitDesign()
./design/apidsl/init.go:// InitDesign initializes the Design global variable and loads the built-in
./design/apidsl/init.go:func InitDesign() {
./design/apidsl/media_type_test.go:		InitDesign()
./design/apidsl/media_type_test.go:		InitDesign()
./design/apidsl/media_type_test.go:			InitDesign()
./design/apidsl/media_type_test.go:			InitDesign()
./design/apidsl/media_type_test.go:			InitDesign()
./design/apidsl/resource_test.go:		InitDesign()
./design/apidsl/response_test.go:		InitDesign()
./design/apidsl/type_test.go:		InitDesign()
./design/types_test.go:			InitDesign()
./design/validation_test.go:			InitDesign()
./dslengine/runner_test.go:			InitDesign()
./dslengine/runner_test.go:			InitDesign()
./dslengine/runner_test.go:			InitDesign()
./dslengine/validation_test.go:			InitDesign()
./goagen/codegen/types_test.go:		InitDesign()
./goagen/gen_swagger/swagger_test.go:		InitDesign()
```