### PR TITLE
Revert to using type names for Swagger schema IDs

### DIFF
--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -236,10 +236,10 @@ func GenerateResourceDefinition(api *design.APIDefinition, r *design.ResourceDef
 
 // MediaTypeRef produces the JSON reference to the media type definition with the given view.
 func MediaTypeRef(api *design.APIDefinition, mt *design.MediaTypeDefinition, view string) string {
-	if _, ok := Definitions[design.CanonicalIdentifier(mt.Identifier)]; !ok {
+	if _, ok := Definitions[mt.TypeName]; !ok {
 		GenerateMediaTypeDefinition(api, mt, view)
 	}
-	ref := fmt.Sprintf("#/definitions/%s", design.CanonicalIdentifier(mt.Identifier))
+	ref := fmt.Sprintf("#/definitions/%s", mt.TypeName)
 	if view != "default" {
 		ref += codegen.Goify(view, true)
 	}
@@ -257,13 +257,12 @@ func TypeRef(api *design.APIDefinition, ut *design.UserTypeDefinition) string {
 // GenerateMediaTypeDefinition produces the JSON schema corresponding to the given media type and
 // given view.
 func GenerateMediaTypeDefinition(api *design.APIDefinition, mt *design.MediaTypeDefinition, view string) {
-	cano := design.CanonicalIdentifier(mt.Identifier)
-	if _, ok := Definitions[cano]; ok {
+	if _, ok := Definitions[mt.TypeName]; ok {
 		return
 	}
 	s := NewJSONSchema()
 	s.Title = fmt.Sprintf("Mediatype identifier: %s", mt.Identifier)
-	Definitions[cano] = s
+	Definitions[mt.TypeName] = s
 	buildMediaTypeSchema(api, mt, view, s)
 }
 

--- a/goagen/gen_schema/json_schema_test.go
+++ b/goagen/gen_schema/json_schema_test.go
@@ -42,7 +42,7 @@ var _ = Describe("TypeSchema", func() {
 
 		It("returns a proper JSON schema type", func() {
 			Ω(s).ShouldNot(BeNil())
-			Ω(s.Ref).Should(Equal("#/definitions/application/foo.bar"))
+			Ω(s.Ref).Should(Equal("#/definitions/FooBar"))
 		})
 	})
 
@@ -74,7 +74,7 @@ var _ = Describe("TypeSchema", func() {
 
 		It("returns a proper JSON schema type", func() {
 			Ω(s).ShouldNot(BeNil())
-			Ω(s.Ref).Should(Equal("#/definitions/application/vnd.menu"))
+			Ω(s.Ref).Should(Equal("#/definitions/Menu"))
 		})
 
 	})


### PR DESCRIPTION
Since the names are different for media type projected to different
views anyway.