### PR TITLE
Change projected media types so they define the "default" view.

### DIFF
--- a/design/types.go
+++ b/design/types.go
@@ -821,8 +821,8 @@ func (m *MediaTypeDefinition) projectSingle(view string) (p *MediaTypeDefinition
 			},
 		},
 	}
-	p.Views = map[string]*ViewDefinition{view: {
-		Name:                view,
+	p.Views = map[string]*ViewDefinition{"default": {
+		Name:                "default",
 		AttributeDefinition: DupAtt(v.AttributeDefinition),
 		Parent:              p,
 	}}

--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -528,7 +528,7 @@ func buildMediaTypeSchema(api *design.APIDefinition, mt *design.MediaTypeDefinit
 				href = toSchemaHref(api, r.CanonicalAction().Routes[0])
 			}
 			sm := NewJSONSchema()
-			sm.Ref = MediaTypeRef(api, lmt, "link")
+			sm.Ref = MediaTypeRef(api, lmt, "default")
 			s.Links = append(s.Links, &JSONLink{
 				Title:        ln,
 				Rel:          ln,


### PR DESCRIPTION
That's instead of the view used to project them so that projecting a
projected media type is idempotent (type name remains the same).