### PR TITLE
#709 fixed readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ goagen bootstrap -d goa-adder/design
 This produces the following outputs:
 
 * `main.go` and `operands.go` contain scaffolding code to help bootstrap the implementation.
-  running `goagen` again does no recreate them so that it's safe to edit their content.
+  running `goagen` again does not recreate them so that it's safe to edit their content.
 * an `app` package which contains glue code that binds the low level HTTP server to your
   implementation.
 * a `client` package with a `Client` struct that implements a `AddOperands` function which calls


### PR DESCRIPTION
Signed-off-by: Shoubhik <shoubhik@dhcp35-156.lab.eng.blr.redhat.com>

WHY:
The documentation is good and helps - and removing typos make it easier.

WHAT:
Fixed the typo "no" to "not"