### PR TITLE
using http.StatusText(...) instead of "internal error"

### DIFF
--- a/middleware/error_handler.go
+++ b/middleware/error_handler.go
@@ -40,7 +40,7 @@ func ErrorHandler(service *goa.Service, verbose bool) goa.Middleware {
 				goa.LogError(ctx, "uncaught error", "id", reqID, "msg", respBody)
 				if !verbose {
 					rw.Header().Set("Content-Type", goa.ErrorMediaIdentifier)
-					respBody = goa.ErrInternal("internal error [%s]", reqID)
+					respBody = goa.ErrInternal("%s [%s]", http.StatusText(http.StatusInternalServerError), reqID)
 				}
 			}
 			return service.Send(ctx, status, respBody)

--- a/middleware/error_handler_test.go
+++ b/middleware/error_handler_test.go
@@ -68,7 +68,7 @@ var _ = Describe("ErrorHandler", func() {
 				Ω(rw.ParentHeader["Content-Type"]).Should(Equal([]string{goa.ErrorMediaIdentifier}))
 				err := service.Decode(&decoded, bytes.NewBuffer(rw.Body), "application/json")
 				Ω(err).ShouldNot(HaveOccurred())
-				msg := fmt.Sprintf("%v", *goa.ErrInternal(`internal error [zzz]`))
+				msg := fmt.Sprintf("%v", *goa.ErrInternal(`Internal Server Error [zzz]`))
 				msg = regexp.QuoteMeta(msg)
 				msg = strings.Replace(msg, "zzz", ".+", 1)
 				Ω(fmt.Sprintf("%v", decoded)).Should(MatchRegexp(msg))

--- a/service.go
+++ b/service.go
@@ -231,8 +231,9 @@ func (ctrl *Controller) ServeFiles(path, filename string) error {
 		// Invoke middleware chain, errors should be caught earlier, e.g. by ErrorHandler middleware
 		if err := handler(ctx, rw, req); err != nil {
 			LogError(ctx, "uncaught error", "err", err)
-			respBody := fmt.Sprintf("internal error: %s", err) // Sprintf catches panics
-			ctrl.Service.Send(ctx, 500, respBody)
+			code := http.StatusInternalServerError
+			respBody := fmt.Sprintf("%s: %s", http.StatusText(code), err) // Sprintf catches panics
+			ctrl.Service.Send(ctx, code, respBody)
 		}
 	}
 	ctrl.Service.Mux.Handle("GET", path, handle)


### PR DESCRIPTION
- Go's `http.StatusText(500)` returns `"Internal Server Error"`