### PR TITLE
ACL-214 400 errors were returned as a string containing a malformed JSON object

### DIFF
--- a/service.go
+++ b/service.go
@@ -457,7 +457,10 @@ func (ctrl *ApplicationController) HandleFunc(name string, h, d Handler) HandleF
 		handler := middleware
 		if err != nil {
 			handler = func(ctx *Context) error {
-				ctx.Respond(400, fmt.Sprintf(`{"kind":"invalid request","msg":"invalid encoding: %s"}`, err))
+				ctx.Respond(400, map[string]interface{}{
+					"kind": "invalid request",
+					"msg":  "invalid encoding: " + err.Error(),
+				})
 				return nil
 			}
 			for i := range chain {

--- a/service.go
+++ b/service.go
@@ -457,10 +457,8 @@ func (ctrl *ApplicationController) HandleFunc(name string, h, d Handler) HandleF
 		handler := middleware
 		if err != nil {
 			handler = func(ctx *Context) error {
-				ctx.Respond(400, map[string]interface{}{
-					"kind": "invalid request",
-					"msg":  "invalid encoding: " + err.Error(),
-				})
+				msg := "invalid encoding: " + err.Error()
+				ctx.Respond(400, fmt.Sprintf(`{"kind":"invalid request","msg":%q}`, msg))
 				return nil
 			}
 			for i := range chain {


### PR DESCRIPTION
… this was due to an unescaped `err` being added to the msg string making the JSON invalid.

E.g. here's what it was returning:
```json
"{\"kind\":\"invalid request\",\"msg\":\"invalid encoding: [{\"id\":8,\"title\":\"value does not match validation pattern\",\"msg\":\"raw.principal.href must match the regexp \\\"^/grs/(users|groups)/(\\\\\\\\d+)$\\\" but got value \\\"/grs/users/1a\\\"\"}]\"}"
```
Now it will return as a JSON object, and probably will work for XML as well:
```json
{
  "kind": "invalid request",
  "msg": "invalid encoding: [{\"id\":8,\"title\":\"value does not match validation pattern\",\"msg\":\"raw.principal.href must match the regexp \\\"^/grs/(users|groups)/(\\\\\\\\d+)$\\\" but got value \\\"/grs/users/1a\\\"\"}]"
}
```

TODO: it would be extra nice if the error details were actually JSON as well, though.. maybe as a separate "detail" field?:
```json
{
  "kind": "invalid request",
  "msg": "invalid encoding",
  "detail": [
    {
      "id":8,
      "title":"value does not match validation pattern",
      "msg":"raw.principal.href must match the regexp \"^/grs/(users|groups)/(\\\\d+)$\" but got value \"/grs/users/1a\""
    }
  ]
}
```