### PR TITLE
Make it possible to use relative URLs for token and authorization OAuth2 URLs.

### DIFF
--- a/design/apidsl/security_test.go
+++ b/design/apidsl/security_test.go
@@ -22,13 +22,15 @@ var _ = Describe("Security", func() {
 
 	It("should be the fully valid and well defined, live on the happy path", func() {
 		API("secure", func() {
+			Host("example.com")
+
 			BasicAuthSecurity("basic_authz", func() {
 				Description("desc")
 			})
 
 			OAuth2Security("googAuthz", func() {
 				Description("desc")
-				AccessCodeFlow("http://example.com/auth", "http://example.com/token")
+				AccessCodeFlow("/auth", "/token")
 				Scope("user:read", "Read users")
 			})
 
@@ -40,7 +42,7 @@ var _ = Describe("Security", func() {
 			JWTSecurity("jwt", func() {
 				Description("desc")
 				Header("Authorization")
-				TokenURL("http://example.com/token")
+				TokenURL("/token")
 				Scope("user:read", "Read users")
 				Scope("user:write", "Write users")
 			})
@@ -92,11 +94,11 @@ var _ = Describe("Security", func() {
 			Ω(dslengine.Errors).Should(HaveOccurred())
 		})
 
-		It("should fail because of invalid declaration of AuthorizationURL", func() {
+		It("should fail because of invalid declaration of TokenURL", func() {
 			API("", func() {
 				BasicAuthSecurity("broken_basic_authz", func() {
 					Description("desc")
-					TokenURL("http://example.com/token")
+					TokenURL("/token")
 				})
 			})
 			dslengine.Run()
@@ -107,7 +109,7 @@ var _ = Describe("Security", func() {
 			API("", func() {
 				BasicAuthSecurity("broken_basic_authz", func() {
 					Description("desc")
-					TokenURL("invalid")
+					TokenURL("in valid")
 				})
 			})
 			dslengine.Run()
@@ -129,9 +131,10 @@ var _ = Describe("Security", func() {
 	Context("with oauth2 security", func() {
 		It("should pass with valid values when well defined", func() {
 			API("", func() {
+				Host("example.com")
 				OAuth2Security("googAuthz", func() {
 					Description("Use Goog's Auth")
-					AccessCodeFlow("http://example.com/auth", "http://example.com/token")
+					AccessCodeFlow("/auth", "/token")
 					Scope("scope:1", "Desc 1")
 					Scope("scope:2", "Desc 2")
 				})
@@ -174,7 +177,7 @@ var _ = Describe("Security", func() {
 		It("should fallback properly to lower-level security", func() {
 			API("", func() {
 				JWTSecurity("jwt", func() {
-					TokenURL("http://example.com/token")
+					TokenURL("/token")
 					Scope("read", "Read")
 					Scope("write", "Write")
 				})

--- a/design/security_test.go
+++ b/design/security_test.go
@@ -1,0 +1,123 @@
+package design_test
+
+import (
+	"fmt"
+
+	. "github.com/goadesign/goa/design"
+	. "github.com/goadesign/goa/design/apidsl"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SecuritySchemeDefinition", func() {
+	var scheme, host, tokenURL, authorizationURL string
+
+	var def *SecuritySchemeDefinition
+
+	BeforeEach(func() {
+		def = nil
+		tokenURL = ""
+		authorizationURL = ""
+		scheme = ""
+		host = ""
+	})
+
+	JustBeforeEach(func() {
+		Design.Schemes = []string{scheme}
+		Design.Host = host
+		def = &SecuritySchemeDefinition{
+			TokenURL:         tokenURL,
+			AuthorizationURL: authorizationURL,
+		}
+	})
+
+	Context("with valid token and authorization URLs", func() {
+		BeforeEach(func() {
+			tokenURL = "http://valid.com/token"
+			authorizationURL = "http://valid.com/auth"
+		})
+
+		It("validates", func() {
+			Ω(def.Validate()).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("with an invalid token URL", func() {
+		BeforeEach(func() {
+			tokenURL = ":"
+			authorizationURL = "http://valid.com/auth"
+		})
+
+		It("does not validate", func() {
+			err := def.Validate()
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring(tokenURL))
+		})
+	})
+
+	Context("with an absolute token URL", func() {
+		BeforeEach(func() {
+			tokenURL = "http://valid.com/auth"
+		})
+
+		It("Finalize does not modify it", func() {
+			priorURL := def.TokenURL
+			def.Finalize()
+			Ω(def.TokenURL).Should(Equal(priorURL))
+		})
+	})
+
+	Context("with a relative token URL", func() {
+		BeforeEach(func() {
+			scheme = "http"
+			host = "foo.com"
+			tokenURL = "/auth"
+		})
+
+		It("Finalize makes it absolute", func() {
+			priorURL := def.TokenURL
+			def.Finalize()
+			Ω(def.TokenURL).Should(Equal(fmt.Sprintf("%s://%s%s", scheme, host, priorURL)))
+		})
+	})
+
+	Context("with an invalid authorization URL", func() {
+		BeforeEach(func() {
+			tokenURL = "http://valid.com/auth"
+			authorizationURL = ":"
+		})
+
+		It("does not validate", func() {
+			err := def.Validate()
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).Should(ContainSubstring(authorizationURL))
+		})
+	})
+
+	Context("with an absolute authorization URL", func() {
+		BeforeEach(func() {
+			authorizationURL = "http://valid.com/auth"
+		})
+
+		It("Finalize does not modify it", func() {
+			priorURL := def.AuthorizationURL
+			def.Finalize()
+			Ω(def.AuthorizationURL).Should(Equal(priorURL))
+		})
+	})
+
+	Context("with a relative authorization URL", func() {
+		BeforeEach(func() {
+			scheme = "http"
+			host = "foo.com"
+			authorizationURL = "/auth"
+		})
+
+		It("Finalize makes it absolute", func() {
+			priorURL := def.AuthorizationURL
+			def.Finalize()
+			Ω(def.AuthorizationURL).Should(Equal(fmt.Sprintf("%s://%s%s", scheme, host, priorURL)))
+		})
+	})
+
+})


### PR DESCRIPTION
Tweak security DSL comments and make scheme description optional.