### PR TITLE
ACL-214 MediaTypesWriter will iterate views in a consistent order

### DIFF
--- a/design/types.go
+++ b/design/types.go
@@ -552,6 +552,16 @@ func (m *MediaTypeDefinition) ComputeViews() map[string]*ViewDefinition {
 	return nil
 }
 
+// SortedViews returns view names in alphabetical order.
+func (m *MediaTypeDefinition) SortedViews() []string {
+	views := make([]string, 0, len(m.Views))
+	for view := range m.Views {
+		views = append(views, view)
+	}
+	sort.Strings(views)
+	return views
+}
+
 // Project creates a MediaTypeDefinition derived from the given definition that matches the given
 // view.
 func (m *MediaTypeDefinition) Project(view string) (p *MediaTypeDefinition, links *UserTypeDefinition, err error) {

--- a/design/types.go
+++ b/design/types.go
@@ -552,14 +552,29 @@ func (m *MediaTypeDefinition) ComputeViews() map[string]*ViewDefinition {
 	return nil
 }
 
-// SortedViews returns view names in alphabetical order.
-func (m *MediaTypeDefinition) SortedViews() []string {
-	views := make([]string, 0, len(m.Views))
-	for view := range m.Views {
-		views = append(views, view)
+// ViewIterator is the type of the function given to IterateViews.
+type ViewIterator func(*ViewDefinition) error
+
+// IterateViews calls the given iterator passing in each attribute sorted in alphabetical order.
+// Iteration stops if an iterator returns an error and in this case IterateViews returns that
+// error.
+func (m *MediaTypeDefinition) IterateViews(it ViewIterator) error {
+	o := m.Views
+	// gather names and sort them
+	names := make([]string, len(o))
+	i := 0
+	for n := range o {
+		names[i] = n
+		i++
 	}
-	sort.Strings(views)
-	return views
+	sort.Strings(names)
+	// iterate
+	for _, n := range names {
+		if err := it(o[n]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Project creates a MediaTypeDefinition derived from the given definition that matches the given

--- a/design/types_test.go
+++ b/design/types_test.go
@@ -178,3 +178,24 @@ var _ = Describe("Project", func() {
 		})
 	})
 })
+
+var _ = FDescribe("MediaTypeDefinition", func() {
+	Describe("SortedViews", func() {
+		It("works with empty", func() {
+			m := &MediaTypeDefinition{}
+			Expect(m.Views).To(BeEmpty())
+			Expect(m.SortedViews()).To(BeEmpty())
+		})
+		It("sorts views", func() {
+			m := &MediaTypeDefinition{}
+			Expect(m.Views).To(BeEmpty())
+			m.Views = map[string]*ViewDefinition{
+				"d": nil,
+				"c": nil,
+				"a": nil,
+				"b": nil,
+			}
+			Expect(m.SortedViews()).To(Equal([]string{"a", "b", "c", "d"}))
+		})
+	})
+})

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -294,8 +294,8 @@ func NewMediaTypesWriter(filename string) (*MediaTypesWriter, error) {
 func (w *MediaTypesWriter) Execute(data *MediaTypeTemplateData) error {
 	mt := data.MediaType
 	var mLinks *design.UserTypeDefinition
-	for _, view := range mt.SortedViews() {
-		p, links, err := mt.Project(view)
+	err := mt.IterateViews(func(view *design.ViewDefinition) error {
+		p, links, err := mt.Project(view.Name)
 		if mLinks == nil {
 			mLinks = links
 		}
@@ -306,6 +306,10 @@ func (w *MediaTypesWriter) Execute(data *MediaTypeTemplateData) error {
 		if err := w.ExecuteTemplate("mediatype", mediaTypeT, nil, data); err != nil {
 			return err
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	if mLinks != nil {
 		lData := &UserTypeTemplateData{

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -294,7 +294,7 @@ func NewMediaTypesWriter(filename string) (*MediaTypesWriter, error) {
 func (w *MediaTypesWriter) Execute(data *MediaTypeTemplateData) error {
 	mt := data.MediaType
 	var mLinks *design.UserTypeDefinition
-	for view := range mt.Views {
+	for _, view := range mt.SortedViews() {
 		p, links, err := mt.Project(view)
 		if mLinks == nil {
 			mLinks = links


### PR DESCRIPTION
This will make the generated code more stable, otherwise types like these would randomly switch positions each time `app` code was generated:
- `MyAppReferenceScope`
- `MyAppReferenceScopeLink`
