### PR TITLE
context values (user types) populated with lookup functions

### DIFF
--- a/design/apidsl/api.go
+++ b/design/apidsl/api.go
@@ -68,6 +68,9 @@ import (
 //				Required("header")
 //			})
 //		})
+//		Lookup("Account", AccountType, func() {	// Creates a new lookup template function
+//			Attribute("id", UUID)		// The input attributes
+//		})
 //	}
 //
 func API(name string, dsl func()) *design.APIDefinition {
@@ -475,7 +478,9 @@ func setupResponseTemplate(a *design.APIDefinition, name string, p interface{}) 
 	} else if tmpl, ok := p.(func(...string)); ok {
 		t := func(params ...string) *design.ResponseDefinition {
 			r := &design.ResponseDefinition{Name: name}
-			dslengine.Execute(func() { tmpl(params...) }, r)
+			dslengine.Execute(func() {
+				tmpl(params...)
+			}, r)
 			return r
 		}
 		a.ResponseTemplates[name] = &design.ResponseTemplateDefinition{
@@ -512,7 +517,9 @@ func setupResponseTemplate(a *design.APIDefinition, name string, p interface{}) 
 				// append input arguments
 				in[i] = reflect.ValueOf(params[i])
 			}
-			dslengine.Execute(func() { val.Call(in) }, r)
+			dslengine.Execute(func() {
+				val.Call(in)
+			}, r)
 			return r
 		}
 		a.ResponseTemplates[name] = &design.ResponseTemplateDefinition{

--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -97,6 +97,11 @@ func Attribute(name string, args ...interface{}) {
 			def.Params = new(design.AttributeDefinition)
 		}
 		parent = def.Params
+	case *design.LookupDefinition:
+		if def.Params == nil {
+			def.Params = new(design.AttributeDefinition)
+		}
+		parent = def.Params
 	default:
 		dslengine.IncompatibleDSL()
 	}

--- a/design/apidsl/current.go
+++ b/design/apidsl/current.go
@@ -131,3 +131,13 @@ func responseDefinition() (*design.ResponseDefinition, bool) {
 	}
 	return r, ok
 }
+
+// lookupDefinition returns true and current context if it is a LookupDefinition,
+// nil and false otherwise.
+func lookupDefinition() (*design.LookupDefinition, bool) {
+	l, ok := dslengine.CurrentDefinition().(*design.LookupDefinition)
+	if !ok {
+		dslengine.IncompatibleDSL()
+	}
+	return l, ok
+}

--- a/design/apidsl/lookup.go
+++ b/design/apidsl/lookup.go
@@ -1,0 +1,99 @@
+package apidsl
+
+import (
+	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
+	"strings"
+)
+
+// Lookup defines a lookup template who is beeing called after the context is created
+func Lookup(name string, userType design.DataStructure, dsl func()) {
+
+	key := mapKey(name)
+
+	if design.Design.Lookups == nil {
+		design.Design.Lookups = make(map[string]*design.LookupDefinition)
+	} else if _, ok := design.Design.Lookups[key]; ok {
+		dslengine.ReportError("redefinition of lookup", name)
+		return
+	}
+
+	_, ok := dslengine.CurrentDefinition().(*design.APIDefinition)
+	if !ok {
+		dslengine.IncompatibleDSL()
+		return
+	}
+
+	var ut *design.UserTypeDefinition
+	switch t := userType.(type) {
+	case *design.UserTypeDefinition:
+		ut = t
+	case *design.MediaTypeDefinition:
+		ut = t.UserTypeDefinition
+	default:
+		dslengine.ReportError("provided type must be a Type or a Media")
+	}
+
+	lookup := &design.LookupDefinition{
+		Name:       key,
+		ReturnType: ut,
+	}
+	dslengine.Execute(dsl, lookup)
+
+	design.Design.Lookups[key] = lookup
+}
+
+// UseLookup can be used inside a Resource or Action to define wich lookup template to use
+func UseLookup(name string, dsl ...func()) {
+
+	var lookups *[]*design.LookupDefinition
+
+	switch d := dslengine.CurrentDefinition().(type) {
+	case *design.ActionDefinition:
+		lookups = &d.Lookups
+
+	case *design.ResourceDefinition:
+		lookups = &d.Lookups
+
+	default:
+		dslengine.IncompatibleDSL()
+		return
+	}
+
+	//if _, ok := lookups[key]; ok {
+	//	dslengine.ReportError("duplicate uselookup with same name", name)
+	//	return
+	//}
+
+	lookup := &design.LookupDefinition{
+		Name: mapKey(name),
+	}
+
+	if len(dsl) >= 1 {
+		dslengine.Execute(dsl[0], lookup)
+	}
+
+	*lookups = append(*lookups, lookup)
+}
+
+// MustResolve indicates that the lookup must return a non nil value
+// otherwise the execution of the chain will stop and return a 404 not found
+func MustResolve() {
+	if l, ok := lookupDefinition(); ok {
+		l.MustResolve = true
+	}
+}
+
+// MapRouteParam reroutes a route param to the argument of the lookup
+func MapRouteParam(from, to string) {
+	if l, ok := lookupDefinition(); ok {
+		if l.Remap == nil {
+			l.Remap = make(map[string]string)
+		}
+		l.Remap[mapKey(to)] = mapKey(from)
+	}
+}
+
+func mapKey(name string) string {
+	return strings.TrimSpace(strings.ToLower(name))
+}

--- a/design/validation.go
+++ b/design/validation.go
@@ -64,7 +64,6 @@ func (r *routeInfo) DifferentWildcards(other *routeInfo) (res [][2]*wildCardInfo
 // Validate tests whether the API definition is consistent: all resource parent names resolve to
 // an actual resource.
 func (a *APIDefinition) Validate() error {
-
 	// This is a little bit hacky but we need the generated media types DSLs to run first so
 	// that their views are defined otherwise we risk running into validation errors where an
 	// attribute defined on a non generated media type uses a generated mediatype (i.e.

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -89,6 +89,9 @@ func (g *Generator) Generate() (_ []string, err error) {
 	if err := g.generateUserTypes(); err != nil {
 		return nil, err
 	}
+	if err := g.generateLookups(); err != nil {
+		return nil, err
+	}
 	if !g.NoTest {
 		if err := g.generateResourceTest(); err != nil {
 			return nil, err
@@ -140,6 +143,11 @@ func (g *Generator) generateContexts() error {
 				params = nil // So that {{if .Params}} returns false in templates
 			}
 
+			lookups := a.AllLookups()
+			if lookups != nil && len(lookups) == 0 {
+				lookups = nil // So that {{if .lookups}} returns false in templates
+			}
+
 			non101 := make(map[string]*design.ResponseDefinition)
 			for k, v := range a.Responses {
 				if v.Status != 101 {
@@ -152,6 +160,7 @@ func (g *Generator) generateContexts() error {
 				ActionName:   a.Name,
 				Payload:      a.Payload,
 				Params:       params,
+				Lookups:      lookups,
 				Headers:      headers,
 				Routes:       a.Routes,
 				Responses:    non101,
@@ -237,6 +246,7 @@ func (g *Generator) generateControllers() error {
 			Resource:       codegen.Goify(r.Name, true),
 			PreflightPaths: r.PreflightPaths(),
 			FileServers:    fileServers,
+			LookupNames:    r.LookupNames(),
 		}
 		ierr := r.IterateActions(func(a *design.ActionDefinition) error {
 			context := fmt.Sprintf("%s%sContext", codegen.Goify(a.Name, true), codegen.Goify(r.Name, true))
@@ -249,10 +259,12 @@ func (g *Generator) generateControllers() error {
 				"Payload":         a.Payload,
 				"PayloadOptional": a.PayloadOptional,
 				"Security":        a.Security,
+				"Lookups":         a.AllLookups(),
 			}
 			data.Actions = append(data.Actions, action)
 			return nil
 		})
+
 		if ierr != nil {
 			return ierr
 		}
@@ -397,6 +409,29 @@ func (g *Generator) generateUserTypes() error {
 		return utWr.Execute(t)
 	})
 	g.genfiles = append(g.genfiles, utFile)
+	if err != nil {
+		return err
+	}
+	return utWr.FormatCode()
+}
+
+// generateLookups iterates through the lookup templats and generates the data structures and
+// marshaling code.
+func (g *Generator) generateLookups() error {
+	lFile := filepath.Join(g.OutDir, "lookups.go")
+	utWr, err := NewLookupsWriter(lFile)
+	if err != nil {
+		panic(err) // bug
+	}
+	title := fmt.Sprintf("%s: Application lookup Interfaces", g.API.Context())
+	imports := []*codegen.ImportSpec{
+		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
+	}
+	utWr.WriteHeader(title, g.Target, imports)
+	err = g.API.IterateLookups(func(t *design.LookupDefinition) error {
+		return utWr.Execute(t)
+	})
+	g.genfiles = append(g.genfiles, lFile)
 	if err != nil {
 		return err
 	}

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -71,6 +71,13 @@ type (
 		Validator    *codegen.Validator
 	}
 
+	// LookupWriter generate code for a goa application lookup interfaces.
+	// Lookups are used to lookup context values
+	LookupsWriter struct {
+		*codegen.SourceFile
+		LookupTmpl *template.Template
+	}
+
 	// ContextTemplateData contains all the information used by the template to render the context
 	// code for an action.
 	ContextTemplateData struct {
@@ -78,6 +85,7 @@ type (
 		ResourceName string // e.g. "bottles"
 		ActionName   string // e.g. "list"
 		Params       *design.AttributeDefinition
+		Lookups      []*design.LookupDefinition
 		Payload      *design.UserTypeDefinition
 		Headers      *design.AttributeDefinition
 		Routes       []*design.RouteDefinition
@@ -97,6 +105,7 @@ type (
 		Decoders       []*EncoderTemplateData         // Decoder data
 		Origins        []*design.CORSDefinition       // CORS policies
 		PreflightPaths []string
+		LookupNames    []string // All lookup names
 	}
 
 	// ResourceData contains the information required to generate the resource GoGenerator
@@ -437,6 +446,25 @@ func (w *UserTypesWriter) Execute(t *design.UserTypeDefinition) error {
 	return w.ExecuteTemplate("types", userTypeT, fn, t)
 }
 
+// NewLookupsWriter returns a contexts code writer.
+// Lookups contain a interface for lookuing up context values defined by DSL "Lookup".
+func NewLookupsWriter(filename string) (*LookupsWriter, error) {
+	file, err := codegen.SourceFileFor(filename)
+	if err != nil {
+		return nil, err
+	}
+	return &LookupsWriter{
+		SourceFile: file,
+		//Finalizer:  codegen.NewFinalizer(),
+		//Validator:  codegen.NewValidator(),
+	}, nil
+}
+
+// Execute writes the code for the context lookups to the writer.
+func (w *LookupsWriter) Execute(l *design.LookupDefinition) error {
+	return w.ExecuteTemplate("lookups", lookupInterfaceT, nil, l)
+}
+
 // newCoerceData is a helper function that creates a map that can be given to the "Coerce" template.
 func newCoerceData(name string, att *design.AttributeDefinition, pointer bool, pkg string, depth int) map[string]interface{} {
 	return map[string]interface{}{
@@ -466,6 +494,8 @@ type {{ .Name }} struct {
 */}}	{{ goifyatt $att $name true }} {{ if and $att.Type.IsPrimitive ($.Headers.IsPrimitivePointer $name) }}*{{ end }}{{ gotyperef .Type nil 0 false }}
 {{ end }}{{ end }}{{ end }}{{ if .Params }}{{ range $name, $att := .Params.Type.ToObject }}{{/*
 */}}	{{ goifyatt $att $name true }} {{ if and $att.Type.IsPrimitive ($.Params.IsPrimitivePointer $name) }}*{{ end }}{{ gotyperef .Type nil 0 false }}
+{{ end }}{{ end }}{{ if .Lookups }}{{ range $i, $lookup := .Lookups }}{{/*
+*/}}	{{ goify $lookup.Name true }} *{{ goify $lookup.ReturnType.TypeName true }}
 {{ end }}{{ end }}{{ if .Payload }}	Payload {{ gotyperef .Payload nil 0 false }}
 {{ end }}}
 `
@@ -689,7 +719,9 @@ func initService(service *goa.Service) {
 	// template input: *ControllerTemplateData
 	mountT = `
 // Mount{{ .Resource }}Controller "mounts" a {{ .Resource }} resource controller on the given service.
-func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Controller) {
+func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Controller{{- range $i, $name := .LookupNames -}}
+, lookup{{ goify $name true }} Lookup{{ goify $name true -}}
+{{ end }}) {
 	initService(service)
 	var h goa.Handler
 {{ $res := .Resource }}{{ if .Origins }}{{ range .PreflightPaths }}{{/*
@@ -711,7 +743,22 @@ func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Co
 {{ if not .PayloadOptional }}		} else {
 			return goa.MissingPayloadError()
 {{ end }}		}
-{{ end }}		return ctrl.{{ .Name }}(rctx)
+{{ end }}{{ if .Lookups }}{{- range $lookup := .Lookups }}
+		// Lookup the context value {{ goify $lookup.Name true }} {{ goify $lookup.ReturnType.TypeName true }}
+{{- $tmp := tempvar }}
+
+		{{ $tmp }}, err := lookup{{ goify $lookup.Name true }}.Lookup{{ goify $lookup.Name true }}({{ range $i, $arg := $lookup.Arguments }}{{ if ne $i 0}}, {{ end }}rctx.{{ goify $arg.ContextParamName true }}{{end}})
+		if err != nil {
+			return goa.ErrInternal("lookup of {{ $lookup.Name }} failed with error", "error", err, "lookup", "{{ $lookup.Name }}")
+		}
+		{{- if $lookup.MustResolve }}
+		if {{ $tmp }} == nil {
+			return goa.ErrNotFound("{{ $lookup.Name }} is not found by id", "lookup", "{{ $lookup.Name }}")
+		}
+		{{ end -}}
+		rctx.{{ goify $lookup.Name true }} = {{ $tmp }}
+
+{{ end }}{{ end }}		return ctrl.{{ .Name }}(rctx)
 	}
 {{ if .Security }}	h = handleSecurity({{ printf "%q" .Security.Scheme.SchemeName }}, h{{ range .Security.Scopes }}, {{ printf "%q" . }}{{ end }})
 {{ end }}{{ if $.Origins }}	h = handle{{ $res }}Origin(h)
@@ -846,6 +893,15 @@ func (ut {{ gotyperef . .AllRequired 0 false }}) Validate() (err error) {
 {{ $validation }}
 	return
 }{{ end }}
+`
+
+	// lookupInterfaceT generates the code for a lookup interface.
+	// template input: map[string]*design.LookupDefinition
+	lookupInterfaceT = `
+type Lookup{{ goify .Name true}} interface {
+	Lookup{{ goify .Name true}}({{ range $i, $arg := .Arguments }}{{ if ne $i 0}},{{ end }} {{ goifyatt $arg.Attribute $arg.ArgumentName false }} {{ gotypename $arg.Attribute.Type nil 0 false }}{{end}}) (*{{ goify .ReturnType.TypeName true }}, error)
+}
+
 `
 
 	// securitySchemesT generates the code for the security module.

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -102,11 +102,11 @@ func (g *Generator) Generate() (_ []string, err error) {
 			g.genfiles = append(g.genfiles, filename)
 			file, err2 := codegen.SourceFileFor(filename)
 			if err2 != nil {
-				return err
+				return err2
 			}
 			file.WriteHeader("", "main", imports)
 			if err2 = file.ExecuteTemplate("controller", ctrlT, funcs, r); err2 != nil {
-				return err
+				return err2
 			}
 			err2 = r.IterateActions(func(a *design.ActionDefinition) error {
 				if a.WebSocket() {
@@ -115,7 +115,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 				return file.ExecuteTemplate("action", actionT, funcs, a)
 			})
 			if err2 != nil {
-				return err
+				return err2
 			}
 			if err2 = file.FormatCode(); err2 != nil {
 				return err2
@@ -127,6 +127,37 @@ func (g *Generator) Generate() (_ []string, err error) {
 		return
 	}
 
+	if len(g.API.Lookups) > 0 {
+		filename := filepath.Join(g.OutDir, "lookups.go")
+		if g.Force {
+			os.Remove(filename)
+		}
+		if _, e := os.Stat(filename); e != nil {
+			title := fmt.Sprintf("%s: Application lookup Interfaces", g.API.Context())
+			imports := []*codegen.ImportSpec{
+				codegen.SimpleImport(imp),
+				codegen.NewImport("uuid", "github.com/satori/go.uuid"),
+			}
+
+			g.genfiles = append(g.genfiles, filename)
+			file, err2 := codegen.SourceFileFor(filename)
+			if err2 != nil {
+				return nil, err2
+			}
+			file.WriteHeader(title, "main", imports)
+
+			for _, l := range g.API.Lookups {
+				if err2 = file.ExecuteTemplate("lookups", lookupT, funcs, l); err2 != nil {
+					return nil, err2
+				}
+
+			}
+			if err2 = file.FormatCode(); err2 != nil {
+				return nil, err2
+			}
+		}
+
+	}
 	return g.genfiles, nil
 }
 
@@ -248,9 +279,15 @@ func main() {
 	service.Use(middleware.ErrorHandler(service, true))
 	service.Use(middleware.Recover())
 {{ $api := .API }}
+{{ range $api.Lookups -}}
+	lookup{{ goify .Name true}} := NewLookup{{ goify .Name true}}()
+{{ end}}
 {{ range $name, $res := $api.Resources }}{{ $name := goify $res.Name true }} // Mount "{{$res.Name}}" controller
 	{{ $tmp := tempvar }}{{ $tmp }} := New{{ $name }}Controller(service)
-	{{ targetPkg }}.Mount{{ $name }}Controller(service, {{ $tmp }})
+	{{ targetPkg }}.Mount{{ $name }}Controller(service, {{ $tmp }}
+	{{- range $i, $name := .LookupNames -}}
+		, lookup{{ goify $name true -}}
+	{{ end }})
 {{ end }}
 
 	// Start service
@@ -301,5 +338,20 @@ func (c *{{ $ctrlName }}) {{ goify .Name true }}WSHandler(ctx *{{ targetPkg }}.{
 		// Dummy echo websocket server
 		io.Copy(ws, ws)
 	}
+}
+`
+
+const lookupT = `
+type lookup{{ goify .Name true}} struct {}
+
+// NewLookup{{ goify .Name true}} creates a new {{ .Name }} lookup
+func NewLookup{{ goify .Name true}}() {{ targetPkg }}.Lookup{{ goify .Name true}} {
+	return &lookup{{ goify .Name true}}{}
+}
+
+// Lookup{{ goify .Name true}} handles the lookup of the context value {{ goify .Name true}}
+func (l *lookup{{ goify .Name true}}) Lookup{{ goify .Name true}}({{ range $i, $arg := .Arguments }}{{ if ne $i 0}},{{ end }} {{ goifyatt $arg.Attribute $arg.ArgumentName false }} {{ gotypename $arg.Attribute.Type nil 0 false }}{{end}}) (*{{ targetPkg }}.{{ goify .ReturnType.TypeName true }}, error) {
+	// Put your lookup logic here
+	return nil, nil
 }
 `


### PR DESCRIPTION
I created a way to make context value lookups possible.
Most of the time i am repeating some part of controller logic by looking up some models from the repositories. I could do it with generic middleware but and store the value in the context. But that doesn't seems to be nice because most of the time my action depends on the lookup values. And also we have a beautiful context structure to store these references. Now with some extra DSL we can create a lookup function and execute it from the context creation.

for example we can create a Lookup template in the api definition like this
```
var _ = API("test", func() {
	//....
	Lookup("Account", Account, func() { //name of the lookup and the usertype to populate in the context
		Param("id", UUID) // the arguments the lookup needs to have
	})
})
```

This will create a lookup interface we can later on create and give as an argument to the mount function
```
type LookupAccount interface {
	LookupAccount(id uuid.UUID) (*Account, error)
}
```

The DSL for the action, you could also define it on the resource.  When stacking routes (parent) the canonical action path also inherits all the lookups in its route. 
```
Action("show", func () {
	Routing(GET("/:account_id"))
	Description("returns a account")
	Params(func () {
		Param("account_id", UUID, "Account ID")
	})
	UseLookup("Account", func (){
		MustResolve()	 //this will indicate the lookup must succeed with a non nil value, otherwise the request will cancel with a 404
		MapRouteParam("account_id", "id") // if the route params do not match 1 on 1  on the lookup arguments we could remap them this way
	})

	Response(OK, Account)
	Response(NotFound)
})
```

this will add a the following attribute to the contexts.go
```
type ShowAccountContext struct {
	context.Context
	*goa.ResponseData
	*goa.RequestData
	AccountID     uuid.UUID
	Account       *Account // << populated by the lookup
}
```

the validation and invocation of the lookup in the controllers.go
```
func MountAccountController(service *goa.Service, ctrl CustomersController, lookupAccount LookupAccount) {
	initService(service)
	var h goa.Handler

	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
		// Check if there was an error loading the request
		//...

		// Lookup the context value Account
		tmp94, err := lookupAccount.LookupAccount(rctx.AccountID)
		if err != nil {
			return goa.ErrInternal("lookup of account failed with error", "error", err, "lookup", "account")
		}

		//this check is only added if MustResolve() is used in UseLookup
		if tmp94 == nil {
			return goa.ErrNotFound("account is not found by id", "lookup", "account")
		}
		rctx.Account = tmp94

		return ctrl.Show(rctx)
	}
	service.Mux.Handle("GET", "/api/stalling/:stalling_id/customers/:customer_id", ctrl.MuxHandler("Show", h, nil))
	//....
}
```

Also the initial creation of main.go the lookups are auto inserted into the Mount functions and a stub lookups.go is created.
main.go
```
	lookupAccount := NewLookupAccount()

	// Mount "account" controller
	c := NewAccountController(service)
	app.MountAccountController(service, c, lookupAccount)
```

and the stub lookups.go
```
package main

import (
	uuid "github.com/satori/go.uuid"
	"stalling/goa2/app"
)

type lookupAccount struct{}

// NewLookupAccount creates a new account lookup
func NewLookupAccount() app.LookupAccount {
	return &lookupAccount{}
}

// LookupAccount handles the lookup of the context value Account
func (l *lookupAccount) LookupAccount(id uuid.UUID) (*app.Account, error) {
	// Put your lookup logic here
	return nil, nil
}
```

Phew i hope i didn't forget anything yet.
What do you think of this proposal, is it something that could be a part of GOA.

I know tests need to be done and i would like to know how to use the validation to ensure the DSL correct.
