### PR TITLE
Properly generate version encoders.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ examples/cellar/client/cellar-cli/cellar-cli
 **/*.coverprofile
 goagen/goagen
 **/autogen
+**/*.test
 vendor
 _integration_tests/*/**/*.*
 public/
+.vscode/

--- a/design/api.go
+++ b/design/api.go
@@ -97,17 +97,17 @@ type (
 
 	// APIVersionDefinition defines the properties of the API for a given version.
 	APIVersionDefinition struct {
-		// API name
+		// Version API name
 		Name string
-		// API Title
+		// Version Title
 		Title string
-		// API description
+		// Version description
 		Description string
-		// API version if any
+		// Version identifier if any
 		Version string
-		// API hostname
+		// Version hostname
 		Host string
-		// API URL schemes
+		// Version URL schemes
 		Schemes []string
 		// Common base path to all API actions
 		BasePath string
@@ -640,6 +640,24 @@ func (v *APIVersionDefinition) IterateResponses(it ResponseIterator) error {
 // DSL returns the initialization DSL.
 func (v *APIVersionDefinition) DSL() func() {
 	return v.DSLFunc
+}
+
+// Init inializes the fields of the version definition from the fields of the API definition.
+// This method is called after the API definition DSL has executed and before the version DSL
+// executes.
+func (v *APIVersionDefinition) Init() {
+	v.Title = Design.Title
+	v.Description = Design.Description
+	v.Host = Design.Host
+	v.Schemes = Design.Schemes
+	v.BasePath = Design.BasePath
+	v.BaseParams = Design.BaseParams
+	v.Consumes = Design.Consumes
+	v.Produces = Design.Produces
+	v.TermsOfService = Design.TermsOfService
+	v.Contact = Design.Contact
+	v.License = Design.License
+	v.Docs = Design.Docs
 }
 
 // CanonicalIdentifier returns the media type identifier sans suffix

--- a/design/apidsl/api.go
+++ b/design/apidsl/api.go
@@ -98,7 +98,13 @@ func API(name string, dsl func()) *design.APIDefinition {
 //              VersionQuery("version", "v")   // Equivalent to the two lines above
 //	})
 func Version(ver string, dsl func()) *design.APIVersionDefinition {
-	verdef := &design.APIVersionDefinition{Version: ver, DSLFunc: dsl}
+	verdef := &design.APIVersionDefinition{Version: ver}
+	verdef.DSLFunc = func() {
+		verdef.Init()
+		if dsl != nil {
+			dsl()
+		}
+	}
 	if _, ok := design.Design.APIVersions[ver]; ok {
 		dslengine.ReportError("API Version %s defined twice", ver)
 		return verdef

--- a/design/apidsl/media_type.go
+++ b/design/apidsl/media_type.go
@@ -174,8 +174,8 @@ func Media(val interface{}) {
 func Reference(t design.DataType) {
 	if mt, ok := mediaTypeDefinition(false); ok {
 		mt.Reference = t
-	} else if ut, ok := typeDefinition(true); ok {
-		ut.Reference = t
+	} else if at, ok := attributeDefinition(true); ok {
+		at.Reference = t
 	}
 }
 

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -323,6 +323,7 @@ func (g *Generator) generateControllers(verdir string, version *design.APIVersio
 		}
 	}
 	ctlWr.WriteHeader(title, packageName(version), imports)
+	ctlWr.WriteInitService(version, encoderMap, decoderMap)
 	var controllersData []*ControllerTemplateData
 	version.IterateResources(func(r *design.ResourceDefinition) error {
 		if !r.SupportsVersion(version.Version) {

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -440,7 +440,6 @@ func initService(service *goa.Service) {
 	}
 	inited = true
 	// Setup encoders and decoders
-
 }
 
 // WidgetController is the controller interface for the Widget actions.
@@ -462,7 +461,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 		rctx.APIVersion = "{{.version}}"{{end}}
 		return ctrl.Get(rctx)
 	}
-	mux.Handle("GET", "/:id", ctrl.MuxHandler("Get", h, nil))
+	mux.Handle("GET", "/:id", ctrl.MuxHandler("Get", "{{.version}}", h, nil))
 	goa.Info(goa.RootContext, "mount", goa.KV{"ctrl", "Widget"},{{if .version}} goa.KV{"version", "{{.version}}"},{{end}} goa.KV{"action", "Get"}, goa.KV{"route", "GET /:id"})
 }
 `
@@ -518,7 +517,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 		}
 		return ctrl.Get(rctx)
 	}
-	mux.Handle("GET", "/:id", ctrl.MuxHandler("Get", h, unmarshalGetWidgetPayload))
+	mux.Handle("GET", "/:id", ctrl.MuxHandler("Get", "", h, unmarshalGetWidgetPayload))
 	goa.Info(goa.RootContext, "mount", goa.KV{"ctrl", "Widget"}, goa.KV{"action", "Get"}, goa.KV{"route", "GET /:id"})
 }
 

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -446,15 +446,6 @@ var _ = Describe("ControllersWriter", func() {
 					DecoderMap: decoderMap,
 				}}
 			})
-
-			It("generates the service initialization code", func() {
-				err := writer.Execute(data)
-				Ω(err).ShouldNot(HaveOccurred())
-				b, err := ioutil.ReadFile(filename)
-				Ω(err).ShouldNot(HaveOccurred())
-				written := string(b)
-				Ω(written).Should(Equal(initController))
-			})
 		})
 
 		Context("with data", func() {
@@ -1071,42 +1062,6 @@ type BottlesController interface {
 }
 `
 
-	initController = `
-// inited is true if initService has been called
-var inited = false
-
-// initService sets up the service encoders, decoders and mux.
-func initService(service *goa.Service) {
-	if inited {
-		return
-	}
-	inited = true
-	// Setup encoders and decoders
-	service.SetEncoder(goa.NewEncoder(), true, "application/json")
-	service.SetDecoder(goa.NewDecoder(), true, "application/json")
-
-	// Configure mux for versioning.
-	if mux, ok := service.Mux.(*goa.RootMux); ok {
-		func0 := goa.PathSelectVersionFunc("/api/:vp", "vp")
-		func1 := goa.HeaderSelectVersionFunc("vh")
-		func2 := goa.QuerySelectVersionFunc("vq")
-		mux.SelectVersionFunc = goa.CombineSelectVersionFunc(func0, func1, func2, )
-	}
-}
-
-// resourceController is the controller interface for the resource actions.
-type resourceController interface {
-	goa.Muxer
-}
-
-// MountresourceController "mounts" a resource resource controller on the given service.
-func MountresourceController(service *goa.Service, ctrl resourceController) {
-	initService(service)
-	var h goa.Handler
-	mux := service.Mux
-}
-`
-
 	encoderController = `
 // MountBottlesController "mounts" a Bottles resource controller on the given service.
 func MountBottlesController(service *goa.Service, ctrl BottlesController) {
@@ -1120,7 +1075,7 @@ func MountBottlesController(service *goa.Service, ctrl BottlesController) {
 		}
 		return ctrl.List(rctx)
 	}
-	mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", h, nil))
+	mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", "", h, nil))
 	goa.Info(goa.RootContext, "mount", goa.KV{"ctrl", "Bottles"}, goa.KV{"action", "List"}, goa.KV{"route", "GET /accounts/:accountID/bottles"})
 }
 `
@@ -1136,7 +1091,7 @@ func MountBottlesController(service *goa.Service, ctrl BottlesController) {
 		}
 		return ctrl.List(rctx)
 	}
-	mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", h, nil))
+	mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", "", h, nil))
 	goa.Info(goa.RootContext, "mount", goa.KV{"ctrl", "Bottles"}, goa.KV{"action", "List"}, goa.KV{"route", "GET /accounts/:accountID/bottles"})
 }
 `
@@ -1160,7 +1115,7 @@ type BottlesController interface {
 		}
 		return ctrl.List(rctx)
 	}
-	mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", h, nil))
+	mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", "", h, nil))
 	goa.Info(goa.RootContext, "mount", goa.KV{"ctrl", "Bottles"}, goa.KV{"action", "List"}, goa.KV{"route", "GET /accounts/:accountID/bottles"})
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 		rctx, err := NewShowBottleContext(ctx)
@@ -1169,7 +1124,7 @@ type BottlesController interface {
 		}
 		return ctrl.Show(rctx)
 	}
-	mux.Handle("GET", "/accounts/:accountID/bottles/:id", ctrl.MuxHandler("Show", h, nil))
+	mux.Handle("GET", "/accounts/:accountID/bottles/:id", ctrl.MuxHandler("Show", "", h, nil))
 	goa.Info(goa.RootContext, "mount", goa.KV{"ctrl", "Bottles"}, goa.KV{"action", "Show"}, goa.KV{"route", "GET /accounts/:accountID/bottles/:id"})
 }
 `

--- a/mux.go
+++ b/mux.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/goadesign/goa/design"
 	"github.com/julienschmidt/httprouter"
 )
@@ -36,15 +34,11 @@ type (
 		Mux(version string) ServeMux
 		// VersionName returns the name of the version targeted by the given request.
 		VersionName(req *http.Request) string
-		// HandleMissingVersion handles requests that target a non-existent API version (that
-		// is requests for which RequestMux returns nil).
-		// The context request data object contains the name of the targeted version.
-		HandleMissingVersion(ctx context.Context, rw http.ResponseWriter, req *http.Request)
 	}
 
 	// Muxer implements an adapter that given a request handler can produce a mux handler.
 	Muxer interface {
-		MuxHandler(name string, hdlr Handler, unm Unmarshaler) MuxHandler
+		MuxHandler(name, version string, hdlr Handler, unm Unmarshaler) MuxHandler
 	}
 
 	// RootMux is the default VersionMux and ServeMux implementation. It dispatches requests to the

--- a/service_test.go
+++ b/service_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Application", func() {
 
 		JustBeforeEach(func() {
 			ctrl := s.NewController("test")
-			muxHandler = ctrl.MuxHandler("testAct", handler, unmarshaler)
+			muxHandler = ctrl.MuxHandler("testAct", "", handler, unmarshaler)
 		})
 
 		BeforeEach(func() {


### PR DESCRIPTION
Fix issues with "Reference": it now properly initializes the version
basic properties from the API's.