### PR TITLE
add metadata dsl test. Initial pass for feedback

### DIFF
--- a/design/dsl/metadata.go
+++ b/design/dsl/metadata.go
@@ -69,6 +69,8 @@ func Metadata(name string, value ...string) {
 		expr.Metadata = appendMetadata(expr.Metadata, name, value...)
 	case *design.APIExpr:
 		expr.Metadata = appendMetadata(expr.Metadata, name, value...)
+	case *design.EndpointExpr:
+		expr.Metadata = appendMetadata(expr.Metadata, name, value...)
 	default:
 		eval.IncompatibleDSL()
 	}

--- a/design/dsl/metadata_test.go
+++ b/design/dsl/metadata_test.go
@@ -36,14 +36,14 @@ func TestMetaData(t *testing.T) {
 			}
 			meta := tc.MetaFunc(tc.Expr)
 			if _, ok := meta[tc.Name]; !ok {
-				t.Fatalf("%s: expected %s to be present", k, tc.Name)
+				t.Errorf("%s: expected %s to be present", k, tc.Name)
 			}
 			if len(meta[tc.Name]) != (len(tc.Values) * tc.Invocations) {
-				t.Fatalf("%s: expected the number of metadata values to match %d got %d ", k, len(tc.Values), len(meta[tc.Name]))
+				t.Errorf("%s: expected the number of metadata values to match %d got %d ", k, len(tc.Values), len(meta[tc.Name]))
 			}
 			for _, caseVal := range tc.Values {
 				if !hasValue(meta[tc.Name], caseVal) {
-					t.Fatalf("%s: meta data %v did not conatin expected value %v", k, meta[tc.Name], caseVal)
+					t.Errorf("%s: meta data %v did not conatin expected value %v", k, meta[tc.Name], caseVal)
 				}
 			}
 		})

--- a/design/dsl/metadata_test.go
+++ b/design/dsl/metadata_test.go
@@ -10,31 +10,52 @@ import (
 
 func TestMetaData(t *testing.T) {
 	cases := map[string]struct {
-		Expr     eval.Expression
-		Name     string
-		Values   []string
-		MetaFunc func(e eval.Expression) design.MetadataExpr
+		Expr        eval.Expression
+		Name        string
+		Values      []string
+		MetaFunc    func(e eval.Expression) design.MetadataExpr
+		Invocations int
 	}{
-		"userType": {&design.UserTypeExpr{AttributeExpr: &design.AttributeExpr{}}, "swagger:summary", []string{"Short summary of what action does"}, userTypeMeta},
-		"api":      {&design.APIExpr{}, "metadata", []string{"some metadata"}, apiExprMeta},
+		"userType":  {&design.UserTypeExpr{AttributeExpr: &design.AttributeExpr{}}, "swagger:summary", []string{"Short summary of what action does"}, userTypeMeta, 1},
+		"api":       {&design.APIExpr{}, "metadata", []string{"some metadata"}, apiExprMeta, 2},
+		"attribute": {&design.AttributeExpr{}, "attribute_meta", []string{"attr meta", "more attr meta"}, attributeMeta, 2},
 	}
 
 	for k, tc := range cases {
-		eval.Context = &eval.DSLContext{}
-		eval.Execute(func() {
-			Metadata(tc.Name, tc.Values...)
-		}, tc.Expr)
-		if eval.Context.Errors != nil {
-			t.Errorf("%s: Description failed unexpectedly with %s", k, eval.Context.Errors)
-		}
-		meta := tc.MetaFunc(tc.Expr)
-		if _, ok := meta[tc.Name]; !ok {
-			t.Fatalf("expected %s to be present", tc.Name)
-		}
-		if len(meta[tc.Name]) != len(tc.Values) {
-			t.Fatal("expected the number of metadata values to match ")
-		}
+		t.Run(k, func(t *testing.T) {
+			eval.Context = &eval.DSLContext{}
+			for i := tc.Invocations; i > 0; i-- {
+				eval.Execute(func() {
+					Metadata(tc.Name, tc.Values...)
+				}, tc.Expr)
+			}
+			if eval.Context.Errors != nil {
+				t.Errorf("%s: Description failed unexpectedly with %s", k, eval.Context.Errors)
+			}
+			meta := tc.MetaFunc(tc.Expr)
+			if _, ok := meta[tc.Name]; !ok {
+				t.Fatalf("%s: expected %s to be present", k, tc.Name)
+			}
+			if len(meta[tc.Name]) != (len(tc.Values) * tc.Invocations) {
+				t.Fatalf("%s: expected the number of metadata values to match %d got %d ", k, len(tc.Values), len(meta[tc.Name]))
+			}
+			for _, caseVal := range tc.Values {
+				if !hasValue(meta[tc.Name], caseVal) {
+					t.Fatalf("%s: meta data %v did not conatin expected value %v", k, meta[tc.Name], caseVal)
+				}
+			}
+		})
 	}
 }
-func apiExprMeta(e eval.Expression) design.MetadataExpr  { return e.(*design.APIExpr).Metadata }
-func userTypeMeta(e eval.Expression) design.MetadataExpr { return e.(*design.UserTypeExpr).Metadata }
+
+func hasValue(vals []string, val string) bool {
+	for _, v := range vals {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}
+func apiExprMeta(e eval.Expression) design.MetadataExpr   { return e.(*design.APIExpr).Metadata }
+func userTypeMeta(e eval.Expression) design.MetadataExpr  { return e.(*design.UserTypeExpr).Metadata }
+func attributeMeta(e eval.Expression) design.MetadataExpr { return e.(*design.AttributeExpr).Metadata }

--- a/design/dsl/metadata_test.go
+++ b/design/dsl/metadata_test.go
@@ -19,6 +19,8 @@ func TestMetaData(t *testing.T) {
 		"userType":  {&design.UserTypeExpr{AttributeExpr: &design.AttributeExpr{}}, "swagger:summary", []string{"Short summary of what action does"}, userTypeMeta, 1},
 		"api":       {&design.APIExpr{}, "metadata", []string{"some metadata"}, apiExprMeta, 2},
 		"attribute": {&design.AttributeExpr{}, "attribute_meta", []string{"attr meta", "more attr meta"}, attributeMeta, 2},
+		"endpoint":  {&design.EndpointExpr{Name: "testendpoint"}, "endpoint", []string{"endpoint meta"}, endpointMeta, 2},
+		"mediaType": {&design.MediaTypeExpr{UserTypeExpr: &design.UserTypeExpr{AttributeExpr: &design.AttributeExpr{}}}, "mediaTypeMeta", []string{"media type meta"}, mediaTypeMeta, 2},
 	}
 
 	for k, tc := range cases {
@@ -59,3 +61,5 @@ func hasValue(vals []string, val string) bool {
 func apiExprMeta(e eval.Expression) design.MetadataExpr   { return e.(*design.APIExpr).Metadata }
 func userTypeMeta(e eval.Expression) design.MetadataExpr  { return e.(*design.UserTypeExpr).Metadata }
 func attributeMeta(e eval.Expression) design.MetadataExpr { return e.(*design.AttributeExpr).Metadata }
+func endpointMeta(e eval.Expression) design.MetadataExpr  { return e.(*design.EndpointExpr).Metadata }
+func mediaTypeMeta(e eval.Expression) design.MetadataExpr { return e.(*design.MediaTypeExpr).Metadata }

--- a/design/dsl/metadata_test.go
+++ b/design/dsl/metadata_test.go
@@ -1,0 +1,40 @@
+package dsl_test
+
+import (
+	"testing"
+
+	"github.com/goadesign/goa/design"
+	. "github.com/goadesign/goa/design/dsl"
+	"github.com/goadesign/goa/eval"
+)
+
+func TestMetaData(t *testing.T) {
+	cases := map[string]struct {
+		Expr     eval.Expression
+		Name     string
+		Values   []string
+		MetaFunc func(e eval.Expression) design.MetadataExpr
+	}{
+		"userType": {&design.UserTypeExpr{AttributeExpr: &design.AttributeExpr{}}, "swagger:summary", []string{"Short summary of what action does"}, userTypeMeta},
+		"api":      {&design.APIExpr{}, "metadata", []string{"some metadata"}, apiExprMeta},
+	}
+
+	for k, tc := range cases {
+		eval.Context = &eval.DSLContext{}
+		eval.Execute(func() {
+			Metadata(tc.Name, tc.Values...)
+		}, tc.Expr)
+		if eval.Context.Errors != nil {
+			t.Errorf("%s: Description failed unexpectedly with %s", k, eval.Context.Errors)
+		}
+		meta := tc.MetaFunc(tc.Expr)
+		if _, ok := meta[tc.Name]; !ok {
+			t.Fatalf("expected %s to be present", tc.Name)
+		}
+		if len(meta[tc.Name]) != len(tc.Values) {
+			t.Fatal("expected the number of metadata values to match ")
+		}
+	}
+}
+func apiExprMeta(e eval.Expression) design.MetadataExpr  { return e.(*design.APIExpr).Metadata }
+func userTypeMeta(e eval.Expression) design.MetadataExpr { return e.(*design.UserTypeExpr).Metadata }

--- a/design/endpoint.go
+++ b/design/endpoint.go
@@ -26,7 +26,7 @@ type (
 		// Service that owns endpoint.
 		Service *ServiceExpr
 		// Metadata is an arbitrary set of key/value pairs, see dsl.Metadata
-		Metadata map[string]string
+		Metadata MetadataExpr
 	}
 )
 


### PR DESCRIPTION
@raphael I have made a first attempt at adding a test for the metadata dsl function. It needs expanding on with more types that can have ```MetadataExpr``` but I wanted to show what was here to allow for feedback before I went too far.

Some questions from me:
1) Are we ok using a separate package as in ```dsl_test``` I think that this allows for clearer testing of the api
2) I believe I have understood how these tests work however I am quite new to the internals of goa, so it is possible I am misunderstanding something.