### PR TITLE
Set header values defined in design in request data Params map.

### DIFF
--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -1028,14 +1028,8 @@ func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottl
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
-		if len(paramParam) > 1 || len(paramParam[0]) > 0 {
-			var params []string
-			for _, rawParam := range paramParam {
-				elemsParam := strings.Split(rawParam, ",")
-				params = elemsParam
-				rctx.Param = append(rctx.Param, params...)
-			}
-		}
+		params := paramParam
+		rctx.Param = params
 	}
 	return &rctx, err
 }
@@ -1059,22 +1053,15 @@ func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottl
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
-		if len(paramParam) > 1 || len(paramParam[0]) > 0 {
-			var params []int
-			for _, rawParam := range paramParam {
-				elemsParam := strings.Split(rawParam, ",")
-				elemsParam2 := make([]int, len(elemsParam))
-				for i, rawElem := range elemsParam {
-					if elem, err2 := strconv.Atoi(rawElem); err2 == nil {
-						elemsParam2[i] = elem
-					} else {
-						err = goa.MergeErrors(err, goa.InvalidParamTypeError("elem", rawElem, "integer"))
-					}
-				}
-				params = elemsParam2
-				rctx.Param = append(rctx.Param, params...)
+		params := make([]int, len(paramParam))
+		for i, rawParam := range paramParam {
+			if param, err2 := strconv.Atoi(rawParam); err2 == nil {
+				params[i] = param
+			} else {
+				err = goa.MergeErrors(err, goa.InvalidParamTypeError("param", rawParam, "integer"))
 			}
 		}
+		rctx.Param = params
 	}
 	return &rctx, err
 }


### PR DESCRIPTION
This makes it possible to iterate over all values defined in the design as being "parameters"
to the action including path parameters, query string parameters and now headers.
This PR also removes the previous behavior or splitting query params on commas to build slices.
Instead params must be passed in as actual arrays i.e. foo=bar&foo=baz. This makes it
possible to properly handle query strings such as foo=bar&foo=baz,abc which now result in the
Foo field being initialized with []string{"bar","baz,abc"} instead of
[]string{"bar","baz","abc"} as was done previously.