### PR TITLE
Rename Logger interface into LogAdapter

### DIFF
--- a/context.go
+++ b/context.go
@@ -68,8 +68,19 @@ func WithAction(ctx context.Context, action string) context.Context {
 }
 
 // WithLogger sets the request context logger and returns the resulting new context.
-func WithLogger(ctx context.Context, logger Logger) context.Context {
+func WithLogger(ctx context.Context, logger LogAdapter) context.Context {
 	return context.WithValue(ctx, logKey, logger)
+}
+
+// WithLogContext instantiates a new logger by appending the given key/value pairs to the context
+// logger and setting the resulting logger in the context.
+func WithLogContext(ctx context.Context, keyvals ...interface{}) context.Context {
+	logger := ContextLogger(ctx)
+	if logger == nil {
+		return ctx
+	}
+	nl := logger.New(keyvals...)
+	return WithLogger(ctx, nl)
 }
 
 // ContextController extracts the controller name from the given context.
@@ -105,9 +116,9 @@ func ContextResponse(ctx context.Context) *ResponseData {
 }
 
 // ContextLogger extracts the logger from the given context.
-func ContextLogger(ctx context.Context) Logger {
+func ContextLogger(ctx context.Context) LogAdapter {
 	if v := ctx.Value(logKey); v != nil {
-		return v.(Logger)
+		return v.(LogAdapter)
 	}
 	return nil
 }

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -625,7 +625,7 @@ func handle{{ .Resource }}Origin(h goa.Handler) goa.Handler {
 			return h(ctx, rw, req)
 		}
 {{ range $policy := .Origins }}		if cors.MatchOrigin(origin, {{ printf "%q" $policy.Origin }}) {
-			ctx = goa.WithLog(ctx, "origin", origin)
+			ctx = goa.WithLogContext(ctx, "origin", origin)
 			rw.Header().Set("Access-Control-Allow-Origin", "{{ $policy.Origin }}")
 {{ if not (eq $policy.Origin "*") }}			rw.Header().Set("Vary", "Origin")
 {{ end }}{{ if $policy.Exposed }}			rw.Header().Set("Access-Control-Expose-Headers", "{{ join $policy.Exposed ", " }}")

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -1078,7 +1078,7 @@ func handleBottlesOrigin(h goa.Handler) goa.Handler {
 			return h(ctx, rw, req)
 		}
 		if cors.MatchOrigin(origin, "here.example.com") {
-			ctx = goa.WithLog(ctx, "origin", origin)
+			ctx = goa.WithLogContext(ctx, "origin", origin)
 			rw.Header().Set("Access-Control-Allow-Origin", "here.example.com")
 			rw.Header().Set("Vary", "Origin")
 			rw.Header().Set("Access-Control-Expose-Headers", "X-Three")
@@ -1091,7 +1091,7 @@ func handleBottlesOrigin(h goa.Handler) goa.Handler {
 			return h(ctx, rw, req)
 		}
 		if cors.MatchOrigin(origin, "there.example.com") {
-			ctx = goa.WithLog(ctx, "origin", origin)
+			ctx = goa.WithLogContext(ctx, "origin", origin)
 			rw.Header().Set("Access-Control-Allow-Origin", "there.example.com")
 			rw.Header().Set("Vary", "Origin")
 			rw.Header().Set("Access-Control-Allow-Credentials", "false")

--- a/logging/kit/logger.go
+++ b/logging/kit/logger.go
@@ -18,24 +18,34 @@ import (
 
 // Logger is the go-kit log goa adapter logger.
 type Logger struct {
-	log.Logger
+	*log.Context
 }
 
 // New wraps a go-kit logger into a goa logger.
-func New(logger log.Logger) goa.Logger {
-	return &Logger{Logger: logger}
+func New(logger log.Logger) goa.LogAdapter {
+	return FromContext(log.NewContext(logger))
 }
 
-// Info logs informational messages using log15.
+// FromContext wraps a go-kit log context into a goa logger.
+func FromContext(ctx *log.Context) goa.LogAdapter {
+	return &Logger{Context: ctx}
+}
+
+// Info logs informational messages using go-kit.
 func (l *Logger) Info(msg string, data ...interface{}) {
 	ctx := []interface{}{"lvl", "info", "msg", msg}
 	ctx = append(ctx, data...)
-	l.Logger.Log(ctx...)
+	l.Context.Log(ctx...)
 }
 
-// Error logs error messages using log15.
+// Error logs error messages using go-kit.
 func (l *Logger) Error(msg string, data ...interface{}) {
 	ctx := []interface{}{"lvl", "error", "msg", msg}
 	ctx = append(ctx, data...)
-	l.Logger.Log(ctx...)
+	l.Context.Log(ctx...)
+}
+
+// New instantiates a new logger from the given context.
+func (l *Logger) New(data ...interface{}) goa.LogAdapter {
+	return &Logger{Context: l.Context.With(data...)}
 }

--- a/logging/kit/logger_test.go
+++ b/logging/kit/logger_test.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("goakit", func() {
 	var buf bytes.Buffer
 	var logger log.Logger
-	var adapter goa.Logger
+	var adapter goa.LogAdapter
 	const msg = "msg"
 
 	BeforeEach(func() {

--- a/logging/log15/logger.go
+++ b/logging/log15/logger.go
@@ -21,7 +21,7 @@ type Logger struct {
 }
 
 // New wraps a log15 logger into a goa logger.
-func New(logger log15.Logger) goa.Logger {
+func New(logger log15.Logger) goa.LogAdapter {
 	return &Logger{Logger: logger}
 }
 
@@ -33,4 +33,9 @@ func (l *Logger) Info(msg string, data ...interface{}) {
 // Error logs error messages using log15.
 func (l *Logger) Error(msg string, data ...interface{}) {
 	l.Logger.Error(msg, data...)
+}
+
+// New creates a new logger given a context.
+func (l *Logger) New(data ...interface{}) goa.LogAdapter {
+	return &Logger{Logger: l.Logger.New(data...)}
 }

--- a/logging/log15/logger_test.go
+++ b/logging/log15/logger_test.go
@@ -19,7 +19,7 @@ func (h *TestHandler) Log(r *log15.Record) error {
 
 var _ = Describe("goalog15", func() {
 	var logger log15.Logger
-	var adapter goa.Logger
+	var adapter goa.LogAdapter
 	var handler *TestHandler
 	const msg = "msg"
 

--- a/logging/logrus/logger.go
+++ b/logging/logrus/logger.go
@@ -19,22 +19,32 @@ import (
 
 // Logger is the logrus goa adapter logger.
 type Logger struct {
-	*logrus.Logger
+	*logrus.Entry
 }
 
 // New wraps a logrus logger into a goa logger.
-func New(logger *logrus.Logger) goa.Logger {
-	return &Logger{Logger: logger}
+func New(logger *logrus.Logger) goa.LogAdapter {
+	return FromEntry(logrus.NewEntry(logger))
+}
+
+// FromEntry wraps a logrus log entry into a goa logger.
+func FromEntry(entry *logrus.Entry) goa.LogAdapter {
+	return &Logger{Entry: entry}
 }
 
 // Info logs messages using logrus.
 func (l *Logger) Info(msg string, data ...interface{}) {
-	l.Logger.WithFields(data2rus(data)).Info(msg)
+	l.Entry.WithFields(data2rus(data)).Info(msg)
 }
 
 // Error logs errors using logrus.
 func (l *Logger) Error(msg string, data ...interface{}) {
-	l.Logger.WithFields(data2rus(data)).Error(msg)
+	l.Entry.WithFields(data2rus(data)).Error(msg)
+}
+
+// New creates a new logger given a context.
+func (l *Logger) New(data ...interface{}) goa.LogAdapter {
+	return &Logger{Entry: l.Entry.WithFields(data2rus(data))}
 }
 
 func data2rus(keyvals []interface{}) logrus.Fields {

--- a/logging/logrus/logger_test.go
+++ b/logging/logrus/logger_test.go
@@ -12,7 +12,7 @@ import (
 
 var _ = Describe("goalogrus", func() {
 	var logger *logrus.Logger
-	var adapter goa.Logger
+	var adapter goa.LogAdapter
 	const msg = "msg"
 	var buffer *bytes.Buffer
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Error", func() {
 
 var _ = Describe("StdLogger", func() {
 	Context("with a valid Log", func() {
-		var logger goa.Logger
+		var logger goa.LogAdapter
 		const msg = "message"
 		data := []interface{}{"data", "foo"}
 

--- a/middleware/log_request.go
+++ b/middleware/log_request.go
@@ -26,7 +26,7 @@ func LogRequest(verbose bool) goa.Middleware {
 			if reqID == nil {
 				reqID = shortID()
 			}
-			ctx = goa.WithLog(ctx, "req_id", reqID)
+			ctx = goa.WithLogContext(ctx, "req_id", reqID)
 			startedAt := time.Now()
 			r := goa.ContextRequest(ctx)
 			goa.LogInfo(ctx, "started", r.Method, r.URL.String(), "from", from(req),

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Helper that sets up a "working" service
-func newService(logger goa.Logger) *goa.Service {
+func newService(logger goa.LogAdapter) *goa.Service {
 	service := goa.New("test")
 	service.Encoder(goa.NewJSONEncoder, "*/*")
 	service.Decoder(goa.NewJSONDecoder, "*/*")
@@ -29,18 +29,24 @@ type logEntry struct {
 }
 
 type testLogger struct {
+	Context      []interface{}
 	InfoEntries  []logEntry
 	ErrorEntries []logEntry
 }
 
 func (t *testLogger) Info(msg string, data ...interface{}) {
-	e := logEntry{msg, data}
+	e := logEntry{msg, append(t.Context, data...)}
 	t.InfoEntries = append(t.InfoEntries, e)
 }
 
 func (t *testLogger) Error(msg string, data ...interface{}) {
-	e := logEntry{msg, data}
+	e := logEntry{msg, append(t.Context, data...)}
 	t.ErrorEntries = append(t.ErrorEntries, e)
+}
+
+func (t *testLogger) New(data ...interface{}) goa.LogAdapter {
+	t.Context = append(t.Context, data...)
+	return t
 }
 
 type testResponseWriter struct {

--- a/service.go
+++ b/service.go
@@ -120,7 +120,7 @@ func (service *Service) Use(m Middleware) {
 }
 
 // WithLogger sets the logger used internally by the service and by Log.
-func (service *Service) WithLogger(logger Logger) {
+func (service *Service) WithLogger(logger LogAdapter) {
 	service.Context = WithLogger(service.Context, logger)
 }
 
@@ -226,7 +226,7 @@ func (ctrl *Controller) ServeFiles(path, filename string) error {
 		handler = chain[ml-i-1](handler)
 	}
 	handle := func(rw http.ResponseWriter, req *http.Request, params url.Values) {
-		baseCtx := WithLog(ctrl.Context, "action", "serve")
+		baseCtx := WithLogContext(ctrl.Context, "action", "serve")
 		ctx := NewContext(baseCtx, rw, req, params)
 		// Invoke middleware chain, errors should be caught earlier, e.g. by ErrorHandler middleware
 		if err := handler(ctx, rw, req); err != nil {


### PR DESCRIPTION
To reflect better its usage. Add New method to the interface
which instantiates a new log adapter given a context. This
makes it possible to keep the log context inside the logger
instead of in the goa context. This in turns allows the
logger to be used more naturally in user code (extract
logger from context, assert against actualy logger type and
use as usual, context is initialized correctly).