### PR TITLE
Give designer the ability to choose how to handle headers and parameters with identical names

### DIFF
--- a/design/apidsl/response.go
+++ b/design/apidsl/response.go
@@ -38,6 +38,7 @@ import (
 //        })
 //
 //        Response("MyResponse", func() {         // Define custom response (using no template)
+//                Description("This is my response")
 //                Media(BottleMedia)
 //                Headers(func() {
 //                        Header("X-Request-Id", func() {

--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -58,6 +58,7 @@ var (
 		"commandLine":         CommandLine,
 		"comment":             Comment,
 		"goify":               Goify,
+		"goifyatt":            GoifyAtt,
 		"gonative":            GoNativeType,
 		"gotypedef":           GoTypeDef,
 		"gotypename":          GoTypeName,


### PR DESCRIPTION
By using the struct metadata the designer can specify different names for headers and
params that have the same names. By default these end up creating a single struct
field with the common name.