### PR TITLE
Add escaped routes to mux.

### DIFF
--- a/mux.go
+++ b/mux.go
@@ -41,8 +41,10 @@ type (
 
 // NewMux returns a Mux.
 func NewMux() ServeMux {
+	r := httptreemux.New()
+	r.EscapeAddedRoutes = true
 	return &mux{
-		router:  httptreemux.New(),
+		router:  r,
 		handles: make(map[string]MuxHandler),
 	}
 }


### PR DESCRIPTION
This fixes an issue where requests sent by clients would not
match routes that contain characters that are escaped by the
net/url algorithm used to build URL strings. In particular
this affected routes with '*' in them.

See https://github.com/dimfeld/httptreemux/issues/32