### PR TITLE
Fixes Issue #314: handle Any while generating examples

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -150,12 +150,12 @@ func (a *AttributeDefinition) finalizeExample(stack []*AttributeDefinition) (int
 	case a.Type.IsArray():
 		ary := a.Type.ToArray()
 		example, isCustom := ary.ElemType.finalizeExample(stack)
-		a.Example, a.isCustomExample = toOriginalType(ary, []interface{}{example}), isCustom
+		a.Example, a.isCustomExample = ary.MakeSlice([]interface{}{example}), isCustom
 	case a.Type.IsHash():
 		h := a.Type.ToHash()
 		exampleK, isCustomK := h.KeyType.finalizeExample(stack)
 		exampleV, isCustomV := h.ElemType.finalizeExample(stack)
-		a.Example, a.isCustomExample = toOriginalType(h, map[interface{}]interface{}{exampleK: exampleV}), isCustomK || isCustomV
+		a.Example, a.isCustomExample = h.MakeMap(map[interface{}]interface{}{exampleK: exampleV}), isCustomK || isCustomV
 	case a.Type.IsObject():
 		// keep track of the type id, in case of a cyclical situation
 		stack = append(stack, a)

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -148,13 +148,14 @@ func (a *AttributeDefinition) finalizeExample(stack []*AttributeDefinition) (int
 	// note: must traverse each node to finalize the examples unless given
 	switch true {
 	case a.Type.IsArray():
-		example, isCustom := a.Type.ToArray().ElemType.finalizeExample(stack)
-		a.Example, a.isCustomExample = []interface{}{example}, isCustom
+		ary := a.Type.ToArray()
+		example, isCustom := ary.ElemType.finalizeExample(stack)
+		a.Example, a.isCustomExample = toOriginalType(ary, []interface{}{example}), isCustom
 	case a.Type.IsHash():
 		h := a.Type.ToHash()
 		exampleK, isCustomK := h.KeyType.finalizeExample(stack)
 		exampleV, isCustomV := h.ElemType.finalizeExample(stack)
-		a.Example, a.isCustomExample = h.MakeMap(map[interface{}]interface{}{exampleK: exampleV}), isCustomK || isCustomV
+		a.Example, a.isCustomExample = toOriginalType(h, map[interface{}]interface{}{exampleK: exampleV}), isCustomK || isCustomV
 	case a.Type.IsObject():
 		// keep track of the type id, in case of a cyclical situation
 		stack = append(stack, a)

--- a/design/example.go
+++ b/design/example.go
@@ -70,6 +70,8 @@ func (eg *exampleGenerator) hasLengthValidation() bool {
 	return eg.a.Validation.MinLength != nil || eg.a.Validation.MaxLength != nil
 }
 
+const maxExampleLength = 10
+
 // generateValidatedLengthExample generates a random size array of examples based on what's given.
 func (eg *exampleGenerator) generateValidatedLengthExample() interface{} {
 	minlength, maxlength := math.Inf(1), math.Inf(-1)
@@ -78,7 +80,7 @@ func (eg *exampleGenerator) generateValidatedLengthExample() interface{} {
 			minlength = float64(*eg.a.Validation.MinLength)
 		}
 		if eg.a.Validation.MaxLength != nil {
-			minlength = float64(*eg.a.Validation.MaxLength)
+			maxlength = float64(*eg.a.Validation.MaxLength)
 		}
 	}
 	count := 0
@@ -87,11 +89,18 @@ func (eg *exampleGenerator) generateValidatedLengthExample() interface{} {
 	} else if math.IsInf(maxlength, -1) {
 		count = int(minlength) + (eg.r.Int() % 3)
 	} else if minlength < maxlength {
-		count = int(minlength) + (eg.r.Int() % int(maxlength-minlength))
+		diff := int(maxlength - minlength)
+		if diff > maxExampleLength {
+			diff = maxExampleLength
+		}
+		count = int(minlength) + (eg.r.Int() % diff)
 	} else if minlength == maxlength {
 		count = int(minlength)
 	} else {
 		panic("Validation: MinLength > MaxLength")
+	}
+	if count > maxExampleLength {
+		count = maxExampleLength
 	}
 	if !eg.a.Type.IsArray() {
 		return eg.r.faker.Characters(count)


### PR DESCRIPTION
Issue #314 Fixes
 * avoid OOM from creating a large slice in example because of high `MinLength`
 * add `Any` type handling in both `Array` and `Hash` `GenerateExample`
 * generate example with more precise type instead of using `interface{}` everywhere (make tests easier)