### PR TITLE
swagger ui fails to send a proper request when a paramter is Arrayof(...)

### DIFF
--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -678,6 +678,7 @@ func paramFor(at *design.AttributeDefinition, name, in string, required bool) *P
 	}
 	if at.Type.IsArray() {
 		p.Items = itemsFromDefinition(at.Type.ToArray().ElemType)
+		p.CollectionFormat = "multi"
 	}
 	p.Extensions = extensionsFromDefinition(at.Metadata)
 	initValidations(at, p)

--- a/goagen/gen_swagger/swagger_test.go
+++ b/goagen/gen_swagger/swagger_test.go
@@ -524,7 +524,7 @@ var _ = Describe("New", func() {
 				Ω(ps).Should(HaveLen(14))
 				// check Headers in detail
 				Ω(ps[3]).Should(Equal(&genswagger.Parameter{In: "header", Name: "Authorization", Type: "string", Required: true}))
-				Ω(ps[4]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OptionalArray", Type: "array",
+				Ω(ps[4]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OptionalArray", Type: "array", CollectionFormat: "multi",
 					Items: &genswagger.Items{Type: "string"}, MinItems: &minItems1, MaxItems: &maxItems5}))
 				Ω(ps[5]).Should(Equal(&genswagger.Parameter{In: "header", Name: "OptionalBoolWithDefault", Type: "boolean",
 					Description: "defaults true", Default: true}))


### PR DESCRIPTION
…nd multiple parameters, instead of a single parameter separated by comma