### PR TITLE
Properly populate request data Params with header values.

### DIFF
--- a/context.go
+++ b/context.go
@@ -28,7 +28,8 @@ type (
 
 		// Payload returns the decoded request body.
 		Payload interface{}
-		// Params is the path and querystring request parameters.
+		// Params contains the raw values for the parameters defined in the design including
+		// path parameters, query string parameters and header parameters.
 		Params url.Values
 	}
 

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -500,15 +500,15 @@ func New{{ .Name }}(ctx context.Context, service *goa.Service) (*{{ .Name }}, er
 		err = goa.MergeErrors(err, goa.MissingHeaderError("{{ $name }}"))
 	} else {
 {{ else }}	if len(header{{ goify $name true }}) > 0 {
-{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}
+{{ end }}{{/* if $mustValidate */}}{{ if $att.Type.IsArray }}		req.Params["{{ $name }}"] = header{{ goify $name true }}
 {{ if eq (arrayAttribute $att).Type.Kind 4 }}		headers := header{{ goify $name true }}
 {{ else }}		headers := make({{ gotypedef $att 2 true false }}, len(header{{ goify $name true }}))
 		for i, raw{{ goify $name true}} := range header{{ goify $name true}} {
 {{ template "Coerce" (newCoerceData $name (arrayAttribute $att) ($.Headers.IsPrimitivePointer $name) "headers[i]" 3) }}{{/*
 */}}		}
 {{ end }}		{{ printf "rctx.%s" (goifyatt $att $name true) }} = headers
-		req.Params["{{ goifyatt $att $name true }}"] = headers
 {{ else }}		raw{{ goify $name true}} := header{{ goify $name true}}[0]
+		req.Params["{{ $name }}"] = []string{raw{{ goify $name true }}}
 {{ template "Coerce" (newCoerceData $name $att ($.Headers.IsPrimitivePointer $name) (printf "rctx.%s" (goifyatt $att $name true)) 2) }}{{ end }}{{/*
 */}}{{ $validation := validationChecker $att ($.Headers.IsNonZero $name) ($.Headers.IsRequired $name) ($.Headers.HasDefaultValue $name) (printf "rctx.%s" (goifyatt $att $name true)) $name 2 false }}{{/*
 */}}{{ if $validation }}{{ $validation }}

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -924,6 +924,7 @@ func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottl
 	headerHeader := req.Header["Header"]
 	if len(headerHeader) > 0 {
 		rawHeader := headerHeader[0]
+		req.Params["Header"] = []string{rawHeader}
 		rctx.Header = &rawHeader
 	}
 	return &rctx, err
@@ -940,6 +941,7 @@ func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottl
 	headerParam := req.Header["Param"]
 	if len(headerParam) > 0 {
 		rawParam := headerParam[0]
+		req.Params["param"] = []string{rawParam}
 		rctx.Param = &rawParam
 	}
 	paramParam := req.Params["param"]


### PR DESCRIPTION
Use the raw header name as key to be consistent with params.