### PR TITLE
Fix generation of examples for media types

### DIFF
--- a/design/apidsl/media_type.go
+++ b/design/apidsl/media_type.go
@@ -120,6 +120,15 @@ func MediaType(identifier string, apidsl func()) *design.MediaTypeDefinition {
 //		Media("application/json")
 //	})
 //
+// If Media uses a media type defined in the design then it may optionally specify a view name:
+//
+//	Response("OK", func() {
+//		Status(200)
+//		Media(BottleMedia, "tiny")
+//	})
+//
+// Specifying a media type is useful for responses that always return the same view.
+//
 // Media can be used inside Response or ResponseTemplate.
 func Media(val interface{}, viewName ...string) {
 	if r, ok := responseDefinition(); ok {

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1054,7 +1054,7 @@ func (a *AttributeDefinition) objectExample(rand *RandomGenerator, seen []string
 	if mt, ok := a.Type.(*MediaTypeDefinition); ok {
 		v := a.View
 		if v == "" {
-			v = mt.DefaultView()
+			v = DefaultView
 		}
 		projected, _, err := mt.Project(v)
 		if err != nil {

--- a/design/types.go
+++ b/design/types.go
@@ -11,6 +11,7 @@ package design
 
 import (
 	"fmt"
+	"mime"
 	"reflect"
 	"sort"
 	"strings"
@@ -20,6 +21,11 @@ import (
 	"github.com/satori/go.uuid"
 )
 
+// DefaultView is the name of the default view.
+const DefaultView = "default"
+
+// It returns the default view - or if not available the link view - or if not available the first
+// view by alphabetical order.
 type (
 	// A Kind defines the JSON type that a DataType represents.
 	Kind uint
@@ -689,7 +695,12 @@ func (m *MediaTypeDefinition) Kind() Kind { return MediaTypeKind }
 
 // IsError returns true if the media type is implemented via a goa struct.
 func (m *MediaTypeDefinition) IsError() bool {
-	return m.Identifier == ErrorMedia.Identifier
+	base, params, err := mime.ParseMediaType(m.Identifier)
+	if err != nil {
+		panic("invalid media type identifier " + m.Identifier) // bug
+	}
+	delete(params, "view")
+	return mime.FormatMediaType(base, params) == ErrorMedia.Identifier
 }
 
 // ComputeViews returns the media type views recursing as necessary if the media type is a
@@ -739,61 +750,34 @@ func (m *MediaTypeDefinition) IterateViews(it ViewIterator) error {
 	return nil
 }
 
-// Project creates a MediaTypeDefinition derived from the given definition that matches the given
-// view. links is a user type of type Object where each key corresponds to a linked media type as
-// defined by the media type "links" attribute.
-func (m *MediaTypeDefinition) Project(view string) (p *MediaTypeDefinition, links *UserTypeDefinition, err error) {
-	if _, ok := m.Views[view]; !ok {
-		return nil, nil, fmt.Errorf("unknown view %#v", view)
-	}
-	if m.IsArray() {
-		return m.projectCollection(view)
-	}
-	if m.Type.ToObject() == nil {
-		return m, nil, nil
-	}
-	return m.projectSingle(view)
-}
-
-// DefaultView returns the name of a view that can be used to project the media type.
-// It returns the default view - or if not available the link view - or if not available the first
-// view by alphabetical order.
-func (m *MediaTypeDefinition) DefaultView() string {
-	if _, ok := m.Views["default"]; ok {
-		return "default"
-	}
-	if _, ok := m.Views["link"]; ok {
-		return "link"
-	}
-	views := make([]string, len(m.Views))
-	i := 0
-	for n := range m.Views {
-		views[i] = n
-		i++
-	}
-	sort.Strings(views)
-	return views[0]
-}
-
-func (m *MediaTypeDefinition) projectSingle(view string) (p *MediaTypeDefinition, links *UserTypeDefinition, err error) {
-	v := m.Views[view]
-	canonical := CanonicalIdentifier(m.Identifier)
-	typeName := m.TypeName
-	if view != "default" {
-		typeName += strings.Title(view)
-		canonical += "; view=" + view
-	}
-	var ok bool
-	if p, ok = ProjectedMediaTypes[canonical]; ok {
+// Project creates a MediaTypeDefinition containing the fields defined in the given view.  The
+// resuling media type only defines the default view and its identifier is modified to indicate that
+// it was projected by adding the view as id parameter.  links is a user type of type Object where
+// each key corresponds to a linked media type as defined by the media type "links" attribute.
+func (m *MediaTypeDefinition) Project(view string) (*MediaTypeDefinition, *UserTypeDefinition, error) {
+	canonical := m.projectCanonical(view)
+	if p, ok := ProjectedMediaTypes[canonical]; ok {
+		var links *UserTypeDefinition
 		mLinks := ProjectedMediaTypes[canonical+"; links"]
 		if mLinks != nil {
 			links = mLinks.UserTypeDefinition
 		}
-		return
+		return p, links, nil
 	}
+	if m.IsArray() {
+		return m.projectCollection(view)
+	}
+	return m.projectSingle(view, canonical)
+}
+
+func (m *MediaTypeDefinition) projectSingle(view, canonical string) (p *MediaTypeDefinition, links *UserTypeDefinition, err error) {
+	v, ok := m.Views[view]
+	if !ok {
+		return nil, nil, fmt.Errorf("unknown view %#v", view)
+	}
+	viewObj := v.Type.ToObject()
 
 	// Compute validations - view may not have all attributes
-	viewObj := v.Type.ToObject()
 	var val *dslengine.ValidationDefinition
 	if m.Validation != nil {
 		names := m.Validation.Required
@@ -806,20 +790,22 @@ func (m *MediaTypeDefinition) projectSingle(view string) (p *MediaTypeDefinition
 		val = m.Validation.Dup()
 		val.Required = required
 	}
+
+	// Compute description
 	desc := m.Description
 	if desc == "" {
 		desc = m.TypeName + " media type"
 	}
 	desc += " (" + view + " view)"
+
 	p = &MediaTypeDefinition{
-		Identifier: m.Identifier,
+		Identifier: m.projectIdentifier(view),
 		UserTypeDefinition: &UserTypeDefinition{
-			TypeName: typeName,
+			TypeName: m.projectTypeName(view),
 			AttributeDefinition: &AttributeDefinition{
 				Description: desc,
 				Type:        Dup(v.Type),
 				Validation:  val,
-				Example:     m.Example,
 			},
 		},
 	}
@@ -871,7 +857,7 @@ func (m *MediaTypeDefinition) projectSingle(view string) (p *MediaTypeDefinition
 						view = at.View
 					}
 					if view == "" {
-						view = mt.DefaultView()
+						view = DefaultView
 					}
 					pr, _, err := mt.Project(view)
 					if err != nil {
@@ -886,7 +872,7 @@ func (m *MediaTypeDefinition) projectSingle(view string) (p *MediaTypeDefinition
 	return
 }
 
-func (m *MediaTypeDefinition) projectCollection(view string) (p *MediaTypeDefinition, links *UserTypeDefinition, err error) {
+func (m *MediaTypeDefinition) projectCollection(view string) (*MediaTypeDefinition, *UserTypeDefinition, error) {
 	// Project the collection element media type
 	e := m.ToArray().ElemType.Type.(*MediaTypeDefinition) // validation checked this cast would work
 	pe, le, err2 := e.Project(view)
@@ -896,8 +882,8 @@ func (m *MediaTypeDefinition) projectCollection(view string) (p *MediaTypeDefini
 
 	// Build the projected collection with the results
 	desc := m.TypeName + " is the media type for an array of " + e.TypeName + " (" + view + " view)"
-	p = &MediaTypeDefinition{
-		Identifier: m.Identifier,
+	p := &MediaTypeDefinition{
+		Identifier: m.projectIdentifier(view),
 		UserTypeDefinition: &UserTypeDefinition{
 			AttributeDefinition: &AttributeDefinition{
 				Description: desc,
@@ -907,17 +893,11 @@ func (m *MediaTypeDefinition) projectCollection(view string) (p *MediaTypeDefini
 			TypeName: pe.TypeName + "Collection",
 		},
 	}
-
-	// Set the collection views with a dup of the element views
-	views := make(map[string]*ViewDefinition, len(pe.Views))
-	for n, v := range pe.Views {
-		views[n] = &ViewDefinition{
-			AttributeDefinition: DupAtt(v.AttributeDefinition),
-			Name:                v.Name,
-			Parent:              p,
-		}
-	}
-	p.Views = views
+	p.Views = map[string]*ViewDefinition{"default": &ViewDefinition{
+		AttributeDefinition: DupAtt(pe.Views["default"].AttributeDefinition),
+		Name:                "default",
+		Parent:              p,
+	}}
 
 	// Run the DSL that was created by the CollectionOf function
 	if !dslengine.Execute(p.DSL(), p) {
@@ -925,6 +905,7 @@ func (m *MediaTypeDefinition) projectCollection(view string) (p *MediaTypeDefini
 	}
 
 	// Build the links user type
+	var links *UserTypeDefinition
 	if le != nil {
 		lTypeName := le.TypeName + "Array"
 		links = &UserTypeDefinition{
@@ -936,7 +917,40 @@ func (m *MediaTypeDefinition) projectCollection(view string) (p *MediaTypeDefini
 		}
 	}
 
-	return
+	return p, links, nil
+}
+
+// projectIdentifier computes the projected media type identifier by adding the "view" param.  We
+// need the projected media type identifier to be different so that looking up projected media types
+// from ProjectedMediaTypes works correctly. It's also good for clients.
+func (m *MediaTypeDefinition) projectIdentifier(view string) string {
+	base, params, err := mime.ParseMediaType(m.Identifier)
+	if err != nil {
+		base = m.Identifier
+	}
+	params["view"] = view
+	return mime.FormatMediaType(base, params)
+}
+
+// projectIdentifier computes the projected canonical media type identifier by adding the "view"
+// param if the view is not the default view.
+func (m *MediaTypeDefinition) projectCanonical(view string) string {
+	cano := CanonicalIdentifier(m.Identifier)
+	base, params, _ := mime.ParseMediaType(cano)
+	if params["view"] != "" {
+		return cano // Already projected
+	}
+	params["view"] = view
+	return mime.FormatMediaType(base, params)
+}
+
+// projectTypeName appends the view name to the media type name if the view name is not "default".
+func (m *MediaTypeDefinition) projectTypeName(view string) string {
+	typeName := m.TypeName
+	if view != "default" {
+		typeName += strings.Title(view)
+	}
+	return typeName
 }
 
 // DataStructure implementation

--- a/design/types_test.go
+++ b/design/types_test.go
@@ -2,6 +2,7 @@ package design_test
 
 import (
 	"errors"
+	"mime"
 	"sync"
 
 	. "github.com/goadesign/goa/design"
@@ -73,6 +74,19 @@ var _ = Describe("Project", func() {
 				view = "default"
 			})
 
+			It("returns a media type with an identifier view param", func() {
+				Ω(prErr).ShouldNot(HaveOccurred())
+				_, params, err := mime.ParseMediaType(projected.Identifier)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(params).Should(HaveKeyWithValue("view", "default"))
+			})
+
+			It("returns a media type with only a default view", func() {
+				Ω(prErr).ShouldNot(HaveOccurred())
+				Ω(projected.Views).Should(HaveLen(1))
+				Ω(projected.Views).Should(HaveKey("default"))
+			})
+
 			It("returns a media type with the default view attributes", func() {
 				Ω(prErr).ShouldNot(HaveOccurred())
 				Ω(projected).ShouldNot(BeNil())
@@ -88,6 +102,19 @@ var _ = Describe("Project", func() {
 		Context("using the tiny view", func() {
 			BeforeEach(func() {
 				view = "tiny"
+			})
+
+			It("returns a media type with an identifier view param", func() {
+				Ω(prErr).ShouldNot(HaveOccurred())
+				_, params, err := mime.ParseMediaType(projected.Identifier)
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(params).Should(HaveKeyWithValue("view", "tiny"))
+			})
+
+			It("returns a media type with only a default view", func() {
+				Ω(prErr).ShouldNot(HaveOccurred())
+				Ω(projected.Views).Should(HaveLen(1))
+				Ω(projected.Views).Should(HaveKey("default"))
 			})
 
 			It("returns a media type with the default view attributes", func() {

--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -208,8 +208,8 @@ func GoTypeName(t design.DataType, required []string, tabs int, private bool) st
 	case *design.UserTypeDefinition:
 		return Goify(actual.TypeName, !private)
 	case *design.MediaTypeDefinition:
-		if builtin := BuiltInTypeName(actual); builtin != "" {
-			return builtin
+		if actual.IsError() {
+			return "error"
 		}
 		return Goify(actual.TypeName, !private)
 	default:
@@ -278,15 +278,6 @@ func GoTypeDesc(t design.DataType, upper bool) string {
 	default:
 		return ""
 	}
-}
-
-// BuiltInTypeName returns the name of the goa struct corresponding to the media type definition
-// or the empty string if there isn't one.
-func BuiltInTypeName(mt *design.MediaTypeDefinition) string {
-	if mt.Identifier == design.ErrorMedia.Identifier {
-		return "error"
-	}
-	return ""
 }
 
 var commonInitialisms = map[string]bool{

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -33,6 +33,8 @@ var _ = Describe("Generate", func() {
 	})
 
 	JustBeforeEach(func() {
+		design.GeneratedMediaTypes = make(design.MediaTypeRoot)
+		design.ProjectedMediaTypes = make(design.MediaTypeRoot)
 		files, genErr = genapp.Generate()
 	})
 
@@ -130,7 +132,7 @@ var _ = Describe("Generate", func() {
 				Name:        "ok",
 				Status:      200,
 				Description: "get of widgets",
-				MediaType:   "vnd.rightscale.codegen.test.widgets",
+				MediaType:   "application/vnd.rightscale.codegen.test.widgets",
 				ViewName:    "default",
 			}
 			route := design.RouteDefinition{
@@ -148,7 +150,7 @@ var _ = Describe("Generate", func() {
 				Name:                "Widget",
 				BasePath:            "/widgets",
 				Description:         "Widgetty",
-				MediaType:           "vnd.rightscale.codegen.test.widgets",
+				MediaType:           "application/vnd.rightscale.codegen.test.widgets",
 				CanonicalActionName: "get",
 			}
 			get := design.ActionDefinition{
@@ -163,8 +165,8 @@ var _ = Describe("Generate", func() {
 			res.Actions = map[string]*design.ActionDefinition{"get": &get}
 			mt := design.MediaTypeDefinition{
 				UserTypeDefinition: &ut,
-				Identifier:         "vnd.rightscale.codegen.test.widgets",
-				ContentType:        "vnd.rightscale.codegen.test.widgets",
+				Identifier:         "application/vnd.rightscale.codegen.test.widgets",
+				ContentType:        "application/vnd.rightscale.codegen.test.widgets",
 				Views: map[string]*design.ViewDefinition{
 					"default": {
 						AttributeDefinition: ut.AttributeDefinition,
@@ -177,7 +179,7 @@ var _ = Describe("Generate", func() {
 				Title:       "dummy API with no resource",
 				Description: "I told you it's dummy",
 				Resources:   map[string]*design.ResourceDefinition{"Widget": &res},
-				MediaTypes:  map[string]*design.MediaTypeDefinition{"vnd.rightscale.codegen.test.widgets": &mt},
+				MediaTypes:  map[string]*design.MediaTypeDefinition{"application/vnd.rightscale.codegen.test.widgets": &mt},
 			}
 		})
 
@@ -290,7 +292,7 @@ func NewGetWidgetContext(ctx context.Context, service *goa.Service) (*GetWidgetC
 
 // OK sends a HTTP response with status code 200.
 func (ctx *GetWidgetContext) OK(r ID) error {
-	ctx.ResponseData.Header().Set("Content-Type", "vnd.rightscale.codegen.test.widgets")
+	ctx.ResponseData.Header().Set("Content-Type", "application/vnd.rightscale.codegen.test.widgets")
 	return ctx.ResponseData.Service.Send(ctx.Context, 200, r)
 }
 `

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -37,6 +37,7 @@ var _ = Describe("ContextsWriter", func() {
 	Context("correctly configured", func() {
 		var f *os.File
 		BeforeEach(func() {
+			dslengine.Reset()
 			f, _ = ioutil.TempFile("", "")
 			filename = f.Name()
 		})

--- a/goagen/gen_js/generator.go
+++ b/goagen/gen_js/generator.go
@@ -183,12 +183,8 @@ func (g *Generator) generateIndexHTML(htmlFile string, exampleAction *design.Act
 		query := exampleAction.QueryParams.Type.ToObject()
 		argValues := make([]string, len(argNames))
 		for i, n := range argNames {
-			q := query[n]
-			if q.Example != nil {
-				argValues[i] = fmt.Sprintf("%v", q.Example)
-			} else {
-				argValues[i] = fmt.Sprintf("%v", q.GenerateExample(g.API.RandomGenerator(), nil))
-			}
+			ex := query[n].GenerateExample(g.API.RandomGenerator(), nil)
+			argValues[i] = fmt.Sprintf("%v", ex)
 		}
 		args = strings.Join(argValues, ", ")
 	}
@@ -198,11 +194,8 @@ func (g *Generator) generateIndexHTML(htmlFile string, exampleAction *design.Act
 		pathVars := exampleAction.AllParams().Type.ToObject()
 		pathValues := make([]interface{}, len(pathParams))
 		for i, n := range pathParams {
-			if pathVars[n].Example != nil {
-				pathValues[i] = fmt.Sprintf("%v", pathVars[n].Example)
-			} else {
-				pathValues[i] = pathVars[n].GenerateExample(g.API.RandomGenerator(), nil)
-			}
+			ex := pathVars[n].GenerateExample(g.API.RandomGenerator(), nil)
+			pathValues[i] = ex
 		}
 		format := design.WildcardRegex.ReplaceAllLiteralString(examplePath, "/%v")
 		examplePath = fmt.Sprintf(format, pathValues...)

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -205,7 +205,7 @@ func (g *Generator) okResp(a *design.ActionDefinition) map[string]interface{} {
 	}
 	view := ok.ViewName
 	if view == "" {
-		view = mt.DefaultView()
+		view = design.DefaultView
 	}
 	pmt, _, err := mt.Project(view)
 	if err != nil {


### PR DESCRIPTION
Using the non default view. This PR cleans up how projected media types are handled:
A projected media type identifier now includes the view so that it's possible to infer
whether a media type has already been projected. Projected media types also only
define the "default" view.