### PR TITLE
Fix bug in gen_client in generation of NewXXXRequest functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,18 @@
-examples/cellar/cellar
-examples/cellar/client/cellar-cli/cellar-cli
+# Golang tools artifacts
 **/*.coverprofile
-goagen/goagen
-**/autogen
 **/*.test
 vendor
+
+# Executables and test outputs
+goagen/goagen
 _integration_tests/*/**/*.*
-public/
+
+# Editor / IDEs cruft
 .idea/
+*.iml
 .vscode/
 *~
 *.orig
+
+# OSes cruft
 .DS_Store

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -375,22 +375,6 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 			}
 			g.generatedTypes[action.Payload.TypeName] = true
 		}
-		if action.Params != nil {
-			params := make(design.Object, len(action.QueryParams.Type.ToObject()))
-			for n, param := range action.QueryParams.Type.ToObject() {
-				name := codegen.Goify(n, false)
-				params[name] = param
-			}
-			action.QueryParams.Type = params
-		}
-		if action.Headers != nil {
-			headers := make(design.Object, len(action.Headers.Type.ToObject()))
-			for n, header := range action.Headers.Type.ToObject() {
-				name := codegen.Goify(n, false)
-				headers[name] = header
-			}
-			action.Headers.Type = headers
-		}
 		for i, r := range action.Routes {
 			data := struct {
 				Route *design.RouteDefinition


### PR DESCRIPTION
That causes query string and header values to be set incorrectly
if their 'goified' name differs from their given name.