### PR TITLE
Add imports in app tests

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -77,6 +77,7 @@ func (g *Generator) generateResourceTest(api *design.APIDefinition) error {
 		codegen.SimpleImport("strconv"),
 		codegen.SimpleImport("strings"),
 		codegen.SimpleImport("testing"),
+		codegen.SimpleImport("time"),
 		codegen.SimpleImport(appPkg),
 		codegen.SimpleImport("github.com/goadesign/goa"),
 		codegen.SimpleImport("github.com/goadesign/goa/goatest"),


### PR DESCRIPTION
`goagen` writes some fixed packages as import paths in app tests.
It should also include packages for types that used in `Params` and `QueryParams`.