### PR TITLE
Added `FailOnError` function, tohandle MultiError

### DIFF
--- a/dslengine/runner.go
+++ b/dslengine/runner.go
@@ -142,6 +142,20 @@ func (m MultiError) Error() string {
 	return strings.Join(msgs, "\n")
 }
 
+func FailOnError(err error) {
+	if merr, ok := err.(MultiError); ok {
+		if len(merr) == 0 {
+			return
+		}
+		fmt.Fprintf(os.Stderr, merr.Error())
+		os.Exit(1)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}
+
 // Error returns the underlying error message.
 func (de *Error) Error() string {
 	if err := de.GoError; err != nil {

--- a/dslengine/runner.go
+++ b/dslengine/runner.go
@@ -142,6 +142,8 @@ func (m MultiError) Error() string {
 	return strings.Join(msgs, "\n")
 }
 
+// FailOnError will exit with code 1 if `err != nil`. This function
+// will handle properly the MultiError this dslengine provides.
 func FailOnError(err error) {
 	if merr, ok := err.(MultiError); ok {
 		if len(merr) == 0 {

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -76,6 +76,8 @@ func (g *Generator) Generate(api *design.APIDefinition) (_ []string, err error) 
 		}
 	}()
 
+	os.RemoveAll(AppOutputDir())
+
 	if err := os.MkdirAll(AppOutputDir(), 0755); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
, and as a way to keep a `gen/main.go` (like the output of `goagen/meta`, but inside the
project).

The goal of having a `gen/main.go` is to ease team discovery, and to
more easily work on our own generators.

The goal is to make this work: https://gist.github.com/abourget/06c803e1e9e102f7dec4