### PR TITLE
Properly generate Swagger for collection media type views

### DIFF
--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -268,12 +268,20 @@ func GoTypeDesc(t design.DataType, upper bool) string {
 		if actual.Description != "" {
 			return strings.Replace(actual.Description, "\n", "\n// ", -1)
 		}
+		name := Goify(actual.TypeName, upper)
+		if actual.View != "default" {
+			name += Goify(actual.View, true)
+		}
 
 		switch elem := actual.UserTypeDefinition.AttributeDefinition.Type.(type) {
 		case *design.Array:
-			return fmt.Sprintf("%s media type is a collection of %s.", Goify(actual.TypeName, upper), GoTypeName(elem.ElemType.Type, nil, 0, !upper))
+			elemName := GoTypeName(elem.ElemType.Type, nil, 0, !upper)
+			if actual.View != "default" {
+				elemName += Goify(actual.View, true)
+			}
+			return fmt.Sprintf("%s media type is a collection of %s.", name, elemName)
 		default:
-			return Goify(actual.TypeName, upper) + " media type."
+			return name + " media type."
 		}
 	default:
 		return ""

--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 
 	"github.com/goadesign/goa/design"
-	"github.com/goadesign/goa/goagen/codegen"
 )
 
 type (
@@ -236,13 +235,14 @@ func GenerateResourceDefinition(api *design.APIDefinition, r *design.ResourceDef
 
 // MediaTypeRef produces the JSON reference to the media type definition with the given view.
 func MediaTypeRef(api *design.APIDefinition, mt *design.MediaTypeDefinition, view string) string {
-	if _, ok := Definitions[mt.TypeName]; !ok {
-		GenerateMediaTypeDefinition(api, mt, view)
+	projected, _, err := mt.Project(view)
+	if err != nil {
+		panic(fmt.Sprintf("failed to project media type %#v: %s", mt.Identifier, err)) // bug
 	}
-	ref := fmt.Sprintf("#/definitions/%s", mt.TypeName)
-	if view != "default" {
-		ref += codegen.Goify(view, true)
+	if _, ok := Definitions[projected.TypeName]; !ok {
+		GenerateMediaTypeDefinition(api, projected, "default")
 	}
+	ref := fmt.Sprintf("#/definitions/%s", projected.TypeName)
 	return ref
 }
 

--- a/goagen/gen_swagger/swagger_test.go
+++ b/goagen/gen_swagger/swagger_test.go
@@ -514,6 +514,9 @@ var _ = Describe("New", func() {
 							Required("Authorization", "X-Account", "OverrideOptionalHeader")
 						})
 						Payload(UpdatePayload)
+						Response(OK, func() {
+							Media(CollectionOf(BottleMedia), "extended")
+						})
 						Response(NoContent)
 						Response(NotFound)
 					})
@@ -574,14 +577,20 @@ var _ = Describe("New", func() {
 			It("should set the inherited tag and the action tag", func() {
 				tags := []string{"res", "Update"}
 				a := swagger.Paths["/orgs/{org}/accounts/{id}"].(*genswagger.Path)
+				Ω(a.Put).ShouldNot(BeNil())
 				Ω(a.Put.Tags).Should(Equal(tags))
 				b := swagger.Paths["/base/bottles/{id}"].(*genswagger.Path)
 				Ω(b.Put.Tags).Should(Equal(tags))
 			})
 
-			It("should set the summary from the summary tag", func() {
+			It("sets the summary from the summary tag", func() {
 				a := swagger.Paths["/orgs/{org}/accounts/{id}"].(*genswagger.Path)
 				Ω(a.Put.Summary).Should(Equal("a summary"))
+			})
+
+			It("generates the media type collection schema", func() {
+				Ω(swagger.Definitions).Should(HaveLen(6))
+				Ω(swagger.Definitions).Should(HaveKey("GoaExampleBottleExtendedCollection"))
 			})
 
 			It("serializes into valid swagger JSON", func() { validateSwagger(swagger) })


### PR DESCRIPTION
This PR fixes an issue where a response defined with a media type such as:

    Media(Collection(Other), "view")

would cause the generated Swagger to lack the corresponding schema definition.

Fix #935 