### PR TITLE
ACL-214 use unmarshaller if provided, so we error if required payload is not provided

### DIFF
--- a/service.go
+++ b/service.go
@@ -449,7 +449,7 @@ func (ctrl *ApplicationController) HandleFunc(name string, h, d Handler) HandleF
 
 		// Load body if any
 		var err error
-		if r.ContentLength > 0 && d != nil {
+		if d != nil {
 			err = d(ctx)
 		}
 


### PR DESCRIPTION
When making a request that requires a payload, Goa is not returning an error if the payload was simply not provided `""`. It should return an error, rather than invoke the controller action with a nil payload.