### PR TITLE
Remove `_client.go` suffix to files generated by `gen_client`.

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -167,7 +167,7 @@ func (g *Generator) generateResourceClient(res *design.ResourceDefinition, funcs
 	clientsWSTmpl := template.Must(template.New("clients").Funcs(funcs).Parse(clientsWSTmpl))
 	pathTmpl := template.Must(template.New("pathTemplate").Funcs(funcs).Parse(pathTmpl))
 
-	filename := filepath.Join(codegen.OutputDir, codegen.SnakeCase(res.Name)+"_client.go")
+	filename := filepath.Join(codegen.OutputDir, codegen.SnakeCase(res.Name)+".go")
 	file, err := codegen.SourceFileFor(filename)
 	if err != nil {
 		return err

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Generate", func() {
 		It("generates the Signer.Sign call from Action", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(7))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo_client.go"))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("c.SignerJWT1.Sign(ctx, req)"))
 		})


### PR DESCRIPTION
There is a slight risk of collision with `datatypes.go` but we'll cross
that bridge when we get there.