### PR TITLE
Misc fixes:

### DIFF
--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -650,12 +650,13 @@ var reserved = map[string]bool{
 	"type":        true,
 	"var":         true,
 
-	// stdlib packages used by generated code
-	"fmt":  true,
-	"http": true,
-	"json": true,
-	"os":   true,
-	"time": true,
+	// stdlib and goa packages used by generated code
+	"fmt":    true,
+	"http":   true,
+	"json":   true,
+	"os":     true,
+	"time":   true,
+	"client": true,
 }
 
 // toSlice returns Go code that represents the given slice.

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -51,10 +51,14 @@ func (g *Generator) generateMain(mainFile string, clientPkg string, funcs templa
 		return err
 	}
 	g.genfiles = append(g.genfiles, mainFile)
+	version := design.Design.Version
+	if version == "" {
+		version = "0"
+	}
 
 	data := map[string]interface{}{
 		"API":     api,
-		"Version": design.Design.Version,
+		"Version": version,
 	}
 	if err := file.ExecuteTemplate("main", mainTmpl, funcs, data); err != nil {
 		return err

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -176,6 +177,7 @@ func (m *Generator) spawn(genbin string) ([]string, error) {
 		args[i] = fmt.Sprintf("--%s=%s", k, v)
 		i++
 	}
+	sort.Strings(args)
 	cmd := exec.Command(genbin, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
* Protect against "client" package and local variable names clash
* Default client CLI tool version to "0" if no version in API
* Sort flags used to spawn generator tool so generated header comments are deterministic.