### PR TITLE
Introduce error handler middleware.

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -273,7 +273,6 @@ var _ = Describe("Merge", func() {
 
 	Context("with two nil errors", func() {
 		It("returns a nil error", func() {
-			Ω(mErr).Should(BeAssignableToTypeOf(&goa.Error{}))
 			Ω(mErr).Should(BeNil())
 		})
 	})

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -239,6 +239,7 @@ func main() {
 	// Setup middleware
 	service.Use(middleware.RequestID())
 	service.Use(middleware.LogRequest(true))
+	service.Use(middleware.ErrorHandler(false))
 	service.Use(middleware.Recover())
 {{$api := .API}}
 {{range $name, $res := $api.Resources}}{{$name := goify $res.Name true}}	// Mount "{{$res.Name}}" controller

--- a/middleware/error_handler.go
+++ b/middleware/error_handler.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/goadesign/goa"
+	"golang.org/x/net/context"
+)
+
+// ErrorHandler turns a Go error into an HTTP response. It should be placed in the middleware chain
+// below the logger middleware so the logger properly logs the HTTP response. ErrorHandler
+// understands instances of goa.Error and returns the status and response body embodied in them,
+// it turns other Go error types into a 500 internal error response.
+// If suppressInternal is true the details of internal errors is not included in HTTP responses.
+func ErrorHandler(suppressInternal bool) goa.Middleware {
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			e := h(ctx, rw, req)
+			if e == nil {
+				return nil
+			}
+
+			goa.LogInfo(ctx, "Default error handler", "err", e)
+			status := 500
+			var respBody interface{}
+			if err, ok := e.(*goa.Error); ok {
+				status = err.Status
+				respBody = err
+				rw.Header().Set("Content-Type", goa.ErrorMediaIdentifier)
+			} else {
+				respBody = e.Error()
+				rw.Header().Set("Content-Type", "text/plain")
+			}
+			if status >= 500 && status < 600 {
+				goa.LogError(ctx, e.Error())
+				if suppressInternal {
+					rw.Header().Set("Content-Type", goa.ErrorMediaIdentifier)
+					respBody = goa.ErrInternal("internal error, detail suppressed")
+				}
+			}
+			return goa.ContextResponse(ctx).Send(ctx, status, respBody)
+		}
+	}
+}

--- a/middleware/error_handler_test.go
+++ b/middleware/error_handler_test.go
@@ -1,0 +1,97 @@
+package middleware_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/net/context"
+
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/middleware"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ErrorHandler", func() {
+	var service *goa.Service
+	var h goa.Handler
+	var suppressInternal bool
+
+	var rw *testResponseWriter
+
+	BeforeEach(func() {
+		service = nil
+		h = nil
+		suppressInternal = false
+		rw = nil
+	})
+
+	JustBeforeEach(func() {
+		rw = newTestResponseWriter()
+		eh := middleware.ErrorHandler(suppressInternal)(h)
+		req, err := http.NewRequest("GET", "/foo", nil)
+		Ω(err).ShouldNot(HaveOccurred())
+		ctx := newContext(service, rw, req, nil)
+		err = eh(ctx, rw, req)
+		Ω(err).ShouldNot(HaveOccurred())
+	})
+
+	Context("with a handler returning a Go error", func() {
+		BeforeEach(func() {
+			service = newService(nil)
+			h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+				return errors.New("boom")
+			}
+		})
+
+		It("turns Go errors into HTTP 500 responses", func() {
+			Ω(rw.Status).Should(Equal(500))
+			Ω(rw.ParentHeader["Content-Type"]).Should(Equal([]string{"text/plain"}))
+			Ω(string(rw.Body)).Should(Equal(`"boom"` + "\n"))
+		})
+
+		Context("suppressing internal errors", func() {
+			BeforeEach(func() {
+				suppressInternal = true
+			})
+
+			It("suppresses the error details", func() {
+				var decoded goa.Error
+				Ω(rw.Status).Should(Equal(500))
+				Ω(rw.ParentHeader["Content-Type"]).Should(Equal([]string{goa.ErrorMediaIdentifier}))
+				err := service.Decode(&decoded, bytes.NewBuffer(rw.Body), "application/json")
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(fmt.Sprintf("%v", decoded)).Should(Equal(fmt.Sprintf("%v", *goa.ErrInternal("internal error, detail suppressed"))))
+			})
+
+		})
+	})
+
+	Context("with a handler returning a goa error", func() {
+		var gerr *goa.Error
+
+		BeforeEach(func() {
+			service = newService(nil)
+			gerr = &goa.Error{
+				Status:     418,
+				Detail:     "teapot",
+				Code:       "code",
+				MetaValues: map[string]interface{}{"foobar": 42},
+			}
+			h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+				return gerr
+			}
+		})
+
+		It("maps goa errors to HTTP responses", func() {
+			var decoded goa.Error
+			Ω(rw.Status).Should(Equal(gerr.Status))
+			Ω(rw.ParentHeader["Content-Type"]).Should(Equal([]string{goa.ErrorMediaIdentifier}))
+			err := service.Decode(&decoded, bytes.NewBuffer(rw.Body), "application/json")
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(fmt.Sprintf("%v", decoded)).Should(Equal(fmt.Sprintf("%v", *gerr)))
+		})
+	})
+})

--- a/middleware/gzip/middleware_test.go
+++ b/middleware/gzip/middleware_test.go
@@ -45,9 +45,7 @@ var _ = Describe("Gzip", func() {
 		req, err = http.NewRequest("POST", "/foo/bar", strings.NewReader(`{"payload":42}`))
 		req.Header.Set("Accept-Encoding", "gzip")
 		Ω(err).ShouldNot(HaveOccurred())
-		rw = &TestResponseWriter{
-			ParentHeader: http.Header{},
-		}
+		rw = &TestResponseWriter{ParentHeader: make(http.Header)}
 
 		ctx = goa.NewContext(nil, rw, req, nil)
 		goa.ContextRequest(ctx).Payload = payload

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -12,6 +12,7 @@ import (
 func newService(logger goa.Logger) *goa.Service {
 	service := goa.New("test")
 	service.Encoder(goa.NewJSONEncoder, "*/*")
+	service.Decoder(goa.NewJSONDecoder, "*/*")
 	service.UseLogger(logger)
 	return service
 }
@@ -46,6 +47,11 @@ type testResponseWriter struct {
 	ParentHeader http.Header
 	Body         []byte
 	Status       int
+}
+
+func newTestResponseWriter() *testResponseWriter {
+	h := make(http.Header)
+	return &testResponseWriter{ParentHeader: h}
 }
 
 func (t *testResponseWriter) Header() http.Header {

--- a/service_test.go
+++ b/service_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Service", func() {
 				errorHandlerCalled := false
 
 				BeforeEach(func() {
-					s.ErrorHandler = TErrorHandler(&errorHandlerCalled)
+					s.Use(TErrorHandler(&errorHandlerCalled))
 				})
 
 				Context("by returning an error", func() {
@@ -219,10 +219,12 @@ var _ = Describe("Service", func() {
 	})
 })
 
-func TErrorHandler(witness *bool) goa.ErrorHandler {
-	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request, err error) {
+func TErrorHandler(witness *bool) goa.Middleware {
+	m, _ := goa.NewMiddleware(func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 		*witness = true
-	}
+		return nil
+	})
+	return m
 }
 
 func TMiddleware(witness *bool) goa.Middleware {


### PR DESCRIPTION
Replaces the service and controller error handlers.
This has several benefits, mainly it fixes a bug where error returned by
middlewares would not be caught because the error handler was at the
bottom of the middleware chain. Putting the error handler at the top of
the chain does not work with middlewares that rely on the HTTP response
being initialized like LogRequest.

Using a middleware allows the client code to control where the mapping
from error to HTTP response is done. The bootstrap code generated by
gen_main builds the middleware stack in the "right order" (i.e. the
error handler middleware is closer to the action handler then the
LogRequest middleware).