### PR TITLE
Fix security empty scopes panic

### DIFF
--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -711,7 +711,8 @@ func Configure{{ goify .SchemeName true }}Security(service *goa.Service, f goa.{
 {{ end }}
 {{ if or (eq .Context "JWTSecurity") (eq .Context "OAuth2Security") }}
 	fetchScopes := func(ctx context.Context) []string {
-		return ctx.Value(securityScopesKey).([]string)
+		scopes, _ := ctx.Value(securityScopesKey).([]string)
+		return scopes
 	}
 	middleware := f(def, fetchScopes)
 {{ else }}


### PR DESCRIPTION
I have a panic error when i use jwt security without Security.Scopes in handleSecurity
I can change this type assertions or add scopes in context (line 732) even it empty