### PR TITLE
Fix duplicate payload types

### DIFF
--- a/design/apidsl/action.go
+++ b/design/apidsl/action.go
@@ -347,8 +347,15 @@ func payload(isOptional bool, p interface{}, dsls ...func()) {
 			att.Type = design.Object{}
 		case *design.AttributeDefinition:
 			att = design.DupAtt(actual)
-		case design.DataStructure:
+		case *design.UserTypeDefinition:
+			if len(dsls) == 0 {
+				a.Payload = actual
+				a.PayloadOptional = isOptional
+				return
+			}
 			att = design.DupAtt(actual.Definition())
+		case *design.MediaTypeDefinition:
+			att = design.DupAtt(actual.AttributeDefinition)
 		case string:
 			ut, ok := design.Design.Types[actual]
 			if !ok {

--- a/encoding/json/encoding_suite_test.go
+++ b/encoding/json/encoding_suite_test.go
@@ -1,0 +1,13 @@
+package json_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestJsonEncoding(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Json Encoding Suite")
+}

--- a/encoding/json/encoding_test.go
+++ b/encoding/json/encoding_test.go
@@ -1,0 +1,73 @@
+package json_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/goadesign/goa/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JsonEncoding", func() {
+
+	Describe("handle goa/uuid/UUID", func() {
+		name := "Test"
+		id, _ := uuid.FromString("c0586f01-87b5-462b-a673-3b2dcf619091")
+
+		type Payload struct {
+			ID   uuid.UUID
+			Name string
+		}
+
+		It("encode", func() {
+			data := Payload{
+				id,
+				name,
+			}
+
+			var b bytes.Buffer
+			encoder := json.NewEncoder(&b)
+			encoder.Encode(data)
+			s := b.String()
+
+			Ω(s).Should(ContainSubstring(id.String()))
+			Ω(s).Should(ContainSubstring(name))
+		})
+
+		It("decode", func() {
+			encoded := fmt.Sprintf(`{"ID":"%s","Name":"%s"}`, id, name)
+
+			var payload Payload
+			var b bytes.Buffer
+			b.WriteString(encoded)
+
+			decoder := json.NewDecoder(&b)
+			decoder.Decode(&payload)
+
+			Ω(payload.ID.String()).Should(Equal(id.String()))
+			Ω(payload.Name).Should(Equal(name))
+		})
+
+		It("round trip", func() {
+			data := Payload{
+				id,
+				name,
+			}
+
+			var payload Payload
+			var b bytes.Buffer
+
+			encoder := json.NewEncoder(&b)
+			encoder.Encode(data)
+
+			decoder := json.NewDecoder(&b)
+			decoder.Decode(&payload)
+
+			Ω(payload.ID.String()).Should(Equal(data.ID.String()))
+			Ω(payload.Name).Should(Equal(data.Name))
+		})
+
+	})
+})

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -207,8 +207,17 @@ func (w *ContextsWriter) Execute(data *ContextTemplateData) error {
 		return err
 	}
 	if data.Payload != nil {
-		if err := w.ExecuteTemplate("payload", payloadT, nil, data); err != nil {
-			return err
+		found := false
+		for _, t := range design.Design.Types {
+			if t.TypeName == data.Payload.TypeName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if err := w.ExecuteTemplate("payload", payloadT, nil, data); err != nil {
+				return err
+			}
 		}
 	}
 	return data.IterateResponses(func(resp *design.ResponseDefinition) error {

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -380,6 +380,7 @@ var _ = Describe("ContextsWriter", func() {
 
 			Context("with a object payload", func() {
 				BeforeEach(func() {
+					design.Design = new(design.APIDefinition)
 					intParam := &design.AttributeDefinition{Type: design.Integer}
 					strParam := &design.AttributeDefinition{Type: design.String}
 					dataType := design.Object{

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -300,8 +300,18 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 
 	err = res.IterateActions(func(action *design.ActionDefinition) error {
 		if action.Payload != nil {
-			if err := payloadTmpl.Execute(file, action); err != nil {
-				return err
+			found := false
+			typeName := action.Payload.TypeName
+			for _, t := range design.Design.Types {
+				if t.TypeName == typeName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				if err := payloadTmpl.Execute(file, action); err != nil {
+					return err
+				}
 			}
 		}
 		for i, r := range action.Routes {

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -18,11 +18,37 @@ func NewV4() UUID {
 	return UUID(uuid.NewV4())
 }
 
-// Used in string method conversion
-const dash byte = '-'
-
-// Returns canonical string representation of UUID:
-// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+// String Wrapper over the real String method
 func (u UUID) String() string {
 	return uuid.UUID(u).String()
+}
+
+// MarshalText Wrapper over the real MarshalText method
+func (u UUID) MarshalText() (text []byte, err error) {
+	return uuid.UUID(u).MarshalText()
+}
+
+// MarshalBinary Wrapper over the real MarshalBinary method
+func (u UUID) MarshalBinary() ([]byte, error) {
+	return uuid.UUID(u).MarshalBinary()
+}
+
+// UnmarshalBinary Wrapper over the real UnmarshalBinary method
+func (u *UUID) UnmarshalBinary(data []byte) error {
+	t := uuid.UUID{}
+	err := t.UnmarshalBinary(data)
+	for i, b := range t.Bytes() {
+		u[i] = b
+	}
+	return err
+}
+
+// UnmarshalText Wrapper over the real UnmarshalText method
+func (u *UUID) UnmarshalText(text []byte) error {
+	t := uuid.UUID{}
+	err := t.UnmarshalText(text)
+	for i, b := range t.Bytes() {
+		u[i] = b
+	}
+	return err
 }


### PR DESCRIPTION
This PR does two things:

1. It makes sure that action definitions that refer to user types to
   define the payload only duplicates the definition if needed (i.e. if
   the payload definition overrides some of the type attributes).

2. It makes sure that a payload type is only generated if there is not
   a user type with the same type name.