### PR TITLE
Pass arguments to final generator

### DIFF
--- a/goagen/main.go
+++ b/goagen/main.go
@@ -141,9 +141,12 @@ package and tool and the Swagger specification for the API.
 	genCmd := &cobra.Command{
 		Use:   "gen",
 		Short: "Run third-party generator",
-		Run:   func(c *cobra.Command, _ []string) { files, err = runGen(c) },
+		Run:   func(c *cobra.Command, args []string) { files, err = runGen(c, args) },
 	}
 	genCmd.Flags().StringVar(&pkgPath, "pkg-path", "", "Package import path of generator. The package must implement the Generate global function.")
+	// stop parsing arguments after -- to prevent an unknown flag error
+	// this also means custom arguments (after --) should be the last arguments
+	genCmd.Flags().SetInterspersed(false)
 	rootCmd.AddCommand(genCmd)
 
 	// boostrapCmd implements the "bootstrap" command.
@@ -235,10 +238,10 @@ func run(pkg string, c *cobra.Command) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid package import path: %s", err)
 	}
-	return generate(pkgName, pkgPath, c)
+	return generate(pkgName, pkgPath, c, []string{})
 }
 
-func runGen(c *cobra.Command) ([]string, error) {
+func runGen(c *cobra.Command, args []string) ([]string, error) {
 	pkgPath := c.Flag("pkg-path").Value.String()
 	pkgSrcPath, err := codegen.PackageSourcePath(pkgPath)
 	if err != nil {
@@ -248,10 +251,10 @@ func runGen(c *cobra.Command) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid plugin package import path: %s", err)
 	}
-	return generate(pkgName, pkgPath, c)
+	return generate(pkgName, pkgPath, c, args)
 }
 
-func generate(pkgName, pkgPath string, c *cobra.Command) ([]string, error) {
+func generate(pkgName, pkgPath string, c *cobra.Command, args []string) ([]string, error) {
 	m := make(map[string]string)
 	c.Flags().Visit(func(f *pflag.Flag) {
 		if f.Name != "pkg-path" {
@@ -272,6 +275,7 @@ func generate(pkgName, pkgPath string, c *cobra.Command) ([]string, error) {
 		pkgName+".Generate",
 		[]*codegen.ImportSpec{codegen.SimpleImport(pkgPath)},
 		m,
+		args,
 	)
 	if err != nil {
 		return nil, err

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -238,7 +238,7 @@ func run(pkg string, c *cobra.Command) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid package import path: %s", err)
 	}
-	return generate(pkgName, pkgPath, c, []string{})
+	return generate(pkgName, pkgPath, c, nil)
 }
 
 func runGen(c *cobra.Command, args []string) ([]string, error) {

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -33,6 +33,10 @@ type Generator struct {
 	// generator on the command line.
 	Flags map[string]string
 
+	// CustomFlags is the list of arguments that appear after the -- separator.
+	// These arguments are appended verbatim to the final generator command line.
+	CustomFlags []string
+
 	// OutDir is the final output directory.
 	OutDir string
 
@@ -44,7 +48,7 @@ type Generator struct {
 
 // NewGenerator returns a meta generator that can run an actual Generator
 // given its factory method and command line flags.
-func NewGenerator(genfunc string, imports []*codegen.ImportSpec, flags map[string]string) (*Generator, error) {
+func NewGenerator(genfunc string, imports []*codegen.ImportSpec, flags map[string]string, customflags []string) (*Generator, error) {
 	var (
 		outDir, designPkgPath string
 		debug                 bool
@@ -68,6 +72,7 @@ func NewGenerator(genfunc string, imports []*codegen.ImportSpec, flags map[strin
 		Genfunc:       genfunc,
 		Imports:       imports,
 		Flags:         flags,
+		CustomFlags:   customflags,
 		OutDir:        outDir,
 		DesignPkgPath: designPkgPath,
 		debug:         debug,
@@ -181,6 +186,7 @@ func (m *Generator) spawn(genbin string) ([]string, error) {
 	}
 	sort.Strings(args)
 	args = append(args, "--version="+version.String())
+	args = append(args, m.CustomFlags...)
 	cmd := exec.Command(genbin, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/goagen/meta/generator_test.go
+++ b/goagen/meta/generator_test.go
@@ -299,7 +299,7 @@ func Generate() ([]string, error) {
 			return nil, nil
 		}
 	}
-	return nil, fmt.Errorf("no flag --custom=arg found")
+	return nil, fmt.Errorf("no flag {{.}} found")
 }
 `
 )


### PR DESCRIPTION
This change will allow arguments to goagen which are add after the '--' argument to be passed allong to the generator.

The generate command becomes goagen gen -d <design> --pkg-path=<generator> -- --custom-arg=value

Fixes #934