### PR TITLE
Fix potential duplicate generation of payload types.

### DIFF
--- a/design/apidsl/action.go
+++ b/design/apidsl/action.go
@@ -347,8 +347,15 @@ func payload(isOptional bool, p interface{}, dsls ...func()) {
 			att.Type = design.Object{}
 		case *design.AttributeDefinition:
 			att = design.DupAtt(actual)
-		case design.DataStructure:
+		case *design.UserTypeDefinition:
+			if len(dsls) == 0 {
+				a.Payload = actual
+				a.PayloadOptional = isOptional
+				return
+			}
 			att = design.DupAtt(actual.Definition())
+		case *design.MediaTypeDefinition:
+			att = design.DupAtt(actual.AttributeDefinition)
 		case string:
 			ut, ok := design.Design.Types[actual]
 			if !ok {

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -207,8 +207,17 @@ func (w *ContextsWriter) Execute(data *ContextTemplateData) error {
 		return err
 	}
 	if data.Payload != nil {
-		if err := w.ExecuteTemplate("payload", payloadT, nil, data); err != nil {
-			return err
+		found := false
+		for _, t := range design.Design.Types {
+			if t.TypeName == data.Payload.TypeName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if err := w.ExecuteTemplate("payload", payloadT, nil, data); err != nil {
+				return err
+			}
 		}
 	}
 	return data.IterateResponses(func(resp *design.ResponseDefinition) error {

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -300,8 +300,18 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 
 	err = res.IterateActions(func(action *design.ActionDefinition) error {
 		if action.Payload != nil {
-			if err := payloadTmpl.Execute(file, action); err != nil {
-				return err
+			found := false
+			typeName := action.Payload.TypeName
+			for _, t := range design.Design.Types {
+				if t.TypeName == typeName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				if err := payloadTmpl.Execute(file, action); err != nil {
+					return err
+				}
 			}
 		}
 		for i, r := range action.Routes {


### PR DESCRIPTION
This commit does two things:

1. It makes sure that action definitions that refer to user types to
   define the payload only duplicates the definition if needed (i.e. if
   the payload definition overrides some of the type attributes).

2. It makes sure that a payload type is only generated if there is not
   a user type with the same type name.