### PR TITLE
Move service to response data in context.

### DIFF
--- a/context.go
+++ b/context.go
@@ -36,6 +36,8 @@ type (
 	ResponseData struct {
 		http.ResponseWriter
 
+		// The service used to encode the response.
+		Service *Service
 		// ErrorCode is the code of the error returned by the action if any.
 		ErrorCode string
 		// Status is the response HTTP status code.

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -268,16 +268,17 @@ type GetWidgetContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
-	ID      string
+	ID string
 }
 
 // NewGetWidgetContext parses the incoming request URL and body, performs validations and creates the
 // context used by the Widget controller get action.
 func NewGetWidgetContext(ctx context.Context, service *goa.Service) (*GetWidgetContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := GetWidgetContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := GetWidgetContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramID := req.Params["id"]
 	if len(paramID) > 0 {
 		rawID := paramID[0]
@@ -289,7 +290,7 @@ func NewGetWidgetContext(ctx context.Context, service *goa.Service) (*GetWidgetC
 // OK sends a HTTP response with status code 200.
 func (ctx *GetWidgetContext) OK(r ID) error {
 	ctx.ResponseData.Header().Set("Content-Type", "vnd.rightscale.codegen.test.widgets")
-	return ctx.Service.Send(ctx.Context, 200, r)
+	return ctx.ResponseData.Service.Send(ctx.Context, 200, r)
 }
 `
 

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -390,7 +390,6 @@ type {{ .Name }} struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 {{ if .Params }}{{ range $name, $att := .Params.Type.ToObject }}{{/*
 */}}	{{ goify $name true }} {{ if and $att.Type.IsPrimitive ($.Params.IsPrimitivePointer $name) }}*{{ end }}{{ gotyperef .Type nil 0 false }}
 {{ end }}{{ end }}{{ if .Payload }}	Payload {{ gotyperef .Payload nil 0 false }}
@@ -479,8 +478,10 @@ type {{ .Name }} struct {
 // context used by the {{ .ResourceName }} controller {{ .ActionName }} action.
 func New{{ .Name }}(ctx context.Context, service *goa.Service) (*{{ .Name }}, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := {{ .Name }}{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := {{ .Name }}{Context: ctx, ResponseData: resp, RequestData: req}
 {{ if .Headers }}{{ $headers := .Headers }}{{ range $name, $att := $headers.Type.ToObject }}	raw{{ goify $name true }} := req.Header.Get("{{ $name }}")
 {{ if $headers.IsRequired $name }}	if raw{{ goify $name true }} == "" {
 		err = goa.MergeErrors(err, goa.MissingHeaderError("{{ $name }}"))
@@ -516,7 +517,7 @@ func New{{ .Name }}(ctx context.Context, service *goa.Service) (*{{ .Name }}, er
 // {{ respName $resp $name }} sends a HTTP response with status code {{ $resp.Status }}.
 func (ctx *{{ $ctx.Name }}) {{ respName $resp $name }}(r {{ gotyperef $projected $projected.AllRequired 0 false }}) error {
 	ctx.ResponseData.Header().Set("Content-Type", "{{ $ct }}")
-	return ctx.Service.Send(ctx.Context, {{ $resp.Status }}, r)
+	return ctx.ResponseData.Service.Send(ctx.Context, {{ $resp.Status }}, r)
 }
 {{ end }}{{ end }}
 `
@@ -526,7 +527,7 @@ func (ctx *{{ $ctx.Name }}) {{ respName $resp $name }}(r {{ gotyperef $projected
 	ctxTRespT = `// {{ goify .Response.Name true }} sends a HTTP response with status code {{ .Response.Status }}.
 func (ctx *{{ .Context.Name }}) {{ goify .Response.Name true }}(r {{ gotyperef .Type nil 0 false }}) error {
 	ctx.ResponseData.Header().Set("Content-Type", "{{ .ContentType }}")
-	return ctx.Service.Send(ctx.Context, {{ .Response.Status }}, r)
+	return ctx.ResponseData.Service.Send(ctx.Context, {{ .Response.Status }}, r)
 }
 `
 

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -758,15 +758,16 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 }
 `
 
 	emptyContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	return &rctx, err
 }
 `
@@ -776,7 +777,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Param *int
 }
 `
@@ -784,8 +784,10 @@ type ListBottleContext struct {
 	intContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
 		rawParam := paramParam[0]
@@ -806,7 +808,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Param *string
 }
 `
@@ -814,8 +815,10 @@ type ListBottleContext struct {
 	strContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
 		rawParam := paramParam[0]
@@ -830,7 +833,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Param *float64
 }
 `
@@ -838,8 +840,10 @@ type ListBottleContext struct {
 	numContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
 		rawParam := paramParam[0]
@@ -858,7 +862,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Param *bool
 }
 `
@@ -866,8 +869,10 @@ type ListBottleContext struct {
 	boolContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
 		rawParam := paramParam[0]
@@ -887,7 +892,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Param []string
 }
 `
@@ -895,8 +899,10 @@ type ListBottleContext struct {
 	arrayContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
 		var params []string
@@ -915,7 +921,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Param []int
 }
 `
@@ -923,8 +928,10 @@ type ListBottleContext struct {
 	intArrayContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
 		var params []int
@@ -951,7 +958,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Int *int
 }
 `
@@ -959,8 +965,10 @@ type ListBottleContext struct {
 	resContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramInt := req.Params["int"]
 	if len(paramInt) > 0 {
 		rawInt := paramInt[0]
@@ -981,7 +989,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Int int
 }
 `
@@ -989,8 +996,10 @@ type ListBottleContext struct {
 	requiredContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramInt := req.Params["int"]
 	if len(paramInt) == 0 {
 		err = goa.MergeErrors(err, goa.MissingParamError("int"))
@@ -1011,7 +1020,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Payload ListBottlePayload
 }
 `
@@ -1019,8 +1027,10 @@ type ListBottleContext struct {
 	payloadContextFactory = `
 func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
 	var err error
+	resp := goa.ContextResponse(ctx)
+	resp.Service = service
 	req := goa.ContextRequest(ctx)
-	rctx := ListBottleContext{Context: ctx, ResponseData: goa.ContextResponse(ctx), RequestData: req, Service: service}
+	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	return &rctx, err
 }
 `
@@ -1029,7 +1039,6 @@ type ListBottleContext struct {
 	context.Context
 	*goa.ResponseData
 	*goa.RequestData
-	Service *goa.Service
 	Payload *ListBottlePayload
 }
 `


### PR DESCRIPTION
Since it should only be used to access encoders.