### PR TITLE
Error: implement DetailedError method on ErrorClass

### DIFF
--- a/context.go
+++ b/context.go
@@ -128,7 +128,7 @@ func (r *ResponseData) BadRequest(ctx context.Context, err *HTTPError) error {
 // The body can be set using a format and substituted values a la fmt.Printf.
 func (r *ResponseData) Bug(ctx context.Context, format string, a ...interface{}) error {
 	msg := fmt.Sprintf(format, a...)
-	return r.Send(ctx, 500, &HTTPError{ErrInternal, msg})
+	return r.Send(ctx, 500, &HTTPError{ErrInternal, msg, nil})
 }
 
 // WriteHeader records the response status code and calls the underlying writer.

--- a/error.go
+++ b/error.go
@@ -103,6 +103,8 @@ type (
 		*ErrorClass
 		// Err describes the specific error occurrence.
 		Err string `json:"err" xml:"err"`
+		// Details is any key-value pairs you want to report with the errors
+		Details map[string]interface{} `json:"details,omitempty" xml:"details,omitempty"`
 	}
 
 	// ErrorClass contains information sent together with the error message in responses.
@@ -128,6 +130,20 @@ func NewErrorClass(id, title string, status int) *ErrorClass {
 // Error wraps an error into a HTTP error of the given class.
 func (class *ErrorClass) Error(err error) *HTTPError {
 	return &HTTPError{ErrorClass: class, Err: err.Error()}
+}
+
+// DetailedError wraps an error into a HTTP error of the given class.
+func (class *ErrorClass) DetailedError(msg string, keyvals ...interface{}) *HTTPError {
+	details := make(map[string]interface{})
+	for i := 0; i < len(keyvals); i += 2 {
+		k := keyvals[i]
+		var v interface{} = "MISSING"
+		if i+1 < len(keyvals) {
+			v = keyvals[i+1]
+		}
+		details[fmt.Sprintf("%s", k)] = v
+	}
+	return &HTTPError{ErrorClass: class, Err: msg, Details: details}
 }
 
 // Errorf builds an HTTP error given a format and values.


### PR DESCRIPTION
Allows adding some keyvalue pairs as details.