### PR TITLE
Create json parsable map type (builtin key) if possible

### DIFF
--- a/design/apidsl/media_type_test.go
+++ b/design/apidsl/media_type_test.go
@@ -344,6 +344,9 @@ var _ = Describe("Example", func() {
 					Attribute("test6", HashOf(String, Integer))
 					Attribute("test7", HashOf(String, ArrayOf(ut)))
 					Attribute("test8", HashOf(Integer, ut))
+					Attribute("test9", HashOf(String, Boolean), func() {
+						Example(map[string]bool{})
+					})
 
 					Attribute("test-failure1", Integer, func() {
 						Minimum(0)
@@ -390,6 +393,9 @@ var _ = Describe("Example", func() {
 			}
 			attr = mt.Type.ToObject()["test8"]
 			Expect(attr.Example).Should(BeAssignableToTypeOf(map[int]map[string]interface{}{}))
+			attr = mt.Type.ToObject()["test9"]
+			Expect(attr.Example).Should(BeAssignableToTypeOf(map[string]bool{}))
+			Expect(attr.Example.(map[string]bool)).Should(HaveLen(0))
 			attr = mt.Type.ToObject()["test-failure1"]
 			Ω(attr.Example).Should(Equal(0))
 			attr = mt.Type.ToObject()["test-failure2"]

--- a/design/apidsl/media_type_test.go
+++ b/design/apidsl/media_type_test.go
@@ -341,6 +341,10 @@ var _ = Describe("Example", func() {
 						Pattern("@")
 					})
 					Attribute("test5", Any)
+					Attribute("test6", HashOf(String, Integer))
+					Attribute("test7", HashOf(String, ArrayOf(ut)))
+					Attribute("test8", HashOf(Integer, ut))
+
 					Attribute("test-failure1", Integer, func() {
 						Minimum(0)
 						Maximum(0)
@@ -369,6 +373,23 @@ var _ = Describe("Example", func() {
 			Ω(attr.Example).Should(MatchRegexp(`\w+@`))
 			attr = mt.Type.ToObject()["test5"]
 			Ω(attr.Example).Should(BeNil())
+			attr = mt.Type.ToObject()["test6"]
+			Expect(attr.Example).Should(BeAssignableToTypeOf(map[string]int{}))
+			attr = mt.Type.ToObject()["test7"]
+			Expect(attr.Example).Should(BeAssignableToTypeOf(map[string][]interface{}{}))
+			attrHash := attr.Example.(map[string][]interface{})
+			Expect(attrHash).ShouldNot(HaveLen(0))
+			for _, aryValue := range attrHash {
+				Expect(aryValue).ShouldNot(HaveLen(0))
+				for _, itemIface := range aryValue {
+					Expect(itemIface).Should(BeAssignableToTypeOf(map[string]interface{}{}))
+					item := itemIface.(map[string]interface{})
+					Expect(item).Should(HaveKey("test1"))
+					Expect(item["test1"]).Should(BeAssignableToTypeOf(int(0)))
+				}
+			}
+			attr = mt.Type.ToObject()["test8"]
+			Expect(attr.Example).Should(BeAssignableToTypeOf(map[int]map[string]interface{}{}))
 			attr = mt.Type.ToObject()["test-failure1"]
 			Ω(attr.Example).Should(Equal(0))
 			attr = mt.Type.ToObject()["test-failure2"]

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -151,9 +151,10 @@ func (a *AttributeDefinition) finalizeExample(stack []*AttributeDefinition) (int
 		example, isCustom := a.Type.ToArray().ElemType.finalizeExample(stack)
 		a.Example, a.isCustomExample = []interface{}{example}, isCustom
 	case a.Type.IsHash():
-		exampleK, isCustomK := a.Type.ToHash().KeyType.finalizeExample(stack)
-		exampleV, isCustomV := a.Type.ToHash().ElemType.finalizeExample(stack)
-		a.Example, a.isCustomExample = map[interface{}]interface{}{exampleK: exampleV}, isCustomK || isCustomV
+		h := a.Type.ToHash()
+		exampleK, isCustomK := h.KeyType.finalizeExample(stack)
+		exampleV, isCustomV := h.ElemType.finalizeExample(stack)
+		a.Example, a.isCustomExample = h.MakeMap(map[interface{}]interface{}{exampleK: exampleV}), isCustomK || isCustomV
 	case a.Type.IsObject():
 		// keep track of the type id, in case of a cyclical situation
 		stack = append(stack, a)

--- a/design/types.go
+++ b/design/types.go
@@ -428,12 +428,26 @@ func (h *Hash) GenerateExample(r *RandomGenerator) interface{} {
 // MakeMap examines the key type from a Hash and create a map with builtin type if possible.
 // The idea is to avoid generating map[interface{}]interface{}, which cannot be handled by json.Marshal.
 func (h *Hash) MakeMap(pair map[interface{}]interface{}) interface{} {
-	if len(pair) == 0 {
+	if !h.KeyType.Type.IsPrimitive() {
+		// well, a type can't be handled by json.Marshal... not much we can do
 		return pair
 	}
-	if !h.KeyType.Type.IsPrimitive() {
-		// well, a type can't be handled by json.Marshal
-		return pair
+	if len(pair) == 0 {
+		// figure out the map type manually
+		switch h.KeyType.Type.Kind() {
+		case BooleanKind:
+			return map[bool]interface{}{}
+		case IntegerKind:
+			return map[int]interface{}{}
+		case NumberKind:
+			return map[float64]interface{}{}
+		case StringKind:
+			return map[string]interface{}{}
+		case DateTimeKind:
+			return map[time.Time]interface{}{}
+		default:
+			return pair
+		}
 	}
 	var newMap reflect.Value
 	for key, value := range pair {

--- a/design/types.go
+++ b/design/types.go
@@ -418,11 +418,32 @@ func (h *Hash) IsCompatible(val interface{}) bool {
 // GenerateExample returns a random hash value.
 func (h *Hash) GenerateExample(r *RandomGenerator) interface{} {
 	count := r.Int()%3 + 1
-	res := make(map[interface{}]interface{})
+	pair := map[interface{}]interface{}{}
 	for i := 0; i < count; i++ {
-		res[h.KeyType.Type.GenerateExample(r)] = h.ElemType.Type.GenerateExample(r)
+		pair[h.KeyType.Type.GenerateExample(r)] = h.ElemType.Type.GenerateExample(r)
 	}
-	return res
+	return h.MakeMap(pair)
+}
+
+// MakeMap examines the key type from a Hash and create a map with builtin type if possible.
+// The idea is to avoid generating map[interface{}]interface{}, which cannot be handled by json.Marshal.
+func (h *Hash) MakeMap(pair map[interface{}]interface{}) interface{} {
+	if len(pair) == 0 {
+		return pair
+	}
+	if !h.KeyType.Type.IsPrimitive() {
+		// well, a type can't be handled by json.Marshal
+		return pair
+	}
+	var newMap reflect.Value
+	for key, value := range pair {
+		rkey, rvalue := reflect.ValueOf(key), reflect.ValueOf(value)
+		if !newMap.IsValid() {
+			newMap = reflect.MakeMap(reflect.MapOf(rkey.Type(), rvalue.Type()))
+		}
+		newMap.SetMapIndex(rkey, rvalue)
+	}
+	return newMap.Interface()
 }
 
 // AttributeIterator is the type of the function given to IterateAttributes.


### PR DESCRIPTION
Address issue #307, where `json.Marshal` cannot handle `map[interface{}]interface{}`. The change examines the key type from the `Hash` and create a `map` with builtin type if possible.