### PR TITLE
Properly handle array params

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -433,6 +433,10 @@ func (g *Generator) generateActionClient(action *design.ActionDefinition, file *
 					optData = append(optData, param)
 				}
 			} else {
+				if q.Type.IsArray() {
+					param.IsArray = true
+					param.ElemAttribute = q.Type.ToArray().ElemType
+				}
 				param.MustToString = true
 				param.ValueName = varName
 				param.CheckNil = true
@@ -810,12 +814,14 @@ func typeName(mt *design.MediaTypeDefinition) string {
 // paramData is the data structure holding the information needed to generate query params and
 // headers handling code.
 type paramData struct {
-	Name         string
-	VarName      string
-	ValueName    string
-	Attribute    *design.AttributeDefinition
-	MustToString bool
-	CheckNil     bool
+	Name          string
+	VarName       string
+	ValueName     string
+	Attribute     *design.AttributeDefinition
+	ElemAttribute *design.AttributeDefinition
+	MustToString  bool
+	IsArray       bool
+	CheckNil      bool
 }
 
 type byParamName []*paramData
@@ -873,9 +879,21 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 	u := url.URL{Host: c.Host, Scheme: scheme, Path: path}
 {{ if .QueryParams }}	values := u.Query()
 {{ range .QueryParams }}{{ if .CheckNil }}	if {{ .VarName }} != nil {
-	{{ end }}{{ if .MustToString}}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}
-	values.Set("{{ .Name }}", {{ $tmp }})
-{{ else }}	values.Set("{{ .Name }}", {{ .ValueName }})
+	{{ end }}{{/*
+
+// ARRAY
+*/}}{{ if .IsArray }}		for _, p := range {{ .VarName }} {
+{{ if .MustToString }}{{ $tmp := tempvar }}			{{ toString "p" $tmp .ElemAttribute }}
+			values.Add("{{ .Name }}", {{ $tmp }})
+{{ else }}			values.Add("{{ .Name }}", {{ .ValueName }})
+{{ end }}{{/*
+
+// NON STRING
+*/}}{{ else if .MustToString }}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}
+	values.Set("{{ .Name }}", {{ $tmp }}){{/*
+
+// STRING
+*/}}{{ else }}	values.Set("{{ .Name }}", {{ .ValueName }})
 {{ end }}{{ if .CheckNil }}	}
 {{ end }}{{ end }}	u.RawQuery = values.Encode()
 {{ end }}	return websocket.Dial(u.String(), "", u.String())
@@ -935,12 +953,28 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 	}
 	u := url.URL{Host: c.Host, Scheme: scheme, Path: path}
 {{ if .QueryParams }}	values := u.Query()
-{{ range .QueryParams }}{{ if .CheckNil }}	if {{ .VarName }} != nil {
-	{{ end }}{{ if .MustToString }}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}
+{{ range .QueryParams }}{{/*
+
+// ARRAY
+*/}}{{ if .IsArray }}		for _, p := range {{ .VarName }} {
+{{ if .MustToString }}{{ $tmp := tempvar }}			{{ toString "p" $tmp .ElemAttribute }}
+			values.Add("{{ .Name }}", {{ $tmp }})
+{{ else }}			values.Add("{{ .Name }}", {{ .ValueName }})
+{{ end }}	 }
+{{/*
+
+// NON STRING
+*/}}{{ else if .MustToString }}{{ if .CheckNil }}	if {{ .VarName }} != nil {
+	{{ end }}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}
 	values.Set("{{ .Name }}", {{ $tmp }})
-{{ else }}	values.Set("{{ .Name }}", {{ .ValueName }})
-{{ end }}{{ if .CheckNil }}	}
-{{ end }}{{ end }}	u.RawQuery = values.Encode()
+{{ if .CheckNil }}	}
+{{ end }}{{/*
+
+// STRING
+*/}}{{ else }}{{ if .CheckNil }}	if {{ .VarName }} != nil {
+	{{ end }}	values.Set("{{ .Name }}", {{ .ValueName }})
+{{ if .CheckNil }}	}
+{{ end }}{{ end }}{{ end }}	u.RawQuery = values.Encode()
 {{ end }}{{ if .HasPayload }}	req, err := http.NewRequest({{ $route := index .Routes 0 }}"{{ $route.Verb }}", u.String(), &body)
 {{ else }}	req, err := http.NewRequest({{ $route := index .Routes 0 }}"{{ $route.Verb }}", u.String(), nil)
 {{ end }}	if err != nil {

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -40,8 +40,11 @@ var _ = Describe("Generate", func() {
 
 	Context("with jsonapi like querystring params", func() {
 		BeforeEach(func() {
+			codegen.TempCount = 0
 			o := design.Object{
 				"fields[foo]": &design.AttributeDefinition{Type: design.String},
+				"fields[bar]": &design.AttributeDefinition{Type: &design.Array{ElemType: &design.AttributeDefinition{Type: design.String}}},
+				"fields[baz]": &design.AttributeDefinition{Type: &design.Array{ElemType: &design.AttributeDefinition{Type: design.Integer}}},
 			}
 			design.Design = &design.APIDefinition{
 				Name: "testapi",
@@ -76,6 +79,16 @@ var _ = Describe("Generate", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
 			Ω(content).Should(ContainSubstring(`values.Set("fields[foo]", *fieldsFoo)`))
+			Ω(content).Should(ContainSubstring(`	for _, p := range fieldsBar {
+		tmp2 := p
+		values.Add("fields[bar]", tmp2)
+	}
+`))
+			Ω(content).Should(ContainSubstring(`	for _, p := range fieldsBaz {
+		tmp3 := strconv.Itoa(p)
+		values.Add("fields[baz]", tmp3)
+	}
+`))
 		})
 	})
 


### PR DESCRIPTION
Add each param to the url query string values instead of building comma separated string.