### PR TITLE
Pass arguments to final generator

### DIFF
--- a/goagen/main.go
+++ b/goagen/main.go
@@ -141,9 +141,12 @@ package and tool and the Swagger specification for the API.
 	genCmd := &cobra.Command{
 		Use:   "gen",
 		Short: "Run third-party generator",
-		Run:   func(c *cobra.Command, _ []string) { files, err = runGen(c) },
+		Run:   func(c *cobra.Command, args []string) { files, err = runGen(c, args) },
 	}
 	genCmd.Flags().StringVar(&pkgPath, "pkg-path", "", "Package import path of generator. The package must implement the Generate global function.")
+	// stop parsing arguments after -- to prevent an unknown flag error
+	// this also means custom arguments (after --) should be the last arguments
+	genCmd.Flags().SetInterspersed(false)
 	rootCmd.AddCommand(genCmd)
 
 	// boostrapCmd implements the "bootstrap" command.
@@ -235,10 +238,10 @@ func run(pkg string, c *cobra.Command) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid package import path: %s", err)
 	}
-	return generate(pkgName, pkgPath, c)
+	return generate(pkgName, pkgPath, c, nil)
 }
 
-func runGen(c *cobra.Command) ([]string, error) {
+func runGen(c *cobra.Command, args []string) ([]string, error) {
 	pkgPath := c.Flag("pkg-path").Value.String()
 	pkgSrcPath, err := codegen.PackageSourcePath(pkgPath)
 	if err != nil {
@@ -248,10 +251,10 @@ func runGen(c *cobra.Command) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid plugin package import path: %s", err)
 	}
-	return generate(pkgName, pkgPath, c)
+	return generate(pkgName, pkgPath, c, args)
 }
 
-func generate(pkgName, pkgPath string, c *cobra.Command) ([]string, error) {
+func generate(pkgName, pkgPath string, c *cobra.Command, args []string) ([]string, error) {
 	m := make(map[string]string)
 	c.Flags().Visit(func(f *pflag.Flag) {
 		if f.Name != "pkg-path" {
@@ -272,6 +275,7 @@ func generate(pkgName, pkgPath string, c *cobra.Command) ([]string, error) {
 		pkgName+".Generate",
 		[]*codegen.ImportSpec{codegen.SimpleImport(pkgPath)},
 		m,
+		args,
 	)
 	if err != nil {
 		return nil, err

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -33,6 +33,10 @@ type Generator struct {
 	// generator on the command line.
 	Flags map[string]string
 
+	// CustomFlags is the list of arguments that appear after the -- separator.
+	// These arguments are appended verbatim to the final generator command line.
+	CustomFlags []string
+
 	// OutDir is the final output directory.
 	OutDir string
 
@@ -44,7 +48,7 @@ type Generator struct {
 
 // NewGenerator returns a meta generator that can run an actual Generator
 // given its factory method and command line flags.
-func NewGenerator(genfunc string, imports []*codegen.ImportSpec, flags map[string]string) (*Generator, error) {
+func NewGenerator(genfunc string, imports []*codegen.ImportSpec, flags map[string]string, customflags []string) (*Generator, error) {
 	var (
 		outDir, designPkgPath string
 		debug                 bool
@@ -68,6 +72,7 @@ func NewGenerator(genfunc string, imports []*codegen.ImportSpec, flags map[strin
 		Genfunc:       genfunc,
 		Imports:       imports,
 		Flags:         flags,
+		CustomFlags:   customflags,
 		OutDir:        outDir,
 		DesignPkgPath: designPkgPath,
 		debug:         debug,
@@ -180,6 +185,7 @@ func (m *Generator) spawn(genbin string) ([]string, error) {
 	}
 	sort.Strings(args)
 	args = append(args, "--version="+version.String())
+	args = append(args, m.CustomFlags...)
 	cmd := exec.Command(genbin, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/goagen/meta/generator_test.go
+++ b/goagen/meta/generator_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Run", func() {
 	var outputDir string
 	var designPkgPath, setDesignPkgPath string
 	var designPackageSource string
+	var customFlags []string
 
 	var m *meta.Generator
 
@@ -41,6 +42,7 @@ var _ = Describe("Run", func() {
 		Ω(err).ShouldNot(HaveOccurred())
 		compiledFiles = nil
 		compileError = nil
+		customFlags = []string{"--custom=arg"}
 	})
 
 	JustBeforeEach(func() {
@@ -57,6 +59,7 @@ var _ = Describe("Run", func() {
 			Genfunc:       genfunc,
 			Imports:       []*codegen.ImportSpec{codegen.SimpleImport(designPkgPath)},
 			OutDir:        outputDir,
+			CustomFlags:   customFlags,
 			DesignPkgPath: setDesignPkgPath,
 		}
 		compiledFiles, compileError = m.Generate()
@@ -240,6 +243,21 @@ var _ = Describe("Run", func() {
 				Ω(compiledFiles).Should(Equal(filePaths))
 			})
 		})
+		Context("with code that uses custom flags", func() {
+			BeforeEach(func() {
+				var b bytes.Buffer
+				tmpl, err := template.New("source").Parse(validSourceTmplWithCustomFlags)
+				Ω(err).ShouldNot(HaveOccurred())
+				err = tmpl.Execute(&b, "--custom=arg")
+				Ω(err).ShouldNot(HaveOccurred())
+				designPackageSource = b.String()
+
+			})
+
+			It("returns no error", func() {
+				Ω(compileError).ShouldNot(HaveOccurred())
+			})
+		})
 	})
 })
 
@@ -268,6 +286,20 @@ func Generate() ([]string, error) {
 	{{range .}}fmt.Println("{{.}}")
 	{{end}}
 	return nil, nil
+}
+`
+
+	validSourceTmplWithCustomFlags = `package foo
+import "fmt"
+import "os"
+
+func Generate() ([]string, error) {
+	for _, arg := range os.Args {
+		if arg == "{{.}}" {
+			return nil, nil
+		}
+	}
+	return nil, fmt.Errorf("no flag {{.}} found")
 }
 `
 )


### PR DESCRIPTION
This change will allow arguments to goagen which are add after the '--' argument to be passed allong to the generator.

The generate command becomes goagen gen -d --pkg-path= -- --custom-arg=value

Fixes #934