### PR TITLE
Fix potential panic when finalizing action definitions

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1493,6 +1493,9 @@ func (a *ActionDefinition) IterateResponses(it ResponseIterator) error {
 func (a *ActionDefinition) mergeResponses() {
 	for name, resp := range a.Parent.Responses {
 		if _, ok := a.Responses[name]; !ok {
+			if a.Responses == nil {
+				a.Responses = make(map[string]*ResponseDefinition)
+			}
 			a.Responses[name] = resp.Dup()
 		}
 	}

--- a/design/definitions_test.go
+++ b/design/definitions_test.go
@@ -71,6 +71,27 @@ var _ = Describe("IterateHeaders", func() {
 	})
 })
 
+var _ = Describe("Finalize ActionDefinition", func() {
+	Context("with an action with no response", func() {
+		var action *design.ActionDefinition
+
+		BeforeEach(func() {
+			// create a Resource with responses, Action with no response
+			resource := &design.ResourceDefinition{
+				Responses: map[string]*design.ResponseDefinition{
+					"NotFound": &design.ResponseDefinition{Name: "NotFound", Status: 404},
+				},
+			}
+			action = &design.ActionDefinition{Parent: resource}
+		})
+
+		It("does not panic and merges the resource responses", func() {
+			Ω(action.Finalize).ShouldNot(Panic())
+			Ω(action.Responses).Should(HaveKey("NotFound"))
+		})
+	})
+})
+
 var _ = Describe("FullPath", func() {
 
 	Context("Given a base resource and a resource with an action with a route", func() {


### PR DESCRIPTION
If the action did not define responses but the parent resource did.