### PR TITLE
Make ErrorMediaIdentifier a variable instead of a constant

### DIFF
--- a/error.go
+++ b/error.go
@@ -38,6 +38,9 @@ import (
 )
 
 var (
+	// ErrorMediaIdentifier is the media type identifier used for error responses.
+	ErrorMediaIdentifier = "application/vnd.goa.error"
+
 	// ErrBadRequest is a generic bad request error.
 	ErrBadRequest = NewErrorClass("bad_request", 400)
 

--- a/service.go
+++ b/service.go
@@ -14,11 +14,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-const (
-	// ErrorMediaIdentifier is the media type identifier used for error responses.
-	ErrorMediaIdentifier = "application/vnd.goa.error"
-)
-
 type (
 	// Service is the data structure supporting goa services.
 	// It provides methods for configuring a service and running it.


### PR DESCRIPTION
So that it's possible to override it, e.g. for clients that can only handle
Content-Type headers of the form 'application/json'