### PR TITLE
Fix codegen issue with type descriptions containing newlines.

### DIFF
--- a/design/validation.go
+++ b/design/validation.go
@@ -83,6 +83,9 @@ func (a *APIDefinition) Validate() error {
 				}
 			}
 			for _, ro := range ac.Routes {
+				if ro.IsAbsolute() {
+					continue
+				}
 				info := newRouteInfo(r, ac, ro)
 				allRoutes = append(allRoutes, info)
 				rwcs := ExtractWildcards(ac.Parent.FullPath())

--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -263,13 +263,13 @@ func GoTypeDesc(t design.DataType, upper bool) string {
 	switch actual := t.(type) {
 	case *design.UserTypeDefinition:
 		if actual.Description != "" {
-			return actual.Description
+			return strings.Replace(actual.Description, "\n", "\n// ", -1)
 		}
 
 		return Goify(actual.TypeName, upper) + " user type."
 	case *design.MediaTypeDefinition:
 		if actual.Description != "" {
-			return actual.Description
+			return strings.Replace(actual.Description, "\n", "\n// ", -1)
 		}
 
 		switch elem := actual.UserTypeDefinition.AttributeDefinition.Type.(type) {

--- a/goagen/codegen/types_test.go
+++ b/goagen/codegen/types_test.go
@@ -2,6 +2,7 @@ package codegen_test
 
 import (
 	"fmt"
+	"strings"
 
 	. "github.com/goadesign/goa/design"
 	. "github.com/goadesign/goa/design/apidsl"
@@ -592,6 +593,38 @@ var _ = Describe("GoTypeTransform", func() {
 	return
 }
 `))
+		})
+	})
+
+	Describe("GoTypeDesc", func() {
+		Context("With a type with a description", func() {
+			var description string
+			var ut *UserTypeDefinition
+
+			var desc string
+
+			BeforeEach(func() {
+				description = "foo"
+			})
+
+			JustBeforeEach(func() {
+				ut = &UserTypeDefinition{AttributeDefinition: &AttributeDefinition{Description: description}}
+				desc = codegen.GoTypeDesc(ut, false)
+			})
+
+			It("uses the description", func() {
+				Ω(desc).Should(Equal(description))
+			})
+
+			Context("containing newlines", func() {
+				BeforeEach(func() {
+					description = "foo\nbar"
+				})
+
+				It("escapes the new lines", func() {
+					Ω(desc).Should(Equal(strings.Replace(description, "\n", "\n// ", -1)))
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
Also fix validation of path that was erroneously taking into account
parent resource and API base paths for absolute routes.