### PR TITLE
Improve overall Swagger support

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1569,6 +1569,11 @@ func (f *FileServerDefinition) Finalize() {
 	}
 }
 
+// IsDir returns true if the file server serves a directory, false otherwise.
+func (f *FileServerDefinition) IsDir() bool {
+	return WildcardRegex.MatchString(f.RequestPath)
+}
+
 // ByFilePath makes FileServerDefinition sortable for code generators.
 type ByFilePath []*FileServerDefinition
 

--- a/design/validation.go
+++ b/design/validation.go
@@ -366,6 +366,15 @@ func (f *FileServerDefinition) Validate() *dslengine.ValidationErrors {
 	if f.Parent == nil {
 		verr.Add(f, "missing parent resource")
 	}
+	matches := WildcardRegex.FindAllString(f.RequestPath, -1)
+	if len(matches) == 1 {
+		if !strings.HasSuffix(f.RequestPath, matches[0]) {
+			verr.Add(f, "invalid request path %s, must end with a wildcard starting with *", f.RequestPath)
+		}
+	}
+	if len(matches) > 2 {
+		verr.Add(f, "invalid request path, may only contain one wildcard")
+	}
 
 	return verr.AsError()
 }

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -640,7 +640,7 @@ func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Co
 {{ end }}{{ range .Routes }}	service.Mux.Handle("{{ .Verb }}", {{ printf "%q" .FullPath }}, ctrl.MuxHandler({{ printf "%q" $action.Name }}, h, {{ if $action.Payload }}{{ $action.Unmarshal }}{{ else }}nil{{ end }}))
 	service.LogInfo("mount", "ctrl", {{ printf "%q" $res }}, "action", {{ printf "%q" $action.Name }}, "route", {{ printf "%q" (printf "%s %s" .Verb .FullPath) }}{{ with $action.Security }}, "security", {{ printf "%q" .Scheme.SchemeName }}{{ end }})
 {{ end }}{{ end }}{{ range .FileServers }}
-	h = ctrl.FileHandler("{{ .RequestPath }}", "{{ .FilePath }}")
+	h = ctrl.FileHandler({{ printf "%q" .RequestPath }}, {{ printf "%q" .FilePath }})
 {{ if $.Origins }}	h = handle{{ $res }}Origin(h)
 {{ end }}{{ if .Security }}	h = handleSecurity({{ printf "%q" .Security.Scheme.SchemeName }}, h{{ range .Security.Scopes }}, {{ printf "%q" . }}{{ end }})
 {{ end }}	service.Mux.Handle("GET", "{{ .RequestPath }}", ctrl.MuxHandler("serve", h, nil))

--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -735,6 +735,10 @@ func buildPathFromDefinition(s *Swagger, api *design.APIDefinition, route *desig
 	action := route.Parent
 
 	tagNames := tagNamesFromDefinitions(action.Parent.Metadata, action.Metadata)
+	if len(tagNames) == 0 {
+		// By default tag with resource name
+		tagNames = []string{route.Parent.Parent.Name}
+	}
 	params, err := paramsFromDefinition(action.AllParams(), route.FullPath())
 	if err != nil {
 		return err
@@ -783,7 +787,7 @@ func buildPathFromDefinition(s *Swagger, api *design.APIDefinition, route *desig
 	operation := &Operation{
 		Tags:         tagNames,
 		Description:  action.Description,
-		Summary:      summaryFromDefinition(action.Name, action.Metadata),
+		Summary:      summaryFromDefinition(action.Name+" "+action.Parent.Name, action.Metadata),
 		ExternalDocs: docsFromDefinition(action.Docs),
 		OperationID:  operationID,
 		Parameters:   params,

--- a/service.go
+++ b/service.go
@@ -304,8 +304,11 @@ func (ctrl *Controller) MuxHandler(name string, hdlr Handler, unm Unmarshaler) M
 // "/assets/x/y/z".
 func (ctrl *Controller) FileHandler(path, filename string) Handler {
 	var wc string
-	if idx := strings.Index(path, "*"); idx > -1 && idx < len(path)-1 {
-		wc = path[idx+1:]
+	if idx := strings.LastIndex(path, "/*"); idx > -1 && idx < len(path)-1 {
+		wc = path[idx+2:]
+		if strings.Contains(wc, "/") {
+			wc = ""
+		}
 	}
 	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 		fname := filename


### PR DESCRIPTION
This PR makes a couple of changes to improve the overall support of Swagger:

1. It fixes an issue where file servers serving a directory do not
   serve the file `index.html` for requests with a path that matches the
   top level directory path. So for example a file server serving the
   content of the directory `public` on `/swagger/*file` will now serve
   `public/index.html` for requests to `/swagger/`.

2. Swagger paths are now tagged with the action resource name by default.
   This can be overridden using the Metadata `swagger:tag:xxx`.

3. The paths summary are now built by concatenating the action and
   resource names with a space in between. This can be overridden using
   the metadata `swagger:summary:xxx`.