### PR TITLE
Fix gen_clinet to suppress blank lines

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -984,8 +984,7 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 {{ if .HasPayload }}	if contentType != "*/*" {
 		header.Set("Content-Type", contentType)
 	}
-{{ end }}{{ range .Headers }}{{ if .CheckNil }}	if {{ .VarName }} != nil {
-	{{ end }}{{ if .MustToString }}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}
+{{ end }}{{ range .Headers }}{{ if .CheckNil }}	if {{ .VarName }} != nil { {{ end }}{{ if .MustToString }}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}
 	header.Set("{{ .Name }}", {{ $tmp }}){{ else }}
 	header.Set("{{ .Name }}", {{ .ValueName }})
 {{ end }}{{ if .CheckNil }}	}


### PR DESCRIPTION
This is a trivial change.

## Before

```go
if bar != nil { 
 
    header.Set("foo", *bar) 
}
```

## After

```go
if bar != nil { 
    header.Set("foo", *bar) 
}
```