### PR TITLE
Change how ErrorClass works to allow for Key/Values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ public/
 .vscode/
 *~
 *.orig
+.DS_Store

--- a/context.go
+++ b/context.go
@@ -128,7 +128,7 @@ func (r *ResponseData) BadRequest(ctx context.Context, err *HTTPError) error {
 // The body can be set using a format and substituted values a la fmt.Printf.
 func (r *ResponseData) Bug(ctx context.Context, format string, a ...interface{}) error {
 	msg := fmt.Sprintf(format, a...)
-	return r.Send(ctx, 500, &HTTPError{ErrInternal, msg})
+	return r.Send(ctx, 500, ErrInternal(msg))
 }
 
 // WriteHeader records the response status code and calls the underlying writer.

--- a/error.go
+++ b/error.go
@@ -94,7 +94,11 @@ type (
 		Details map[string]interface{} `json:"details,omitempty" xml:"details,omitempty"`
 	}
 
-	// ErrorClass contains information sent together with the error message in responses.
+	// ErrorClass is an error generating function.
+	// It accepts a format and values and produces errors with the resulting string.
+	// If the format is a string or a Stringer then the string value is used.
+	// If the format is an error then the string returned by Error() is used.
+	// Otherwise the string produced using fmt.Sprintf("%v") is used.
 	ErrorClass func(fm interface{}, v ...interface{}) *HTTPError
 
 	// MultiError is an error composed of potentially multiple errors.
@@ -187,8 +191,8 @@ func (e *HTTPError) Error() string {
 	return e.Err
 }
 
-// KV adds to the error details.
-func (e *HTTPError) KV(keyvals ...interface{}) {
+// WithFields adds to the error details.
+func (e *HTTPError) WithFields(keyvals ...interface{}) {
 	for i := 0; i < len(keyvals); i += 2 {
 		k := keyvals[i]
 		var v interface{} = "MISSING"

--- a/error.go
+++ b/error.go
@@ -84,14 +84,14 @@ var (
 type (
 	// HTTPError describes an error that can be returned in a response.
 	HTTPError struct {
-		// ID identifies the class of errors for client programs.
-		ID string `json:"id" xml:"id"`
+		// Code identifies the class of errors for client programs.
+		Code string `json:"code" xml:"code"`
 		// Status is the HTTP status code used by responses that cary the error.
-		Status int `json:"-" xml:"-"`
-		// Err describes the specific error occurrence.
-		Err string `json:"err" xml:"err"`
-		// Details contains additional key/value pairs useful to clients.
-		Details map[string]interface{} `json:"details,omitempty" xml:"details,omitempty"`
+		Status int `json:"status" xml:"status"`
+		// Detail describes the specific error occurrence.
+		Detail string `json:"detail" xml:"detail"`
+		// MetaValues contains additional key/value pairs useful to clients.
+		MetaValues map[string]interface{} `json:"meta,omitempty" xml:"meta,omitempty"`
 	}
 
 	// ErrorClass is an error generating function.
@@ -106,8 +106,8 @@ type (
 )
 
 // NewErrorClass creates a new error class.
-// It is the responsability of the client to guarantee uniqueness of id.
-func NewErrorClass(id string, status int) ErrorClass {
+// It is the responsability of the client to guarantee uniqueness of code.
+func NewErrorClass(code string, status int) ErrorClass {
 	return func(fm interface{}, v ...interface{}) *HTTPError {
 		var f string
 		switch actual := fm.(type) {
@@ -120,7 +120,7 @@ func NewErrorClass(id string, status int) ErrorClass {
 		default:
 			f = fmt.Sprintf("%v", actual)
 		}
-		return &HTTPError{ID: id, Status: status, Err: fmt.Sprintf(f, v...)}
+		return &HTTPError{Code: code, Status: status, Detail: fmt.Sprintf(f, v...)}
 	}
 }
 
@@ -188,18 +188,18 @@ func InvalidLengthError(ctx string, target interface{}, ln, value int, min bool)
 
 // Error returns the error occurrence details.
 func (e *HTTPError) Error() string {
-	return e.Err
+	return e.Detail
 }
 
-// WithFields adds to the error details.
-func (e *HTTPError) WithFields(keyvals ...interface{}) {
+// Meta adds to the error metadata.
+func (e *HTTPError) Meta(keyvals ...interface{}) {
 	for i := 0; i < len(keyvals); i += 2 {
 		k := keyvals[i]
 		var v interface{} = "MISSING"
 		if i+1 < len(keyvals) {
 			v = keyvals[i+1]
 		}
-		e.Details[fmt.Sprintf("%v", k)] = v
+		e.MetaValues[fmt.Sprintf("%v", k)] = v
 	}
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -12,22 +12,22 @@ import (
 
 var _ = Describe("HTTPError", func() {
 	const (
-		id     = "goa.1"
-		title  = "title"
+		id     = "invalid"
 		status = 400
 		err    = "error"
 	)
+	var details = map[string]interface{}{"what": 42}
 
 	var httpError *goa.HTTPError
 
 	BeforeEach(func() {
-		httpError = &goa.HTTPError{&goa.ErrorClass{id, title, status}, err}
+		httpError = &goa.HTTPError{id, status, err, details}
 	})
 
 	It("serializes to JSON", func() {
 		b, err := json.Marshal(httpError)
 		Ω(err).ShouldNot(HaveOccurred())
-		Ω(string(b)).Should(Equal(`{"id":"goa.1","title":"title","err":"error"}`))
+		Ω(string(b)).Should(Equal(`{"id":"invalid","err":"error","details":{"what":42}}`))
 	})
 })
 

--- a/error_test.go
+++ b/error_test.go
@@ -12,22 +12,22 @@ import (
 
 var _ = Describe("HTTPError", func() {
 	const (
-		id     = "invalid"
+		code   = "invalid"
 		status = 400
-		err    = "error"
+		detail = "error"
 	)
-	var details = map[string]interface{}{"what": 42}
+	var meta = map[string]interface{}{"what": 42}
 
 	var httpError *goa.HTTPError
 
 	BeforeEach(func() {
-		httpError = &goa.HTTPError{id, status, err, details}
+		httpError = &goa.HTTPError{code, status, detail, meta}
 	})
 
 	It("serializes to JSON", func() {
 		b, err := json.Marshal(httpError)
 		Ω(err).ShouldNot(HaveOccurred())
-		Ω(string(b)).Should(Equal(`{"id":"invalid","err":"error","details":{"what":42}}`))
+		Ω(string(b)).Should(Equal(`{"code":"invalid","status":400,"detail":"error","meta":{"what":42}}`))
 	})
 })
 
@@ -45,9 +45,9 @@ var _ = Describe("InvalidParamTypeError", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(name))
-		Ω(err.Err).Should(ContainSubstring("%d", val))
-		Ω(err.Err).Should(ContainSubstring(expected))
+		Ω(err.Detail).Should(ContainSubstring(name))
+		Ω(err.Detail).Should(ContainSubstring("%d", val))
+		Ω(err.Detail).Should(ContainSubstring(expected))
 	})
 })
 
@@ -63,7 +63,7 @@ var _ = Describe("MissingParaerror", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(name))
+		Ω(err.Detail).Should(ContainSubstring(name))
 	})
 })
 
@@ -81,9 +81,9 @@ var _ = Describe("InvalidAttributeTypeError", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(ctx))
-		Ω(err.Err).Should(ContainSubstring("%d", val))
-		Ω(err.Err).Should(ContainSubstring(expected))
+		Ω(err.Detail).Should(ContainSubstring(ctx))
+		Ω(err.Detail).Should(ContainSubstring("%d", val))
+		Ω(err.Detail).Should(ContainSubstring(expected))
 	})
 })
 
@@ -100,8 +100,8 @@ var _ = Describe("MissingAttributeError", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(ctx))
-		Ω(err.Err).Should(ContainSubstring(name))
+		Ω(err.Detail).Should(ContainSubstring(ctx))
+		Ω(err.Detail).Should(ContainSubstring(name))
 	})
 })
 
@@ -117,7 +117,7 @@ var _ = Describe("MissingHeaderError", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(name))
+		Ω(err.Detail).Should(ContainSubstring(name))
 	})
 })
 
@@ -135,9 +135,9 @@ var _ = Describe("InvalidEnumValueError", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(ctx))
-		Ω(err.Err).Should(ContainSubstring("%d", val))
-		Ω(err.Err).Should(ContainSubstring(`"43", "44"`))
+		Ω(err.Detail).Should(ContainSubstring(ctx))
+		Ω(err.Detail).Should(ContainSubstring("%d", val))
+		Ω(err.Detail).Should(ContainSubstring(`"43", "44"`))
 	})
 })
 
@@ -156,10 +156,10 @@ var _ = Describe("InvalidFormaerror", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(ctx))
-		Ω(err.Err).Should(ContainSubstring(target))
-		Ω(err.Err).Should(ContainSubstring("date-time"))
-		Ω(err.Err).Should(ContainSubstring(formatError.Error()))
+		Ω(err.Detail).Should(ContainSubstring(ctx))
+		Ω(err.Detail).Should(ContainSubstring(target))
+		Ω(err.Detail).Should(ContainSubstring("date-time"))
+		Ω(err.Detail).Should(ContainSubstring(formatError.Error()))
 	})
 })
 
@@ -177,9 +177,9 @@ var _ = Describe("InvalidPatternError", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(ctx))
-		Ω(err.Err).Should(ContainSubstring(target))
-		Ω(err.Err).Should(ContainSubstring(pattern))
+		Ω(err.Detail).Should(ContainSubstring(ctx))
+		Ω(err.Detail).Should(ContainSubstring(target))
+		Ω(err.Detail).Should(ContainSubstring(pattern))
 	})
 })
 
@@ -198,10 +198,10 @@ var _ = Describe("InvalidRangeError", func() {
 		Ω(valErr).ShouldNot(BeNil())
 		Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 		err := valErr.(*goa.HTTPError)
-		Ω(err.Err).Should(ContainSubstring(ctx))
-		Ω(err.Err).Should(ContainSubstring("greater or equal"))
-		Ω(err.Err).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
-		Ω(err.Err).Should(ContainSubstring(target))
+		Ω(err.Detail).Should(ContainSubstring(ctx))
+		Ω(err.Detail).Should(ContainSubstring("greater or equal"))
+		Ω(err.Detail).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
+		Ω(err.Detail).Should(ContainSubstring(target))
 	})
 })
 
@@ -229,10 +229,10 @@ var _ = Describe("InvalidLengthError", func() {
 			Ω(valErr).ShouldNot(BeNil())
 			Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 			err := valErr.(*goa.HTTPError)
-			Ω(err.Err).Should(ContainSubstring(ctx))
-			Ω(err.Err).Should(ContainSubstring("greater or equal"))
-			Ω(err.Err).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
-			Ω(err.Err).Should(ContainSubstring(target.(string)))
+			Ω(err.Detail).Should(ContainSubstring(ctx))
+			Ω(err.Detail).Should(ContainSubstring("greater or equal"))
+			Ω(err.Detail).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
+			Ω(err.Detail).Should(ContainSubstring(target.(string)))
 		})
 	})
 
@@ -246,10 +246,10 @@ var _ = Describe("InvalidLengthError", func() {
 			Ω(valErr).ShouldNot(BeNil())
 			Ω(valErr).Should(BeAssignableToTypeOf(&goa.HTTPError{}))
 			err := valErr.(*goa.HTTPError)
-			Ω(err.Err).Should(ContainSubstring(ctx))
-			Ω(err.Err).Should(ContainSubstring("greater or equal"))
-			Ω(err.Err).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
-			Ω(err.Err).Should(ContainSubstring(fmt.Sprintf("%#v", target)))
+			Ω(err.Detail).Should(ContainSubstring(ctx))
+			Ω(err.Detail).Should(ContainSubstring("greater or equal"))
+			Ω(err.Detail).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
+			Ω(err.Detail).Should(ContainSubstring(fmt.Sprintf("%#v", target)))
 		})
 	})
 })

--- a/service.go
+++ b/service.go
@@ -257,7 +257,7 @@ func (ctrl *Controller) MuxHandler(name string, hdlr Handler, unm Unmarshaler) M
 		handler := middleware
 		if err != nil {
 			handler = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-				ctrl.ErrorHandler(ctx, rw, req, ErrInvalidEncoding.Error(err))
+				ctrl.ErrorHandler(ctx, rw, req, ErrInvalidEncoding(err))
 				return nil
 			}
 			for i := range chain {


### PR DESCRIPTION
The usage is now as follows:

1. Create an error class, this returns a function
2. Use the function to create errors
3. Call `Meta` on the errors to add key/value pairs

The ErrorClass function accepts a format and values a la `Printf`.
The format may be any type which makes it simple to wrap "raw"
errors.