### PR TITLE
Implement "swagger:generate" metadata

### DIFF
--- a/design/apidsl/metadata.go
+++ b/design/apidsl/metadata.go
@@ -26,6 +26,17 @@ import (
 //        Metadata("struct:tag:json", "myName,omitempty")
 //        Metadata("struct:tag:xml", "myName,attr")
 //
+// `swagger:generate`: specifies whether Swagger specification should be generated. Defaults to
+// true.
+// Applicable to resources, actions and file servers.
+//
+//        Metadata("swagger:generate", "false")
+//
+// `swagger:summary`: sets the Swagger operation summary field.
+// Applicable to actions.
+//
+//        Metadata("swagger:summary", "Short summary of what action does")
+//
 // `swagger:tag:xxx`: sets the Swagger object field tag xxx.
 // Applicable to resources and actions.
 //
@@ -33,11 +44,6 @@ import (
 //        Metadata("swagger:tag:Backend:desc", "Quick description of what 'Backend' is")
 //        Metadata("swagger:tag:Backend:url", "http://example.com")
 //        Metadata("swagger:tag:Backend:url:desc", "See more docs here")
-//
-// `swagger:summary`: sets the Swagger operation summary field.
-// Applicable to actions.
-//
-//        Metadata("swagger:summary", "Short summary of what action does")
 //
 // `swagger:extension:xxx`: sets the Swagger extensions xxx. It can have any valid JSON format value.
 // Applicable to

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -832,11 +832,22 @@ func (r *ResourceDefinition) DSL() func() {
 // parameters, initializes querystring parameters, sets path parameters as non zero attributes
 // and sets the fallbacks for security schemes.
 func (r *ResourceDefinition) Finalize() {
+	meta := r.Metadata["swagger:generate"]
 	r.IterateFileServers(func(f *FileServerDefinition) error {
+		if meta != nil {
+			if _, ok := f.Metadata["swagger:generate"]; !ok {
+				f.Metadata["swagger:generate"] = meta
+			}
+		}
 		f.Finalize()
 		return nil
 	})
 	r.IterateActions(func(a *ActionDefinition) error {
+		if meta != nil {
+			if _, ok := a.Metadata["swagger:generate"]; !ok {
+				a.Metadata["swagger:generate"] = meta
+			}
+		}
 		a.Finalize()
 		return nil
 	})

--- a/goagen/gen_swagger/swagger_test.go
+++ b/goagen/gen_swagger/swagger_test.go
@@ -496,6 +496,13 @@ var _ = Describe("New", func() {
 						Response(NoContent)
 						Response(NotFound)
 					})
+
+					Action("hidden", func() {
+						Description("Does not show up in Swagger spec")
+						Metadata("swagger:generate", "false")
+						Routing(GET("/hidden"))
+						Response(OK)
+					})
 				})
 				base := Design.DSLFunc
 				Design.DSLFunc = func() {


### PR DESCRIPTION
Can be applied to resources, actions and file servers.
Set the value to "false" to prevent Swagger specification from being generated. Example:

    Resource("invisible", func() {
        Metadata("swagger:generate", "false")
        Action("visible", func() {
            Metadata("swagger:generate", "true") // Override resource swagger:generate metadata
       })
    })

Fix #628 