### PR TITLE
Add UUID datatype.

### DIFF
--- a/design/apidsl/attribute_test.go
+++ b/design/apidsl/attribute_test.go
@@ -140,6 +140,24 @@ var _ = Describe("Attribute", func() {
 			Ω(o[name].Type).Should(Equal(Integer))
 		})
 	})
+
+	Context("with a name and uuid datatype", func() {
+		BeforeEach(func() {
+			name = "foo"
+			dataType = UUID
+		})
+
+		It("produces an attribute of uuid type", func() {
+			t := parent.Type
+			Ω(t).ShouldNot(BeNil())
+			Ω(t).Should(BeAssignableToTypeOf(Object{}))
+			o := t.(Object)
+			Ω(o).Should(HaveLen(1))
+			Ω(o).Should(HaveKey(name))
+			Ω(o[name].Type).Should(Equal(UUID))
+		})
+	})
+
 	Context("with a name and date datatype", func() {
 		BeforeEach(func() {
 			name = "foo"
@@ -235,6 +253,24 @@ var _ = Describe("Attribute", func() {
 			Ω(o[name].Validation.Values).Should(Equal([]interface{}{"one", "two"}))
 		})
 	})
+
+	Context("with a name and type uuid", func() {
+		BeforeEach(func() {
+			name = "birthdate"
+			dataType = UUID
+		})
+
+		It("produces an attribute of type date with a validation and the description", func() {
+			t := parent.Type
+			Ω(t).ShouldNot(BeNil())
+			Ω(t).Should(BeAssignableToTypeOf(Object{}))
+			o := t.(Object)
+			Ω(o).Should(HaveLen(1))
+			Ω(o).Should(HaveKey(name))
+			Ω(o[name].Type).Should(Equal(UUID))
+		})
+	})
+
 	Context("with a name and type date", func() {
 		BeforeEach(func() {
 			name = "birthdate"

--- a/design/apidsl/type_test.go
+++ b/design/apidsl/type_test.go
@@ -64,6 +64,28 @@ var _ = Describe("Type", func() {
 			Ω(o).Should(HaveKey(attName))
 		})
 	})
+
+	Context("with a name and uuid datatype", func() {
+		const attName = "att"
+		BeforeEach(func() {
+			name = "foo"
+			dsl = func() {
+				Attribute(attName, UUID)
+			}
+		})
+
+		It("produces an attribute of date type", func() {
+			Ω(ut).ShouldNot(BeNil())
+			Ω(ut.Validate("test", Design)).ShouldNot(HaveOccurred())
+			Ω(ut.AttributeDefinition).ShouldNot(BeNil())
+			Ω(ut.Type).Should(BeAssignableToTypeOf(Object{}))
+			o := ut.Type.(Object)
+			Ω(o).Should(HaveLen(1))
+			Ω(o).Should(HaveKey(attName))
+			Ω(o[attName].Type).Should(Equal(UUID))
+		})
+	})
+
 	Context("with a name and date datatype", func() {
 		const attName = "att"
 		BeforeEach(func() {

--- a/design/random.go
+++ b/design/random.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/manveru/faker"
+	"github.com/satori/go.uuid"
 )
 
 // RandomGenerator generates consistent random values of different types given a seed.
@@ -55,7 +56,11 @@ func (r *RandomGenerator) DateTime() time.Time {
 	max := time.Date(2016, time.July, 11, 23, 0, 0, 0, time.UTC).Unix()
 	unix := r.rand.Int63n(max)
 	return time.Unix(unix, 0)
+}
 
+// UUID produces a random UUID.
+func (r *RandomGenerator) UUID() uuid.UUID {
+	return uuid.NewV4()
 }
 
 // Bool produces a random boolean.

--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -259,6 +259,8 @@ func GoNativeType(t design.DataType) string {
 			return "string"
 		case design.DateTimeKind:
 			return "time.Time"
+		case design.UUIDKind:
+			return "uuid.UUID"
 		case design.AnyKind:
 			return "interface{}"
 		default:

--- a/goagen/codegen/types_test.go
+++ b/goagen/codegen/types_test.go
@@ -163,6 +163,7 @@ var _ = Describe("code generation", func() {
 						"foo": &AttributeDefinition{Type: Integer},
 						"bar": &AttributeDefinition{Type: String},
 						"baz": &AttributeDefinition{Type: DateTime},
+						"qux": &AttributeDefinition{Type: UUID},
 					}
 					required = nil
 				})
@@ -172,6 +173,7 @@ var _ = Describe("code generation", func() {
 						"	Bar *string `json:\"bar,omitempty\" xml:\"bar,omitempty\"`\n" +
 						"	Baz *time.Time `json:\"baz,omitempty\" xml:\"baz,omitempty\"`\n" +
 						"	Foo *int `json:\"foo,omitempty\" xml:\"foo,omitempty\"`\n" +
+						"	Qux *uuid.UUID `json:\"qux,omitempty\" xml:\"qux,omitempty\"`\n" +
 						"}"
 					Ω(st).Should(Equal(expected))
 				})
@@ -195,6 +197,7 @@ var _ = Describe("code generation", func() {
 							"	Bar *string `json:\"bar,omitempty\" xml:\"bar,omitempty\"`\n"+
 							"	Baz *time.Time `json:\"baz,omitempty\" xml:\"baz,omitempty\"`\n"+
 							"	Foo *int `%s:\"%s,%s\" %s:\"%s\"`\n"+
+							"	Qux *uuid.UUID `json:\"qux,omitempty\" xml:\"qux,omitempty\"`\n"+
 							"}", tn1[11:], tv11, tv12, tn2[11:], tv21)
 						Ω(st).Should(Equal(expected))
 					})
@@ -212,6 +215,7 @@ var _ = Describe("code generation", func() {
 							"	Bar *string `json:\"bar,omitempty\" xml:\"bar,omitempty\"`\n" +
 							"	Baz *time.Time `json:\"baz,omitempty\" xml:\"baz,omitempty\"`\n" +
 							"	ServiceName *int `json:\"foo,omitempty\" xml:\"foo,omitempty\"`\n" +
+							"	Qux *uuid.UUID `json:\"qux,omitempty\" xml:\"qux,omitempty\"`\n" +
 							"}"
 						Ω(st).Should(Equal(expected))
 					})

--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -259,7 +259,11 @@ func (f *SourceFile) FormatCode() error {
 		for _, imp := range group {
 			path := strings.Trim(imp.Path.Value, `"`)
 			if !astutil.UsesImport(file, path) {
-				astutil.DeleteImport(fset, file, path)
+				if imp.Name != nil {
+					astutil.DeleteNamedImport(fset, file, imp.Name.Name, path)
+				} else {
+					astutil.DeleteImport(fset, file, path)
+				}
 			}
 		}
 	}

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -162,6 +162,7 @@ func (g *Generator) generateContexts(api *design.APIDefinition) error {
 		codegen.SimpleImport("strings"),
 		codegen.SimpleImport("time"),
 		codegen.SimpleImport("github.com/goadesign/goa"),
+		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 	}
 	ctxWr.WriteHeader(title, TargetPackage, imports)
 	err = api.IterateResources(func(r *design.ResourceDefinition) error {
@@ -520,6 +521,7 @@ func (g *Generator) generateMediaTypes(api *design.APIDefinition) error {
 		codegen.SimpleImport("github.com/goadesign/goa"),
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("time"),
+		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 	}
 	mtWr.WriteHeader(title, TargetPackage, imports)
 	err = api.IterateMediaTypes(func(mt *design.MediaTypeDefinition) error {

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Generate", func() {
 									Type: design.Object{
 										"param": &design.AttributeDefinition{Type: design.Integer},
 										"time":  &design.AttributeDefinition{Type: design.DateTime},
+										"uuid":  &design.AttributeDefinition{Type: design.UUID},
 									},
 								},
 								Routes: []*design.RouteDefinition{
@@ -90,6 +91,7 @@ var _ = Describe("Generate", func() {
 									Type: design.Object{
 										"param": &design.AttributeDefinition{Type: design.Integer},
 										"time":  &design.AttributeDefinition{Type: design.DateTime},
+										"uuid":  &design.AttributeDefinition{Type: design.UUID},
 									},
 								},
 								Routes: []*design.RouteDefinition{

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -441,11 +441,21 @@ type {{ .Name }} struct {
 {{ tabs .Depth }}}
 {{ end }}{{ if eq .Attribute.Type.Kind 6 }}{{/*
 
+*/}}{{/* UUIDType */}}{{/*
+*/}}{{ $varName := or (and (not .Pointer) .VarName) tempvar }}{{/*
+*/}}{{ tabs .Depth }}if {{ .VarName }}, err2 := uuid.FromString(raw{{ goify .Name true }}); err2 == nil {
+{{ if .Pointer }}{{ tabs .Depth }}	{{ $varName }} := &{{ .VarName }}
+{{ end }}{{ tabs .Depth }}	{{ .Pkg }} = {{ $varName }}
+{{ tabs .Depth }}} else {
+{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", raw{{ goify .Name true }}, "uuid"))
+{{ tabs .Depth }}}
+{{ end }}{{ if eq .Attribute.Type.Kind 7 }}{{/*
+
 */}}{{/* AnyType */}}{{/*
 */}}{{ if .Pointer }}{{ $tmp := tempvar }}{{ tabs .Depth }}{{ $tmp }} := interface{}(raw{{ goify .Name true }})
 {{ tabs .Depth }}{{ .Pkg }} = &{{ $tmp }}
 {{ else }}{{ tabs .Depth }}{{ .Pkg }} = raw{{ goify .Name true }}
-{{ end }}{{ end }}{{ if eq .Attribute.Type.Kind 7 }}{{/*
+{{ end }}{{ end }}{{ if eq .Attribute.Type.Kind 8 }}{{/*
 
 */}}{{/* ArrayType */}}{{/*
 */}}{{ tabs .Depth }}elems{{ goify .Name true }} := strings.Split(raw{{ goify .Name true }}, ",")

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -98,6 +98,7 @@ func (g *Generator) generateClientResources(clientPkg string, funcs template.Fun
 		codegen.SimpleImport("github.com/goadesign/goa"),
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("time"),
+		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 	}
 	if err := file.WriteHeader("User Types", "client", imports); err != nil {
 		return err
@@ -150,6 +151,7 @@ func (g *Generator) generateResourceClient(res *design.ResourceDefinition, funcs
 		codegen.SimpleImport("time"),
 		codegen.SimpleImport("golang.org/x/net/context"),
 		codegen.SimpleImport("golang.org/x/net/websocket"),
+		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 	}
 	if err := file.WriteHeader("", "client", imports); err != nil {
 		return err
@@ -339,7 +341,7 @@ func goTypeRefExt(t design.DataType, tabs int, pkg string) string {
 
 // cmdFieldType computes the Go type name used to store command flags of the given design type.
 func cmdFieldType(t design.DataType) string {
-	if t.Kind() == design.DateTimeKind {
+	if t.Kind() == design.DateTimeKind || t.Kind() == design.UUIDKind {
 		return "string"
 	}
 	return codegen.GoNativeType(t)
@@ -360,7 +362,7 @@ func toString(name, target string, att *design.AttributeDefinition) string {
 			return fmt.Sprintf("%s := strconv.FormatBool(%s)", target, name)
 		case design.NumberKind:
 			return fmt.Sprintf("%s := strconv.FormatFloat(%s, 'f', -1, 64)", target, name)
-		case design.StringKind, design.DateTimeKind:
+		case design.StringKind, design.DateTimeKind, design.UUIDKind:
 			return fmt.Sprintf("%s := %s", target, name)
 		case design.AnyKind:
 			return fmt.Sprintf("%s := fmt.Sprintf(\"%%v\", %s)", target, name)
@@ -391,6 +393,8 @@ func flagType(att *design.AttributeDefinition) string {
 	case design.StringKind:
 		return "String"
 	case design.DateTimeKind:
+		return "String"
+	case design.UUIDKind:
 		return "String"
 	case design.AnyKind:
 		return "String"

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Generate", func() {
 									Type: design.Object{
 										"param": &design.AttributeDefinition{Type: design.Integer},
 										"time":  &design.AttributeDefinition{Type: design.DateTime},
+										"uuid":  &design.AttributeDefinition{Type: design.UUID},
 									},
 								},
 								Routes: []*design.RouteDefinition{

--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -266,6 +266,8 @@ func TypeSchema(api *design.APIDefinition, t design.DataType) *JSONSchema {
 	case design.Primitive:
 		s.Type = JSONType(actual.Name())
 		switch actual.Kind() {
+		case design.UUIDKind:
+			s.Format = "uuid"
 		case design.DateTimeKind:
 			s.Format = "date-time"
 		case design.NumberKind:

--- a/validation.go
+++ b/validation.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"regexp"
 	"time"
+
+	"github.com/satori/go.uuid"
 )
 
 // Format defines a validation format.
@@ -15,6 +17,9 @@ type Format string
 const (
 	// FormatDateTime defines RFC3339 date time values.
 	FormatDateTime Format = "date-time"
+
+	// FormatUUID defines RFC4122 uuid values.
+	FormatUUID Format = "uuid"
 
 	// FormatEmail defines RFC5322 email addresses.
 	FormatEmail = "email"
@@ -68,6 +73,8 @@ func ValidateFormat(f Format, val string) error {
 	switch f {
 	case FormatDateTime:
 		_, err = time.Parse(time.RFC3339, val)
+	case FormatUUID:
+		_, err = uuid.FromString(val)
 	case FormatEmail:
 		_, err = mail.ParseAddress(val)
 	case FormatHostname:

--- a/validation_test.go
+++ b/validation_test.go
@@ -43,7 +43,32 @@ var _ = Describe("ValidateFormat", func() {
 				Ω(valErr).ShouldNot(HaveOccurred())
 			})
 		})
+	})
 
+	Context("UUID", func() {
+		BeforeEach(func() {
+			f = goa.FormatUUID
+		})
+
+		Context("with an invalid value", func() {
+			BeforeEach(func() {
+				val = "96054a62-a9e45ed26688389b"
+			})
+
+			It("does not validate", func() {
+				Ω(valErr).Should(HaveOccurred())
+			})
+		})
+
+		Context("with an valid value", func() {
+			BeforeEach(func() {
+				val = "0f14d0ab-9605-4a62-a9e45ed26688389b"
+			})
+
+			It("validates", func() {
+				Ω(valErr).ShouldNot(HaveOccurred())
+			})
+		})
 	})
 
 	Context("Email", func() {


### PR DESCRIPTION
This adds the functionality of handling UUID's as a primary key, in the routes, and payloads. This is to compliment the addition of uuid support as primary key in gorma. https://github.com/goadesign/gorma/pull/93

In addition, this fixes a small bug when removing imports. It will now properly call the right method for named and non-named imports.