### PR TITLE
fix improperly formatted responses due to "null\n" being appended

### DIFF
--- a/service.go
+++ b/service.go
@@ -113,7 +113,7 @@ func New(name string) *Service {
 		}
 		ctx := NewContext(service.Context, rw, req, params)
 		err := notFoundHandler(ctx, ContextResponse(ctx), req)
-		if err != nil {
+		if !ContextResponse(ctx).Written() {
 			service.Send(ctx, 404, err)
 		}
 	})

--- a/service.go
+++ b/service.go
@@ -113,7 +113,9 @@ func New(name string) *Service {
 		}
 		ctx := NewContext(service.Context, rw, req, params)
 		err := notFoundHandler(ctx, ContextResponse(ctx), req)
-		service.Send(ctx, 404, err)
+		if err != nil {
+			service.Send(ctx, 404, err)
+		}
 	})
 
 	return service


### PR DESCRIPTION
the default `NotFound` implementation can mess up the JSON response, appending `"null\n"` to an otherwise good 404 string:
So the client would receive:
```json
{"code":"not_found","status":404,"detail":"/"}
null

```
instead of:
```json
{"code":"not_found","status":404,"detail":"/"}

```