### PR TITLE
Fix code that sets request headers in client package

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -1007,8 +1007,8 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 {{ end }}{{ if .MustToString }}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}
 	header.Set("{{ .Name }}", {{ $tmp }}){{ else }}
 	header.Set("{{ .Name }}", {{ .ValueName }})
-{{ end }}{{ if .CheckNil }}	}
-{{ end }}{{ end }}{{ end }}{{ if .Signer }}	if c.{{ .Signer }}Signer != nil {
+{{ end }}{{ if .CheckNil }}	}{{ end }}
+{{ end }}{{ end }}{{ if .Signer }}	if c.{{ .Signer }}Signer != nil {
 		c.{{ .Signer }}Signer.Sign(req)
 	}
 {{ end }}	return req, nil


### PR DESCRIPTION
When the conversion of the header value to string requires multiple lines such
as when it is a UUID.

Fix #958 