### PR TITLE
Corretly call Validate on user type attributes

### DIFF
--- a/goagen/codegen/validation.go
+++ b/goagen/codegen/validation.go
@@ -141,6 +141,14 @@ func (v *Validator) recurse(att *design.AttributeDefinition, nonzero, required, 
 		}
 		val := v.Code(a.ElemType, true, false, false, "e", context+"[*]", depth+1, false)
 		if val != "" {
+			switch a.ElemType.Type.(type) {
+			case *design.UserTypeDefinition, *design.MediaTypeDefinition:
+				// For user and media types, call the Validate method
+				val = RunTemplate(v.userValT, map[string]interface{}{
+					"depth":  depth + 1,
+					"target": "e",
+				})
+			}
 			data := map[string]interface{}{
 				"elemType":   a.ElemType,
 				"context":    context,

--- a/goagen/codegen/validation_test.go
+++ b/goagen/codegen/validation_test.go
@@ -273,8 +273,8 @@ const (
 	}`
 
 	utRequiredCode = `	for _, e := range val.Foo {
-		if e.Bar == "" {
-			err = goa.MergeErrors(err, goa.MissingAttributeError(` + "`context.foo[*]`" + `, "bar"))
+		if err2 := e.Validate(); err2 != nil {
+			err = goa.MergeErrors(err, err2)
 		}
 	}`
 )


### PR DESCRIPTION
When validating arrays. Only call Validate if the array element type
defines validations

Fix #922 