### PR TITLE
request_id_length_limit

### DIFF
--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -13,8 +13,13 @@ import (
 	"golang.org/x/net/context"
 )
 
-// RequestIDHeader is the name of the header used to transmit the request ID.
-const RequestIDHeader = "X-Request-Id"
+const (
+	// RequestIDHeader is the name of the header used to transmit the request ID.
+	RequestIDHeader = "X-Request-Id"
+
+	// DefaultRequestIDLengthLimit is the default maximum length for header value.
+	DefaultRequestIDLengthLimit = 128
+)
 
 // Counter used to create new request ids.
 var reqID int64
@@ -38,11 +43,20 @@ func init() {
 // RequestIDWithHeader behaves like the middleware RequestID, but it takes the request id header
 // as the (first) argument.
 func RequestIDWithHeader(requestIDHeader string) goa.Middleware {
+	return RequestIDWithHeaderAndLengthLimit(requestIDHeader, DefaultRequestIDLengthLimit)
+}
+
+// RequestIDWithHeaderAndLengthLimit behaves like the middleware RequestID, but it takes the
+// request id header as the (first) argument and a length limit for truncation of the request
+// header value if it exceeds a reasonable length. The limit can be negative for unlimited.
+func RequestIDWithHeaderAndLengthLimit(requestIDHeader string, lengthLimit int) goa.Middleware {
 	return func(h goa.Handler) goa.Handler {
 		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 			id := req.Header.Get(requestIDHeader)
 			if id == "" {
 				id = fmt.Sprintf("%s-%d", reqPrefix, atomic.AddInt64(&reqID, 1))
+			} else if lengthLimit >= 0 && len(id) > lengthLimit {
+				id = id[:lengthLimit]
 			}
 			ctx = context.WithValue(ctx, reqIDKey, id)
 

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -17,7 +17,7 @@ const (
 	// RequestIDHeader is the name of the header used to transmit the request ID.
 	RequestIDHeader = "X-Request-Id"
 
-	// DefaultRequestIDLengthLimit is the default maximum length for header value.
+	// DefaultRequestIDLengthLimit is the default maximum length for the request ID header value.
 	DefaultRequestIDLengthLimit = 128
 )
 

--- a/middleware/request_id_test.go
+++ b/middleware/request_id_test.go
@@ -26,7 +26,7 @@ var _ = Describe("RequestID", func() {
 		var err error
 		req, err = http.NewRequest("GET", "/goo", nil)
 		Ω(err).ShouldNot(HaveOccurred())
-		req.Header.Set("X-Request-Id", reqID)
+		req.Header.Set(middleware.RequestIDHeader, reqID)
 		rw = new(testResponseWriter)
 		params = url.Values{"query": []string{"value"}}
 		service.Encoder.Register(goa.NewJSONEncoder, "*/*")
@@ -43,4 +43,52 @@ var _ = Describe("RequestID", func() {
 		Ω(rg(ctx, rw, req)).ShouldNot(HaveOccurred())
 		Ω(middleware.ContextRequestID(newCtx)).Should(Equal(reqID))
 	})
+
+	It("truncates request ID when it exceeds a default limit", func() {
+		var newCtx context.Context
+		h := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			newCtx = ctx
+			return service.Send(ctx, 200, "ok")
+		}
+		tooLong := makeRequestID(2 * middleware.DefaultRequestIDLengthLimit)
+		expected := makeRequestID(middleware.DefaultRequestIDLengthLimit)
+		req.Header.Set(middleware.RequestIDHeader, tooLong)
+		rg := middleware.RequestID()(h)
+		Ω(rg(ctx, rw, req)).ShouldNot(HaveOccurred())
+		Ω(middleware.ContextRequestID(newCtx)).Should(Equal(expected))
+	})
+
+	It("sets the request ID in the context for a custom header and limit", func() {
+		var newCtx context.Context
+		h := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			newCtx = ctx
+			return service.Send(ctx, 200, "ok")
+		}
+		req.Header.Set("Foo", "abcdefghij")
+		rg := middleware.RequestIDWithHeaderAndLengthLimit("Foo", 7)(h)
+		Ω(rg(ctx, rw, req)).ShouldNot(HaveOccurred())
+		Ω(middleware.ContextRequestID(newCtx)).Should(Equal("abcdefg"))
+	})
+
+	It("allows any request ID when length limit is negative", func() {
+		var newCtx context.Context
+		h := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			newCtx = ctx
+			return service.Send(ctx, 200, "ok")
+		}
+		original := makeRequestID(2 * middleware.DefaultRequestIDLengthLimit)
+		req.Header.Set(middleware.RequestIDHeader, string(original))
+		rg := middleware.RequestIDWithHeaderAndLengthLimit(middleware.RequestIDHeader, -1)(h)
+		Ω(rg(ctx, rw, req)).ShouldNot(HaveOccurred())
+		Ω(middleware.ContextRequestID(newCtx)).Should(Equal(string(original)))
+	})
+
 })
+
+func makeRequestID(length int) string {
+	buffer := make([]byte, length)
+	for i := range buffer {
+		buffer[i] = 'x'
+	}
+	return string(buffer)
+}


### PR DESCRIPTION
added a default length limit of 128 for incoming X-Request-Id header values for safety
the issue is that request IDs will appear frequently in logs and the server could be impacted if a bad actor sends very long request IDs
