### PR TITLE
Allow the ability to generate no tool.

### DIFF
--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -37,6 +37,18 @@ var _ = Describe("Generate", func() {
 		delete(codegen.Reserved, "app")
 	})
 
+	Context("with notest flag", func() {
+		BeforeEach(func() {
+			os.Args = []string{"goagen", "app", "--out=" + outDir, "--design=foo", "--notest"}
+		})
+
+		It("does not generate tests", func() {
+			_, err := os.Stat(filepath.Join(outDir, "app", "test"))
+			Expect(err).To(HaveOccurred())
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+	})
+
 	Context("with an basic action", func() {
 		BeforeEach(func() {
 			codegen.TempCount = 0

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -76,6 +76,7 @@ package and tool and the Swagger specification for the API.
 	// clientCmd implements the "client" command.
 	var (
 		toolDir, tool string
+		notool        bool
 	)
 	clientCmd := &cobra.Command{
 		Use:   "client",
@@ -85,6 +86,7 @@ package and tool and the Swagger specification for the API.
 	clientCmd.Flags().StringVar(&pkg, "pkg", "client", "Name of generated client Go package")
 	clientCmd.Flags().StringVar(&toolDir, "tooldir", "tool", "Name of generated tool directory")
 	clientCmd.Flags().StringVar(&tool, "tool", "[API-name]-cli", "Name of generated tool")
+	clientCmd.Flags().BoolVar(&notool, "notool", false, "Prevent generation of cli tool")
 	rootCmd.AddCommand(clientCmd)
 
 	// swaggerCmd implements the "swagger" command.


### PR DESCRIPTION
I have been finding myself using quite of bit of the helpers in the client library but not the tool itself. This adds the ability to prevent the generation of the tool and cli.