### PR TITLE
Add DSL argument to ArrayOf

### DIFF
--- a/design/apidsl/type_test.go
+++ b/design/apidsl/type_test.go
@@ -135,6 +135,29 @@ var _ = Describe("ArrayOf", func() {
 		})
 	})
 
+	Context("with a DSL", func() {
+		var (
+			pattern = "foo"
+			ar      *Array
+		)
+
+		BeforeEach(func() {
+			dslengine.Reset()
+			ar = ArrayOf(String, func() {
+				Pattern(pattern)
+			})
+			Ω(dslengine.Errors).ShouldNot(HaveOccurred())
+		})
+
+		It("records the validations", func() {
+			Ω(ar).ShouldNot(BeNil())
+			Ω(ar.Kind()).Should(Equal(ArrayKind))
+			Ω(ar.ElemType.Type).Should(Equal(String))
+			Ω(ar.ElemType.Validation).ShouldNot(BeNil())
+			Ω(ar.ElemType.Validation.Pattern).Should(Equal(pattern))
+		})
+	})
+
 	Context("defined with the type name", func() {
 		var ar *UserTypeDefinition
 		BeforeEach(func() {

--- a/goagen/codegen/validation.go
+++ b/goagen/codegen/validation.go
@@ -71,7 +71,7 @@ func NewValidator() *Validator {
 		"constant":         constant,
 		"goifyAtt":         GoifyAtt,
 		"add":              Add,
-		"recursiveChecker": v.Code,
+		"recurseAttribute": v.recurseAttribute,
 	}
 	v.arrayValT, err = template.New("array").Funcs(fm).Parse(arrayValTmpl)
 	if err != nil {
@@ -139,15 +139,25 @@ func (v *Validator) recurse(att *design.AttributeDefinition, nonzero, required, 
 			buf.WriteString(validation)
 			first = false
 		}
-		data := map[string]interface{}{
-			"elemType": a.ElemType,
-			"context":  context,
-			"target":   target,
-			"depth":    1,
-			"private":  private,
+		var val string
+		if _, ok := a.ElemType.Type.(*design.UserTypeDefinition); ok {
+			val = RunTemplate(v.userValT, map[string]interface{}{
+				"depth":  depth + 1,
+				"target": "e",
+			})
+		} else {
+			val = v.Code(a.ElemType, true, false, false, "e", context+"[*]", depth+1, false)
 		}
-		validation = RunTemplate(v.arrayValT, data)
-		if validation != "" {
+		if val != "" {
+			data := map[string]interface{}{
+				"elemType":   a.ElemType,
+				"context":    context,
+				"target":     target,
+				"depth":      1,
+				"private":    private,
+				"validation": val,
+			}
+			validation = RunTemplate(v.arrayValT, data)
 			if !first {
 				buf.WriteByte('\n')
 			} else {
@@ -359,10 +369,9 @@ func constant(formatName string) string {
 }
 
 const (
-	arrayValTmpl = `{{$validation := recursiveChecker .elemType false false false "e" (printf "%s[*]" .context) (add .depth 1) .private}}{{/*
-*/}}{{if $validation}}{{tabs .depth}}for _, e := range {{.target}} {
-{{$validation}}
-{{tabs .depth}}}{{end}}`
+	arrayValTmpl = `{{tabs .depth}}for _, e := range {{.target}} {
+{{.validation}}
+{{tabs .depth}}}`
 
 	userValTmpl = `{{tabs .depth}}if err2 := {{.target}}.Validate(); err2 != nil {
 {{tabs .depth}}	err = goa.MergeErrors(err, err2)


### PR DESCRIPTION
To make it possible to define validation rules on the array element. For example:

    var Names = ArrayOf(String, func() {
         Pattern("[a-zA-Z]+")
    })

Fix #552 