### PR TITLE
Media view

### DIFF
--- a/design/apidsl/media_type.go
+++ b/design/apidsl/media_type.go
@@ -121,7 +121,7 @@ func MediaType(identifier string, apidsl func()) *design.MediaTypeDefinition {
 //	})
 //
 // Media can be used inside Response or ResponseTemplate.
-func Media(val interface{}) {
+func Media(val interface{}, viewName ...string) {
 	if r, ok := responseDefinition(); ok {
 		if m, ok := val.(*design.MediaTypeDefinition); ok {
 			if m != nil {
@@ -131,6 +131,11 @@ func Media(val interface{}) {
 			r.MediaType = identifier
 		} else {
 			dslengine.ReportError("media type must be a string or a pointer to MediaTypeDefinition, got %#v", val)
+		}
+		if len(viewName) == 1 {
+			r.ViewName = viewName[0]
+		} else if len(viewName) > 1 {
+			dslengine.ReportError("too many arguments given to DefaultMedia")
 		}
 	}
 }

--- a/design/apidsl/resource.go
+++ b/design/apidsl/resource.go
@@ -98,7 +98,7 @@ func DefaultMedia(val interface{}, viewName ...string) {
 			return
 		}
 		if len(viewName) == 1 {
-			r.ViewName = viewName[0]
+			r.DefaultViewName = viewName[0]
 		} else if len(viewName) > 1 {
 			dslengine.ReportError("too many arguments given to DefaultMedia")
 		}

--- a/design/apidsl/resource.go
+++ b/design/apidsl/resource.go
@@ -82,7 +82,7 @@ func Resource(name string, dsl func()) *design.ResourceDefinition {
 // properties of attributes listed in action payloads and params. So if a media type defines an
 // attribute "name" with associated validations then simply calling Attribute("name") inside a
 // request Payload or Param defines the attribute with the same type and validations.
-func DefaultMedia(val interface{}) {
+func DefaultMedia(val interface{}, viewName ...string) {
 	if r, ok := resourceDefinition(); ok {
 		if m, ok := val.(*design.MediaTypeDefinition); ok {
 			if m.UserTypeDefinition == nil {
@@ -95,6 +95,12 @@ func DefaultMedia(val interface{}) {
 			r.MediaType = identifier
 		} else {
 			dslengine.ReportError("media type must be a string or a *design.MediaTypeDefinition, got %#v", val)
+			return
+		}
+		if len(viewName) == 1 {
+			r.ViewName = viewName[0]
+		} else if len(viewName) > 1 {
+			dslengine.ReportError("too many arguments given to DefaultMedia")
 		}
 	}
 }

--- a/design/apidsl/resource_test.go
+++ b/design/apidsl/resource_test.go
@@ -185,7 +185,6 @@ var _ = Describe("Resource", func() {
 			Ω(res).ShouldNot(BeNil())
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.MediaType).Should(Equal(mediaType))
-			Ω(res.DefaultViewName).Should(Equal("default"))
 		})
 	})
 
@@ -244,7 +243,6 @@ var _ = Describe("Resource", func() {
 			Ω(res).ShouldNot(BeNil())
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.MediaType).Should(Equal(identifier))
-			Ω(res.DefaultViewName).Should(Equal("default"))
 		})
 	})
 

--- a/design/apidsl/resource_test.go
+++ b/design/apidsl/resource_test.go
@@ -185,6 +185,25 @@ var _ = Describe("Resource", func() {
 			Ω(res).ShouldNot(BeNil())
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.MediaType).Should(Equal(mediaType))
+			Ω(res.ViewName).Should(Equal("default"))
+		})
+	})
+
+	Context("with a view name", func() {
+		const mediaType = "application/mt"
+
+		BeforeEach(func() {
+			name = "foo"
+			dsl = func() {
+				DefaultMedia(mediaType, "compact")
+			}
+		})
+
+		It("sets the media type", func() {
+			Ω(res).ShouldNot(BeNil())
+			Ω(res.Validate()).ShouldNot(HaveOccurred())
+			Ω(res.MediaType).Should(Equal(mediaType))
+			Ω(res.ViewName).Should(Equal("compact"))
 		})
 	})
 
@@ -225,6 +244,7 @@ var _ = Describe("Resource", func() {
 			Ω(res).ShouldNot(BeNil())
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.MediaType).Should(Equal(identifier))
+			Ω(res.ViewName).Should(Equal("default"))
 		})
 	})
 

--- a/design/apidsl/resource_test.go
+++ b/design/apidsl/resource_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Resource", func() {
 			Ω(res).ShouldNot(BeNil())
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.MediaType).Should(Equal(mediaType))
-			Ω(res.ViewName).Should(Equal("default"))
+			Ω(res.DefaultViewName).Should(Equal("default"))
 		})
 	})
 
@@ -203,7 +203,7 @@ var _ = Describe("Resource", func() {
 			Ω(res).ShouldNot(BeNil())
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.MediaType).Should(Equal(mediaType))
-			Ω(res.ViewName).Should(Equal("compact"))
+			Ω(res.DefaultViewName).Should(Equal("compact"))
 		})
 	})
 
@@ -244,7 +244,7 @@ var _ = Describe("Resource", func() {
 			Ω(res).ShouldNot(BeNil())
 			Ω(res.Validate()).ShouldNot(HaveOccurred())
 			Ω(res.MediaType).Should(Equal(identifier))
-			Ω(res.ViewName).Should(Equal("default"))
+			Ω(res.DefaultViewName).Should(Equal("default"))
 		})
 	})
 

--- a/design/apidsl/response.go
+++ b/design/apidsl/response.go
@@ -83,7 +83,7 @@ func Response(name string, paramsAndDSL ...interface{}) {
 		if resp := executeResponseDSL(name, paramsAndDSL...); resp != nil {
 			if resp.Status == 200 && resp.MediaType == "" {
 				resp.MediaType = def.Parent.MediaType
-				resp.ViewName = def.Parent.ViewName
+				resp.ViewName = def.Parent.DefaultViewName
 			}
 			resp.Parent = def
 			def.Responses[name] = resp
@@ -100,7 +100,7 @@ func Response(name string, paramsAndDSL ...interface{}) {
 		if resp := executeResponseDSL(name, paramsAndDSL...); resp != nil {
 			if resp.Status == 200 && resp.MediaType == "" {
 				resp.MediaType = def.MediaType
-				resp.ViewName = def.ViewName
+				resp.ViewName = def.DefaultViewName
 			}
 			resp.Parent = def
 			def.Responses[name] = resp

--- a/design/apidsl/response.go
+++ b/design/apidsl/response.go
@@ -83,6 +83,7 @@ func Response(name string, paramsAndDSL ...interface{}) {
 		if resp := executeResponseDSL(name, paramsAndDSL...); resp != nil {
 			if resp.Status == 200 && resp.MediaType == "" {
 				resp.MediaType = def.Parent.MediaType
+				resp.ViewName = def.Parent.ViewName
 			}
 			resp.Parent = def
 			def.Responses[name] = resp
@@ -99,6 +100,7 @@ func Response(name string, paramsAndDSL ...interface{}) {
 		if resp := executeResponseDSL(name, paramsAndDSL...); resp != nil {
 			if resp.Status == 200 && resp.MediaType == "" {
 				resp.MediaType = def.MediaType
+				resp.ViewName = def.ViewName
 			}
 			resp.Parent = def
 			def.Responses[name] = resp

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1237,9 +1237,6 @@ func (r *ResponseDefinition) Context() string {
 // Finalize sets the response media type from its type if the type is a media type and no media
 // type is already specified.
 func (r *ResponseDefinition) Finalize() {
-	if r.ViewName == "" {
-		r.ViewName = "default"
-	}
 	if r.Type == nil {
 		return
 	}

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -121,6 +121,8 @@ type (
 		Description string
 		// Default media type, describes the resource attributes
 		MediaType string
+		// Default view name if default media type is MediaTypeDefinition
+		ViewName string
 		// Exposed resource actions indexed by name
 		Actions map[string]*ActionDefinition
 		// FileServers is the list of static asset serving endpoints
@@ -188,6 +190,8 @@ type (
 		Type DataType
 		// Response body media type if any
 		MediaType string
+		// Response view name if MediaType is MediaTypeDefinition
+		ViewName string
 		// Response header definitions
 		Headers *AttributeDefinition
 		// Parent action or resource
@@ -1253,6 +1257,7 @@ func (r *ResponseDefinition) Dup() *ResponseDefinition {
 		Status:      r.Status,
 		Description: r.Description,
 		MediaType:   r.MediaType,
+		ViewName:    r.ViewName,
 	}
 	if r.Headers != nil {
 		res.Headers = DupAtt(r.Headers)
@@ -1276,6 +1281,7 @@ func (r *ResponseDefinition) Merge(other *ResponseDefinition) {
 	}
 	if r.MediaType == "" {
 		r.MediaType = other.MediaType
+		r.ViewName = other.ViewName
 	}
 	if other.Headers != nil {
 		otherHeaders := other.Headers.Type.ToObject()

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -122,7 +122,7 @@ type (
 		// Default media type, describes the resource attributes
 		MediaType string
 		// Default view name if default media type is MediaTypeDefinition
-		ViewName string
+		DefaultViewName string
 		// Exposed resource actions indexed by name
 		Actions map[string]*ActionDefinition
 		// FileServers is the list of static asset serving endpoints
@@ -1237,6 +1237,9 @@ func (r *ResponseDefinition) Context() string {
 // Finalize sets the response media type from its type if the type is a media type and no media
 // type is already specified.
 func (r *ResponseDefinition) Finalize() {
+	if r.ViewName == "" {
+		r.ViewName = "default"
+	}
 	if r.Type == nil {
 		return
 	}

--- a/design/validation.go
+++ b/design/validation.go
@@ -541,18 +541,17 @@ func (m *MediaTypeDefinition) Validate() *dslengine.ValidationErrors {
 			}
 		}
 	}
-	if !m.Type.IsArray() {
-		hasDefaultView := false
-		for n, v := range m.Views {
-			if n == "default" {
-				hasDefaultView = true
-			}
-			verr.Merge(v.Validate())
+	hasDefaultView := false
+	for n, v := range m.Views {
+		if n == "default" {
+			hasDefaultView = true
 		}
-		if !hasDefaultView {
-			verr.Add(m, `media type does not define the default view, use View("default", ...) to define it.`)
-		}
+		verr.Merge(v.Validate())
 	}
+	if !hasDefaultView {
+		verr.Add(m, `media type does not define the default view, use View("default", ...) to define it.`)
+	}
+
 	for _, l := range m.Links {
 		verr.Merge(l.Validate())
 	}

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -131,6 +131,7 @@ var _ = Describe("Generate", func() {
 				Status:      200,
 				Description: "get of widgets",
 				MediaType:   "vnd.rightscale.codegen.test.widgets",
+				ViewName:    "default",
 			}
 			route := design.RouteDefinition{
 				Verb: "GET",

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -232,10 +232,11 @@ func (w *ContextsWriter) Execute(data *ContextTemplateData) error {
 			if resp.ViewName != "" {
 				views = []string{resp.ViewName}
 			} else {
-				views := make([]string, len(mt.Views))
+				views = make([]string, len(mt.Views))
 				i := 0
 				for name := range mt.Views {
 					views[i] = name
+					i++
 				}
 				sort.Strings(views)
 			}
@@ -548,9 +549,9 @@ func New{{ .Name }}(ctx context.Context, service *goa.Service) (*{{ .Name }}, er
 
 	// ctxMTRespT generates the response helpers for responses with media types.
 	// template input: map[string]interface{}
-	ctxMTRespT = `{{ $projected := project .MediaType .ViewName }}// {{ respName .Response .ViewName }} sends a HTTP response with status code {{ .Response.Status }}.
-func (ctx *{{ .Context.Name }}) {{ .RespName }}(r {{ gotyperef .Projected .Projected.AllRequired 0 false }}) error {
-	ctx.ResponseData.Header().Set("Content-Type", "{{ .ContentType }}")
+	ctxMTRespT = `// {{ goify .RespName true }} sends a HTTP response with status code {{ .Response.Status }}.
+func (ctx *{{ .Context.Name }}) {{ goify .RespName true }}(r {{ gotyperef .Projected .Projected.AllRequired 0 false }}) error {
+	ctx.ResponseData.Header().Set("Content-Type", "{{ .Response.MediaType }}")
 	return ctx.ResponseData.Service.Send(ctx.Context, {{ .Response.Status }}, r)
 }
 `

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -211,46 +211,57 @@ func (w *ContextsWriter) Execute(data *ContextTemplateData) error {
 			return err
 		}
 	}
-	fn = template.FuncMap{
-		"project": func(mt *design.MediaTypeDefinition, v string) *design.MediaTypeDefinition {
-			p, _, _ := mt.Project(v)
-			return p
-		},
-	}
-	data.IterateResponses(func(resp *design.ResponseDefinition) error {
+	return data.IterateResponses(func(resp *design.ResponseDefinition) error {
 		respData := map[string]interface{}{
 			"Context":  data,
 			"Response": resp,
 		}
+		var mt *design.MediaTypeDefinition
 		if resp.Type != nil {
-			if mt, ok := resp.Type.(*design.MediaTypeDefinition); ok {
-				return w.executeRespMT(mt, respData, fn)
+			var ok bool
+			if mt, ok = resp.Type.(*design.MediaTypeDefinition); !ok {
+				respData["Type"] = resp.Type
+				respData["ContentType"] = resp.MediaType
+				return w.ExecuteTemplate("response", ctxTRespT, nil, respData)
 			}
-			respData["Type"] = resp.Type
-			respData["ContentType"] = resp.MediaType
-			return w.ExecuteTemplate("response", ctxTRespT, fn, respData)
-		} else if mt := design.Design.MediaTypeWithIdentifier(resp.MediaType); mt != nil {
-			return w.executeRespMT(mt, respData, fn)
 		} else {
-			return w.ExecuteTemplate("response", ctxNoMTRespT, fn, respData)
+			mt = design.Design.MediaTypeWithIdentifier(resp.MediaType)
 		}
+		if mt != nil {
+			var views []string
+			if resp.ViewName != "" {
+				views = []string{resp.ViewName}
+			} else {
+				views := make([]string, len(mt.Views))
+				i := 0
+				for name := range mt.Views {
+					views[i] = name
+				}
+				sort.Strings(views)
+			}
+			for _, view := range views {
+				projected, _, err := mt.Project(view)
+				if err != nil {
+					return err
+				}
+				respData["Projected"] = projected
+				respData["ViewName"] = view
+				respData["MediaType"] = mt
+				respData["ContentType"] = mt.ContentType
+				if view == "default" {
+					respData["RespName"] = codegen.Goify(resp.Name, true)
+				} else {
+					base := fmt.Sprintf("%s%s", resp.Name, strings.Title(view))
+					respData["RespName"] = codegen.Goify(base, true)
+				}
+				if err := w.ExecuteTemplate("response", ctxMTRespT, fn, respData); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		return w.ExecuteTemplate("response", ctxNoMTRespT, nil, respData)
 	})
-	return nil
-}
-
-// executeRespMT executes the template that generates the response functions for the given media
-// type.
-func (w *ContextsWriter) executeRespMT(mt *design.MediaTypeDefinition, data map[string]interface{}, fn template.FuncMap) error {
-	data["MediaType"] = mt
-	data["ContentType"] = mt.ContentType
-	fn["respName"] = func(resp *design.ResponseDefinition, view string) string {
-		if view == "default" {
-			return codegen.Goify(resp.Name, true)
-		}
-		base := fmt.Sprintf("%s%s", resp.Name, strings.Title(view))
-		return codegen.Goify(base, true)
-	}
-	return w.ExecuteTemplate("response", ctxMTRespT, fn, data)
 }
 
 // NewControllersWriter returns a handlers code writer.
@@ -537,14 +548,11 @@ func New{{ .Name }}(ctx context.Context, service *goa.Service) (*{{ .Name }}, er
 
 	// ctxMTRespT generates the response helpers for responses with media types.
 	// template input: map[string]interface{}
-	ctxMTRespT = `{{ $ctx := .Context }}{{ $resp := .Response }}{{ $mt := .MediaType }}{{ $ct := .ContentType }}{{/*
-*/}}{{ range $name, $view := $mt.Views }}{{ if not (eq $name "link") }}{{ $projected := project $mt $name }}
-// {{ respName $resp $name }} sends a HTTP response with status code {{ $resp.Status }}.
-func (ctx *{{ $ctx.Name }}) {{ respName $resp $name }}(r {{ gotyperef $projected $projected.AllRequired 0 false }}) error {
-	ctx.ResponseData.Header().Set("Content-Type", "{{ $ct }}")
-	return ctx.ResponseData.Service.Send(ctx.Context, {{ $resp.Status }}, r)
+	ctxMTRespT = `{{ $projected := project .MediaType .ViewName }}// {{ respName .Response .ViewName }} sends a HTTP response with status code {{ .Response.Status }}.
+func (ctx *{{ .Context.Name }}) {{ .RespName }}(r {{ gotyperef .Projected .Projected.AllRequired 0 false }}) error {
+	ctx.ResponseData.Header().Set("Content-Type", "{{ .ContentType }}")
+	return ctx.ResponseData.Service.Send(ctx.Context, {{ .Response.Status }}, r)
 }
-{{ end }}{{ end }}
 `
 
 	// ctxTRespT generates the response helpers for responses with overridden types.

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -199,7 +199,10 @@ func (g *Generator) okResp(a *design.ActionDefinition) map[string]interface{} {
 	if mt, ok2 = design.Design.MediaTypes[design.CanonicalIdentifier(ok.MediaType)]; !ok2 {
 		return nil
 	}
-	view := mt.DefaultView()
+	view := ok.ViewName
+	if view == "" {
+		view = mt.DefaultView()
+	}
 	pmt, _, err := mt.Project(view)
 	if err != nil {
 		return nil


### PR DESCRIPTION
This PR makes it possible to specify which view to generate for a given response media type. If no view is specified then the structs corresponding to all views are generated (identical to the behavior prior to this PR). A view for a given response can be specified with:
```go
Response(OK, func() {
    Media(BottleMedia, "tiny")
})
```
A view can also be specified for the default media type:
```go
Resource("bottle", func() {
    DefaultMedia(BottleMedia, "default")
    // ...
})
```