### PR TITLE
Keep file extension when generating "Download" client method.

### DIFF
--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -150,10 +150,11 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 			hasDownloads = true
 		}
 		return res.IterateActions(func(action *design.ActionDefinition) error {
-			if as, ok := actions[action.Name]; ok {
-				actions[action.Name] = append(as, action)
+			name := codegen.Goify(action.Name, false)
+			if as, ok := actions[name]; ok {
+				actions[name] = append(as, action)
 			} else {
-				actions[action.Name] = []*design.ActionDefinition{action}
+				actions[name] = []*design.ActionDefinition{action}
 			}
 			return nil
 		})

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -575,7 +575,9 @@ func (g *Generator) fileServerMethod(fs *design.FileServerDefinition) string {
 
 	if len(wcs) == 0 {
 		suffix = path.Base(fs.RequestPath)
-		suffix = strings.TrimSuffix(suffix, filepath.Ext(suffix))
+		ext := filepath.Ext(suffix)
+		suffix = strings.TrimSuffix(suffix, ext)
+		suffix += codegen.Goify(ext, true)
 	} else {
 		if len(reqElems) == 1 {
 			suffix = filepath.Base(fs.RequestPath)

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Generate", func() {
 				Ω(files).Should(HaveLen(8))
 				content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 				Ω(err).ShouldNot(HaveOccurred())
-				Ω(content).Should(ContainSubstring("func (c *Client) DownloadSwagger("))
+				Ω(content).Should(ContainSubstring("func (c *Client) DownloadSwaggerJSON("))
 			})
 
 		})


### PR DESCRIPTION
So that there is no clashes between names of commands.