### PR TITLE
Add Context param to Doer.Do

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,21 +37,17 @@ type (
 )
 
 // New creates a new API client that wraps c.
-// If c is nil, the returned client wraps the default http client.
+// If c is nil, the returned client wraps http.DefaultClient.
 func New(c Doer) *Client {
 	if c == nil {
-		return NewWithHTTPClient(nil)
+		c = HTTPClientDoer(http.DefaultClient)
 	}
 	return &Client{Doer: c}
 }
 
-// NewWithHTTPClient creates a new API client that wraps hc.
-// If hc is nil, the returned client wraps the default http client.
-func NewWithHTTPClient(hc *http.Client) *Client {
-	if hc == nil {
-		hc = http.DefaultClient
-	}
-	return &Client{Doer: &httpClientDoer{Client: hc}}
+// HTTPClientDoer turns a stdlib http.Client into a Doer. Used to create a new Client from an http.Client using New().
+func HTTPClientDoer(hc *http.Client) Doer {
+	return &httpClientDoer{Client: hc}
 }
 
 // httpClientDoer turns a stdlib http.Client into a Doer.

--- a/client/client.go
+++ b/client/client.go
@@ -40,14 +40,14 @@ type (
 // If c is nil, the returned client wraps the default http client.
 func New(c Doer) *Client {
 	if c == nil {
-		return NewWithHttpClient(nil)
+		return NewWithHTTPClient(nil)
 	}
 	return &Client{Doer: c}
 }
 
-// NewWithHttpClient creates a new API client that wraps hc.
+// NewWithHTTPClient creates a new API client that wraps hc.
 // If hc is nil, the returned client wraps the default http client.
-func NewWithHttpClient(hc *http.Client) *Client {
+func NewWithHTTPClient(hc *http.Client) *Client {
 	if hc == nil {
 		hc = http.DefaultClient
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -45,7 +45,7 @@ func New(c Doer) *Client {
 	return &Client{Doer: c}
 }
 
-// New created a new API client that wraps hc.
+// NewWithHttpClient creates a new API client that wraps hc.
 // If hc is nil, the returned client wraps the default http client.
 func NewWithHttpClient(hc *http.Client) *Client {
 	if hc == nil {

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -401,7 +401,7 @@ func main() {
 	}
 
 	// Create client struct
-	httpClient:= newHTTPClient()
+	httpClient := newHTTPClient()
 	c := {{ .Package }}.New(goaclient.HTTPClientDoer(httpClient))
 
 	// Register global flags

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -401,8 +401,8 @@ func main() {
 	}
 
 	// Create client struct
-	httpClient := newHTTPClient()
-	c := {{ .Package }}.New(httpClient)
+	httpClient:= newHTTPClient()
+	c := {{ .Package }}.New(goaclient.HTTPClientDoer(httpClient))
 
 	// Register global flags
 	app.PersistentFlags().StringVarP(&c.Scheme, "scheme", "s", "", "Set the requests scheme")


### PR DESCRIPTION
This PR is for #646

BREAKING CHANGE - should be announced on #goa
- client.Doer.Do() takes a Context parameter
- existing callers that pass nil work as before
- existing callers that pass an http.Client instance need to wrap it using client.HTTPClientDoer
- existing callers that pass a custom Doer need to update the Do method in their impls to take the Context parameter

