### PR TITLE
Do not use default scheme when computing auth URLs

### DIFF
--- a/design/apidsl/security.go
+++ b/design/apidsl/security.go
@@ -279,14 +279,14 @@ func Scope(name string, desc ...string) {
 
 // inHeader is called by `Header()`, see documentation there.
 func inHeader(headerName string) {
-	if parent, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
-		if parent.Kind == design.APIKeySecurityKind || parent.Kind == design.JWTSecurityKind {
-			if parent.In != "" {
+	if current, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
+		if current.Kind == design.APIKeySecurityKind || current.Kind == design.JWTSecurityKind {
+			if current.In != "" {
 				dslengine.ReportError("'In' previously defined through Header or Query")
 				return
 			}
-			parent.In = "header"
-			parent.Name = headerName
+			current.In = "header"
+			current.Name = headerName
 			return
 		}
 	}
@@ -296,14 +296,14 @@ func inHeader(headerName string) {
 // Query defines that an APIKeySecurity or JWTSecurity implementation must check in the query
 // parameter named "parameterName" to get the api key.
 func Query(parameterName string) {
-	if parent, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
-		if parent.Kind == design.APIKeySecurityKind || parent.Kind == design.JWTSecurityKind {
-			if parent.In != "" {
+	if current, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
+		if current.Kind == design.APIKeySecurityKind || current.Kind == design.JWTSecurityKind {
+			if current.In != "" {
 				dslengine.ReportError("'In' previously defined through Header or Query")
 				return
 			}
-			parent.In = "query"
-			parent.Name = parameterName
+			current.In = "query"
+			current.Name = parameterName
 			return
 		}
 	}
@@ -312,11 +312,11 @@ func Query(parameterName string) {
 
 // AccessCodeFlow defines an "access code" OAuth2 flow.  Use within an OAuth2Security definition.
 func AccessCodeFlow(authorizationURL, tokenURL string) {
-	if parent, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
-		if parent.Kind == design.OAuth2SecurityKind {
-			parent.Flow = "accessCode"
-			parent.AuthorizationURL = authorizationURL
-			parent.TokenURL = tokenURL
+	if current, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
+		if current.Kind == design.OAuth2SecurityKind {
+			current.Flow = "accessCode"
+			current.AuthorizationURL = authorizationURL
+			current.TokenURL = tokenURL
 			return
 		}
 	}

--- a/design/apidsl/security_test.go
+++ b/design/apidsl/security_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Security", func() {
 	It("should be the fully valid and well defined, live on the happy path", func() {
 		API("secure", func() {
 			Host("example.com")
+			Scheme("http")
 
 			BasicAuthSecurity("basic_authz", func() {
 				Description("desc")
@@ -132,6 +133,7 @@ var _ = Describe("Security", func() {
 		It("should pass with valid values when well defined", func() {
 			API("", func() {
 				Host("example.com")
+				Scheme("http")
 				OAuth2Security("googAuthz", func() {
 					Description("Use Goog's Auth")
 					AccessCodeFlow("/auth", "/token")

--- a/design/security.go
+++ b/design/security.go
@@ -112,7 +112,7 @@ func (s *SecuritySchemeDefinition) Finalize() {
 	if tokenOK && authOK {
 		return
 	}
-	scheme := "http"
+	var scheme string
 	if len(Design.Schemes) > 0 {
 		scheme = Design.Schemes[0]
 	}


### PR DESCRIPTION
Only use scheme defined in API if any. This means that relative URLs are
possible which is better than an incorrect URL because of default scheme
and no host.