### PR TITLE
Fix the generation of length validation for strings that contain multi-byte UTF-8 characters.

### DIFF
--- a/goagen/codegen/validation.go
+++ b/goagen/codegen/validation.go
@@ -260,6 +260,7 @@ func ValidationChecker(att *design.AttributeDefinition, nonzero, required, hasDe
 		"context":   context,
 		"target":    target,
 		"targetVal": t,
+		"string":    att.Type.Name() == "string",
 		"array":     att.Type.IsArray(),
 		"hash":      att.Type.IsHash(),
 		"depth":     depth,
@@ -411,13 +412,13 @@ const (
 {{ if .isPointer }}{{ tabs $depth }}}
 {{ end }}{{ tabs .depth }}}`
 
-	lengthValTmpl = `{{ $depth := or (and .isPointer (add .depth 1)) .depth }}{{/*
-*/}}{{ $target := or (and (or (or .array .hash) .nonzero) .target) .targetVal }}{{/*
-*/}}{{ if .isPointer }}{{ tabs .depth }}if {{ .target }} != nil {
-{{ end }}{{ tabs .depth }}	if len({{ $target }}) {{ if .isMinLength }}<{{ else }}>{{ end }} {{ if .isMinLength }}{{ .minLength }}{{ else }}{{ .maxLength }}{{ end }} {
-{{ tabs $depth }}	err = goa.MergeErrors(err, goa.InvalidLengthError(` + "`" + `{{ .context }}` + "`" + `, {{ $target }}, len({{ $target }}), {{ if .isMinLength }}{{ .minLength }}, true{{ else }}{{ .maxLength }}, false{{ end }}))
-{{ if .isPointer }}{{ tabs $depth }}}
-{{ end }}{{ tabs .depth }}}`
+	lengthValTmpl = `{{$depth := or (and .isPointer (add .depth 1)) .depth}}{{/*
+*/}}{{$target := or (and (or (or .array .hash) .nonzero) .target) .targetVal}}{{/*
+*/}}{{if .isPointer}}{{tabs .depth}}if {{.target}} != nil {
+{{end}}{{tabs .depth}}	if {{if .string}}utf8.RuneCountInString({{$target}}){{else}}len({{$target}}){{end}} {{if .isMinLength}}<{{else}}>{{end}} {{if .isMinLength}}{{.minLength}}{{else}}{{.maxLength}}{{end}} {
+{{tabs $depth}}	err = goa.MergeErrors(err, goa.InvalidLengthError(` + "`" + `{{.context}}` + "`" + `, {{$target}}, {{if .string}}utf8.RuneCountInString({{$target}}){{else}}len({{$target}}){{end}}, {{if .isMinLength}}{{.minLength}}, true{{else}}{{.maxLength}}, false{{end}}))
+{{if .isPointer}}{{tabs $depth}}}
+{{end}}{{tabs .depth}}}`
 
 	requiredValTmpl = `{{ $att := index $.attribute.Type.ToObject .required }}{{/*
 */}}{{ if and (not $.private) (eq $att.Type.Kind 4) }}{{ tabs $.depth }}if {{ $.target }}.{{ goifyAtt $att .required true }} == "" {

--- a/goagen/codegen/validation.go
+++ b/goagen/codegen/validation.go
@@ -260,7 +260,7 @@ func ValidationChecker(att *design.AttributeDefinition, nonzero, required, hasDe
 		"context":   context,
 		"target":    target,
 		"targetVal": t,
-		"string":    att.Type.Name() == "string",
+		"string":    att.Type.Kind() == design.StringKind,
 		"array":     att.Type.IsArray(),
 		"hash":      att.Type.IsHash(),
 		"depth":     depth,

--- a/goagen/codegen/validation_test.go
+++ b/goagen/codegen/validation_test.go
@@ -71,7 +71,7 @@ var _ = Describe("validation code generation", func() {
 				})
 			})
 
-			Context("of min length 1", func() {
+			Context("of array min length 1", func() {
 				BeforeEach(func() {
 					attType = &design.Array{
 						ElemType: &design.AttributeDefinition{
@@ -85,7 +85,21 @@ var _ = Describe("validation code generation", func() {
 				})
 
 				It("produces the validation go code", func() {
-					Ω(code).Should(Equal(minLengthValCode))
+					Ω(code).Should(Equal(arrayMinLengthValCode))
+				})
+			})
+
+			Context("of string min length 2", func() {
+				BeforeEach(func() {
+					attType = design.String
+					min := 2
+					validation = &dslengine.ValidationDefinition{
+						MinLength: &min,
+					}
+				})
+
+				It("produces the validation go code", func() {
+					Ω(code).Should(Equal(stringMinLengthValCode))
 				})
 			})
 
@@ -227,9 +241,15 @@ const (
 		}
 	}`
 
-	minLengthValCode = `	if val != nil {
+	arrayMinLengthValCode = `	if val != nil {
 		if len(val) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError(` + "`" + `context` + "`" + `, val, len(val), 1, true))
+		}
+	}`
+
+	stringMinLengthValCode = `	if val != nil {
+		if utf8.RuneCountInString(*val) < 2 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError(` + "`" + `context` + "`" + `, *val, utf8.RuneCountInString(*val), 2, true))
 		}
 	}`
 

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -122,6 +122,7 @@ func (g *Generator) generateContexts() error {
 		codegen.SimpleImport("strconv"),
 		codegen.SimpleImport("strings"),
 		codegen.SimpleImport("time"),
+		codegen.SimpleImport("unicode/utf8"),
 		codegen.SimpleImport("github.com/goadesign/goa"),
 		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 	}
@@ -355,6 +356,7 @@ func (g *Generator) generateMediaTypes() error {
 		codegen.SimpleImport("github.com/goadesign/goa"),
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("time"),
+		codegen.SimpleImport("unicode/utf8"),
 		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 	}
 	mtWr.WriteHeader(title, g.Target, imports)
@@ -386,6 +388,7 @@ func (g *Generator) generateUserTypes() error {
 	imports := []*codegen.ImportSpec{
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("time"),
+		codegen.SimpleImport("unicode/utf8"),
 		codegen.SimpleImport("github.com/goadesign/goa"),
 		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
 	}

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -555,6 +555,7 @@ func (g *Generator) generateMediaTypes(pkgDir string, funcs template.FuncMap) er
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("net/http"),
 		codegen.SimpleImport("time"),
+		codegen.SimpleImport("unicode/utf8"),
 		codegen.NewImport("uuid", "github.com/goadesign/goa/uuid"),
 	}
 	mtWr.WriteHeader(title, g.Target, imports)
@@ -597,6 +598,7 @@ func (g *Generator) generateUserTypes(pkgDir string) error {
 		codegen.SimpleImport("fmt"),
 		codegen.SimpleImport("time"),
 		codegen.NewImport("uuid", "github.com/goadesign/goa/uuid"),
+		codegen.SimpleImport("unicode/utf8"),
 	}
 	utWr.WriteHeader(title, g.Target, imports)
 	err = g.API.IterateUserTypes(func(t *design.UserTypeDefinition) error {


### PR DESCRIPTION
Checking the difference of v1.1.0, I noticed that #740 is not backporting to the v1 branch.
