### PR TITLE
Add TeeReader to service.DecodeRequest

### DIFF
--- a/service.go
+++ b/service.go
@@ -1,8 +1,10 @@
 package goa
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -187,8 +189,14 @@ func (service *Service) ServeFiles(path, filename string) error {
 // DecodeRequest uses the HTTP decoder to unmarshal the request body into the provided value based
 // on the request Content-Type header.
 func (service *Service) DecodeRequest(req *http.Request, v interface{}) error {
-	body, contentType := req.Body, req.Header.Get("Content-Type")
-	defer body.Close()
+	closer := req.Body
+	defer closer.Close()
+
+	var buf bytes.Buffer
+	body := io.TeeReader(req.Body, &buf)
+	req.Body = ioutil.NopCloser(&buf)
+
+	contentType := req.Header.Get("Content-Type")
 
 	if err := service.Decoder.Decode(v, body, contentType); err != nil {
 		return fmt.Errorf("failed to decode request body with content type %#v: %s", contentType, err)


### PR DESCRIPTION
Hi,

I changed the function `DecodeRequest` such that middlewares still can read the request body afterwards. In my case, this is required to implement an authentication middleware which computes a hash sum over the plain request body as part of the protocol. Currently, this does not work for non-trivial bodies, since `DecodeRequest` closes the body.

Would be nice to see the patch upstream.

Thanks!

Cheers,
Stefan
