### PR TITLE
goagen: clean up gen_app templates

### DIFF
--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -434,10 +434,10 @@ type {{.Name}} struct {
 */}}{{/* IntegerType */}}{{/*
 */}}{{$tmp := tempvar}}{{/*
 */}}{{tabs .Depth}}if {{.VarName}}, err2 := strconv.Atoi(raw{{goify .Name true}}); err2 == nil {
-{{if .Pointer}}{{$tmp2 := tempvar}}{{tabs .Depth}}	{{$tmp2}} := int({{.VarName}})
+{{if .Pointer}}{{$tmp2 := tempvar}}{{tabs .Depth}}	{{$tmp2}} := {{.VarName}}
 {{tabs .Depth}}	{{$tmp}} := &{{$tmp2}}
 {{tabs .Depth}}	{{.Pkg}} = {{$tmp}}
-{{else}}{{tabs .Depth}}	{{.Pkg}} = int({{.VarName}})
+{{else}}{{tabs .Depth}}	{{.Pkg}} = {{.VarName}}
 {{end}}{{tabs .Depth}}} else {
 {{tabs .Depth}}	err = goa.InvalidParamTypeError("{{.Name}}", raw{{goify .Name true}}, "integer", err)
 {{tabs .Depth}}}
@@ -537,8 +537,9 @@ func (ctx *{{.Context.Name}}) {{goify .Response.Name true}}(r {{gopkgtyperef .Ty
 func (ctx *{{.Context.Name}}) {{goify .Response.Name true}}({{if .Response.MediaType}}resp []byte{{end}}) error {
 {{if .Response.MediaType}}	ctx.ResponseData.Header().Set("Content-Type", "{{.Response.MediaType}}")
 {{end}}	ctx.ResponseData.WriteHeader({{.Response.Status}}){{if .Response.MediaType}}
-	ctx.ResponseData.Write(resp){{end}}
-	return nil
+	_, err := ctx.ResponseData.Write(resp)
+	return err{{else}}
+	return nil{{end}}
 }
 `
 

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -818,7 +818,7 @@ func NewListBottleContext(ctx context.Context) (*ListBottleContext, error) {
 	rawParam := req.Params.Get("param")
 	if rawParam != "" {
 		if param, err2 := strconv.Atoi(rawParam); err2 == nil {
-			tmp2 := int(param)
+			tmp2 := param
 			tmp1 := &tmp2
 			rctx.Param = tmp1
 		} else {
@@ -947,7 +947,7 @@ func NewListBottleContext(ctx context.Context) (*ListBottleContext, error) {
 		elemsParam2 := make([]int, len(elemsParam))
 		for i, rawElem := range elemsParam {
 			if elem, err2 := strconv.Atoi(rawElem); err2 == nil {
-				elemsParam2[i] = int(elem)
+				elemsParam2[i] = elem
 			} else {
 				err = goa.InvalidParamTypeError("elem", rawElem, "integer", err)
 			}
@@ -975,7 +975,7 @@ func NewListBottleContext(ctx context.Context) (*ListBottleContext, error) {
 	rawInt := req.Params.Get("int")
 	if rawInt != "" {
 		if int_, err2 := strconv.Atoi(rawInt); err2 == nil {
-			tmp2 := int(int_)
+			tmp2 := int_
 			tmp1 := &tmp2
 			rctx.Int = tmp1
 		} else {
@@ -1005,7 +1005,7 @@ func NewListBottleContext(ctx context.Context) (*ListBottleContext, error) {
 		err = goa.MissingParamError("int", err)
 	} else {
 		if int_, err2 := strconv.Atoi(rawInt); err2 == nil {
-			rctx.Int = int(int_)
+			rctx.Int = int_
 		} else {
 			err = goa.InvalidParamTypeError("int", rawInt, "integer", err)
 		}


### PR DESCRIPTION
This commit cleans up two small issues:

- Remove unnecessary int-to-int type conversions for Integer types.
- Return error from ctx.ResponseData.Write call in context response func.