### PR TITLE
Introduce Doer interface

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -16,10 +16,15 @@ import (
 )
 
 type (
+	// Doer defines the Do method of the http client.
+	Doer interface {
+		Do(*http.Request) (*http.Response, error)
+	}
+
 	// Client is the common client data structure for all goa service clients.
 	Client struct {
-		// Client is the underlying http client.
-		*http.Client
+		// Doer is the underlying http client.
+		Doer
 		// Scheme overrides the default action scheme.
 		Scheme string
 		// Host is the service hostname.
@@ -33,11 +38,11 @@ type (
 
 // New creates a new API client that wraps c.
 // If c is nil the returned client wraps the default http client.
-func New(c *http.Client) *Client {
+func New(c Doer) *Client {
 	if c == nil {
 		c = http.DefaultClient
 	}
-	return &Client{Client: c}
+	return &Client{Doer: c}
 }
 
 // Do wraps the underlying http client Do method and adds logging.
@@ -52,7 +57,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, err
 	if c.Dump {
 		c.dumpRequest(ctx, req)
 	}
-	resp, err := c.Client.Do(req)
+	resp, err := c.Doer.Do(req)
 	if err != nil {
 		goa.LogError(ctx, "failed", "err", err)
 		return nil, err

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -356,12 +356,13 @@ func main() {
 	}
 
 	// Create client struct
-	c := {{ .Package }}.New(newHTTPClient())
+	httpClient := newHTTPClient()
+	c := {{ .Package }}.New(httpClient)
 
 	// Register global flags
 	app.PersistentFlags().StringVarP(&c.Scheme, "scheme", "s", "", "Set the requests scheme")
 	app.PersistentFlags().StringVarP(&c.Host, "host", "H", "{{ .API.Host }}", "API hostname")
-	app.PersistentFlags().DurationVarP(&c.Timeout, "timeout", "t", time.Duration(20) * time.Second, "Set the request timeout")
+	app.PersistentFlags().DurationVarP(&httpClient.Timeout, "timeout", "t", time.Duration(20) * time.Second, "Set the request timeout")
 	app.PersistentFlags().BoolVar(&c.Dump, "dump", false, "Dump HTTP request and response.")
 
 {{ if .HasSigners }}	// Register signer flags

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -947,7 +947,7 @@ type Client struct {
 }
 
 // New instantiates the client.
-func New(c *http.Client) *Client {
+func New(c goaclient.Doer) *Client {
 	client := &Client{
 		Client: goaclient.New(c),
 		Encoder: goa.NewHTTPEncoder(),


### PR DESCRIPTION
Use an interface instead of the http package `Client` struct so that
it's easier to mock and override the client `Do` method.