### PR TITLE
Fix return type in app tests

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -156,7 +156,9 @@ func (g *Generator) createTestMethod(resource *design.ResourceDefinition, action
 
 		returnType := ObjectType{}
 		returnType.Type = tmp
-		returnType.Pointer = "*"
+		if p.IsObject() {
+			returnType.Pointer = "*"
+		}
 		returnType.Validatable = validate != ""
 
 		method.ReturnType = &returnType


### PR DESCRIPTION
Test methods created by `goagen` return the result as pointer, but they should use pointer and non-pointer properly.

