### PR TITLE
Add `--pkg` flag to `client` command.

### DIFF
--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -395,6 +395,59 @@ func Goify(str string, firstUpper bool) string {
 	return fixReserved(string(runes))
 }
 
+// Reserved golang keywords and package names
+var Reserved = map[string]bool{
+	"byte":       true,
+	"complex128": true,
+	"complex64":  true,
+	"float32":    true,
+	"float64":    true,
+	"int":        true,
+	"int16":      true,
+	"int32":      true,
+	"int64":      true,
+	"int8":       true,
+	"rune":       true,
+	"string":     true,
+	"uint16":     true,
+	"uint32":     true,
+	"uint64":     true,
+	"uint8":      true,
+
+	"break":       true,
+	"case":        true,
+	"chan":        true,
+	"const":       true,
+	"continue":    true,
+	"default":     true,
+	"defer":       true,
+	"else":        true,
+	"fallthrough": true,
+	"for":         true,
+	"func":        true,
+	"go":          true,
+	"goto":        true,
+	"if":          true,
+	"import":      true,
+	"interface":   true,
+	"map":         true,
+	"package":     true,
+	"range":       true,
+	"return":      true,
+	"select":      true,
+	"struct":      true,
+	"switch":      true,
+	"type":        true,
+	"var":         true,
+
+	// stdlib and goa packages used by generated code
+	"fmt":  true,
+	"http": true,
+	"json": true,
+	"os":   true,
+	"time": true,
+}
+
 // validIdentifier returns true if the rune is a letter or number
 func validIdentifier(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsDigit(r)
@@ -402,7 +455,7 @@ func validIdentifier(r rune) bool {
 
 // fixReserved appends an underscore on to Go reserved keywords.
 func fixReserved(w string) string {
-	if _, ok := reserved[w]; ok {
+	if _, ok := Reserved[w]; ok {
 		w += "_"
 	}
 	return w
@@ -604,60 +657,6 @@ func computeMapping(source, target design.Object, sctx, tctx string) (map[string
 		}
 	}
 	return attributeMap, nil
-}
-
-// reserved golang keywords
-var reserved = map[string]bool{
-	"byte":       true,
-	"complex128": true,
-	"complex64":  true,
-	"float32":    true,
-	"float64":    true,
-	"int":        true,
-	"int16":      true,
-	"int32":      true,
-	"int64":      true,
-	"int8":       true,
-	"rune":       true,
-	"string":     true,
-	"uint16":     true,
-	"uint32":     true,
-	"uint64":     true,
-	"uint8":      true,
-
-	"break":       true,
-	"case":        true,
-	"chan":        true,
-	"const":       true,
-	"continue":    true,
-	"default":     true,
-	"defer":       true,
-	"else":        true,
-	"fallthrough": true,
-	"for":         true,
-	"func":        true,
-	"go":          true,
-	"goto":        true,
-	"if":          true,
-	"import":      true,
-	"interface":   true,
-	"map":         true,
-	"package":     true,
-	"range":       true,
-	"return":      true,
-	"select":      true,
-	"struct":      true,
-	"switch":      true,
-	"type":        true,
-	"var":         true,
-
-	// stdlib and goa packages used by generated code
-	"fmt":    true,
-	"http":   true,
-	"json":   true,
-	"os":     true,
-	"time":   true,
-	"client": true,
 }
 
 // toSlice returns Go code that represents the given slice.

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -35,7 +35,9 @@ func Generate() (files []string, err error) {
 	set.Parse(os.Args[2:])
 	outDir = filepath.Join(outDir, target)
 
+	target = codegen.Goify(target, false)
 	g := &Generator{outDir: outDir, target: target, notest: notest}
+	codegen.Reserved[target] = true
 
 	return g.Generate(design.Design)
 }

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Generate", func() {
 
 	AfterEach(func() {
 		workspace.Delete()
+		delete(codegen.Reserved, "app")
 	})
 
 	Context("with a dummy API", func() {

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Generate", func() {
 
 	AfterEach(func() {
 		os.RemoveAll(outDir)
+		delete(codegen.Reserved, "app")
 	})
 
 	Context("with an basic action", func() {

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (g *Generator) makeToolDir(apiName string) (toolDir string, err error) {
-	g.outDir = filepath.Join(g.outDir, "client")
+	g.outDir = filepath.Join(g.outDir, g.target)
 	if err = os.RemoveAll(g.outDir); err != nil {
 		return
 	}
@@ -127,6 +127,7 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 			data := map[string]interface{}{
 				"Action":   action,
 				"Resource": action.Parent,
+				"Package":  g.target,
 			}
 			var err error
 			if action.WebSocket() {
@@ -316,7 +317,7 @@ func (cmd *{{ $cmdName }}) Run(c *client.Client, args []string) error {
 {{ $default := defaultPath .Action }}{{ if $default }}	path = "{{ $default }}"
 {{ else }}{{ $pparams := defaultRouteParams .Action }}	path = fmt.Sprintf("{{ defaultRouteTemplate .Action }}", {{ joinNames $pparams }})
 {{ end }}	}
-{{ if .Action.Payload }}var payload {{ gotyperefext .Action.Payload 2 "client" }}
+{{ if .Action.Payload }}var payload {{ gotyperefext .Action.Payload 2 .Package }}
 	if cmd.Payload != "" {
 		err := json.Unmarshal([]byte(cmd.Payload), &payload)
 		if err != nil {

--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Generate", func() {
 
 	AfterEach(func() {
 		os.RemoveAll(outDir)
+		delete(codegen.Reserved, "client")
 	})
 
 	Context("with a dummy API", func() {

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Generate", func() {
 
 	AfterEach(func() {
 		os.RemoveAll(outDir)
+		delete(codegen.Reserved, "client")
 	})
 
 	Context("with an action with multiple routes", func() {

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -36,7 +36,9 @@ func Generate() (files []string, err error) {
 	set.BoolVar(&force, "force", false, "")
 	set.Parse(os.Args[2:])
 
+	target = codegen.Goify(target, false)
 	g := &Generator{outDir: outDir, target: target, force: force}
+	codegen.Reserved[target] = true
 
 	return g.Generate(design.Design)
 }

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -79,6 +79,7 @@ package and tool and the Swagger specification for the API.
 		Short: "Generate client package and tool",
 		Run:   func(c *cobra.Command, _ []string) { files, err = run("genclient", c) },
 	}
+	clientCmd.Flags().StringVar(&pkg, "pkg", "client", "Name of generated client Go package")
 	rootCmd.AddCommand(clientCmd)
 
 	// swaggerCmd implements the "swagger" command.


### PR DESCRIPTION
Behaves identically to the `app` and `main` command flags with the same
name.
Also protect generated code against clashes between variable names and
target package name.