### PR TITLE
Add ability to set "Content-Type" response header explicitly.

### DIFF
--- a/design/apidsl/media_type_test.go
+++ b/design/apidsl/media_type_test.go
@@ -67,6 +67,28 @@ var _ = Describe("MediaType", func() {
 		})
 	})
 
+	Context("with a content type", func() {
+		const attName = "att"
+		const contentType = "application/json"
+
+		BeforeEach(func() {
+			name = "application/foo"
+			dslFunc = func() {
+				ContentType(contentType)
+				Attributes(func() {
+					Attribute(attName)
+				})
+				View("default", func() { Attribute(attName) })
+			}
+		})
+
+		It("sets the content type", func() {
+			Ω(mt).ShouldNot(BeNil())
+			Ω(mt.Validate()).ShouldNot(HaveOccurred())
+			Ω(mt.ContentType).Should(Equal(contentType))
+		})
+	})
+
 	Context("with a description", func() {
 		const description = "desc"
 

--- a/design/types.go
+++ b/design/types.go
@@ -118,6 +118,9 @@ type (
 		*UserTypeDefinition
 		// Identifier is the RFC 6838 media type identifier.
 		Identifier string
+		// ContentType identifies the value written to the response "Content-Type" header.
+		// Defaults to Identifier.
+		ContentType string
 		// Links list the rendered links indexed by name.
 		Links map[string]*LinkDefinition
 		// Views list the supported views indexed by name.
@@ -699,6 +702,14 @@ func (m *MediaTypeDefinition) ComputeViews() map[string]*ViewDefinition {
 		}
 	}
 	return nil
+}
+
+// Finalize sets the value of ContentType to the identifier if not set.
+func (m *MediaTypeDefinition) Finalize() {
+	if m.ContentType == "" {
+		m.ContentType = m.Identifier
+	}
+	m.UserTypeDefinition.Finalize()
 }
 
 // ViewIterator is the type of the function given to IterateViews.

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -162,6 +162,7 @@ var _ = Describe("Generate", func() {
 			mt := design.MediaTypeDefinition{
 				UserTypeDefinition: &ut,
 				Identifier:         "vnd.rightscale.codegen.test.widgets",
+				ContentType:        "vnd.rightscale.codegen.test.widgets",
 				Views: map[string]*design.ViewDefinition{
 					"default": {
 						AttributeDefinition: ut.AttributeDefinition,


### PR DESCRIPTION
Instead of always using the media type identifier. In particular this
makes it possible to have different media types use the same value for
Content-Type. This also helps with APIs that must support multiple
encodings.