### PR TITLE
Fix spurious call to Validate() in test helpers

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -162,7 +162,7 @@ func (g *Generator) createTestMethod(resource *design.ResourceDefinition, action
 		if !p.IsError() {
 			tmp = fmt.Sprintf("%s.%s", g.Target, tmp)
 		}
-		validate := codegen.RecursiveChecker(p.AttributeDefinition, false, false, false, "payload", "raw", 1, true)
+		validate := codegen.RecursiveChecker(p.AttributeDefinition, false, false, false, "payload", "raw", 1, false)
 		returnType = &ObjectType{}
 		returnType.Type = tmp
 		if p.IsObject() && !p.IsError() {


### PR DESCRIPTION
The generated test helper code would sometimes call Validate()
on media types that did not define it because the test was being
made against the private MT data structure instead of the public one.