### PR TITLE
Use concrete signer type in generated client fields

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -597,8 +597,8 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{/*
 
 const clientTmpl = `// Client is the {{ .Name }} service client.
 type Client struct {
-	*goaclient.Client{{range $security := .SecuritySchemes }}
-	Signer{{ goify $security.SchemeName true }} goaclient.Signer{{ end }}
+	*goaclient.Client{{range $security := .SecuritySchemes }}{{ $signer := signerType $security }}{{ if $signer }}
+	Signer{{ goify $security.SchemeName true }} *{{ $signer }}{{ end }}{{ end }}
 }
 
 // New instantiates the client.

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Generate", func() {
 			Ω(files).Should(HaveLen(7))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring("SignerJWT1 goaclient.Signer"))
+			Ω(content).Should(ContainSubstring("SignerJWT1 *goaclient.JWTSigner"))
 			Ω(content).Should(ContainSubstring("SignerJWT1: &goaclient.JWTSigner{},"))
 		})
 


### PR DESCRIPTION
So that it's possible to configure each signer properly from user code
without having to go through the command line.