### PR TITLE
genclient: generate all projected media types

### DIFF
--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Generate", func() {
 
 		It("generates a dummy app", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(7))
+			Ω(files).Should(HaveLen(8))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "testapi-cli", "main.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(len(strings.Split(string(content), "\n"))).Should(BeNumerically(">=", 16))
@@ -97,7 +97,7 @@ var _ = Describe("Generate", func() {
 
 		It("generates the correct command flag initialization code", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(8))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(len(strings.Split(string(content), "\n"))).Should(BeNumerically(">=", 3))
@@ -118,7 +118,7 @@ var _ = Describe("Generate", func() {
 
 			It("properly escapes the multi-line string used in the short description", func() {
 				Ω(genErr).Should(BeNil())
-				Ω(files).Should(HaveLen(8))
+				Ω(files).Should(HaveLen(9))
 				content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(content)).Should(ContainSubstring(multiline))
@@ -135,7 +135,7 @@ var _ = Describe("Generate", func() {
 
 			It("properly escapes the multi-line string used in the short description", func() {
 				Ω(genErr).Should(BeNil())
-				Ω(files).Should(HaveLen(8))
+				Ω(files).Should(HaveLen(9))
 				content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(string(content)).Should(ContainSubstring(pre + "` + \"`\" + `" + post))
@@ -191,7 +191,7 @@ var _ = Describe("Generate", func() {
 
 		It("generates registers the signer flags from main", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(8))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "testapi-cli", "main.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("jwt1Signer := newJWT1Signer()"))

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Generate", func() {
 
 		It("generates param initialization code that uses the param name given in the design", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(8))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
@@ -113,7 +113,7 @@ var _ = Describe("Generate", func() {
 
 		It("generates Path function with unique names", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(8))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
@@ -136,7 +136,7 @@ var _ = Describe("Generate", func() {
 
 			It("generates a Download function", func() {
 				Ω(genErr).Should(BeNil())
-				Ω(files).Should(HaveLen(8))
+				Ω(files).Should(HaveLen(9))
 				content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(content).Should(ContainSubstring("func (c *Client) DownloadSwaggerJSON("))
@@ -194,7 +194,7 @@ var _ = Describe("Generate", func() {
 
 		It("generates the correct client Fields", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(8))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "client.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("JWT1Signer goaclient.Signer"))
@@ -203,7 +203,7 @@ var _ = Describe("Generate", func() {
 
 		It("generates the Signer.Sign call from Action", func() {
 			Ω(genErr).Should(BeNil())
-			Ω(files).Should(HaveLen(8))
+			Ω(files).Should(HaveLen(9))
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "client", "foo.go"))
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("c.JWT1Signer.Sign(req)"))


### PR DESCRIPTION
Update client generator to generate all projected media types. The media types and user types are now generated in `media_types.go` and `user_types.go` respectively.