### PR TITLE
Remove special case for JSON media type.

### DIFF
--- a/design/apidsl/action_test.go
+++ b/design/apidsl/action_test.go
@@ -128,6 +128,33 @@ var _ = Describe("Action", func() {
 		})
 	})
 
+	Context("using a response with a media type modifier", func() {
+		const mtID = "application/vnd.app.foo+json"
+
+		BeforeEach(func() {
+			MediaType(mtID, func() {
+				Attributes(func() { Attribute("foo") })
+				View("default", func() { Attribute("foo") })
+			})
+			name = "foo"
+			dsl = func() {
+				Routing(GET("/:id"))
+				Response(OK, mtID)
+			}
+		})
+
+		It("produces a response that keeps the modifier", func() {
+			Ω(dslengine.Errors).ShouldNot(HaveOccurred())
+			Ω(action).ShouldNot(BeNil())
+			Ω(action.Validate()).ShouldNot(HaveOccurred())
+			Ω(action.Responses).ShouldNot(BeNil())
+			Ω(action.Responses).Should(HaveLen(1))
+			Ω(action.Responses).Should(HaveKey("OK"))
+			resp := action.Responses["OK"]
+			Ω(resp.MediaType).Should(Equal(mtID))
+		})
+	})
+
 	Context("using a response template", func() {
 		const tmplName = "tmpl"
 		const respMediaType = "media"

--- a/design/apidsl/media_type.go
+++ b/design/apidsl/media_type.go
@@ -81,24 +81,7 @@ func MediaType(identifier string, apidsl func()) *design.MediaTypeDefinition {
 		dslengine.ReportError("media type %#v is defined twice", identifier)
 		return nil
 	}
-	parts := strings.Split(identifier, "+")
-	// Make sure it has the `+json` suffix (TBD update when goa supports other encodings)
-	if len(parts) > 1 {
-		parts = parts[1:]
-		found := false
-		for _, part := range parts {
-			if part == "json" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			identifier += "+json"
-		}
-	}
 	identifier = mime.FormatMediaType(identifier, params)
-	// Concoct a Go type name from the identifier, should it be possible to set it in the apidsl?
-	// pros: control the type name generated, cons: not needed in apidsl, adds one more thing to worry about
 	lastPart := identifier
 	lastPartIndex := strings.LastIndex(identifier, "/")
 	if lastPartIndex > -1 {

--- a/design/apidsl/resource.go
+++ b/design/apidsl/resource.go
@@ -85,11 +85,11 @@ func DefaultMedia(val interface{}) {
 			if m.UserTypeDefinition == nil {
 				dslengine.ReportError("invalid media type specification, media type is not initialized")
 			} else {
-				r.MediaType = design.CanonicalIdentifier(m.Identifier)
+				r.MediaType = m.Identifier
 				m.Resource = r
 			}
 		} else if identifier, ok := val.(string); ok {
-			r.MediaType = design.CanonicalIdentifier(identifier)
+			r.MediaType = identifier
 		} else {
 			dslengine.ReportError("media type must be a string or a *design.MediaTypeDefinition, got %#v", val)
 		}

--- a/design/apidsl/resource_test.go
+++ b/design/apidsl/resource_test.go
@@ -228,6 +228,31 @@ var _ = Describe("Resource", func() {
 		})
 	})
 
+	Context("with a valid media type using a modifier", func() {
+		const typeName = "typeName"
+		const identifier = "application/vnd.raphael.goa.test+json"
+
+		var mediaType = &MediaTypeDefinition{
+			UserTypeDefinition: &UserTypeDefinition{
+				TypeName: typeName,
+			},
+			Identifier: identifier,
+		}
+
+		BeforeEach(func() {
+			name = "foo"
+			dsl = func() {
+				DefaultMedia(mediaType)
+			}
+		})
+
+		It("sets the media type and keeps the modifier", func() {
+			Ω(res).ShouldNot(BeNil())
+			Ω(res.Validate()).ShouldNot(HaveOccurred())
+			Ω(res.MediaType).Should(Equal(identifier))
+		})
+	})
+
 	Context("with a trait that does not exist", func() {
 		BeforeEach(func() {
 			name = "foo"


### PR DESCRIPTION
When creating identifier since goa now supports arbitrary encodings.
Also properly keep media type modifiers when using `DefaultMedia`.