### PR TITLE
Change test filenames to add `_testing` suffix.

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -78,7 +78,7 @@ func (g *Generator) generateResourceTest(api *design.APIDefinition) error {
 	}
 
 	return api.IterateResources(func(res *design.ResourceDefinition) error {
-		filename := filepath.Join(outDir, codegen.SnakeCase(res.Name)+".go")
+		filename := filepath.Join(outDir, codegen.SnakeCase(res.Name)+"_testing.go")
 		file, err := codegen.SourceFileFor(filename)
 		if err != nil {
 			return err

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Generate", func() {
 		It("generates the ActionRouteResponse test methods ", func() {
 			Ω(genErr).Should(BeNil())
 			Ω(files).Should(HaveLen(8))
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo.go"))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring("ShowFooOK("))
@@ -144,7 +144,7 @@ var _ = Describe("Generate", func() {
 		})
 
 		It("generates the route path parameters", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo.go"))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring(`["param"] = []string{`))
@@ -153,21 +153,21 @@ var _ = Describe("Generate", func() {
 		})
 
 		It("generates calls to new Context ", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo.go"))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring("app.NewShowFooContext("))
 		})
 
 		It("generates calls controller action method", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo.go"))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring("ctrl.Show("))
 		})
 
 		It("generates non pointer references to primitive/array/hash payloads", func() {
-			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo.go"))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "app", "test", "foo_testing.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 
 			Ω(content).Should(ContainSubstring(", payload app.CustomName)"))


### PR DESCRIPTION
This helps with looking up the file where an error happened since
`go test` only prints the file name and not the path thereby confusing
tools like vim-go when the file name matches the controller file name.