### PR TITLE
Properly handle float range errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -203,8 +203,8 @@ func InvalidPatternError(ctx, target string, pattern string) error {
 }
 
 // InvalidRangeError is the error produced when the value of a parameter or payload field does
-// not match the range validation defined in the design.
-func InvalidRangeError(ctx string, target interface{}, value int, min bool) error {
+// not match the range validation defined in the design. value may be a int or a float64.
+func InvalidRangeError(ctx string, target interface{}, value interface{}, min bool) error {
 	comp := "greater or equal"
 	if !min {
 		comp = "lesser or equal"

--- a/error_test.go
+++ b/error_test.go
@@ -185,23 +185,46 @@ var _ = Describe("InvalidPatternError", func() {
 
 var _ = Describe("InvalidRangeError", func() {
 	var valErr error
+	var value interface{}
+
 	ctx := "ctx"
 	target := "target"
-	value := 42
 	min := true
 
 	JustBeforeEach(func() {
 		valErr = InvalidRangeError(ctx, target, value, min)
 	})
 
-	It("creates a http error", func() {
-		Ω(valErr).ShouldNot(BeNil())
-		Ω(valErr).Should(BeAssignableToTypeOf(&ErrorResponse{}))
-		err := valErr.(*ErrorResponse)
-		Ω(err.Detail).Should(ContainSubstring(ctx))
-		Ω(err.Detail).Should(ContainSubstring("greater or equal"))
-		Ω(err.Detail).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
-		Ω(err.Detail).Should(ContainSubstring(target))
+	Context("with an int value", func() {
+		BeforeEach(func() {
+			value = 42
+		})
+
+		It("creates a http error", func() {
+			Ω(valErr).ShouldNot(BeNil())
+			Ω(valErr).Should(BeAssignableToTypeOf(&ErrorResponse{}))
+			err := valErr.(*ErrorResponse)
+			Ω(err.Detail).Should(ContainSubstring(ctx))
+			Ω(err.Detail).Should(ContainSubstring("greater or equal"))
+			Ω(err.Detail).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
+			Ω(err.Detail).Should(ContainSubstring(target))
+		})
+	})
+
+	Context("with a float64 value", func() {
+		BeforeEach(func() {
+			value = 42.42
+		})
+
+		It("creates a http error with no value truncation", func() {
+			Ω(valErr).ShouldNot(BeNil())
+			Ω(valErr).Should(BeAssignableToTypeOf(&ErrorResponse{}))
+			err := valErr.(*ErrorResponse)
+			Ω(err.Detail).Should(ContainSubstring(ctx))
+			Ω(err.Detail).Should(ContainSubstring("greater or equal"))
+			Ω(err.Detail).Should(ContainSubstring(fmt.Sprintf("%#v", value)))
+			Ω(err.Detail).Should(ContainSubstring(target))
+		})
 	})
 })
 


### PR DESCRIPTION
Fix #743 

Make InvalidRangeError accept `interface{}` for the type of the value so that it works correctly both for `int` and `float64` values.