### PR TITLE
Add DSL for defining param, header and querystring based versioning

### DIFF
--- a/design/api.go
+++ b/design/api.go
@@ -82,6 +82,15 @@ type (
 		Types map[string]*UserTypeDefinition
 		// MediaTypes indexes the API media types by canonical identifier.
 		MediaTypes map[string]*MediaTypeDefinition
+		// VersionParams list the names of the path parameter wildcards that may contain
+		// the name of the targeted API version.
+		VersionParams []string
+		// VersionHeaders list the names of the HTTP request headers that may contain the
+		// name of the targeted API version.
+		VersionHeaders []string
+		// VersionQueries list the names of the HTTP request querystrings that may contain
+		// the name of the targeted API version.
+		VersionQueries []string
 		// rand is the random generator used to generate examples.
 		rand *RandomGenerator
 	}

--- a/design/apidsl/api_test.go
+++ b/design/apidsl/api_test.go
@@ -315,4 +315,110 @@ var _ = Describe("API", func() {
 			})
 		})
 	})
+
+	Context("using VersionParam", func() {
+		const vparam = "version"
+		BeforeEach(func() {
+			name = "v1"
+			dsl = func() {
+				BasePath("/api/:" + vparam)
+				VersionParam(vparam)
+			}
+		})
+
+		It("stores the version header name", func() {
+			Ω(Design.Validate()).ShouldNot(HaveOccurred())
+			Ω(Design.VersionParams).Should(Equal([]string{vparam}))
+		})
+	})
+
+	Context("using VersionHeader", func() {
+		const vheader = "X-Api-Version"
+		BeforeEach(func() {
+			name = "v1"
+			dsl = func() {
+				VersionHeader(vheader)
+			}
+		})
+
+		It("stores the version header name", func() {
+			Ω(Design.Validate()).ShouldNot(HaveOccurred())
+			Ω(Design.VersionHeaders).Should(Equal([]string{vheader}))
+		})
+	})
+
+	Context("using VersionQuery", func() {
+		const vquery = "version"
+		BeforeEach(func() {
+			name = "v1"
+			dsl = func() {
+				VersionQuery(vquery)
+			}
+		})
+
+		It("stores the version query name", func() {
+			Ω(Design.Validate()).ShouldNot(HaveOccurred())
+			Ω(Design.VersionQueries).Should(Equal([]string{vquery}))
+		})
+	})
+
+	Context("using VersionHeader to specify duplicates", func() {
+		const vheader = "X-Api-Version"
+		BeforeEach(func() {
+			name = "v1"
+			dsl = func() {
+				VersionHeader(vheader)
+				VersionHeader(vheader)
+			}
+		})
+
+		It("stores the version header name only once", func() {
+			Ω(Design.Validate()).ShouldNot(HaveOccurred())
+			Ω(Design.VersionHeaders).Should(Equal([]string{vheader}))
+		})
+	})
+
+	Context("using VersionQuery to specify duplicates", func() {
+		const vquery = "version"
+		BeforeEach(func() {
+			name = "v1"
+			dsl = func() {
+				VersionQuery(vquery, vquery)
+			}
+		})
+
+		It("stores the version query name only once", func() {
+			Ω(Design.Validate()).ShouldNot(HaveOccurred())
+			Ω(Design.VersionQueries).Should(Equal([]string{vquery}))
+		})
+	})
+})
+
+var _ = Describe("Version", func() {
+	var name string
+	var dsl func()
+
+	BeforeEach(func() {
+		InitDesign()
+		dslengine.Errors = nil
+		name = ""
+		dsl = nil
+	})
+
+	JustBeforeEach(func() {
+		Version(name, dsl)
+		dslengine.Run()
+	})
+
+	Context("with no DSL", func() {
+		BeforeEach(func() {
+			name = "v1"
+		})
+
+		It("produces a valid version definition", func() {
+			Ω(Design.Validate()).ShouldNot(HaveOccurred())
+			Ω(Design.Versions()).Should(HaveLen(1))
+			Ω(Design.Versions()[0]).Should(Equal(name))
+		})
+	})
 })

--- a/design/validation.go
+++ b/design/validation.go
@@ -71,6 +71,7 @@ func (a *APIDefinition) Validate() error {
 	a.validateContact(verr)
 	a.validateLicense(verr)
 	a.validateDocs(verr)
+	a.validateVersionParams(verr)
 
 	a.IterateVersions(func(ver *APIVersionDefinition) error {
 		var allRoutes []*routeInfo
@@ -175,6 +176,23 @@ func (a *APIDefinition) validateDocs(verr *dslengine.ValidationErrors) {
 	if a.Docs != nil && a.Docs.URL != "" {
 		if _, err := url.ParseRequestURI(a.Docs.URL); err != nil {
 			verr.Add(a, "invalid docs URL value: %s", err)
+		}
+	}
+}
+
+func (a *APIDefinition) validateVersionParams(verr *dslengine.ValidationErrors) {
+	bwcs := ExtractWildcards(a.BasePath)
+	for _, param := range a.VersionParams {
+		found := false
+		for _, wc := range bwcs {
+			if wc == param {
+				found = true
+				break
+			}
+		}
+		if !found {
+			verr.Add(a, "invalid version param, %s is not an API base path param (base path is %#v)",
+				param, a.BasePath)
 		}
 	}
 }

--- a/doc.go
+++ b/doc.go
@@ -69,8 +69,7 @@ The definitions of the Bottle and UpdateBottlePayload data structures are ommitt
 Controllers
 
 There is one controller interface generated per resource defined via the design language. The
-interface exposes the controller actions as well as methods to set controller specific middleware
-and error handlers (see below). User code must provide data structures that implement these
+interface exposes the controller actions. User code must provide data structures that implement these
 interfaces when mounting a controller onto a service. The controller data structure should include
 an anonymous field of type *goa.Controller which takes care of implementing the middleware and
 error handler handling.
@@ -113,5 +112,12 @@ input (Consumes) and output (Produces). goagen uses that information to registed
 packages with the service encoders and decoders via the SetEncoder and SetDecoder methods. The
 service exposes the Decode, DecodeRequest, Encode and EncodeResponse that implement a simple content
 type negotiation algorithm for picking the right encoder for the "Accept" request header.
+
+Versioning
+
+The VersionMux interface implemented by the RootMux struct exposes methods used by the generated
+code to setup the routing to versioned endpoints. The DSL defines how the API handles versioning:
+via request path, header, querystring or a combination. The generated code uses the VersionMux
+interface to setup the root mux accordingly.
 */
 package goa

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -328,7 +328,7 @@ func (g *Generator) generateControllers(verdir string, version *design.APIVersio
 		if !r.SupportsVersion(version.Version) {
 			return nil
 		}
-		data := &ControllerTemplateData{Resource: codegen.Goify(r.Name, true)}
+		data := &ControllerTemplateData{API: design.Design, Resource: codegen.Goify(r.Name, true)}
 		err := r.IterateActions(func(a *design.ActionDefinition) error {
 			context := fmt.Sprintf("%s%sContext", codegen.Goify(a.Name, true), codegen.Goify(r.Name, true))
 			unmarshal := fmt.Sprintf("unmarshal%s%sPayload", codegen.Goify(a.Name, true), codegen.Goify(r.Name, true))

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -430,6 +430,19 @@ import (
 	"net/http"
 )
 
+// inited is true if initService has been called
+var inited = false
+
+// initService sets up the service encoders, decoders and mux.
+func initService(service *goa.Service) {
+	if inited {
+		return
+	}
+	inited = true
+	// Setup encoders and decoders
+
+}
+
 // WidgetController is the controller interface for the Widget actions.
 type WidgetController interface {
 	goa.Muxer
@@ -438,9 +451,7 @@ type WidgetController interface {
 
 // MountWidgetController "mounts" a Widget resource controller on the given service.
 func MountWidgetController(service *goa.Service, ctrl WidgetController) {
-	// Setup encoders and decoders. This is idempotent and is done by each MountXXX function.
-
-	// Setup endpoint handler
+	initService(service)
 	var h goa.Handler
 	mux := service.{{if .version}}Version("{{.version}}").Mux{{else}}Mux{{end}}
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
@@ -448,7 +459,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 		if err != nil {
 			return goa.NewBadRequestError(err)
 		}{{if .version}}
-		rctx.APIVersion = service.Version("{{.version}}").VersionName{{end}}
+		rctx.APIVersion = "{{.version}}"{{end}}
 		return ctrl.Get(rctx)
 	}
 	mux.Handle("GET", "/:id", ctrl.MuxHandler("Get", h, nil))
@@ -494,9 +505,7 @@ package app
 const controllersSlicePayloadCode = `
 // MountWidgetController "mounts" a Widget resource controller on the given service.
 func MountWidgetController(service *goa.Service, ctrl WidgetController) {
-	// Setup encoders and decoders. This is idempotent and is done by each MountXXX function.
-
-	// Setup endpoint handler
+	initService(service)
 	var h goa.Handler
 	mux := service.Mux
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {

--- a/mux_test.go
+++ b/mux_test.go
@@ -9,21 +9,23 @@ import (
 )
 
 var _ = Describe("PathSelectVersionFunc", func() {
-	var pattern, zeroVersion string
+	var pattern, param string
 	var request *http.Request
 
 	var fn goa.SelectVersionFunc
 	var version string
 
 	JustBeforeEach(func() {
-		fn = goa.PathSelectVersionFunc(pattern, zeroVersion)
+		var err error
+		fn, err = goa.PathSelectVersionFunc(pattern, param)
+		Ω(err).ShouldNot(HaveOccurred())
 		version = fn(request)
 	})
 
-	Context("using the default settings", func() {
+	Context("using path versioning", func() {
 		BeforeEach(func() {
 			pattern = "/:version/"
-			zeroVersion = "api"
+			param = "version"
 		})
 
 		Context("and a versioned request", func() {
@@ -35,18 +37,6 @@ var _ = Describe("PathSelectVersionFunc", func() {
 
 			It("routes to the versioned controller", func() {
 				Ω(version).Should(Equal("v1"))
-			})
-		})
-
-		Context("and an unversioned request", func() {
-			BeforeEach(func() {
-				var err error
-				request, err = http.NewRequest("GET", "/api/foo", nil)
-				Ω(err).ShouldNot(HaveOccurred())
-			})
-
-			It("routes to the unversioned controller", func() {
-				Ω(version).Should(Equal(""))
 			})
 		})
 	})


### PR DESCRIPTION
And generate code that sets up the service mux accordingly.

This PR makes it possible to do:
```go
var _ = API("foo", func() {
    BasePath("/api/:version")
    VersionParam("version")        // Path param used to specify targeted API version
    VersionHeader("X-Api-Version") // Header used to specify targeted API version
    VersionQuery("version")        // Querystring value used to specify targeted API version
    ...
})
```
Where the `VersionXXX` DSL functions may each appear 0 or more times and may take one or more argument(s). `goagen` then generates code that sets up the mux so it "just works".