### PR TITLE
Always use goas uuid package

### DIFF
--- a/design/random.go
+++ b/design/random.go
@@ -6,8 +6,8 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/goadesign/goa/uuid"
 	"github.com/manveru/faker"
-	"github.com/satori/go.uuid"
 )
 
 // RandomGenerator generates consistent random values of different types given a seed.

--- a/design/types.go
+++ b/design/types.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/goadesign/goa/dslengine"
-	"github.com/satori/go.uuid"
+	"github.com/goadesign/goa/uuid"
 )
 
 // DefaultView is the name of the default view.

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -122,7 +122,7 @@ func (g *Generator) generateContexts() error {
 		codegen.SimpleImport("time"),
 		codegen.SimpleImport("unicode/utf8"),
 		codegen.SimpleImport("github.com/goadesign/goa"),
-		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
+		codegen.SimpleImport("github.com/goadesign/goa/uuid"),
 	}
 	g.genfiles = append(g.genfiles, ctxFile)
 	ctxWr.WriteHeader(title, g.Target, imports)
@@ -355,7 +355,7 @@ func (g *Generator) generateMediaTypes() error {
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("time"),
 		codegen.SimpleImport("unicode/utf8"),
-		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
+		codegen.NewImport("uuid", "github.com/goadesign/goa/uuid"),
 	}
 	mtWr.WriteHeader(title, g.Target, imports)
 	err = g.API.IterateMediaTypes(func(mt *design.MediaTypeDefinition) error {
@@ -388,7 +388,7 @@ func (g *Generator) generateUserTypes() error {
 		codegen.SimpleImport("time"),
 		codegen.SimpleImport("unicode/utf8"),
 		codegen.SimpleImport("github.com/goadesign/goa"),
-		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
+		codegen.SimpleImport("github.com/goadesign/goa/uuid"),
 	}
 	utWr.WriteHeader(title, g.Target, imports)
 	err = g.API.IterateUserTypes(func(t *design.UserTypeDefinition) error {


### PR DESCRIPTION
This avoids generating incompatible types.

Fixes #795
