### PR TITLE
Add unix domain socket listener to service.ListenAndServeUnix

### DIFF
--- a/service.go
+++ b/service.go
@@ -157,9 +157,9 @@ func (service *Service) ListenAndServeTLS(addr, certFile, keyFile string) error 
 	return http.ListenAndServeTLS(addr, certFile, keyFile, service.Mux)
 }
 
-// Serve starts specified listener on the given host.
-func (service *Service) Serve(listener net.Listener) error {
-	if err := http.Serve(listener, service.Mux); err != nil {
+// Serve accepts incoming HTTP connections on the listener l, invoking the service mux handler for each.
+func (service *Service) Serve(l net.Listener) error {
+	if err := http.Serve(l, service.Mux); err != nil {
 		return err
 	}
 	return nil

--- a/service.go
+++ b/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -154,6 +155,14 @@ func (service *Service) ListenAndServe(addr string) error {
 func (service *Service) ListenAndServeTLS(addr, certFile, keyFile string) error {
 	service.LogInfo("listen", "transport", "https", "addr", addr)
 	return http.ListenAndServeTLS(addr, certFile, keyFile, service.Mux)
+}
+
+// Serve starts specified listener on the given host.
+func (service *Service) Serve(listener net.Listener) error {
+	if err := http.Serve(listener, service.Mux); err != nil {
+		return err
+	}
+	return nil
 }
 
 // NewController returns a controller for the given resource. This method is mainly intended for

--- a/service.go
+++ b/service.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"golang.org/x/net/context"
 )
@@ -154,6 +157,20 @@ func (service *Service) ListenAndServe(addr string) error {
 func (service *Service) ListenAndServeTLS(addr, certFile, keyFile string) error {
 	service.LogInfo("listen", "transport", "https", "addr", addr)
 	return http.ListenAndServeTLS(addr, certFile, keyFile, service.Mux)
+}
+
+// ListenAndServeUnix starts a unix domain socket listener on the given host.
+func (service *Service) ListenAndServeUnix(addr string) error {
+	listener, err := net.Listen("unix", addr)
+	if err != nil {
+		return err
+	}
+	// enable SIGTERM and SIGKILL handler
+	onTermOrKill(service.Context, listener)
+	if err := http.Serve(listener, service.Mux); err != nil {
+		return err
+	}
+	return nil
 }
 
 // NewController returns a controller for the given resource. This method is mainly intended for
@@ -348,6 +365,18 @@ func (ctrl *Controller) FileHandler(path, filename string) Handler {
 		http.ServeContent(rw, req, d.Name(), d.ModTime(), f)
 		return nil
 	}
+}
+
+func onTermOrKill(ctx context.Context, listener net.Listener) {
+	s := make(chan os.Signal, 2)
+	signal.Notify(s, os.Interrupt, syscall.SIGTERM, syscall.SIGKILL)
+	go func() {
+		<-s
+		if err := listener.Close(); err != nil {
+			LogError(ctx, "uncaught error", "err", err)
+		}
+		os.Exit(1)
+	}()
 }
 
 var replacer = strings.NewReplacer(


### PR DESCRIPTION
Hi.

I very often use unix domain socket listener with HTTP proxy server. (e.g, Nginx)
In goa, it looks no way to use that.
This p-r add function `service.ListenAndServeUnix` that support unix domain socket listener.
Can you review this?

Thank you.