### PR TITLE
Include vendor directory in valid pkg paths

### DIFF
--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -320,12 +320,12 @@ func PackageSourcePath(pkg string) (string, error) {
 	for i, gopath := range candidates {
 		candidates[i] = filepath.Join(gopath, "src", pkg)
 	}
-	
-        // add vendor directory to the available source paths, this can
-        // probably be more idomatic
-        if dir, err := filepath.Abs(filepath.Base(DesignPackagePath)); err == nil {
-                candidates = append(candidates, filepath.Join(dir, "/../vendor/", pkg))
-        }
+
+	// add vendor directory to the available source paths, this can
+	// probably be more idomatic
+	if dir, err := filepath.Abs(filepath.Base(DesignPackagePath)); err == nil {
+		candidates = append(candidates, filepath.Join(dir, "/../vendor/", pkg))
+	}
 
 	var absPath string
 	for _, path := range candidates {

--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -320,6 +320,13 @@ func PackageSourcePath(pkg string) (string, error) {
 	for i, gopath := range candidates {
 		candidates[i] = filepath.Join(gopath, "src", pkg)
 	}
+	
+        // add vendor directory to the available source paths, this can
+        // probably be more idomatic
+        if dir, err := filepath.Abs(filepath.Base(DesignPackagePath)); err == nil {
+                candidates = append(candidates, filepath.Join(dir, "/../vendor/", pkg))
+        }
+
 	var absPath string
 	for _, path := range candidates {
 		if _, err := os.Stat(path); err == nil {


### PR DESCRIPTION
Add the vendor directory as valid path for packages to be in.
Fixes #444