### PR TITLE
Make it possible to set service used by test helpers

### DIFF
--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -137,12 +137,10 @@ var _ = Describe("Generate", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring("ShowFooOK("))
-			Ω(content).Should(ContainSubstring("ShowFooOKWithContext("))
 			// Multiple Routes
 			Ω(content).Should(ContainSubstring("ShowFooOK1("))
-			Ω(content).Should(ContainSubstring("ShowFooOK1WithContext("))
 			// Get returns an error media type
-			Ω(content).Should(ContainSubstring("GetFooOK(t *testing.T, ctrl app.FooController, payload app.CustomName) (http.ResponseWriter, *goa.Error)"))
+			Ω(content).Should(ContainSubstring("GetFooOK(t *testing.T, ctx context.Context, service *goa.Service, ctrl app.FooController, payload app.CustomName) (http.ResponseWriter, *goa.Error)"))
 		})
 
 		It("generates the route path parameters", func() {


### PR DESCRIPTION
This change makes it possible to set the service used by the test helpers to run the action.
Also it removes the `WithContext` variations to instead only have one helper generated by response that always accepts a context.
The helper takes care of initializing the context if a nil value is given.
It also initialized the service to a default test service if it is nil.