### PR TITLE
Generate cors headers without wildcards

### DIFF
--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -703,7 +703,7 @@ func handle{{ .Resource }}Origin(h goa.Handler) goa.Handler {
 		}
 {{ range $policy := .Origins }}		if cors.MatchOrigin(origin, {{ printf "%q" $policy.Origin }}) {
 			ctx = goa.WithLogContext(ctx, "origin", origin)
-			rw.Header().Set("Access-Control-Allow-Origin", "{{ $policy.Origin }}")
+			rw.Header().Set("Access-Control-Allow-Origin", origin)
 {{ if not (eq $policy.Origin "*") }}			rw.Header().Set("Vary", "Origin")
 {{ end }}{{ if $policy.Exposed }}			rw.Header().Set("Access-Control-Expose-Headers", "{{ join $policy.Exposed ", " }}")
 {{ end }}{{ if gt $policy.MaxAge 0 }}			rw.Header().Set("Access-Control-Max-Age", "{{ $policy.MaxAge }}")

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -1240,7 +1240,7 @@ func handleBottlesOrigin(h goa.Handler) goa.Handler {
 		}
 		if cors.MatchOrigin(origin, "here.example.com") {
 			ctx = goa.WithLogContext(ctx, "origin", origin)
-			rw.Header().Set("Access-Control-Allow-Origin", "here.example.com")
+			rw.Header().Set("Access-Control-Allow-Origin", origin)
 			rw.Header().Set("Vary", "Origin")
 			rw.Header().Set("Access-Control-Expose-Headers", "X-Three")
 			rw.Header().Set("Access-Control-Allow-Credentials", "true")
@@ -1253,7 +1253,7 @@ func handleBottlesOrigin(h goa.Handler) goa.Handler {
 		}
 		if cors.MatchOrigin(origin, "there.example.com") {
 			ctx = goa.WithLogContext(ctx, "origin", origin)
-			rw.Header().Set("Access-Control-Allow-Origin", "there.example.com")
+			rw.Header().Set("Access-Control-Allow-Origin", origin)
 			rw.Header().Set("Vary", "Origin")
 			rw.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := req.Header.Get("Access-Control-Request-Method"); acrm != "" {


### PR DESCRIPTION
The header Access-Control-Allow-Origin doesn't accept
wildcards such as *.example.com. Therefore after the
origin has been checked as valid, the header should
contain the origin without wildcards.

For example if we got an origin such as test.example.com
and we accept origins matching *.example.com, the resulting
header will be: Access-Control-Allow-Origin: test.example.com

Fix #711 

Signed-off-by: Matteo Suppo <matteo.suppo@gmail.com>