### PR TITLE
Fixup for 2e83b0dfdd45e1e54615606924dca565b547b08b

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -989,8 +989,7 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 {{ end }}	if err != nil {
 		return nil, err
 	}
-{{ if or .Headers .HasPayload }}	header := req.Header
-		_ = header // Avoid "header declared and not used" error
+{{ if or .Headers (and .HasPayload .HasMultiContent) }}	header := req.Header
 {{ if .HasPayload }}{{ if .HasMultiContent }}	if contentType != "*/*" {
 		header.Set("Content-Type", contentType)
 	}

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -869,8 +869,8 @@ func {{ $funcName }}({{ pathParams . }}) string {
 	clientsTmpl = `{{ $funcName := goify (printf "%s%s" .Name (title .ResourceName)) true }}{{ $desc := .Description }}{{/*
 */}}{{ if $desc }}{{ multiComment $desc }}{{ else }}{{/*
 */}}// {{ $funcName }} makes a request to the {{ .Name }} action endpoint of the {{ .ResourceName }} resource{{ end }}
-func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params}},  {{ .Params }}{{ end }}{{ if .HasPayload }}, contentType string{{ end }}) (*http.Response, error) {
-	req, err := c.New{{ $funcName }}Request(ctx, path{{ if .ParamNames }}, {{ .ParamNames }}{{ end }}{{ if .HasPayload }}, contentType{{ end }})
+func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params}},  {{ .Params }}{{ end }}{{ if .HasPayload }}{{ if .HasMultiContent }}, contentType string{{ end }}{{ end }}) (*http.Response, error) {
+	req, err := c.New{{ $funcName }}Request(ctx, path{{ if .ParamNames }}, {{ .ParamNames }}{{ end }}{{ if .HasPayload }}{{ if .HasMultiContent }}, contentType{{ end }}{{ end }})
 	if err != nil {
 		return nil, err
 	}
@@ -990,6 +990,7 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 		return nil, err
 	}
 {{ if or .Headers .HasPayload }}	header := req.Header
+		_ = header // Avoid "header declared and not used" error
 {{ if .HasPayload }}{{ if .HasMultiContent }}	if contentType != "*/*" {
 		header.Set("Content-Type", contentType)
 	}


### PR DESCRIPTION
We are using the v1 branch and lately there seems to be a change about the `contentType` parameter. I've commented on the recent commit [here](https://github.com/goadesign/goa/commit/2e83b0dfdd45e1e54615606924dca565b547b08b#commitcomment-19905560). 

This change removes the parameter `contentType` parameter from a function call under the same conditions as introduced in 2e83b0dfdd45e1e54615606924dca565b547b08b.

Also, I've added a workaround to remove the `header declared and not used error` which was caused because no content type is being anymore.