### PR TITLE
Fix a comment in app tests

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -199,7 +199,7 @@ func (g *Generator) createTestMethod(resource *design.ResourceDefinition, action
 		Name:           fmt.Sprintf("%s%s%s%s%s", actionName, ctrlName, respQualifier, routeQualifier, viewQualifier),
 		ActionName:     actionName,
 		ResourceName:   ctrlName,
-		Comment:        fmt.Sprintf("%s %s", actionName, comment),
+		Comment:        comment,
 		Params:         pathParams(action, route),
 		QueryParams:    queryParams(action),
 		Payload:        payload,


### PR DESCRIPTION
`gen_app` generates following comment.

```go
// CreateBottleCreated Create runs the method Create of the given controller with the given parameters and payload.
```

Maybe second word `Create` is unneeded.

```go
// CreateBottleCreated runs the method Create of the given controller with the given parameters and payload.
```

https://github.com/goadesign/goa-cellar/blob/f923c55476595a95fa4f97b03eb33b084fd9e58a/app/test/bottle_testing.go#L18