### PR TITLE
Turn client tool info scaffold

### DIFF
--- a/_integration_tests/integration_test.go
+++ b/_integration_tests/integration_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 func TestBootstrapReadme(t *testing.T) {
-	defer os.RemoveAll("./main.go")
+	defer os.RemoveAll("./readme/main.go")
+	defer os.RemoveAll("./readme/tool")
 	if err := goagen("./readme", "bootstrap", "-d", "github.com/goadesign/goa/_integration_tests/readme/design"); err != nil {
 		t.Error(err.Error())
 	}
@@ -30,7 +31,7 @@ func TestCellar(t *testing.T) {
 	if err := gobuild("./goa-cellar"); err != nil {
 		t.Error(err.Error())
 	}
-	if err := gobuild("./goa-cellar/client/cellar-cli"); err != nil {
+	if err := gobuild("./goa-cellar/tool/cellar-cli"); err != nil {
 		t.Error(err.Error())
 	}
 }

--- a/client/signers.go
+++ b/client/signers.go
@@ -1,15 +1,11 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"time"
 
 	"golang.org/x/net/context"
 
-	"github.com/goadesign/goa"
 	"github.com/spf13/cobra"
 )
 
@@ -33,10 +29,13 @@ type (
 
 	// APIKeySigner implements API Key auth.
 	APIKeySigner struct {
-		// Header is the name of the HTTP header that contains the API key.
-		Header string
-		// Key stores the actual key.
-		Key string
+		// SignHeader indicates whether to set the API key in the header with name KeyName
+		// or whether to use a query string with name KeyName.
+		SignHeader bool
+		// KeyName is the name of the HTTP header or query string that contains the API key.
+		KeyName string
+		// KeyValue stores the actual key.
+		KeyValue string
 		// Format is the format used to render the key, defaults to "Bearer %s"
 		Format string
 	}
@@ -49,36 +48,27 @@ type (
 		// Format represents the format used to render the JWT.
 		// The default is "Bearer %s"
 		Format string
-		// Token stores the actual JWT.
-		Token string
+		// TokenSource is a JWT token source.
+		// See https://godoc.org/golang.org/x/oauth2/jwt#Config.TokenSource for an example
+		// of an implementation.
+		TokenSource TokenSource
 	}
 
-	// OAuth2Signer enables the use of OAuth2 refresh tokens. It takes care of creating access
-	// tokens given a refresh token and a refresh URL as defined in RFC 6749.
-	// Note that this signer does not concern itself with generating the initial refresh token,
-	// this has to be done prior to using the client.
-	// Also it assumes the response of the refresh request response is JSON encoded and of the
-	// form:
-	// 	{
-	//		"access_token":"2YotnFZFEjr1zCsicMWpAA",
-	// 		"expires_in":3600,
-	// 		"refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA"
-	// 	}
-	// where the "expires_in" and "refresh_token" properties are optional and additional
-	// properties are ignored. If the response contains a "expires_in" property then the signer
-	// takes care of making refresh requests prior to the token expiration.
+	// OAuth2Signer adds a authorization header to the request using the given OAuth2 token
+	// source to produce the header value.
 	OAuth2Signer struct {
-		// RefreshURLFormat is a format that generates the refresh access token URL given a
-		// refresh token.
-		RefreshURLFormat string
-		// RefreshToken contains the OAuth3 refresh token from which access tokens are
-		// created.
-		RefreshToken string
+		// TokenSource is an OAuth2 access token source.
+		// See package golang/oauth2 and its subpackage for implementations of token
+		// sources.
+		TokenSource TokenSource
+	}
 
-		// accessToken is the temporary access token.
-		accessToken string
-		// expiresAt specifies when to create a new access token.
-		expiresAt time.Time
+	// A TokenSource is anything that can return a token.
+	TokenSource interface {
+		// Token returns a token or an error.
+		// Token must be safe for concurrent use by multiple goroutines.
+		// The returned Token must not be modified.
+		Token() (*Token, error)
 	}
 )
 
@@ -90,31 +80,23 @@ func (s *BasicSigner) Sign(ctx context.Context, req *http.Request) error {
 	return nil
 }
 
-// RegisterFlags adds the "--user" and "--pass" flags to the client tool.
-func (s *BasicSigner) RegisterFlags(app *cobra.Command) {
-	app.Flags().StringVar(&s.Username, "user", "", "Basic Auth username")
-	app.Flags().StringVar(&s.Password, "pass", "", "Basic Auth password")
-}
-
 // Sign adds the API key header to the request.
 func (s *APIKeySigner) Sign(ctx context.Context, req *http.Request) error {
-	header := s.Header
-	if header == "" {
-		header = "Authorization"
+	if s.KeyName == "" {
+		s.KeyName = "Authorization"
 	}
+	if s.Format == "" {
+		s.Format = "Bearer %s"
+	}
+	name := s.KeyName
 	format := s.Format
-	if format == "" {
-		format = "Bearer %s"
+	val := fmt.Sprintf(format, s.KeyValue)
+	if s.SignHeader {
+		req.Header.Set(name, val)
+	} else {
+		req.URL.Query().Set(name, val)
 	}
-	req.Header.Set(header, fmt.Sprintf(format, s.Key))
 	return nil
-}
-
-// RegisterFlags adds the "--key" and "--key-header" flags to the client tool.
-func (s *APIKeySigner) RegisterFlags(app *cobra.Command) {
-	app.Flags().StringVar(&s.Key, "key", "", "API key")
-	app.Flags().StringVar(&s.Header, "header", "Authorization", "API key header name")
-	app.Flags().StringVar(&s.Format, "format", "Bearer %s", "Format used to render header value from key")
 }
 
 // Sign adds the JWT auth header.
@@ -127,74 +109,20 @@ func (s *JWTSigner) Sign(ctx context.Context, req *http.Request) error {
 	if format == "" {
 		format = "Bearer %s"
 	}
-	req.Header.Set(header, fmt.Sprintf(format, s.Token))
+	token, err := s.TokenSource()
+	if err != nil {
+		return err
+	}
+	req.Header.Set(header, token)
 	return nil
-}
-
-// RegisterFlags adds the "--jwt" flag to the client tool.
-func (s *JWTSigner) RegisterFlags(app *cobra.Command) {
-	app.Flags().StringVar(&s.Token, "jwt", "", "JWT value")
-	app.Flags().StringVar(&s.Header, "header", "Authorization", "JWT header name")
-	app.Flags().StringVar(&s.Format, "format", "Bearer %s", "Format used to render header value from JWT")
 }
 
 // Sign refreshes the access token if needed and adds the OAuth header.
 func (s *OAuth2Signer) Sign(ctx context.Context, req *http.Request) error {
-	if s.expiresAt.Before(time.Now()) {
-		if err := s.Refresh(ctx); err != nil {
-			return fmt.Errorf("failed to refresh OAuth token: %s", err)
-		}
-	}
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.accessToken))
-	return nil
-}
-
-// RegisterFlags adds the "--refreshURL" and "--refreshToken" flags to the client tool.
-func (s *OAuth2Signer) RegisterFlags(app *cobra.Command) {
-	app.Flags().StringVar(&s.RefreshURLFormat, "refreshURL", "", "OAuth2 refresh URL format, e.g. https://somewhere.com/token?grant_type=authorization_code&code=%s&client_id=xxx")
-	app.Flags().StringVar(&s.RefreshToken, "refreshToken", "", "OAuth2 refresh token or authorization code")
-}
-
-// ouath2RefreshResponse is the data structure representing the interesting subset of a OAuth2
-// refresh response.
-type oauth2RefreshResponse struct {
-	RefreshToken string `json:"refresh_token,omitempty"`
-	ExpiresIn    int    `json:"expires_in,omitempty"`
-	AccessToken  string `json:"access_token"`
-}
-
-// Refresh makes a OAuth2 refresh access token request.
-func (s *OAuth2Signer) Refresh(ctx context.Context) error {
-	url := fmt.Sprintf(s.RefreshURLFormat, s.RefreshToken)
-	req, err := http.NewRequest("POST", url, nil)
+	token, err := s.TokenSource.Token()
 	if err != nil {
 		return err
 	}
-	id := shortID()
-	goa.LogInfo(ctx, "refresh", "id", id, "url", fmt.Sprintf(s.RefreshURLFormat, "*****"))
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		goa.LogError(ctx, "failed", "id", id, "err", err)
-		return err
-	}
-	goa.LogInfo(ctx, "completed", "id", id, "status", resp.Status)
-	defer resp.Body.Close()
-	var r oauth2RefreshResponse
-	respBody, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response body: %s", err)
-	}
-	err = json.Unmarshal(respBody, &r)
-	if err != nil {
-		return fmt.Errorf("failed to decode refresh request response: %s", err)
-	}
-	s.accessToken = r.AccessToken
-	if r.ExpiresIn > 0 {
-		s.expiresAt = time.Now().Add(time.Duration(r.ExpiresIn) * time.Second)
-		goa.LogInfo(ctx, "refreshed", "expires", s.expiresAt)
-	}
-	if r.RefreshToken != "" {
-		s.RefreshToken = r.RefreshToken
-	}
+	token.SetAuthHeader(req)
 	return nil
 }

--- a/design/security.go
+++ b/design/security.go
@@ -49,7 +49,7 @@ type SecuritySchemeDefinition struct {
 	SchemeName string `json:"scheme"`
 
 	// Type is one of "apiKey", "oauth2" or "basic", according to the
-	// Swagger specs.
+	// Swagger specs. We also support "jwt".
 	Type string `json:"type"`
 	// Description describes the security scheme. Ex: "Google OAuth2"
 	Description string `json:"description"`

--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -49,11 +49,11 @@ var _ = Describe("Generate", func() {
 
 		It("generates a dummy app", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(6))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "testapi-cli", "main.go"))
+			Ω(files).Should(HaveLen(8))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "testapi-cli", "main.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(len(strings.Split(string(content), "\n"))).Should(BeNumerically(">=", 16))
-			_, err = gexec.Build(filepath.Join(testgenPackagePath, "client", "testapi-cli"))
+			_, err = gexec.Build(filepath.Join(testgenPackagePath, "tool", "testapi-cli"))
 			Ω(err).ShouldNot(HaveOccurred())
 		})
 	})
@@ -96,14 +96,14 @@ var _ = Describe("Generate", func() {
 
 		It("generates the correct command flag initialization code", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(7))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "testapi-cli", "commands.go"))
+			Ω(files).Should(HaveLen(9))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(len(strings.Split(string(content), "\n"))).Should(BeNumerically(">=", 3))
 			Ω(content).Should(ContainSubstring("var param int"))
 			Ω(content).Should(ContainSubstring("var time_ string"))
 			Ω(content).Should(ContainSubstring(".Flags()"))
-			_, err = gexec.Build(filepath.Join(testgenPackagePath, "client", "testapi-cli"))
+			_, err = gexec.Build(filepath.Join(testgenPackagePath, "tool", "testapi-cli"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 		})
@@ -117,8 +117,8 @@ var _ = Describe("Generate", func() {
 
 			It("properly escapes the multi-line string used in the short description", func() {
 				Ω(genErr).Should(BeNil())
-				Ω(files).Should(HaveLen(7))
-				content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "testapi-cli", "main.go"))
+				Ω(files).Should(HaveLen(9))
+				content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(content)).Should(ContainSubstring(multiline))
 			})
@@ -134,8 +134,8 @@ var _ = Describe("Generate", func() {
 
 			It("properly escapes the multi-line string used in the short description", func() {
 				Ω(genErr).Should(BeNil())
-				Ω(files).Should(HaveLen(7))
-				content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "testapi-cli", "main.go"))
+				Ω(files).Should(HaveLen(9))
+				content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(content)).Should(ContainSubstring(pre + "` + \"`\" + `" + post))
 			})
@@ -188,12 +188,13 @@ var _ = Describe("Generate", func() {
 			showAct.Routes[0].Parent = showAct
 		})
 
-		It("generates the Signer.RegisterFlags call from Command", func() {
+		It("generates registers the signer flags from main", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(7))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "testapi-cli", "commands.go"))
+			Ω(files).Should(HaveLen(9))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "testapi-cli", "main.go"))
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring("c.JWT1Signer.RegisterFlags(cc)"))
+			Ω(content).Should(ContainSubstring("jwt1Signer := newJWT1Signer()"))
+			Ω(content).Should(ContainSubstring("c.SetJWT1Signer(jwt1Signer)"))
 		})
 	})
 })

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Generate", func() {
 
 		It("generates Path function with unique names", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(7))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
@@ -94,7 +94,7 @@ var _ = Describe("Generate", func() {
 
 			It("generates a Download function", func() {
 				Ω(genErr).Should(BeNil())
-				Ω(files).Should(HaveLen(7))
+				Ω(files).Should(HaveLen(9))
 				content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("func (c *Client) DownloadSwagger("))
@@ -152,19 +152,19 @@ var _ = Describe("Generate", func() {
 
 		It("generates the correct client Fields", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(7))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring("JWT1Signer *goaclient.JWTSigner"))
-			Ω(content).Should(ContainSubstring("JWT1Signer: &goaclient.JWTSigner{},"))
+			Ω(content).Should(ContainSubstring("JWT1Signer goaclient.Signer"))
+			Ω(content).Should(ContainSubstring("func (c *Client) SetJWT1Signer(signer goaclient.Signer) {\n	c.JWT1Signer = signer\n}"))
 		})
 
 		It("generates the Signer.Sign call from Action", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(7))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring("c.JWT1Signer.Sign(ctx, req)"))
+			Ω(content).Should(ContainSubstring("c.JWT1Signer.Sign(req)"))
 		})
 	})
 })

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -74,12 +74,17 @@ package and tool and the Swagger specification for the API.
 	rootCmd.AddCommand(mainCmd)
 
 	// clientCmd implements the "client" command.
+	var (
+		toolDir, tool string
+	)
 	clientCmd := &cobra.Command{
 		Use:   "client",
 		Short: "Generate client package and tool",
 		Run:   func(c *cobra.Command, _ []string) { files, err = run("genclient", c) },
 	}
 	clientCmd.Flags().StringVar(&pkg, "pkg", "client", "Name of generated client Go package")
+	clientCmd.Flags().StringVar(&toolDir, "tooldir", "tool", "Name of generated tool directory")
+	clientCmd.Flags().StringVar(&tool, "tool", "[API-name]-cli", "Name of generated tool")
 	rootCmd.AddCommand(clientCmd)
 
 	// swaggerCmd implements the "swagger" command.


### PR DESCRIPTION
This PR changes how the client tool is generated. The file `main.go` is now a scaffold meaning that it is generated once and does not get overridden with further invocations of `goagen client`. The code that creates the cli commands is moved from the `main` package to the new `cli` package so that it does get regenerated each time.

The file `main.go` thus becomes an example rather than an authoritative implementation of the client tool making it possible to change it for example to register custom auth signers. The `goa` package signers is also changed to a more generic implementation allowing for any implementation of the `JWT` or `OAuth2` security schemes to be plugged in. The interfaces used by the `JWT` and `OAuth2` signers is now compatible with the [golang oauth2](https://godoc.org/golang.org/x/oauth2) package.

The files generated by `goagen client` now follows this layout (taking the `adder` README example):
```
├── client
│   ├── client.go
│   ├── datatypes.go
│   ├── operands.go
│   └── swagger.go
└── tool
    ├── adder-cli
    │   └── main.go // Generated once
    └── cli
        └── commands.go
```