### PR TITLE
Use 'Signer' as a suffix rather than prefix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 #
 DIRS=$(shell go list -f {{.Dir}} ./...)
 
+# Only list test and build dependencies
+# Standard dependencies are installed via go get
 DEPEND=\
 	github.com/go-openapi/loads \
 	github.com/goadesign/goa-cellar \

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -282,7 +282,7 @@ func (cmd *{{ $cmdName }}) RegisterFlags(cc *cobra.Command, c *client.Client) {
 {{ end }}{{ end }}{{ $headers := .Action.Headers }}{{ if $headers }}{{ range $name, $header := $headers.Type.ToObject }}{{/*
 */}} cc.Flags().StringVar(&cmd.{{ goify $name true }}, "{{ $name }}", {{/*
 */}}{{ if $header.DefaultValue }}{{ printf "%q" $header.DefaultValue }}{{ else }}""{{ end }}, ` + "`" + `{{ escapeBackticks $header.Description }}` + "`" + `)
-{{ end }}{{ end }}{{ if .Action.Security }}   c.Signer{{ goify .Action.Security.Scheme.SchemeName true }}.RegisterFlags(cc){{ end }}}`
+{{ end }}{{ end }}{{ if .Action.Security }}   c.{{ goify .Action.Security.Scheme.SchemeName true }}Signer.RegisterFlags(cc){{ end }}}`
 
 const commandsTmpl = `
 {{ $cmdName := goify (printf "%s%sCommand" .Action.Name (title .Resource.Name)) true }}// Run makes the HTTP request corresponding to the {{ $cmdName }} command.

--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -197,7 +197,7 @@ var _ = Describe("Generate", func() {
 			Ω(files).Should(HaveLen(7))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "testapi-cli", "commands.go"))
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring("c.SignerJWT1.RegisterFlags(cc)"))
+			Ω(content).Should(ContainSubstring("c.JWT1Signer.RegisterFlags(cc)"))
 		})
 	})
 })

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -571,7 +571,7 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Payload 
 {{ else }}{{ $tmp := tempvar }}{{ toString (goify $name false) $tmp $att }}
 	header.Set("{{ $name }}", {{ $tmp }})
 {{ end }}{{ end }}{{ end }}	header.Set("Content-Type", "application/json"){{ if .Security }}
-	c.Signer{{ goify .Security.Scheme.SchemeName true }}.Sign(ctx, req){{ end }}
+	c.{{ goify .Security.Scheme.SchemeName true }}Signer.Sign(ctx, req){{ end }}
 	return c.Client.Do(ctx, req)
 }
 `
@@ -598,14 +598,14 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{/*
 const clientTmpl = `// Client is the {{ .Name }} service client.
 type Client struct {
 	*goaclient.Client{{range $security := .SecuritySchemes }}{{ $signer := signerType $security }}{{ if $signer }}
-	Signer{{ goify $security.SchemeName true }} *{{ $signer }}{{ end }}{{ end }}
+	{{ goify $security.SchemeName true }}Signer *{{ $signer }}{{ end }}{{ end }}
 }
 
 // New instantiates the client.
 func New(c *http.Client) *Client {
 	return &Client{
 		Client: goaclient.New(c),{{range $security := .SecuritySchemes }}{{ $signer := signerType $security }}{{ if $signer }}
-		Signer{{ goify $security.SchemeName true }}: &{{ $signer }}{},{{ end }}{{ end }}
+		{{ goify $security.SchemeName true }}Signer: &{{ $signer }}{},{{ end }}{{ end }}
 	}
 }
 `

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -137,8 +137,8 @@ var _ = Describe("Generate", func() {
 			Ω(files).Should(HaveLen(7))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring("SignerJWT1 *goaclient.JWTSigner"))
-			Ω(content).Should(ContainSubstring("SignerJWT1: &goaclient.JWTSigner{},"))
+			Ω(content).Should(ContainSubstring("JWT1Signer *goaclient.JWTSigner"))
+			Ω(content).Should(ContainSubstring("JWT1Signer: &goaclient.JWTSigner{},"))
 		})
 
 		It("generates the Signer.Sign call from Action", func() {
@@ -146,7 +146,7 @@ var _ = Describe("Generate", func() {
 			Ω(files).Should(HaveLen(7))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring("c.SignerJWT1.Sign(ctx, req)"))
+			Ω(content).Should(ContainSubstring("c.JWT1Signer.Sign(ctx, req)"))
 		})
 	})
 })


### PR DESCRIPTION
Makes for more natural names