### PR TITLE
Refactor how payload is unmarshaled

### DIFF
--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -328,6 +328,11 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 	var h goa.Handler
 
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		// Check if there was an error loading the request
+		if err := goa.ContextError(ctx); err != nil {
+			return err
+		}
+		// Build the context
 		rctx, err := NewGetWidgetContext(ctx, service)
 		if err != nil {
 			return err
@@ -381,14 +386,20 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 	var h goa.Handler
 
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		// Check if there was an error loading the request
+		if err := goa.ContextError(ctx); err != nil {
+			return err
+		}
+		// Build the context
 		rctx, err := NewGetWidgetContext(ctx, service)
 		if err != nil {
 			return err
 		}
+		// Build the payload
 		if rawPayload := goa.ContextRequest(ctx).Payload; rawPayload != nil {
 			rctx.Payload = rawPayload.(Collection)
 		} else {
-			return goa.ErrInvalidEncoding(goa.MissingPayloadError())
+			return goa.MissingPayloadError()
 		}
 		return ctrl.Get(rctx)
 	}
@@ -414,10 +425,16 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 	var h goa.Handler
 
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		// Check if there was an error loading the request
+		if err := goa.ContextError(ctx); err != nil {
+			return err
+		}
+		// Build the context
 		rctx, err := NewGetWidgetContext(ctx, service)
 		if err != nil {
 			return err
 		}
+		// Build the payload
 		if rawPayload := goa.ContextRequest(ctx).Payload; rawPayload != nil {
 			rctx.Payload = rawPayload.(Collection)
 		}

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -1115,6 +1115,11 @@ func MountBottlesController(service *goa.Service, ctrl BottlesController) {
 	var h goa.Handler
 
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		// Check if there was an error loading the request
+		if err := goa.ContextError(ctx); err != nil {
+			return err
+		}
+		// Build the context
 		rctx, err := NewListBottleContext(ctx, service)
 		if err != nil {
 			return err
@@ -1131,6 +1136,11 @@ func MountBottlesController(service *goa.Service, ctrl BottlesController) {
 	var h goa.Handler
 
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		// Check if there was an error loading the request
+		if err := goa.ContextError(ctx); err != nil {
+			return err
+		}
+		// Build the context
 		rctx, err := NewListBottleContext(ctx, service)
 		if err != nil {
 			return err
@@ -1155,6 +1165,11 @@ type BottlesController interface {
 	var h goa.Handler
 
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		// Check if there was an error loading the request
+		if err := goa.ContextError(ctx); err != nil {
+			return err
+		}
+		// Build the context
 		rctx, err := NewListBottleContext(ctx, service)
 		if err != nil {
 			return err
@@ -1165,6 +1180,11 @@ type BottlesController interface {
 	service.LogInfo("mount", "ctrl", "Bottles", "action", "List", "route", "GET /accounts/:accountID/bottles")
 
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		// Check if there was an error loading the request
+		if err := goa.ContextError(ctx); err != nil {
+			return err
+		}
+		// Build the context
 		rctx, err := NewShowBottleContext(ctx, service)
 		if err != nil {
 			return err


### PR DESCRIPTION
Store unmarshaler error in context and handle it in generated code so
that middleware that is request specific such as CORS is properly
executed. This also simplifies the setup and makes the code easier to
evolve to the point where goa MuxHandlers do not return errors (for
compatibility with Go 1.7 HTTP handlers).