### PR TITLE
Fix potential panic due to using default view on MT without a default view

### DIFF
--- a/goagen/gen_schema/generator_test.go
+++ b/goagen/gen_schema/generator_test.go
@@ -7,7 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/design/apidsl"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_schema"
 	"github.com/goadesign/goa/version"
@@ -40,11 +41,12 @@ var _ = Describe("Generate", func() {
 
 	Context("with a dummy API", func() {
 		BeforeEach(func() {
-			design.Design = &design.APIDefinition{
-				Name:        "test api",
-				Title:       "dummy API with no resource",
-				Description: "I told you it's dummy",
-			}
+			dslengine.Reset()
+			apidsl.API("test api", func() {
+				apidsl.Title("dummy API with no resource")
+				apidsl.Description("I told you it's dummy")
+			})
+			dslengine.Run()
 		})
 
 		It("generates a dummy schema", func() {

--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -311,7 +311,7 @@ func TypeSchema(api *design.APIDefinition, t design.DataType) *JSONSchema {
 		s.Ref = TypeRef(api, actual)
 	case *design.MediaTypeDefinition:
 		// Use "default" view by default
-		s.Ref = MediaTypeRef(api, actual, "default")
+		s.Ref = MediaTypeRef(api, actual, actual.DefaultView())
 	}
 	return s
 }

--- a/goagen/gen_schema/json_schema_test.go
+++ b/goagen/gen_schema/json_schema_test.go
@@ -1,0 +1,81 @@
+package genschema_test
+
+import (
+	"github.com/goadesign/goa/design"
+	. "github.com/goadesign/goa/design/apidsl"
+	"github.com/goadesign/goa/dslengine"
+	"github.com/goadesign/goa/goagen/gen_schema"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TypeSchema", func() {
+	var typ design.DataType
+
+	var s *genschema.JSONSchema
+
+	BeforeEach(func() {
+		typ = nil
+		s = nil
+		dslengine.Reset()
+		design.ProjectedMediaTypes = make(design.MediaTypeRoot)
+	})
+
+	JustBeforeEach(func() {
+		s = genschema.TypeSchema(design.Design, typ)
+	})
+
+	Context("with a media type", func() {
+		BeforeEach(func() {
+			MediaType("application/foo.bar", func() {
+				Attributes(func() {
+					Attribute("bar")
+				})
+				View("default", func() {
+					Attribute("bar")
+				})
+			})
+
+			Ω(dslengine.Run()).ShouldNot(HaveOccurred())
+			typ = design.Design.MediaTypes["application/foo.bar"]
+		})
+
+		It("returns a proper JSON schema type", func() {
+			Ω(s).ShouldNot(BeNil())
+			Ω(s.Ref).Should(Equal("#/definitions/FooBar"))
+		})
+	})
+
+	Context("with a media type with self-referencing attributes", func() {
+		BeforeEach(func() {
+			MediaType("application/vnd.menu+json", func() {
+				Attributes(func() {
+					Attribute("name", design.String, "The name of an application")
+					Attribute("children", CollectionOf("application/vnd.menu+json"), func() {
+						View("nameonly")
+					})
+
+				})
+				View("default", func() {
+					Attribute("name")
+					Attribute("children", func() {
+						View("nameonly")
+					})
+				})
+				View("nameonly", func() {
+					Attribute("name")
+				})
+			})
+
+			Ω(func() { dslengine.Run() }).ShouldNot(Panic())
+			Ω(dslengine.Errors).ShouldNot(HaveOccurred())
+			typ = design.Design.MediaTypes["application/vnd.menu"]
+		})
+
+		It("returns a proper JSON schema type", func() {
+			Ω(s).ShouldNot(BeNil())
+			Ω(s.Ref).Should(Equal("#/definitions/Menu"))
+		})
+
+	})
+})


### PR DESCRIPTION
Also fixed issue where a MT attribute using a generated MT with a specific view would cause validation to fail. This is because the generated MT DSL has not been executed yet at this point. So moved that execution up to before the standard MT validation happens. This may need to get revisited as really the strong coupling between the two kinds of MTs means that generated MTs should probably not be a separate DSL root.