### PR TITLE
Allow "raw value" responses

### DIFF
--- a/design/api.go
+++ b/design/api.go
@@ -213,6 +213,8 @@ type (
 		Status int
 		// Response description
 		Description string
+		// Response body type if any
+		Type DataType
 		// Response body media type if any
 		MediaType string
 		// Response header definitions

--- a/design/apidsl/response_test.go
+++ b/design/apidsl/response_test.go
@@ -10,6 +10,7 @@ import (
 
 var _ = Describe("Response", func() {
 	var name string
+	var dt DataType
 	var dsl func()
 
 	var res *ResponseDefinition
@@ -19,12 +20,17 @@ var _ = Describe("Response", func() {
 		dslengine.Errors = nil
 		name = ""
 		dsl = nil
+		dt = nil
 	})
 
 	JustBeforeEach(func() {
 		Resource("res", func() {
 			Action("action", func() {
-				Response(name, dsl)
+				if dt != nil {
+					Response(name, dt, dsl)
+				} else {
+					Response(name, dsl)
+				}
 			})
 		})
 		dslengine.Run()
@@ -68,6 +74,24 @@ var _ = Describe("Response", func() {
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.Status).Should(Equal(status))
 			Ω(res.Parent).ShouldNot(BeNil())
+		})
+	})
+
+	Context("with a type override", func() {
+		const status = 201
+
+		BeforeEach(func() {
+			name = "foo"
+			dsl = func() {
+				Status(status)
+			}
+			dt = HashOf(String, Any)
+		})
+
+		It("produces a response definition with the given type", func() {
+			Ω(res).ShouldNot(BeNil())
+			Ω(res.Type).Should(Equal(dt))
+			Ω(res.Validate()).ShouldNot(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
This PR makes it possible to define responses with "raw values" i.e. values that are not described by media types (not objects). For example `HashOf(String, Any)`. The design syntax for such responses is:
```go
Response(OK, Integer)
```
This defines a response whose body is an integer. Another more complete example would be:
```go
Response(OK, HashOf(String, Any), "vnd.application.enumerated", func() {
    Status(200)
}
```
Where all the arguments but the first are optional. This example assumes the existence of a response template taking one argument (whose value here is `"vnd.application.enumerated"`).