### PR TITLE
Properly handler requests sent to unregistered paths.

### DIFF
--- a/error.go
+++ b/error.go
@@ -49,6 +49,9 @@ var (
 	// or non-readable files.
 	ErrInvalidFile = NewErrorClass("invalid_file", 400)
 
+	// ErrNotFound is the error returned to requests that don't match a registered handler.
+	ErrNotFound = NewErrorClass("not_found", 404)
+
 	// ErrInternal is the class of error used for non Error.
 	ErrInternal = NewErrorClass("internal", 500)
 )

--- a/mux.go
+++ b/mux.go
@@ -19,6 +19,10 @@ type (
 		http.Handler
 		// Handle sets the MuxHandler for a given HTTP method and path.
 		Handle(method, path string, handle MuxHandler)
+		// HandleNotFound sets the MuxHandler invoked for requests that don't match any
+		// handler registered with Handle. The values argument given to the handler is
+		// always nil.
+		HandleNotFound(handle MuxHandler)
 		// Lookup returns the MuxHandler associated with the given HTTP method and path.
 		Lookup(method, path string) MuxHandler
 	}
@@ -54,6 +58,19 @@ func (m *mux) Handle(method, path string, handle MuxHandler) {
 	}
 	m.handles[method+path] = handle
 	m.router.Handle(method, path, hthandle)
+}
+
+// HandleNotFound sets the MuxHandler invoked for requests that don't match any
+// handler registered with Handle.
+func (m *mux) HandleNotFound(handle MuxHandler) {
+	nfh := func(rw http.ResponseWriter, req *http.Request) {
+		handle(rw, req, nil)
+	}
+	m.router.NotFoundHandler = nfh
+	mna := func(rw http.ResponseWriter, req *http.Request, methods map[string]httptreemux.HandlerFunc) {
+		handle(rw, req, nil)
+	}
+	m.router.MethodNotAllowedHandler = mna
 }
 
 // Lookup returns the MuxHandler associated with the given method and path.


### PR DESCRIPTION
Part of this commit involves making the middlewares service field
private to make sure middleware setup goes through Use which now
checks whether controllers are already mounted and panics if that's the
case. This serves two purposes:

1. It prevents registering middleware that won't actually take effect
because mounted after the middleware chain for a controller has been
computed.

2. It also prevents middleware to be registered after the middleware
chain for the "NotFound" handler has been computed.