### PR TITLE
Add DSL argument to ArrayOf

### DIFF
--- a/design/apidsl/type_test.go
+++ b/design/apidsl/type_test.go
@@ -135,6 +135,29 @@ var _ = Describe("ArrayOf", func() {
 		})
 	})
 
+	Context("with a DSL", func() {
+		var (
+			pattern = "foo"
+			ar      *Array
+		)
+
+		BeforeEach(func() {
+			dslengine.Reset()
+			ar = ArrayOf(String, func() {
+				Pattern(pattern)
+			})
+			Ω(dslengine.Errors).ShouldNot(HaveOccurred())
+		})
+
+		It("records the validations", func() {
+			Ω(ar).ShouldNot(BeNil())
+			Ω(ar.Kind()).Should(Equal(ArrayKind))
+			Ω(ar.ElemType.Type).Should(Equal(String))
+			Ω(ar.ElemType.Validation).ShouldNot(BeNil())
+			Ω(ar.ElemType.Validation.Pattern).Should(Equal(pattern))
+		})
+	})
+
 	Context("defined with the type name", func() {
 		var ar *UserTypeDefinition
 		BeforeEach(func() {


### PR DESCRIPTION
To make it possible to define validation rules on the array element. For example:

    var Names = ArrayOf(String, func() {
         Pattern("[a-zA-Z]+")
    })

Fix #552 