### PR TITLE
Generating path for client is transforming all relevant types to string first.

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -134,7 +134,6 @@ func (g *Generator) Generate() (_ []string, err error) {
 			"join":               join,
 			"joinStrings":        strings.Join,
 			"multiComment":       multiComment,
-			"pathParamNames":     pathParamNames,
 			"pathParams":         pathParams,
 			"pathTemplate":       pathTemplate,
 			"signerType":         signerType,
@@ -334,13 +333,50 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 				}
 			}
 		}
+		initParams := func(att *design.AttributeDefinition) []*paramData {
+			if att == nil {
+				return nil
+			}
+			obj := att.Type.ToObject()
+			var pdata []*paramData
+			for n, q := range obj {
+				varName := codegen.Goify(n, false)
+				param := &paramData{
+					Name:      n,
+					VarName:   varName,
+					Attribute: q,
+				}
+				if q.Type.IsPrimitive() {
+					param.MustToString = q.Type.Kind() != design.StringKind
+					param.ValueName = varName
+					pdata = append(pdata, param)
+				} else {
+					if q.Type.IsArray() {
+						param.IsArray = true
+						param.ElemAttribute = q.Type.ToArray().ElemType
+					}
+					param.MustToString = true
+					param.ValueName = varName
+					param.CheckNil = true
+					pdata = append(pdata, param)
+				}
+			}
+			sort.Sort(byParamName(pdata))
+			return pdata
+		}
 		for i, r := range action.Routes {
+			params := make(design.Object, len(r.Params()))
+			for _, p := range r.Params() {
+				params[p] = action.Params.Type.ToObject()[p]
+			}
 			data := struct {
-				Route *design.RouteDefinition
-				Index int
+				Route  *design.RouteDefinition
+				Index  int
+				Params []*paramData
 			}{
-				Route: r,
-				Index: i,
+				Route:  r,
+				Index:  i,
+				Params: initParams(&design.AttributeDefinition{Type: params}),
 			}
 			if err := pathTmpl.Execute(file, data); err != nil {
 				return err
@@ -791,9 +827,9 @@ func signerType(scheme *design.SecuritySchemeDefinition) string {
 	return ""
 }
 
-// pathTemplate returns a fmt format suitable to build a request path to the reoute.
+// pathTemplate returns a fmt format suitable to build a request path to the route.
 func pathTemplate(r *design.RouteDefinition) string {
-	return design.WildcardRegex.ReplaceAllLiteralString(r.FullPath(), "/%v")
+	return design.WildcardRegex.ReplaceAllLiteralString(r.FullPath(), "/%s")
 }
 
 // pathParams return the function signature of the path factory function for the given route.
@@ -804,26 +840,6 @@ func pathParams(r *design.RouteDefinition) string {
 		params[p] = r.Parent.Params.Type.ToObject()[p]
 	}
 	return join(&design.AttributeDefinition{Type: params}, false, pnames)
-}
-
-// pathParamNames return the names of the parameters of the path factory function for the given route.
-func pathParamNames(r *design.RouteDefinition) string {
-	params := r.Params()
-	goified := make([]string, len(params))
-	for i, p := range params {
-		if po, ok := r.Parent.Params.Type.ToObject()[p]; ok {
-			switch t := po.Type.(type) {
-			case design.Primitive:
-				switch t.Kind() {
-				case design.DateTimeKind:
-					goified[i] = fmt.Sprintf("%s.Format(time.RFC3339)", codegen.Goify(p, false))
-					continue
-				}
-			}
-		}
-		goified[i] = codegen.Goify(p, false)
-	}
-	return strings.Join(goified, ", ")
 }
 
 func typeName(mt *design.MediaTypeDefinition) string {
@@ -873,11 +889,16 @@ func (c *Client) {{ $funcName }}(resp *http.Response) ({{ decodegotyperef . .All
 `
 
 	pathTmpl = `{{ $funcName := printf "%sPath%s" (goify (printf "%s%s" .Route.Parent.Name (title .Route.Parent.Parent.Name)) true) ((or (and .Index (add .Index 1)) "") | printf "%v") }}{{/*
-*/}}{{ with .Route }}// {{ $funcName }} computes a request path to the {{ .Parent.Name }} action of {{ .Parent.Parent.Name }}.
-func {{ $funcName }}({{ pathParams . }}) string {
-	return fmt.Sprintf({{ printf "%q" (pathTemplate .) }}, {{ pathParamNames . }})
+*/}}// {{ $funcName }} computes a request path to the {{ .Route.Parent.Name }} action of {{ .Route.Parent.Parent.Name }}.
+func {{ $funcName }}({{ pathParams .Route }}) string {
+	var params []interface{}
+	{{ range $param := .Params }}{{ $tmp := tempvar }}{{/*
+*/}}{{ toString "p" $tmp $param.Attribute }}
+	params = append(params, {{ $tmp }})
+	{{ end }}
+	return fmt.Sprintf({{ printf "%q" (pathTemplate .Route) }}, params...)
 }
-{{ end }}`
+`
 
 	clientsTmpl = `{{ $funcName := goify (printf "%s%s" .Name (title .ResourceName)) true }}{{ $desc := .Description }}{{/*
 */}}{{ if $desc }}{{ multiComment $desc }}{{ else }}{{/*

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	"github.com/goadesign/goa/goagen/gen_app"
 	"github.com/goadesign/goa/goagen/utils"
@@ -333,42 +334,18 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 				}
 			}
 		}
-		initParams := func(att *design.AttributeDefinition) []*paramData {
-			if att == nil {
-				return nil
-			}
-			obj := att.Type.ToObject()
-			var pdata []*paramData
-			for n, q := range obj {
-				varName := codegen.Goify(n, false)
-				param := &paramData{
-					Name:      n,
-					VarName:   varName,
-					Attribute: q,
-				}
-				if q.Type.IsPrimitive() {
-					param.MustToString = q.Type.Kind() != design.StringKind
-					param.ValueName = varName
-					pdata = append(pdata, param)
-				} else {
-					if q.Type.IsArray() {
-						param.IsArray = true
-						param.ElemAttribute = q.Type.ToArray().ElemType
-					}
-					param.MustToString = true
-					param.ValueName = varName
-					param.CheckNil = true
-					pdata = append(pdata, param)
-				}
-			}
-			sort.Sort(byParamName(pdata))
-			return pdata
-		}
 		for i, r := range action.Routes {
-			params := make(design.Object, len(r.Params()))
+			genParams := make(design.Object, len(r.Params()))
 			for _, p := range r.Params() {
-				params[p] = action.Params.Type.ToObject()[p]
+				genParams[p] = action.Params.Type.ToObject()[p]
 			}
+			reqParams, _ := initParams(&design.AttributeDefinition{
+				Type: genParams,
+				Validation: &dslengine.ValidationDefinition{
+					Required: r.Params(),
+				},
+			})
+
 			data := struct {
 				Route  *design.RouteDefinition
 				Index  int
@@ -376,7 +353,7 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 			}{
 				Route:  r,
 				Index:  i,
-				Params: initParams(&design.AttributeDefinition{Type: params}),
+				Params: reqParams,
 			}
 			if err := pathTmpl.Execute(file, data); err != nil {
 				return err
@@ -448,51 +425,12 @@ func (g *Generator) generateActionClient(action *design.ActionDefinition, file *
 		params = append(params, "payload "+codegen.GoTypeRef(action.Payload, action.Payload.AllRequired(), 1, false))
 		names = append(names, "payload")
 	}
-	initParams := func(att *design.AttributeDefinition) []*paramData {
-		if att == nil {
-			return nil
-		}
-		obj := att.Type.ToObject()
-		var pdata []*paramData
-		var optData []*paramData
-		for n, q := range obj {
-			varName := codegen.Goify(n, false)
-			param := &paramData{
-				Name:      n,
-				VarName:   varName,
-				Attribute: q,
-			}
-			if q.Type.IsPrimitive() {
-				param.MustToString = q.Type.Kind() != design.StringKind
-				if att.IsRequired(n) {
-					param.ValueName = varName
-					pdata = append(pdata, param)
-				} else {
-					param.ValueName = "*" + varName
-					param.CheckNil = true
-					optData = append(optData, param)
-				}
-			} else {
-				if q.Type.IsArray() {
-					param.IsArray = true
-					param.ElemAttribute = q.Type.ToArray().ElemType
-				}
-				param.MustToString = true
-				param.ValueName = varName
-				param.CheckNil = true
-				if att.IsRequired(n) {
-					pdata = append(pdata, param)
-				} else {
-					optData = append(optData, param)
-				}
-			}
-		}
 
-		sort.Sort(byParamName(pdata))
-		sort.Sort(byParamName(optData))
+	initParamsScoped := func(att *design.AttributeDefinition) []*paramData {
+		reqData, optData := initParams(att)
 
 		// Update closure
-		for _, p := range pdata {
+		for _, p := range reqData {
 			names = append(names, p.VarName)
 			params = append(params, p.VarName+" "+cmdFieldType(p.Attribute.Type, false))
 		}
@@ -500,11 +438,11 @@ func (g *Generator) generateActionClient(action *design.ActionDefinition, file *
 			names = append(names, p.VarName)
 			params = append(params, p.VarName+" "+cmdFieldType(p.Attribute.Type, p.Attribute.Type.IsPrimitive()))
 		}
-
-		return append(pdata, optData...)
+		return append(reqData, optData...)
 	}
-	queryParams = initParams(action.QueryParams)
-	headers = initParams(action.Headers)
+	queryParams = initParamsScoped(action.QueryParams)
+	headers = initParamsScoped(action.Headers)
+
 	if action.Security != nil {
 		signer = codegen.Goify(action.Security.Scheme.SchemeName, true)
 	}
@@ -842,11 +780,59 @@ func pathParams(r *design.RouteDefinition) string {
 	return join(&design.AttributeDefinition{Type: params}, false, pnames)
 }
 
+// typeName returns Go type name of given MediaType definition.
 func typeName(mt *design.MediaTypeDefinition) string {
 	if mt.IsError() {
 		return "ErrorResponse"
 	}
 	return codegen.GoTypeName(mt, mt.AllRequired(), 1, false)
+}
+
+// initParams returns required and optional paramData extracted from given attribute definition.
+func initParams(att *design.AttributeDefinition) ([]*paramData, []*paramData) {
+	if att == nil {
+		return nil, nil
+	}
+	obj := att.Type.ToObject()
+	var reqParamData []*paramData
+	var optParamData []*paramData
+	for n, q := range obj {
+		varName := codegen.Goify(n, false)
+		param := &paramData{
+			Name:      n,
+			VarName:   varName,
+			Attribute: q,
+		}
+		if q.Type.IsPrimitive() {
+			param.MustToString = q.Type.Kind() != design.StringKind
+			if att.IsRequired(n) {
+				param.ValueName = varName
+				reqParamData = append(reqParamData, param)
+			} else {
+				param.ValueName = "*" + varName
+				param.CheckNil = true
+				optParamData = append(optParamData, param)
+			}
+		} else {
+			if q.Type.IsArray() {
+				param.IsArray = true
+				param.ElemAttribute = q.Type.ToArray().ElemType
+			}
+			param.MustToString = true
+			param.ValueName = varName
+			param.CheckNil = true
+			if att.IsRequired(n) {
+				reqParamData = append(reqParamData, param)
+			} else {
+				optParamData = append(optParamData, param)
+			}
+		}
+	}
+
+	sort.Sort(byParamName(reqParamData))
+	sort.Sort(byParamName(optParamData))
+
+	return reqParamData, optParamData
 }
 
 // paramData is the data structure holding the information needed to generate query params and
@@ -891,12 +877,10 @@ func (c *Client) {{ $funcName }}(resp *http.Response) ({{ decodegotyperef . .All
 	pathTmpl = `{{ $funcName := printf "%sPath%s" (goify (printf "%s%s" .Route.Parent.Name (title .Route.Parent.Parent.Name)) true) ((or (and .Index (add .Index 1)) "") | printf "%v") }}{{/*
 */}}// {{ $funcName }} computes a request path to the {{ .Route.Parent.Name }} action of {{ .Route.Parent.Parent.Name }}.
 func {{ $funcName }}({{ pathParams .Route }}) string {
-	var params []interface{}
-	{{ range $param := .Params }}{{ $tmp := tempvar }}{{/*
-*/}}{{ toString "p" $tmp $param.Attribute }}
-	params = append(params, {{ $tmp }})
+	{{ range $i, $param := .Params }}{{/*
+*/}}{{ toString $param.VarName (printf "param%d" $i) $param.Attribute }}
 	{{ end }}
-	return fmt.Sprintf({{ printf "%q" (pathTemplate .Route) }}, params...)
+	return fmt.Sprintf({{ printf "%q" (pathTemplate .Route) }}{{ range $i, $param := .Params }}, {{ printf "param%d" $i }}{{ end }})
 }
 `
 

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -128,15 +128,15 @@ var _ = Describe("Generate", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			content := string(c)
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
+			Ω(content).Should(ContainSubstring(`param0 := foo`))
 			Ω(content).Should(ContainSubstring(`tmp2 := make([]string, len(bar))
 	for i, e := range bar {
 		tmp3 := strconv.Itoa(e)
 		tmp2[i] = tmp3
 	}
-	param0 := strings.Join(tmp2, ",")`))
-			Ω(content).Should(ContainSubstring(`param1 := bat.String()`))
+	param1 := strings.Join(tmp2, ",")`))
 			Ω(content).Should(ContainSubstring(`param2 := baz.Format(time.RFC3339)`))
-			Ω(content).Should(ContainSubstring(`param3 := foo`))
+			Ω(content).Should(ContainSubstring(`param3 := bat.String()`))
 			Ω(content).Should(ContainSubstring(`fmt.Sprintf("/foo/%s/bar/%s/baz/%s/bat/%s", param0, param1, param2, param3)`))
 		})
 	})

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Generate", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			content := string(c)
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
-			Ω(content).Should(ContainSubstring(`fmt.Sprintf("/foo/%v/bar/%v/baz/%v/bat/%v", foo, bar, baz.Format(time.RFC3339), bat)`))
+			Ω(content).Should(ContainSubstring(`fmt.Sprintf("/foo/%s/bar/%s/baz/%s/bat/%s", params...`))
 		})
 	})
 

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -128,7 +128,16 @@ var _ = Describe("Generate", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			content := string(c)
 			Ω(content).Should(ContainSubstring("func ShowFooPath("))
-			Ω(content).Should(ContainSubstring(`fmt.Sprintf("/foo/%s/bar/%s/baz/%s/bat/%s", params...`))
+			Ω(content).Should(ContainSubstring(`tmp2 := make([]string, len(bar))
+	for i, e := range bar {
+		tmp3 := strconv.Itoa(e)
+		tmp2[i] = tmp3
+	}
+	param0 := strings.Join(tmp2, ",")`))
+			Ω(content).Should(ContainSubstring(`param1 := bat.String()`))
+			Ω(content).Should(ContainSubstring(`param2 := baz.Format(time.RFC3339)`))
+			Ω(content).Should(ContainSubstring(`param3 := foo`))
+			Ω(content).Should(ContainSubstring(`fmt.Sprintf("/foo/%s/bar/%s/baz/%s/bat/%s", param0, param1, param2, param3)`))
 		})
 	})
 


### PR DESCRIPTION
I have a feeling that it could be done with a bit less duplicity within `initParams`. Opened to any ideas (or just push a change) :).

PR is fixing issue #961, which was partially fixed yesterday.