### PR TITLE
Do not copy attribute type in DupAtt

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1553,6 +1553,7 @@ func (a *ActionDefinition) initQueryParams() {
 	// 3. Compute QueryParams from Params and set all path params as non zero attributes
 	if params := a.AllParams(); params != nil {
 		queryParams := DupAtt(params)
+		queryParams.Type = Dup(queryParams.Type)
 		if a.Params == nil {
 			a.Params = &AttributeDefinition{Type: Object{}}
 		}

--- a/design/dup.go
+++ b/design/dup.go
@@ -40,12 +40,8 @@ func (d *dupper) DupAttribute(att *AttributeDefinition) *AttributeDefinition {
 	if att.Validation != nil {
 		valDup = att.Validation.Dup()
 	}
-	var dupType DataType
-	if att.Type != nil {
-		dupType = d.DupType(att.Type)
-	}
 	dup := AttributeDefinition{
-		Type:              dupType,
+		Type:              att.Type,
 		Description:       att.Description,
 		Validation:        valDup,
 		Metadata:          att.Metadata,

--- a/design/dup_test.go
+++ b/design/dup_test.go
@@ -145,3 +145,23 @@ var _ = Describe("Dup", func() {
 		})
 	})
 })
+
+var _ = Describe("DupAtt", func() {
+	var att *AttributeDefinition
+	var dup *AttributeDefinition
+
+	JustBeforeEach(func() {
+		dup = DupAtt(att)
+	})
+
+	Context("with an attribute with a type which is a media type", func() {
+		BeforeEach(func() {
+			att = &AttributeDefinition{Type: &MediaTypeDefinition{}}
+		})
+
+		It("does not clone the type", func() {
+			Ω(dup == att).Should(BeFalse())
+			Ω(dup.Type == att.Type).Should(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
This is so that if the type is a media type or user type then it's OK
if the DSL hasn't run yet. The DSL will run later initializing the
referred type. If we dupped then the dupped type DSL would never get
run and the media type would not have its views initialized for example.