### PR TITLE
Simplify a potential `gen/main.go` in project's files.

### DIFF
--- a/dslengine/runner.go
+++ b/dslengine/runner.go
@@ -181,6 +181,14 @@ func FailOnError(err error) {
 	}
 }
 
+// PrintFilesOrFail will print the file list. Use it with a
+// generator's `Generate()` function to output the generated list of
+// files or quit on error.
+func PrintFilesOrFail(files []string, err error) {
+	FailOnError(err)
+	fmt.Println(strings.Join(files, "\n"))
+}
+
 // IncompatibleDSL should be called by DSL functions when they are
 // invoked in an incorrect context (e.g. "Params" in "Resource").
 func IncompatibleDSL() {


### PR DESCRIPTION
I'd like have a `gen/main.go` file like this:

```
package main

import (
	_ "github.com/abourget/featurette/design"
	"github.com/abourget/featurette/gensec"

	"github.com/goadesign/goa/design"
	"github.com/goadesign/goa/dslengine"
	"github.com/goadesign/goa/goagen/gen_app"
	"github.com/goadesign/goa/goagen/gen_swagger"
)

// Run with: "go run gen/main.go" from the root of your project.

func main() {
	dslengine.FailOnError(dslengine.Errors)
	dslengine.FailOnError(dslengine.Run())

	genapp.TargetPackage = "app"
	dslengine.PrintFilesOrFail(new(genapp.Generator).Generate(design.Design))
	dslengine.PrintFilesOrFail(gensec.Generate("app"))

	dslengine.PrintFilesOrFail(new(genswagger.Generator).Generate(design.Design))
}
```

These small fixes enable that.