### PR TITLE
Fix a bug that the payload is always required 'true' in swagger documents.

### DIFF
--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -885,7 +885,7 @@ func buildPathFromDefinition(s *Swagger, api *design.APIDefinition, route *desig
 			Name:        "payload",
 			In:          "body",
 			Description: action.Payload.Description,
-			Required:    true,
+			Required:    !action.PayloadOptional,
 			Schema:      payloadSchema,
 		}
 		params = append(params, pp)

--- a/goagen/gen_swagger/swagger_test.go
+++ b/goagen/gen_swagger/swagger_test.go
@@ -214,6 +214,52 @@ var _ = Describe("New", func() {
 			It("serializes into valid swagger JSON", func() { validateSwagger(swagger) })
 		})
 
+		Context("with required payload", func() {
+			BeforeEach(func() {
+				p := Type("RequiredPayload", func() {
+					Member("m1", String)
+				})
+				Resource("res", func() {
+					Action("act", func() {
+						Routing(
+							PUT("/"),
+						)
+						Payload(p)
+					})
+				})
+			})
+
+			It("serializes into valid swagger JSON", func() {
+				validateSwaggerWithFragments(swagger, [][]byte{
+					[]byte(`"required":true`),
+				})
+			})
+
+		})
+
+		Context("with optional payload", func() {
+			BeforeEach(func() {
+				p := Type("OptionalPayload", func() {
+					Member("m1", String)
+				})
+				Resource("res", func() {
+					Action("act", func() {
+						Routing(
+							PUT("/"),
+						)
+						OptionalPayload(p)
+					})
+				})
+			})
+
+			It("serializes into valid swagger JSON", func() {
+				validateSwaggerWithFragments(swagger, [][]byte{
+					[]byte(`"required":false`),
+				})
+			})
+
+		})
+
 		Context("with zero value validations", func() {
 			const (
 				intParam = "intParam"


### PR DESCRIPTION
https://github.com/goadesign/goa/blob/master/goagen/gen_swagger/swagger.go#L882
```go
	if action.Payload != nil {
		payloadSchema := genschema.TypeSchema(api, action.Payload)
		pp := &Parameter{
			Name:        "payload",
			In:          "body",
			Description: action.Payload.Description,
			Required:    true,            // ←★ always true even if optional payloads be used.
			Schema:      payloadSchema,
		}
		params = append(params, pp)
	}
```