### PR TITLE
Properly handle cycles in media type definitions

### DIFF
--- a/design/apidsl/media_type.go
+++ b/design/apidsl/media_type.go
@@ -111,7 +111,6 @@ func MediaType(identifier string, apidsl func()) *design.MediaTypeDefinition {
 	mt := design.NewMediaTypeDefinition(typeName, identifier, apidsl)
 	design.Design.MediaTypes[canonicalID] = mt
 	return mt
-
 }
 
 // Media sets a response media type by name or by reference using a value returned by MediaType:

--- a/design/security_test.go
+++ b/design/security_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	. "github.com/goadesign/goa/design"
-	. "github.com/goadesign/goa/design/apidsl"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
When an attribute uses a collection on the media type itself such as:

```go
MediaType("application/vnd.menu+json", func() {
	Attributes(func() {
		Attribute("child", CollectionOf("application/vnd.menu"))
	})
	// ...
```