### PR TITLE
Add proper versioning support to goagen

### DIFF
--- a/goagen/codegen/helpers.go
+++ b/goagen/codegen/helpers.go
@@ -9,7 +9,22 @@ import (
 	"unicode"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/version"
 )
+
+// CheckVersion returns an error if the ver is empty, contains an incorrect value or
+// a version number that is not compatible with the version of this repo.
+func CheckVersion(ver string) error {
+	compat, err := version.Compatible(ver)
+	if err != nil {
+		return err
+	}
+	if !compat {
+		return fmt.Errorf("version mismatch: using goagen %s to generate code that compiles with goa %s",
+			ver, version.String())
+	}
+	return nil
+}
 
 // CommandLine return the command used to run this process.
 func CommandLine() string {

--- a/goagen/codegen/version.go
+++ b/goagen/codegen/version.go
@@ -1,4 +1,0 @@
-package codegen
-
-// Version of generator tools.
-const Version = "0.0.1"

--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/goadesign/goa/version"
+
 	"golang.org/x/tools/go/ast/astutil"
 )
 
@@ -219,7 +221,7 @@ func SourceFileFor(path string) (*SourceFile, error) {
 func (f *SourceFile) WriteHeader(title, pack string, imports []*ImportSpec) error {
 	ctx := map[string]interface{}{
 		"Title":       title,
-		"ToolVersion": Version,
+		"ToolVersion": version.String(),
 		"Pkg":         pack,
 		"Imports":     imports,
 	}
@@ -353,7 +355,7 @@ const (
 	headerT = `{{if .Title}}//************************************************************************//
 // {{.Title}}
 //
-// Generated with goagen v{{.ToolVersion}}, command line:
+// Generated with goagen {{.ToolVersion}}, command line:
 {{comment commandLine}}
 //
 // The content of this file is auto-generated, DO NOT MODIFY

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -23,18 +23,25 @@ type Generator struct {
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
 	var (
-		outDir, target string
-		notest         bool
+		outDir, target, ver string
+		notest              bool
 	)
 
 	set := flag.NewFlagSet("app", flag.PanicOnError)
 	set.String("design", "", "")
 	set.StringVar(&outDir, "out", "", "")
 	set.StringVar(&target, "pkg", "app", "")
+	set.StringVar(&ver, "version", "", "")
 	set.BoolVar(&notest, "notest", false, "")
 	set.Parse(os.Args[2:])
 	outDir = filepath.Join(outDir, target)
 
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+
+	// Now proceed
 	target = codegen.Goify(target, false)
 	g := &Generator{outDir: outDir, target: target, notest: notest}
 	codegen.Reserved[target] = true

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_app"
+	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -28,7 +29,7 @@ var _ = Describe("Generate", func() {
 		Ω(err).ShouldNot(HaveOccurred())
 		outDir, err = ioutil.TempDir(filepath.Join(workspace.Path, "src"), "")
 		Ω(err).ShouldNot(HaveOccurred())
-		os.Args = []string{"goagen", "app", "--out=" + outDir, "--design=foo"}
+		os.Args = []string{"goagen", "app", "--out=" + outDir, "--design=foo", "--version=" + version.String()}
 	})
 
 	JustBeforeEach(func() {
@@ -181,7 +182,7 @@ var _ = Describe("Generate", func() {
 
 		Context("", func() {
 			BeforeEach(func() {
-				runCodeTemplates(map[string]string{"outDir": outDir, "design": "foo", "tmpDir": filepath.Base(outDir)})
+				runCodeTemplates(map[string]string{"outDir": outDir, "design": "foo", "tmpDir": filepath.Base(outDir), "version": version.String()})
 			})
 
 			It("generates the corresponding code", func() {
@@ -205,7 +206,7 @@ var _ = Describe("Generate", func() {
 					TypeName: "Collection",
 				}
 				design.Design.Resources["Widget"].Actions["get"].Payload = payload
-				runCodeTemplates(map[string]string{"outDir": outDir, "design": "foo", "tmpDir": filepath.Base(outDir)})
+				runCodeTemplates(map[string]string{"outDir": outDir, "design": "foo", "tmpDir": filepath.Base(outDir), "version": version.String()})
 			})
 
 			It("generates the correct payload assignment code", func() {
@@ -228,7 +229,7 @@ var _ = Describe("Generate", func() {
 				}
 				design.Design.Resources["Widget"].Actions["get"].Payload = payload
 				design.Design.Resources["Widget"].Actions["get"].PayloadOptional = true
-				runCodeTemplates(map[string]string{"outDir": outDir, "design": "foo", "tmpDir": filepath.Base(outDir)})
+				runCodeTemplates(map[string]string{"outDir": outDir, "design": "foo", "tmpDir": filepath.Base(outDir), "version": version.String()})
 			})
 
 			It("generates the no payloads assignment code", func() {
@@ -246,10 +247,11 @@ var _ = Describe("Generate", func() {
 const contextsCodeTmpl = `//************************************************************************//
 // API "test api": Application Contexts
 //
-// Generated with goagen v0.0.1, command line:
+// Generated with goagen {{ .version }}, command line:
 // $ goagen app
 // --out=$(GOPATH){{sep}}src{{sep}}{{.tmpDir}}
 // --design={{.design}}
+// --version={{.version}}
 //
 // The content of this file is auto-generated, DO NOT MODIFY
 //************************************************************************//
@@ -294,10 +296,11 @@ func (ctx *GetWidgetContext) OK(r ID) error {
 const controllersCodeTmpl = `//************************************************************************//
 // API "test api": Application Controllers
 //
-// Generated with goagen v0.0.1, command line:
+// Generated with goagen {{ .version }}, command line:
 // $ goagen app
 // --out=$(GOPATH){{sep}}src{{sep}}{{.tmpDir}}
 // --design={{.design}}
+// --version={{.version}}
 //
 // The content of this file is auto-generated, DO NOT MODIFY
 //************************************************************************//
@@ -348,10 +351,11 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 const hrefsCodeTmpl = `//************************************************************************//
 // API "test api": Application Resource Href Factories
 //
-// Generated with goagen v0.0.1, command line:
+// Generated with goagen {{.version}}, command line:
 // $ goagen app
 // --out=$(GOPATH){{sep}}src{{sep}}{{.tmpDir}}
 // --design={{.design}}
+// --version={{.version}}
 //
 // The content of this file is auto-generated, DO NOT MODIFY
 //************************************************************************//
@@ -369,10 +373,11 @@ func WidgetHref(id interface{}) string {
 const mediaTypesCodeTmpl = `//************************************************************************//
 // API "test api": Application Media Types
 //
-// Generated with goagen v0.0.1, command line:
+// Generated with goagen {{ .version }}, command line:
 // $ goagen app
 // --out=$(GOPATH){{sep}}src{{sep}}{{.tmpDir}}
 // --design={{.design}}
+// --version={{.version}}
 //
 // The content of this file is auto-generated, DO NOT MODIFY
 //************************************************************************//

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_app"
+	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -24,7 +25,7 @@ var _ = Describe("Generate", func() {
 		outDir = filepath.Join(gopath, "src", testgenPackagePath)
 		err := os.MkdirAll(outDir, 0777)
 		Ω(err).ShouldNot(HaveOccurred())
-		os.Args = []string{"goagen", "app", "--out=" + outDir, "--design=foo"}
+		os.Args = []string{"goagen", "app", "--out=" + outDir, "--design=foo", "--version=" + version.String()}
 		design.GeneratedMediaTypes = make(design.MediaTypeRoot)
 	})
 
@@ -39,7 +40,7 @@ var _ = Describe("Generate", func() {
 
 	Context("with notest flag", func() {
 		BeforeEach(func() {
-			os.Args = []string{"goagen", "app", "--out=" + outDir, "--design=foo", "--notest"}
+			os.Args = []string{"goagen", "app", "--out=" + outDir, "--design=foo", "--notest", "--version=" + version.String()}
 		})
 
 		It("does not generate tests", func() {

--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_client"
+	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -26,7 +27,7 @@ var _ = Describe("Generate", func() {
 		outDir = filepath.Join(gopath, "src", testgenPackagePath)
 		err := os.MkdirAll(outDir, 0777)
 		Ω(err).ShouldNot(HaveOccurred())
-		os.Args = []string{"goagen", "client", "--out=" + outDir, "--design=foo"}
+		os.Args = []string{"goagen", "client", "--out=" + outDir, "--design=foo", "--version=" + version.String()}
 	})
 
 	JustBeforeEach(func() {

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -36,8 +36,8 @@ type Generator struct {
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
 	var (
-		outDir, target, toolDir, tool string
-		notool                        bool
+		outDir, target, toolDir, tool, ver string
+		notool                             bool
 	)
 	dtool := strings.Replace(strings.ToLower(design.Design.Name), " ", "-", -1) + "-cli"
 
@@ -47,9 +47,16 @@ func Generate() (files []string, err error) {
 	set.StringVar(&target, "pkg", "client", "")
 	set.StringVar(&toolDir, "tooldir", "tool", "")
 	set.StringVar(&tool, "tool", dtool, "")
+	set.StringVar(&ver, "version", "", "")
 	set.BoolVar(&notool, "notool", false, "")
 	set.Parse(os.Args[2:])
 
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+
+	// Now proceed
 	target = codegen.Goify(target, false)
 	g := &Generator{outDir: outDir, target: target, toolDirName: toolDir, tool: tool, notool: notool}
 	codegen.Reserved[target] = true

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_client"
+	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -25,7 +26,7 @@ var _ = Describe("Generate", func() {
 		outDir = filepath.Join(gopath, "src", testgenPackagePath)
 		err := os.MkdirAll(outDir, 0777)
 		Ω(err).ShouldNot(HaveOccurred())
-		os.Args = []string{"goagen", "client", "--out=" + outDir, "--design=foo"}
+		os.Args = []string{"goagen", "client", "--out=" + outDir, "--design=foo", "--version=" + version.String()}
 	})
 
 	JustBeforeEach(func() {

--- a/goagen/gen_js/generator.go
+++ b/goagen/gen_js/generator.go
@@ -29,7 +29,7 @@ type Generator struct {
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
 	var (
-		outDir       string
+		outDir, ver  string
 		timeout      time.Duration
 		scheme, host string
 		noexample    bool
@@ -41,9 +41,16 @@ func Generate() (files []string, err error) {
 	set.DurationVar(&timeout, "timeout", time.Duration(20)*time.Second, "")
 	set.StringVar(&scheme, "scheme", "", "")
 	set.StringVar(&host, "host", "", "")
+	set.StringVar(&ver, "version", "", "")
 	set.BoolVar(&noexample, "noexample", false, "")
 	set.Parse(os.Args[2:])
 
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+
+	// Now proceed
 	g := &Generator{outDir: outDir, timeout: timeout, scheme: scheme, host: host, noexample: noexample}
 
 	return g.Generate(design.Design)

--- a/goagen/gen_js/generator_test.go
+++ b/goagen/gen_js/generator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/gen_js"
+	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -24,7 +25,7 @@ var _ = Describe("Generate", func() {
 		outDir = filepath.Join(gopath, "src", testgenPackagePath)
 		err := os.MkdirAll(outDir, 0777)
 		Ω(err).ShouldNot(HaveOccurred())
-		os.Args = []string{"goagen", "js", "--out=" + outDir, "--design=foo", "--host=baz"}
+		os.Args = []string{"goagen", "js", "--out=" + outDir, "--design=foo", "--host=baz", "--version=" + version.String()}
 	})
 
 	JustBeforeEach(func() {

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -25,17 +25,24 @@ type Generator struct {
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
 	var (
-		outDir, target string
-		force          bool
+		outDir, target, ver string
+		force               bool
 	)
 
 	set := flag.NewFlagSet("main", flag.PanicOnError)
 	set.StringVar(&outDir, "out", "", "")
 	set.String("design", "", "")
 	set.StringVar(&target, "pkg", "app", "")
+	set.StringVar(&ver, "version", "", "")
 	set.BoolVar(&force, "force", false, "")
 	set.Parse(os.Args[2:])
 
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+
+	// Now proceed
 	target = codegen.Goify(target, false)
 	g := &Generator{outDir: outDir, target: target, force: force}
 	codegen.Reserved[target] = true

--- a/goagen/gen_main/generator_test.go
+++ b/goagen/gen_main/generator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/gen_main"
+	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -25,7 +26,7 @@ var _ = Describe("Generate", func() {
 		outDir = filepath.Join(gopath, "src", testgenPackagePath)
 		err := os.MkdirAll(outDir, 0777)
 		Ω(err).ShouldNot(HaveOccurred())
-		os.Args = []string{"goagen", "main", "--out=" + outDir, "--design=foo"}
+		os.Args = []string{"goagen", "main", "--out=" + outDir, "--design=foo", "--version=" + version.String()}
 	})
 
 	JustBeforeEach(func() {

--- a/goagen/gen_schema/generator.go
+++ b/goagen/gen_schema/generator.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/utils"
 )
 
@@ -18,12 +19,19 @@ type Generator struct {
 
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
-	var outDir string
+	var outDir, ver string
 	set := flag.NewFlagSet("app", flag.PanicOnError)
 	set.StringVar(&outDir, "out", "", "")
+	set.StringVar(&ver, "version", "", "")
 	set.String("design", "", "")
 	set.Parse(os.Args[2:])
 
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+
+	// Now proceed
 	g := &Generator{outDir: outDir}
 
 	return g.Generate(design.Design)

--- a/goagen/gen_schema/generator_test.go
+++ b/goagen/gen_schema/generator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_schema"
+	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -26,7 +27,7 @@ var _ = Describe("Generate", func() {
 		Ω(err).ShouldNot(HaveOccurred())
 		testPkg, err = workspace.NewPackage("schematest")
 		Ω(err).ShouldNot(HaveOccurred())
-		os.Args = []string{"goagen", "schema", "--out=" + testPkg.Abs(), "--design=foo"}
+		os.Args = []string{"goagen", "schema", "--out=" + testPkg.Abs(), "--design=foo", "--version=" + version.String()}
 	})
 
 	JustBeforeEach(func() {

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/utils"
 )
 
@@ -21,12 +22,19 @@ type Generator struct {
 
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
-	var outDir string
+	var outDir, ver string
 	set := flag.NewFlagSet("swagger", flag.PanicOnError)
 	set.StringVar(&outDir, "out", "", "")
+	set.StringVar(&ver, "version", "", "")
 	set.String("design", "", "")
 	set.Parse(os.Args[2:])
 
+	// First check compatibility
+	if err := codegen.CheckVersion(ver); err != nil {
+		return nil, err
+	}
+
+	// Now proceed
 	g := &Generator{outDir: outDir}
 
 	return g.Generate(design.Design)

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/meta"
 	"github.com/goadesign/goa/goagen/utils"
+	"github.com/goadesign/goa/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -51,6 +52,16 @@ package and tool and the Swagger specification for the API.
 	rootCmd.PersistentFlags().StringVarP(&cwd, "out", "o", cwd, "output directory")
 	rootCmd.PersistentFlags().StringVarP(&designPkg, "design", "d", "", "design package import path")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug mode, does not cleanup temporary files.")
+
+	// versionCmd implements the "version" command
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of goagen",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("goagen " + version.String() + "\nThe goa generation tool.")
+		},
+	}
+	rootCmd.AddCommand(versionCmd)
 
 	// appCmd implements the "app" command.
 	var (

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -12,6 +12,7 @@ import (
 	"text/template"
 
 	"github.com/goadesign/goa/goagen/codegen"
+	"github.com/goadesign/goa/version"
 )
 
 // Generator generates the code of, compiles and runs generators.
@@ -178,6 +179,7 @@ func (m *Generator) spawn(genbin string) ([]string, error) {
 		i++
 	}
 	sort.Strings(args)
+	args = append(args, "--version="+version.String())
 	cmd := exec.Command(genbin, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,48 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	// Major version number
+	Major = 0
+	// Minor version number
+	Minor = 2
+)
+
+var (
+	// Build number
+	Build string
+)
+
+func init() {
+	if Build == "" { // Not set by link flags
+		Build = "dev"
+	}
+}
+
+// String returns the complete version number.
+func String() string {
+	return "v" + strconv.Itoa(Major) + "." + strconv.Itoa(Minor) + "." + Build
+}
+
+// Compatible returns true if Major matches the major version of the given version string.
+// It returns an error if the given string is not a valid version string.
+func Compatible(v string) (bool, error) {
+	if len(v) < 5 {
+		return false, fmt.Errorf("invalid version string format %#v", v)
+	}
+	v = v[1:]
+	elems := strings.Split(v, ".")
+	if len(elems) != 3 {
+		return false, fmt.Errorf("version not of the form Major.Minor.Build %#v", v)
+	}
+	mj, err := strconv.Atoi(elems[0])
+	if err != nil {
+		return false, fmt.Errorf("invalid major version number %#v, must be number", elems[0])
+	}
+	return mj == Major, nil
+}

--- a/version/version_suite_test.go
+++ b/version/version_suite_test.go
@@ -1,0 +1,13 @@
+package version_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,87 @@
+package version_test
+
+import (
+	"strconv"
+
+	"github.com/goadesign/goa/version"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("version", func() {
+	var ver string
+	var build, oldBuild string
+
+	BeforeEach(func() {
+		build = ""
+	})
+
+	JustBeforeEach(func() {
+		oldBuild = version.Build
+		if build != "" {
+			version.Build = build
+		}
+		ver = version.String()
+		version.Build = oldBuild
+	})
+
+	Context("with the default build number", func() {
+		It("should be properly formatted", func() {
+			Ω(ver).Should(HavePrefix("v"))
+		})
+
+		It("returns the default version", func() {
+			Ω(ver).Should(HaveSuffix(".dev"))
+		})
+	})
+
+	Context("with an overridden build number", func() {
+		BeforeEach(func() {
+			build = "custom"
+		})
+		It("returns the overridden version", func() {
+			Ω(ver).Should(HaveSuffix("." + build))
+		})
+	})
+
+	Context("checking compatibility", func() {
+		var otherVersion string
+		var compatible bool
+		var compErr error
+
+		JustBeforeEach(func() {
+			compatible, compErr = version.Compatible(otherVersion)
+		})
+
+		Context("with a version with identical major", func() {
+			BeforeEach(func() {
+				otherVersion = "v" + strconv.Itoa(version.Major) + ".12.13"
+			})
+			It("returns true", func() {
+				Ω(compErr).ShouldNot(HaveOccurred())
+				Ω(compatible).Should(BeTrue())
+			})
+		})
+
+		Context("with a version with different major", func() {
+			BeforeEach(func() {
+				otherVersion = "v99999121299999.1.0"
+			})
+			It("returns false", func() {
+				Ω(compErr).ShouldNot(HaveOccurred())
+				Ω(compatible).Should(BeFalse())
+			})
+		})
+
+		Context("with a non version string", func() {
+			BeforeEach(func() {
+				otherVersion = "v99999121299999.2"
+			})
+			It("returns an error", func() {
+				Ω(compErr).Should(HaveOccurred())
+				Ω(compatible).Should(BeFalse())
+			})
+		})
+	})
+
+})


### PR DESCRIPTION
Generators now check whether the version of goa used to compile the
final code generation tool is compatible with the version used to
compile goagen itself.