### PR TITLE
Create empty array when query string is empty.

### DIFF
--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -495,10 +495,12 @@ func New{{ .Name }}(ctx context.Context, service *goa.Service) (*{{ .Name }}, er
 		err = goa.MergeErrors(err, goa.MissingParamError("{{ $name }}"))
 	} else {
 {{ else }}	if len(param{{ goify $name true }}) > 0 {
-{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}		var params {{ gotypedef $att 2 true false }}
-		for _, raw{{ goify $name true}} := range param{{ goify $name true}} {
-{{ template "Coerce" (newCoerceData $name $att ($.Params.IsPrimitivePointer $name) "params" 3) }}{{/*
-*/}}			{{ printf "rctx.%s" (goify $name true) }} = append({{ printf "rctx.%s" (goify $name true) }}, params...)
+{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}		if len(param{{ goify $name true }}) > 1 || len(param{{ goify $name true }}[0]) > 0 {
+			var params {{ gotypedef $att 2 true false }}
+			for _, raw{{ goify $name true}} := range param{{ goify $name true}} {
+{{ template "Coerce" (newCoerceData $name $att ($.Params.IsPrimitivePointer $name) "params" 4) }}{{/*
+*/}}				{{ printf "rctx.%s" (goify $name true) }} = append({{ printf "rctx.%s" (goify $name true) }}, params...)
+			}
 		}
 {{ else }}		raw{{ goify $name true}} := param{{ goify $name true}}[0]
 {{ template "Coerce" (newCoerceData $name $att ($.Params.IsPrimitivePointer $name) (printf "rctx.%s" (goify $name true)) 2) }}{{ end }}{{/*

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -905,11 +905,13 @@ func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottl
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
-		var params []string
-		for _, rawParam := range paramParam {
-			elemsParam := strings.Split(rawParam, ",")
-			params = elemsParam
-			rctx.Param = append(rctx.Param, params...)
+		if len(paramParam) > 1 || len(paramParam[0]) > 0 {
+			var params []string
+			for _, rawParam := range paramParam {
+				elemsParam := strings.Split(rawParam, ",")
+				params = elemsParam
+				rctx.Param = append(rctx.Param, params...)
+			}
 		}
 	}
 	return &rctx, err
@@ -934,19 +936,21 @@ func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottl
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
-		var params []int
-		for _, rawParam := range paramParam {
-			elemsParam := strings.Split(rawParam, ",")
-			elemsParam2 := make([]int, len(elemsParam))
-			for i, rawElem := range elemsParam {
-				if elem, err2 := strconv.Atoi(rawElem); err2 == nil {
-					elemsParam2[i] = elem
-				} else {
-					err = goa.MergeErrors(err, goa.InvalidParamTypeError("elem", rawElem, "integer"))
+		if len(paramParam) > 1 || len(paramParam[0]) > 0 {
+			var params []int
+			for _, rawParam := range paramParam {
+				elemsParam := strings.Split(rawParam, ",")
+				elemsParam2 := make([]int, len(elemsParam))
+				for i, rawElem := range elemsParam {
+					if elem, err2 := strconv.Atoi(rawElem); err2 == nil {
+						elemsParam2[i] = elem
+					} else {
+						err = goa.MergeErrors(err, goa.InvalidParamTypeError("elem", rawElem, "integer"))
+					}
 				}
+				params = elemsParam2
+				rctx.Param = append(rctx.Param, params...)
 			}
-			params = elemsParam2
-			rctx.Param = append(rctx.Param, params...)
 		}
 	}
 	return &rctx, err


### PR DESCRIPTION
Instead of array with a single empty string item.
The flip side is that it's not possible to encode an array with a single empty string,
but that seems better than not being able to encode an empty array.