### PR TITLE
Allow cors spec to be defined as regexps

### DIFF
--- a/cors/cors.go
+++ b/cors/cors.go
@@ -26,7 +26,6 @@ const OriginKey key = "origin"
 // - a plain string identifying an origin. eg http://swagger.goa.design
 // - a plain string containing a wildcard. eg *.goa.design
 // - the special string * that matches every host
-// - A regular expression wrapped in //. eg /[api|swagger].goa.design/
 func MatchOrigin(origin, spec string) bool {
 	if spec == "*" {
 		return true
@@ -50,6 +49,13 @@ func MatchOrigin(origin, spec string) bool {
 		return false
 	}
 	return true
+}
+
+// MatchOriginRegexp returns true if the given Origin header value matches the
+// origin specification.
+// Spec must be a valid regex
+func MatchOriginRegexp(origin string, spec *regexp.Regexp) bool {
+	return spec.Match([]byte(origin))
 }
 
 // HandlePreflight returns a simple 200 response. The middleware takes care of handling CORS.

--- a/cors/cors.go
+++ b/cors/cors.go
@@ -6,6 +6,7 @@ package cors
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -21,10 +22,23 @@ const OriginKey key = "origin"
 
 // MatchOrigin returns true if the given Origin header value matches the
 // origin specification.
+// Spec can be one of:
+// - a plain string identifying an origin. eg http://swagger.goa.design
+// - a plain string containing a wildcard. eg *.goa.design
+// - the special string * that matches every host
+// - A regular expression wrapped in //. eg /[api|swagger].goa.design/
 func MatchOrigin(origin, spec string) bool {
 	if spec == "*" {
 		return true
 	}
+
+	// Check regular expression
+	if strings.HasPrefix(spec, "/") && strings.HasSuffix(spec, "/") {
+		stripped := strings.Trim(spec, "/")
+		r := regexp.MustCompile(stripped)
+		return r.Match([]byte(origin))
+	}
+
 	if !strings.Contains(spec, "*") {
 		return origin == spec
 	}

--- a/cors/cors_test.go
+++ b/cors/cors_test.go
@@ -1,0 +1,36 @@
+package cors_test
+
+import (
+	"testing"
+
+	"github.com/goadesign/goa/cors"
+)
+
+func TestMatchOrigin(t *testing.T) {
+	data := []struct {
+		Origin string
+		Spec   string
+		Result bool
+	}{
+		{"http://example.com", "*", true},
+		{"http://example.com", "http://example.com", true},
+		{"http://example.com", "https://example.com", false},
+		{"http://test.example.com", "*.example.com", true},
+		{"http://test.example.com:80", "*.example.com", false},
+		{"http://test.example.com:80", "http://test.example.com*", true},
+		{"http://test.example.com:80", "/(.*).example.com(.*)/", true},
+		{"http://test.example.com:80", "/.*.example.com.*/", true},
+		{"http://test.example.com:80", "/.*.other.com.*/", false},
+		{"http://test.example.com", "/[test|swag].example.com/", true},
+		{"http://swag.example.com", "/[test|swag].example.com/", true},
+		{"http://other.example.com", "/[test|swag].example.com/", false},
+		{"http://other.example.com", "/[test|swag].other.com/", false},
+	}
+
+	for _, test := range data {
+		result := cors.MatchOrigin(test.Origin, test.Spec)
+		if result != test.Result {
+			t.Errorf("cors.MatchOrigin(%s, %s) should return %t", test.Origin, test.Spec, test.Result)
+		}
+	}
+}

--- a/cors/cors_test.go
+++ b/cors/cors_test.go
@@ -1,6 +1,7 @@
 package cors_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/goadesign/goa/cors"
@@ -18,17 +19,33 @@ func TestMatchOrigin(t *testing.T) {
 		{"http://test.example.com", "*.example.com", true},
 		{"http://test.example.com:80", "*.example.com", false},
 		{"http://test.example.com:80", "http://test.example.com*", true},
-		{"http://test.example.com:80", "/(.*).example.com(.*)/", true},
-		{"http://test.example.com:80", "/.*.example.com.*/", true},
-		{"http://test.example.com:80", "/.*.other.com.*/", false},
-		{"http://test.example.com", "/[test|swag].example.com/", true},
-		{"http://swag.example.com", "/[test|swag].example.com/", true},
-		{"http://other.example.com", "/[test|swag].example.com/", false},
-		{"http://other.example.com", "/[test|swag].other.com/", false},
 	}
 
 	for _, test := range data {
 		result := cors.MatchOrigin(test.Origin, test.Spec)
+		if result != test.Result {
+			t.Errorf("cors.MatchOrigin(%s, %s) should return %t", test.Origin, test.Spec, test.Result)
+		}
+	}
+}
+
+func TestMatchOriginRegexp(t *testing.T) {
+	data := []struct {
+		Origin string
+		Spec   string
+		Result bool
+	}{
+		{"http://test.example.com:80", "(.*).example.com(.*)", true},
+		{"http://test.example.com:80", ".*.example.com.*", true},
+		{"http://test.example.com:80", ".*.other.com.*", false},
+		{"http://test.example.com", "[test|swag].example.com", true},
+		{"http://swag.example.com", "[test|swag].example.com", true},
+		{"http://other.example.com", "[test|swag].example.com", false},
+		{"http://other.example.com", "[test|swag].other.com", false},
+	}
+
+	for _, test := range data {
+		result := cors.MatchOriginRegexp(test.Origin, regexp.MustCompile(test.Spec))
 		if result != test.Result {
 			t.Errorf("cors.MatchOrigin(%s, %s) should return %t", test.Origin, test.Spec, test.Result)
 		}

--- a/design/apidsl/api.go
+++ b/design/apidsl/api.go
@@ -166,14 +166,8 @@ func Origin(origin string, dsl func()) {
 	cors := &design.CORSDefinition{Origin: origin}
 
 	if strings.HasPrefix(origin, "/") && strings.HasSuffix(origin, "/") {
-		stripped := strings.Trim(origin, "/")
-		_, err := regexp.Compile(stripped)
-		if err != nil {
-			dslengine.ReportError("%s doesn't contain a valid regular expression for Origin", origin)
-			return
-		}
 		cors.Regexp = true
-		cors.Origin = stripped
+		cors.Origin = strings.Trim(origin, "/")
 	}
 
 	if !dslengine.Execute(dsl, cors) {

--- a/design/apidsl/api.go
+++ b/design/apidsl/api.go
@@ -149,7 +149,9 @@ func BasePath(val string) {
 
 // Origin defines the CORS policy for a given origin. The origin can use a wildcard prefix
 // such as "https://*.mydomain.com". The special value "*" defines the policy for all origins
-// (in which case there should be only one Origin DSL in the parent resource). Example:
+// (in which case there should be only one Origin DSL in the parent resource).
+// The origin can also be a regular expression wrapped into "/".
+// Example:
 //
 //        Origin("http://swagger.goa.design", func() { // Define CORS policy, may be prefixed with "*" wildcard
 //                Headers("X-Shared-Secret")           // One or more authorized headers, use "*" to authorize all
@@ -159,7 +161,17 @@ func BasePath(val string) {
 //                Credentials()                        // Sets Access-Control-Allow-Credentials header
 //        })
 //
+//        Origin("/[api|swagger].goa.design/", func() {}) // Define CORS policy with a regular expression
 func Origin(origin string, dsl func()) {
+	if strings.HasPrefix(origin, "/") && strings.HasSuffix(origin, "/") {
+		stripped := strings.Trim(origin, "/")
+		_, err := regexp.Compile(stripped)
+		if err != nil {
+			dslengine.ReportError("%s doesn't contain a valid regular expression for Origin", origin)
+			return
+		}
+	}
+
 	cors := &design.CORSDefinition{Origin: origin}
 	if !dslengine.Execute(dsl, cors) {
 		return

--- a/design/apidsl/api.go
+++ b/design/apidsl/api.go
@@ -163,6 +163,8 @@ func BasePath(val string) {
 //
 //        Origin("/[api|swagger].goa.design/", func() {}) // Define CORS policy with a regular expression
 func Origin(origin string, dsl func()) {
+	cors := &design.CORSDefinition{Origin: origin}
+
 	if strings.HasPrefix(origin, "/") && strings.HasSuffix(origin, "/") {
 		stripped := strings.Trim(origin, "/")
 		_, err := regexp.Compile(stripped)
@@ -170,9 +172,10 @@ func Origin(origin string, dsl func()) {
 			dslengine.ReportError("%s doesn't contain a valid regular expression for Origin", origin)
 			return
 		}
+		cors.Regexp = true
+		cors.Origin = stripped
 	}
 
-	cors := &design.CORSDefinition{Origin: origin}
 	if !dslengine.Execute(dsl, cors) {
 		return
 	}

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -161,6 +161,8 @@ type (
 		MaxAge uint
 		// Sets Access-Control-Allow-Credentials header
 		Credentials bool
+		// Sets Whether the Origin string is a regular expression
+		Regexp bool
 	}
 
 	// EncodingDefinition defines an encoder supported by the API.

--- a/design/validation.go
+++ b/design/validation.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -250,8 +251,14 @@ func (r *ResourceDefinition) validateParent(verr *dslengine.ValidationErrors) {
 // Validate makes sure the CORS definition origin is valid.
 func (cors *CORSDefinition) Validate() *dslengine.ValidationErrors {
 	verr := new(dslengine.ValidationErrors)
-	if strings.Count(cors.Origin, "*") > 1 {
+	if !cors.Regexp && strings.Count(cors.Origin, "*") > 1 {
 		verr.Add(cors, "invalid origin, can only contain one wildcard character")
+	}
+	if cors.Regexp {
+		_, err := regexp.Compile(cors.Origin)
+		if err != nil {
+			verr.Add(cors, "invalid origin, should be a valid regular expression")
+		}
 	}
 	return verr
 }

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -180,6 +180,7 @@ func (g *Generator) generateControllers() error {
 		codegen.SimpleImport("golang.org/x/net/context"),
 		codegen.SimpleImport("github.com/goadesign/goa"),
 		codegen.SimpleImport("github.com/goadesign/goa/cors"),
+		codegen.SimpleImport("regexp"),
 	}
 	encoders, err := BuildEncoders(g.API.Produces, true)
 	if err != nil {

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -695,14 +695,15 @@ func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Co
 	// template input: *ControllerTemplateData
 	handleCORST = `// handle{{ .Resource }}Origin applies the CORS response headers corresponding to the origin.
 func handle{{ .Resource }}Origin(h goa.Handler) goa.Handler {
-	{{ range $i, $policy := .Origins }}{{ if $policy.Regexp }}spec{{$i}} := regexp.MustCompile({{ printf "%q" $policy.Origin }}){{end}}{{end}}
+{{ range $i, $policy := .Origins }}{{ if $policy.Regexp }}	spec{{$i}} := regexp.MustCompile({{ printf "%q" $policy.Origin }})
+{{ end }}{{ end }}
 	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 		origin := req.Header.Get("Origin")
 		if origin == "" {
 			// Not a CORS request
 			return h(ctx, rw, req)
 		}
-{{ range $i, $policy := .Origins }}	{{ if $policy.Regexp }}	if cors.MatchOriginRegexp(origin, spec{{$i}}) {{else}} if cors.MatchOrigin(origin, {{ printf "%q" $policy.Origin }}) {{end}} {
+{{ range $i, $policy := .Origins }}		{{ if $policy.Regexp }}if cors.MatchOriginRegexp(origin, spec{{$i}}){{else}}if cors.MatchOrigin(origin, {{ printf "%q" $policy.Origin }}){{end}} {
 			ctx = goa.WithLogContext(ctx, "origin", origin)
 			rw.Header().Set("Access-Control-Allow-Origin", origin)
 {{ if not (eq $policy.Origin "*") }}			rw.Header().Set("Vary", "Origin")

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -695,13 +695,14 @@ func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Co
 	// template input: *ControllerTemplateData
 	handleCORST = `// handle{{ .Resource }}Origin applies the CORS response headers corresponding to the origin.
 func handle{{ .Resource }}Origin(h goa.Handler) goa.Handler {
+	{{ range $i, $policy := .Origins }}{{ if $policy.Regexp }}spec{{$i}} := regexp.MustCompile({{ printf "%q" $policy.Origin }}){{end}}{{end}}
 	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 		origin := req.Header.Get("Origin")
 		if origin == "" {
 			// Not a CORS request
 			return h(ctx, rw, req)
 		}
-{{ range $policy := .Origins }}		if cors.MatchOrigin(origin, {{ printf "%q" $policy.Origin }}) {
+{{ range $i, $policy := .Origins }}	{{ if $policy.Regexp }}	if cors.MatchOriginRegexp(origin, spec{{$i}}) {{else}} if cors.MatchOrigin(origin, {{ printf "%q" $policy.Origin }}) {{end}} {
 			ctx = goa.WithLogContext(ctx, "origin", origin)
 			rw.Header().Set("Access-Control-Allow-Origin", origin)
 {{ if not (eq $policy.Origin "*") }}			rw.Header().Set("Vary", "Origin")


### PR DESCRIPTION
If the string passed into Origin() begins and ends with a "/"
it's considered a regular expression.

For example "/[api|swagger].goa.design/" can match both
api.goa.design and swagger.goa.design

Fix #718

Signed-off-by: Matteo Suppo <matteo.suppo@gmail.com>