### PR TITLE
goa.adapter#logit(): remove unneeded check which would make an unsafe concurrent modification

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -76,9 +76,6 @@ func (a *adapter) logit(msg string, keyvals []interface{}, iserror bool) {
 		keyvals = append(keyvals, ErrMissingLogValue)
 	}
 	m := (len(a.keyvals) + 1) / 2
-	if len(a.keyvals)%2 != 0 {
-		a.keyvals = append(a.keyvals, ErrMissingLogValue)
-	}
 	n += m
 	var fm bytes.Buffer
 	lvl := "INFO"


### PR DESCRIPTION
- logit() doesn't need to modify `a.keyvals` because it was already fixed up in New()