### PR TITLE
Make sure to escape path parameters when building request URL

### DIFF
--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -116,6 +116,7 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 		codegen.SimpleImport("encoding/json"),
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("log"),
+		codegen.SimpleImport("net/url"),
 		codegen.SimpleImport("os"),
 		codegen.SimpleImport("path"),
 		codegen.SimpleImport("path/filepath"),
@@ -274,7 +275,15 @@ func joinRouteParams(action *design.ActionDefinition, att *design.AttributeDefin
 		elems  = make([]string, len(params))
 	)
 	for i, p := range params {
-		field := fmt.Sprintf("cmd.%s", codegen.Goify(p, true))
+		patt, ok := att.Type.ToObject()[p]
+		if !ok {
+			continue
+		}
+		pf := "cmd.%s"
+		if patt.Type.Kind() == design.StringKind {
+			pf = "url.QueryEscape(cmd.%s)"
+		}
+		field := fmt.Sprintf(pf, codegen.Goify(p, true))
 		elems[i] = field
 	}
 	return strings.Join(elems, ", ")

--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Generate", func() {
 		})
 	})
 
-	Context("with an action with an integer parameter with no default value", func() {
+	Context("with an action with two parameters", func() {
 		BeforeEach(func() {
 			codegen.TempCount = 0
 			design.Design = &design.APIDefinition{
@@ -100,7 +100,7 @@ var _ = Describe("Generate", func() {
 			Ω(genErr).Should(BeNil())
 			content, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring(`path = fmt.Sprintf("/nics/%v/add/%v", cmd.NicID, cmd.IPAddress`))
+			Ω(content).Should(ContainSubstring(`path = fmt.Sprintf("/nics/%v/add/%v", url.QueryEscape(cmd.NicID), url.QueryEscape(cmd.IPAddress)`))
 		})
 	})
 


### PR DESCRIPTION
in the CLI code. Query string parameters are already escaped properly.

Fix #944 