### PR TITLE
Properly generate user types required by client package.

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -826,6 +826,21 @@ func (r *ResourceDefinition) Finalize() {
 	})
 }
 
+// UserTypes returns all the user types used by the resource action payloads and parameters.
+func (r *ResourceDefinition) UserTypes() map[string]*UserTypeDefinition {
+	types := make(map[string]*UserTypeDefinition)
+	for _, a := range r.Actions {
+		atypes := a.UserTypes()
+		for n, ut := range atypes {
+			types[n] = ut
+		}
+	}
+	if len(types) == 0 {
+		return nil
+	}
+	return types
+}
+
 // Context returns the generic definition name used in error messages.
 func (cors *CORSDefinition) Context() string {
 	return fmt.Sprintf("CORS policy for resource %s origin %s", cors.Parent.Context(), cors.Origin)
@@ -1370,6 +1385,22 @@ func (a *ActionDefinition) Finalize() {
 	if a.Security != nil && a.Security.Scheme.Kind == NoSecurityKind {
 		a.Security = nil
 	}
+}
+
+// UserTypes returns all the user types used by the action payload and parameters.
+func (a *ActionDefinition) UserTypes() map[string]*UserTypeDefinition {
+	types := make(map[string]*UserTypeDefinition)
+	allp := a.AllParams().Type.ToObject()
+	if a.Payload != nil {
+		allp["__payload__"] = &AttributeDefinition{Type: a.Payload}
+	}
+	for n, ut := range UserTypes(allp) {
+		types[n] = ut
+	}
+	if len(types) == 0 {
+		return nil
+	}
+	return types
 }
 
 // Context returns the generic definition name used in error messages.

--- a/design/types_test.go
+++ b/design/types_test.go
@@ -159,6 +159,68 @@ var _ = Describe("Project", func() {
 	})
 })
 
+var _ = Describe("UserTypes", func() {
+	var (
+		o         Object
+		userTypes map[string]*UserTypeDefinition
+	)
+
+	JustBeforeEach(func() {
+		userTypes = UserTypes(o)
+	})
+
+	Context("with an object not using user types", func() {
+		BeforeEach(func() {
+			o = Object{"foo": &AttributeDefinition{Type: String}}
+		})
+
+		It("returns nil", func() {
+			Ω(userTypes).Should(BeNil())
+		})
+	})
+
+	Context("with an object with an attribute using a user type", func() {
+		var ut *UserTypeDefinition
+		BeforeEach(func() {
+			ut = &UserTypeDefinition{
+				TypeName:            "foo",
+				AttributeDefinition: &AttributeDefinition{Type: String},
+			}
+
+			o = Object{"foo": &AttributeDefinition{Type: ut}}
+		})
+
+		It("returns the user type", func() {
+			Ω(userTypes).Should(HaveLen(1))
+			Ω(userTypes[ut.TypeName]).Should(Equal(ut))
+		})
+	})
+
+	Context("with an object with an attribute using recursive user types", func() {
+		var ut, childut *UserTypeDefinition
+
+		BeforeEach(func() {
+			childut = &UserTypeDefinition{
+				TypeName:            "child",
+				AttributeDefinition: &AttributeDefinition{Type: String},
+			}
+			child := Object{"child": &AttributeDefinition{Type: childut}}
+			ut = &UserTypeDefinition{
+				TypeName:            "parent",
+				AttributeDefinition: &AttributeDefinition{Type: child},
+			}
+
+			o = Object{"foo": &AttributeDefinition{Type: ut}}
+		})
+
+		It("returns the user types", func() {
+			Ω(userTypes).Should(HaveLen(2))
+			Ω(userTypes[ut.TypeName]).Should(Equal(ut))
+			Ω(userTypes[childut.TypeName]).Should(Equal(childut))
+		})
+	})
+})
+
 var _ = Describe("MediaTypeDefinition", func() {
 	Describe("IterateViews", func() {
 		var (


### PR DESCRIPTION
Add UserTypes to ActionDefinition and ResourceDefinition.
This method returns the user types used by the respective targets recursively.