### PR TITLE
Correctly project media type attributes that use the default view.

### DIFF
--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -17,7 +17,7 @@ import (
 // attributes may include other attributes. At the basic level an attribute has a name,
 // a type and optionally a default value and validation rules. The type of an attribute can be one of:
 //
-// * The primitive types Boolean, Integer, Number or String.
+// * The primitive types Boolean, Integer, Number, DateTime, UUID or String.
 //
 // * A type defined via the Type function.
 //


### PR DESCRIPTION
The bug affects media type attributes which themselves are attributes and
use the default view (don't have a view specified in the DSL). These are
not projected which produces incorrect validation code if the default
view attribute list differ from the media type attributes.