### PR TITLE
Fix a bug of #570

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -128,7 +128,7 @@ func (g *Generator) createTestMethod(resource *design.ResourceDefinition, action
 	mediaType *design.MediaTypeDefinition, view *design.ViewDefinition) *TestMethod {
 
 	var (
-		actionName, ctrlName                         string
+		actionName, ctrlName, varName                string
 		routeQualifier, viewQualifier, respQualifier string
 		comment                                      string
 		returnType                                   *ObjectType
@@ -138,6 +138,7 @@ func (g *Generator) createTestMethod(resource *design.ResourceDefinition, action
 
 	actionName = codegen.Goify(action.Name, true)
 	ctrlName = codegen.Goify(resource.Name, true)
+	varName = codegen.Goify(action.Name, false)
 	routeQualifier = suffixRoute(action.Routes, routeIndex)
 	if view != nil && view.Name != "default" {
 		viewQualifier = codegen.Goify(view.Name, true)
@@ -208,7 +209,7 @@ func (g *Generator) createTestMethod(resource *design.ResourceDefinition, action
 		Payload:        payload,
 		ReturnType:     returnType,
 		ControllerName: fmt.Sprintf("%s.%sController", g.target, ctrlName),
-		ContextVarName: fmt.Sprintf("%sCtx", action.Name),
+		ContextVarName: fmt.Sprintf("%sCtx", varName),
 		ContextType:    fmt.Sprintf("%s.New%s%sContext", g.target, actionName, ctrlName),
 		RouteVerb:      route.Verb,
 		Status:         response.Status,


### PR DESCRIPTION
Probably it is a typo.

before #570 

```
	method := TestMethod{}
//snip...
	method.ActionName = codegen.Goify(action.Name, true) // ← << true >>
//snip...
	method.ContextVarName = fmt.Sprintf("%sCtx", codegen.Goify(action.Name, false)) // ← << false >>
```

#570 
 
```
	actionName = codegen.Goify(action.Name, true) //← << true >>

//snip...

	return &TestMethod{
		Name:           fmt.Sprintf("%s%s%s%s%s", actionName, ctrlName, respQualifier, routeQualifier, viewQualifier),
		ActionName:     actionName, // ← << true >>
		ResourceName:   ctrlName,
		Comment:        fmt.Sprintf("%s %s", actionName, comment),
		Params:         params,
		Payload:        payload,
		ReturnType:     returnType,
		ControllerName: fmt.Sprintf("%s.%sController", g.target, ctrlName),
		ContextVarName: fmt.Sprintf("%sCtx", action.Name), // ← << ??? >>
		ContextType:    fmt.Sprintf("%s.New%s%sContext", g.target, actionName, ctrlName),
		RouteVerb:      route.Verb,
		Status:         response.Status,
		FullPath:       goPathFormat(route.FullPath()),
	}

```