### PR TITLE
Fix potential infinite recursions during codegen.

### DIFF
--- a/goagen/codegen/publicizer.go
+++ b/goagen/codegen/publicizer.go
@@ -49,11 +49,8 @@ func init() {
 func RecursivePublicizer(att *design.AttributeDefinition, source, target string, depth int) string {
 	var publications []string
 	if o := att.Type.ToObject(); o != nil {
-		if mt, ok := att.Type.(*design.MediaTypeDefinition); ok {
-			// Hmm media types should never get here
-			att = mt.AttributeDefinition
-		} else if ut, ok := att.Type.(*design.UserTypeDefinition); ok {
-			att = ut.AttributeDefinition
+		if ds, ok := att.Type.(design.DataStructure); ok {
+			att = ds.Definition()
 		}
 		o.IterateAttributes(func(n string, catt *design.AttributeDefinition) error {
 			publication := Publicizer(


### PR DESCRIPTION
When a type has a field whose type is itself - which in case you are
wondering is a valid scenario :) (e.g. a "Person" type with a "friend"
attribute of type "Person").