### PR TITLE
Only set API BasePath if all actions are relative to it.

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1566,17 +1566,6 @@ func (f *FileServerDefinition) Finalize() {
 	}
 }
 
-// FullPath computes the full request path recursively.
-// FullPath returns the file server request full path computed by concatenating the API and resource
-// base paths with the file server specific path.
-func (f *FileServerDefinition) FullPath() string {
-	var base string
-	if f.Parent != nil {
-		base = f.Parent.FullPath()
-	}
-	return httppath.Clean(path.Join(base, f.RequestPath))
-}
-
 // ByFilePath makes FileServerDefinition sortable for code generators.
 type ByFilePath []*FileServerDefinition
 

--- a/goagen/gen_swagger/swagger_test.go
+++ b/goagen/gen_swagger/swagger_test.go
@@ -422,15 +422,15 @@ var _ = Describe("New", func() {
 				Ω(ps[10]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OverrideRequiredHeader", Type: "string", Required: true}))
 				Ω(ps[11]).Should(Equal(&genswagger.Parameter{In: "header", Name: "X-Account", Type: "integer", Required: true}))
 				Ω(ps[12]).Should(Equal(&genswagger.Parameter{In: "header", Name: "header", Type: "string", Required: true}))
-				Ω(swagger.Paths["/bottles/{id}"]).ShouldNot(BeNil())
-				Ω(swagger.Paths["/bottles/{id}"].Put).ShouldNot(BeNil())
-				Ω(swagger.Paths["/bottles/{id}"].Put.Parameters).Should(HaveLen(14))
+				Ω(swagger.Paths["/base/bottles/{id}"]).ShouldNot(BeNil())
+				Ω(swagger.Paths["/base/bottles/{id}"].Put).ShouldNot(BeNil())
+				Ω(swagger.Paths["/base/bottles/{id}"].Put.Parameters).Should(HaveLen(14))
 			})
 
 			It("should set the inherited tag and the action tag", func() {
 				tags := []string{"res", "Update"}
 				Ω(swagger.Paths["/orgs/{org}/accounts/{id}"].Put.Tags).Should(Equal(tags))
-				Ω(swagger.Paths["/bottles/{id}"].Put.Tags).Should(Equal(tags))
+				Ω(swagger.Paths["/base/bottles/{id}"].Put.Tags).Should(Equal(tags))
 			})
 
 			It("should set the summary from the summary tag", func() {


### PR DESCRIPTION
As Swagger does not support "exceptions". So if the API uses any
absolute route or file servers then set the BasePath to "" and use
absolute paths everywhere.