### PR TITLE
goagen: pass extra flags to gen plugins

### DIFF
--- a/goagen/codegen/command.go
+++ b/goagen/codegen/command.go
@@ -27,6 +27,11 @@ var (
 
 	// CommandName is the name of the command being run.
 	CommandName string
+
+	// ExtraFlags is the list of extra, arbitrary flags to was read from the
+	// command line.  These flags will be passed as command line flags to the
+	// final generator.
+	ExtraFlags []string
 )
 
 type (

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -69,7 +69,10 @@ func main() {
 		sub := &cobra.Command{
 			Use:   command.Name(),
 			Short: command.Description(),
-			Run:   func(*cobra.Command, []string) { files, err = run() },
+			Run: func(cmd *cobra.Command, args []string) {
+				codegen.ExtraFlags = args
+				files, err = run()
+			},
 		}
 		command.RegisterFlags(sub)
 		codegen.RegisterFlags(sub)

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -157,6 +157,7 @@ func (m *Generator) spawn(genbin string) ([]string, error) {
 			args = append(args, fmt.Sprintf("--%s=%s", name, value))
 		}
 	}
+	args = append(args, codegen.ExtraFlags...)
 	cmd := exec.Command(genbin, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
When running a gen command, capture and pass additional, arbitrary command line flags to the
final generator.  For example, given the following command

    goagen --design=... gen --pkg-path=... -- --special=true -o test

The `--special=true -o test` flags will be passed to the final generator.