### PR TITLE
Fix for #908

### DIFF
--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -74,6 +74,7 @@ func (g *Generator) generateMain(mainFile string, clientPkg, cliPkg string, func
 		HasBasicAuthSigners bool
 		HasAPIKeySigners    bool
 		HasTokenSigners     bool
+		HasMultiContent     bool
 	}{
 		API:                 g.API,
 		Version:             version,
@@ -82,6 +83,7 @@ func (g *Generator) generateMain(mainFile string, clientPkg, cliPkg string, func
 		HasBasicAuthSigners: hasBasicAuthSigners,
 		HasAPIKeySigners:    hasAPIKeySigners,
 		HasTokenSigners:     hasTokenSigners,
+		HasMultiContent:     len(g.API.Consumes) > 1,
 	}
 	if err := file.ExecuteTemplate("main", mainTmpl, funcs, data); err != nil {
 		return err
@@ -819,7 +821,7 @@ func (cmd *{{ $cmdName }}) Run(c *{{ .Package }}.Client, args []string) error {
 	resp, err := c.{{ goify (printf "%s%s" .Action.Name (title .Resource.Name)) true }}(ctx, path{{ if .Action.Payload }}, {{/*
 	*/}}{{ if or .Action.Payload.Type.IsObject .Action.Payload.IsPrimitive }}&{{ end }}payload{{ else }}{{ end }}{{/*
 	*/}}{{ $params := joinNames true .Action.QueryParams .Action.Headers }}{{ if $params }}, {{ format $params $specialTypeResult.Temps }}{{ end }}{{/*
-	*/}}{{ if .Action.Payload }}, cmd.ContentType{{ end }})
+	*/}}{{ if .Action.Payload }}{{ if .HasMultiContent }}, cmd.ContentType{{ end }}{{ end }})
 	if err != nil {
 		goa.LogError(ctx, "failed", "err", err)
 		return err


### PR DESCRIPTION
In issue #908 I noticed that the CLI command still wants to pass in a `contentType` into a generated function that no longer accepts a `contentType` by default, only if the API has more than one type defined using `Consumes()`. I've applied the same logic from 4efae3cfe69f54efd4f8cb6bc2999a7e7ff8a6b2 to the `cli_generator.go` file.

Fixes #908