### PR TITLE
Fail test fatally if media type is not of the right type

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -359,10 +359,7 @@ func {{ $test.Name }}(t *testing.T, ctx context.Context, service *goa.Service, c
 		var ok bool
 		mt, ok = resp.({{ $test.ReturnType.Pointer }}{{ $test.ReturnType.Type }})
 		if !ok {
-			t.Errorf("invalid response media: got %+v, expected instance of {{ $test.ReturnType.Type }}", resp)
-		}
-		if mt == nil {
-			t.Errorf("nil response media type, expected instance of {{ $test.ReturnType.Type }}")
+			t.Fatalf("invalid response media: got %+v, expected instance of {{ $test.ReturnType.Type }}", resp)
 		}
 {{ if $test.ReturnType.Validatable }}		err = mt.Validate()
 		if err != nil {


### PR DESCRIPTION
So that further checks don't panic.