### PR TITLE
Return err when some payloads required but no payloads specified

### DIFF
--- a/design/apidsl/action.go
+++ b/design/apidsl/action.go
@@ -274,6 +274,20 @@ func Params(dsl func()) {
 //	})
 //
 func Payload(p interface{}, dsls ...func()) {
+	payload(false, p, dsls...)
+}
+
+// OptionalPayload implements the action optional payload DSL. The function works identically to the
+// Payload DSL except it would set a bit in the action definition to denote that the payload is not
+// required. Examples:
+//
+//	OptionalPayload(BottlePayload)		// Request payload is described by the BottlePayload type
+//
+func OptionalPayload(p interface{}, dsls ...func()) {
+	payload(true, p, dsls...)
+}
+
+func payload(isOptional bool, p interface{}, dsls ...func()) {
 	if len(dsls) > 1 {
 		dslengine.ReportError("too many arguments given to Payload")
 		return
@@ -320,6 +334,9 @@ func Payload(p interface{}, dsls ...func()) {
 		a.Payload = &design.UserTypeDefinition{
 			AttributeDefinition: att,
 			TypeName:            fmt.Sprintf("%s%sPayload", an, rn),
+		}
+		if isOptional {
+			a.PayloadOptional = true
 		}
 	}
 }

--- a/design/apidsl/action.go
+++ b/design/apidsl/action.go
@@ -71,6 +71,7 @@ func Files(path, filename string, dsls ...func()) {
 //			Required("Authorization", "X-Account")
 //		})
 //		Payload(UpdatePayload)				// Payload describes the HTTP request body (here using a type)
+//		OptionalPayload(UpdatePayload)			// You can use OptionalPayload instead of Payload
 //		Response(NoContent)				// Each possible HTTP response is described via Response
 //		Response(NotFound)
 //	})
@@ -278,10 +279,10 @@ func Payload(p interface{}, dsls ...func()) {
 }
 
 // OptionalPayload implements the action optional payload DSL. The function works identically to the
-// Payload DSL except it would set a bit in the action definition to denote that the payload is not
-// required. Examples:
+// Payload DSL except it sets a bit in the action definition to denote that the payload is not
+// required. Example:
 //
-//	OptionalPayload(BottlePayload)		// Request payload is described by the BottlePayload type
+//	OptionalPayload(BottlePayload)		// Request payload is described by the BottlePayload type and is optional
 //
 func OptionalPayload(p interface{}, dsls ...func()) {
 	payload(true, p, dsls...)
@@ -335,9 +336,7 @@ func payload(isOptional bool, p interface{}, dsls ...func()) {
 			AttributeDefinition: att,
 			TypeName:            fmt.Sprintf("%s%sPayload", an, rn),
 		}
-		if isOptional {
-			a.PayloadOptional = true
-		}
+		a.PayloadOptional = isOptional
 	}
 }
 

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -236,7 +236,7 @@ type (
 		QueryParams *AttributeDefinition
 		// Payload blueprint (request body) if any
 		Payload *UserTypeDefinition
-		// PayloadOptional describes Payload is optional or not
+		// PayloadOptional is true if the request payload is optional, false otherwise.
 		PayloadOptional bool
 		// Request headers that need to be made available to action
 		Headers *AttributeDefinition

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -236,6 +236,8 @@ type (
 		QueryParams *AttributeDefinition
 		// Payload blueprint (request body) if any
 		Payload *UserTypeDefinition
+		// PayloadOptional describes Payload is optional or not
+		PayloadOptional bool
 		// Request headers that need to be made available to action
 		Headers *AttributeDefinition
 		// Metadata is a list of key/value pairs

--- a/error.go
+++ b/error.go
@@ -99,6 +99,11 @@ func NewErrorClass(code string, status int) ErrorClass {
 	}
 }
 
+// MissingPayloadError is the error produced when a request is missing a required payload.
+func MissingPayloadError() *Error {
+	return ErrInvalidRequest("missing required payload")
+}
+
 // InvalidParamTypeError is the error produced when the type of a parameter does not match the type
 // defined in the design.
 func InvalidParamTypeError(name string, val interface{}, expected string) *Error {

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -214,12 +214,13 @@ func (g *Generator) generateControllers(api *design.APIDefinition) error {
 			context := fmt.Sprintf("%s%sContext", codegen.Goify(a.Name, true), codegen.Goify(r.Name, true))
 			unmarshal := fmt.Sprintf("unmarshal%s%sPayload", codegen.Goify(a.Name, true), codegen.Goify(r.Name, true))
 			action := map[string]interface{}{
-				"Name":      codegen.Goify(a.Name, true),
-				"Routes":    a.Routes,
-				"Context":   context,
-				"Unmarshal": unmarshal,
-				"Payload":   a.Payload,
-				"Security":  a.Security,
+				"Name":            codegen.Goify(a.Name, true),
+				"Routes":          a.Routes,
+				"Context":         context,
+				"Unmarshal":       unmarshal,
+				"Payload":         a.Payload,
+				"PayloadOptional": a.PayloadOptional,
+				"Security":        a.Security,
 			}
 			data.Actions = append(data.Actions, action)
 			return nil

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -364,6 +364,8 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 		}
 		if rawPayload := goa.ContextRequest(ctx).Payload; rawPayload != nil {
 			rctx.Payload = rawPayload.(Collection)
+		} else {
+			return goa.ErrInvalidEncoding(goa.MissingPayloadError())
 		}
 		return ctrl.Get(rctx)
 	}

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -617,9 +617,9 @@ func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Co
 		}
 {{ if .Payload }}if rawPayload := goa.ContextRequest(ctx).Payload; rawPayload != nil {
 			rctx.Payload = rawPayload.({{ gotyperef .Payload nil 1 false }})
-		} else {
+{{ if not .PayloadOptional }}} else {
 			return goa.ErrInvalidEncoding(goa.MissingPayloadError())
-		}
+{{ end }}}
 		{{ end }}		return ctrl.{{ .Name }}(rctx)
 	}
 {{ if $.Origins }}	h = handle{{ $res }}Origin(h)

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -617,6 +617,8 @@ func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Co
 		}
 {{ if .Payload }}if rawPayload := goa.ContextRequest(ctx).Payload; rawPayload != nil {
 			rctx.Payload = rawPayload.({{ gotyperef .Payload nil 1 false }})
+		} else {
+			return goa.ErrInvalidEncoding(goa.MissingPayloadError())
 		}
 		{{ end }}		return ctrl.{{ .Name }}(rctx)
 	}


### PR DESCRIPTION
```go
Action("Update", func() {
	Payload(func() {
		Member("id")
		Required("id")
	})
})
```

The above `Action` should return `400 Bad Request` when no payloads given.
This pull request implement that.
