### PR TITLE
Fix spurious call to Validate() in test helpers

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -162,7 +162,7 @@ func (g *Generator) createTestMethod(resource *design.ResourceDefinition, action
 		if !p.IsError() {
 			tmp = fmt.Sprintf("%s.%s", g.Target, tmp)
 		}
-		validate := codegen.RecursiveChecker(p.AttributeDefinition, false, false, false, "payload", "raw", 1, true)
+		validate := codegen.RecursiveChecker(p.AttributeDefinition, false, false, false, "payload", "raw", 1, false)
 		returnType = &ObjectType{}
 		returnType.Type = tmp
 		if p.IsObject() && !p.IsError() {

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -381,6 +381,7 @@ var _ = Describe("ContextsWriter", func() {
 
 			Context("with a object payload", func() {
 				BeforeEach(func() {
+					design.Design = new(design.APIDefinition)
 					intParam := &design.AttributeDefinition{Type: design.Integer}
 					strParam := &design.AttributeDefinition{Type: design.String}
 					dataType := design.Object{


### PR DESCRIPTION
The generated test helper code would sometimes call Validate()
on media types that did not define it because the test was being
made against the private MT data structure instead of the public one.