### PR TITLE
Generate proper media type godocs

### DIFF
--- a/design/types.go
+++ b/design/types.go
@@ -625,18 +625,13 @@ func (m *MediaTypeDefinition) projectSingle(view string) (p *MediaTypeDefinition
 		val = m.Validation.Dup()
 		val.Required = required
 	}
-	description := m.Description
-	if view != "default" {
-		description += fmt.Sprintf(", %s view", view)
-	}
 	p = &MediaTypeDefinition{
 		Identifier: m.Identifier,
 		UserTypeDefinition: &UserTypeDefinition{
 			TypeName: typeName,
 			AttributeDefinition: &AttributeDefinition{
-				Description: description,
-				Type:        Dup(v.Type),
-				Validation:  val,
+				Type:       Dup(v.Type),
+				Validation: val,
 			},
 		},
 	}
@@ -701,8 +696,7 @@ func (m *MediaTypeDefinition) projectCollection(view string) (p *MediaTypeDefini
 		Identifier: m.Identifier,
 		UserTypeDefinition: &UserTypeDefinition{
 			AttributeDefinition: &AttributeDefinition{
-				Type:        &Array{ElemType: &AttributeDefinition{Type: pe}},
-				Description: fmt.Sprintf("%s, %s view", m.Description, view),
+				Type: &Array{ElemType: &AttributeDefinition{Type: pe}},
 			},
 			TypeName: pe.TypeName + "Collection",
 		},

--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -237,6 +237,32 @@ func GoNativeType(t design.DataType) string {
 	}
 }
 
+// GoTypeDesc returns the description of a type.  If no description is defined
+// for the type, one will be generated.
+func GoTypeDesc(t design.DataType, upper bool) string {
+	switch actual := t.(type) {
+	case *design.UserTypeDefinition:
+		if actual.Description != "" {
+			return actual.Description
+		}
+
+		return Goify(actual.TypeName, upper) + " user type."
+	case *design.MediaTypeDefinition:
+		if actual.Description != "" {
+			return actual.Description
+		}
+
+		switch elem := actual.UserTypeDefinition.AttributeDefinition.Type.(type) {
+		case *design.Array:
+			return fmt.Sprintf("%s media type is a collection of %s.", Goify(actual.TypeName, upper), GoPackageTypeName(elem.ElemType.Type, nil, 0))
+		default:
+			return Goify(actual.TypeName, upper) + " media type."
+		}
+	default:
+		return ""
+	}
+}
+
 var commonInitialisms = map[string]bool{
 	"API":   true,
 	"ASCII": true,

--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -58,6 +58,7 @@ var (
 		"gonative":          GoNativeType,
 		"gotypedef":         GoTypeDef,
 		"gotypename":        GoTypeName,
+		"gotypedesc":        GoTypeDesc,
 		"gotyperef":         GoTypeRef,
 		"join":              strings.Join,
 		"recursiveValidate": RecursiveChecker,

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -577,11 +577,12 @@ func {{.Name}}Href({{if .CanonicalParams}}{{join .CanonicalParams ", "}} interfa
 
 	// mediaTypeT generates the code for a media type.
 	// template input: MediaTypeTemplateData
-	mediaTypeT = `// {{if .Description}}{{.Description}}{{else}}{{gotypename . .AllRequired 0}} media type{{end}}
+	mediaTypeT = `// {{gotypedesc . true}}
+//
 // Identifier: {{.Identifier}}{{$typeName := gotypename . .AllRequired 0}}
 type {{$typeName}} {{gotypedef . 0 true}}
 
-{{$validation := recursiveValidate .AttributeDefinition false false "mt" "response" 1}}{{if $validation}}// Validate validates the media type instance.
+{{$validation := recursiveValidate .AttributeDefinition false false "mt" "response" 1}}{{if $validation}}// Validate validates the {{$typeName}} media type instance.
 func (mt {{gotyperef . .AllRequired 0}}) Validate() (err error) {
 {{$validation}}
 	return
@@ -591,10 +592,10 @@ func (mt {{gotyperef . .AllRequired 0}}) Validate() (err error) {
 
 	// userTypeT generates the code for a user type.
 	// template input: UserTypeTemplateData
-	userTypeT = `// {{if .Description}}{{.Description}}{{else}}{{gotypename . .AllRequired 0}} type{{end}}
-type {{gotypename . .AllRequired 0}} {{gotypedef . 0 true}}
+	userTypeT = `// {{gotypedesc . true}}{{$typeName := gotypename . .AllRequired 0}}
+type {{$typeName}} {{gotypedef . 0 true}}
 
-{{$validation := recursiveValidate .AttributeDefinition false false "ut" "response" 1}}{{if $validation}}// Validate validates the type instance.
+{{$validation := recursiveValidate .AttributeDefinition false false "ut" "response" 1}}{{if $validation}}// Validate validates the {{$typeName}} type instance.
 func (ut {{gotyperef . .AllRequired 0}}) Validate() (err error) {
 {{$validation}}
 	return


### PR DESCRIPTION
This commit updates the descriptions for media type views and collections to
proper godoc formatting.

I had to import `codegen` to get access to `Goify`.