### PR TITLE
Fix potential panic when finalizing resource definitions

### DIFF
--- a/design/apidsl/action.go
+++ b/design/apidsl/action.go
@@ -41,6 +41,7 @@ func Files(path, filename string, dsls ...func()) {
 			Parent:      r,
 			RequestPath: path,
 			FilePath:    filename,
+			Metadata:    make(dslengine.MetadataDefinition),
 		}
 		if len(dsls) > 0 {
 			if !dslengine.Execute(dsls[0], server) {
@@ -99,8 +100,9 @@ func Action(name string, dsl func()) {
 		action, ok := r.Actions[name]
 		if !ok {
 			action = &design.ActionDefinition{
-				Parent: r,
-				Name:   name,
+				Parent:   r,
+				Name:     name,
+				Metadata: make(dslengine.MetadataDefinition),
 			}
 		}
 		if !dslengine.Execute(dsl, action) {

--- a/design/apidsl/resource_test.go
+++ b/design/apidsl/resource_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Resource", func() {
 			}
 		})
 
-		It("sets the actions", func() {
+		It("sets the files", func() {
 			Ω(res).ShouldNot(BeNil())
 			Ω(res.Finalize).ShouldNot(Panic())
 			Ω(res.Validate()).ShouldNot(HaveOccurred())

--- a/design/apidsl/resource_test.go
+++ b/design/apidsl/resource_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Resource", func() {
 		})
 	})
 
-	Context("with files and actions", func() {
+	Context("with metadata and files", func() {
 		BeforeEach(func() {
 			name = "foo"
 			dsl = func() {

--- a/design/apidsl/resource_test.go
+++ b/design/apidsl/resource_test.go
@@ -96,6 +96,43 @@ var _ = Describe("Resource", func() {
 		})
 	})
 
+	Context("with metadata and actions", func() {
+		const actionName = "action"
+
+		BeforeEach(func() {
+			name = "foo"
+			dsl = func() {
+				Metadata("swagger:generate", "false")
+				Action(actionName, func() { Routing(PUT(":/id")) })
+			}
+		})
+
+		It("sets the actions", func() {
+			Ω(res).ShouldNot(BeNil())
+			Ω(res.Finalize).ShouldNot(Panic())
+			Ω(res.Validate()).ShouldNot(HaveOccurred())
+			Ω(res.Actions).Should(HaveLen(1))
+			Ω(res.Actions).Should(HaveKey(actionName))
+		})
+	})
+
+	Context("with files and actions", func() {
+		BeforeEach(func() {
+			name = "foo"
+			dsl = func() {
+				Metadata("swagger:generate", "false")
+				Files("path", "filename")
+			}
+		})
+
+		It("sets the actions", func() {
+			Ω(res).ShouldNot(BeNil())
+			Ω(res.Finalize).ShouldNot(Panic())
+			Ω(res.Validate()).ShouldNot(HaveOccurred())
+			Ω(res.FileServers).Should(HaveLen(1))
+		})
+	})
+
 	Context("with a canonical action that does not exist", func() {
 		const can = "can"
 


### PR DESCRIPTION
Using `Metadata(''swagger:generate", "true")` in `Resource()` cases panic.

```
$ goagen app -d cellar/design
exit status 2
panic: assignment to entry in nil map

goroutine 1 [running]:
panic(0x39bd20, 0xc420169e10)
	/usr/local/Cellar/go/1.7.4/libexec/src/runtime/panic.go:500 +0x1a1
github.com/goadesign/goa/design.(*ResourceDefinition).Finalize.func2(0xc4201b8280, 0xc4201af260, 0x401402)
	/Users/ikawaha/go/src/github.com/goadesign/goa/design/definitions.go:848 +0x10b
github.com/goadesign/goa/design.(*ResourceDefinition).IterateActions(0xc42017e2a0, 0xc4201f9bf8, 0x0, 0x0)
	/Users/ikawaha/go/src/github.com/goadesign/goa/design/definitions.go:682 +0x1d8
github.com/goadesign/goa/design.(*ResourceDefinition).Finalize(0xc42017e2a0)
	/Users/ikawaha/go/src/github.com/goadesign/goa/design/definitions.go:853 +0x138
github.com/goadesign/goa/dslengine.finalizeSet(0xc42016d840, 0x2, 0x2, 0x0, 0x2)
	/Users/ikawaha/go/src/github.com/goadesign/goa/dslengine/runner.go:328 +0xaa
github.com/goadesign/goa/design.(*APIDefinition).IterateSets(0xc42017c420, 0x453458)
	/Users/ikawaha/go/src/github.com/goadesign/goa/design/definitions.go:498 +0x55c
github.com/goadesign/goa/dslengine.Run(0x5f95a0, 0xc42016cec0)
	/Users/ikawaha/go/src/github.com/goadesign/goa/dslengine/runner.go:114 +0x200
main.main()
	/Users/ikawaha/go/src/cellar/goagen575729628/main.go:24 +0x63
```

## Where is the error occurring?

```go:
// Finalize is run post DSL execution. It merges response definitions, creates implicit action
// parameters, initializes querystring parameters, sets path parameters as non zero attributes
// and sets the fallbacks for security schemes.
func (r *ResourceDefinition) Finalize() {
        meta := r.Metadata["swagger:generate"]
        r.IterateFileServers(func(f *FileServerDefinition) error {
                if meta != nil {
                        if _, ok := f.Metadata["swagger:generate"]; !ok {
                                f.Metadata["swagger:generate"] = meta // ← !!! nil map
                        }
                }
                f.Finalize()
                return nil
        })
        r.IterateActions(func(a *ActionDefinition) error {
                if meta != nil {
                        if _, ok := a.Metadata["swagger:generate"]; !ok {
                                a.Metadata["swagger:generate"] = meta //← !!! nil map
                        }
                }
                a.Finalize()
                return nil
        })
}
```

## Sample design:

```
package design

import (
	. "github.com/goadesign/goa/design"
	. "github.com/goadesign/goa/design/apidsl"
)

var _ = API("cellar", func() {
	Scheme("http")
	Host("localhost:8080")
})

var _ = Resource("bottle", func() {
	BasePath("/bottles")
	DefaultMedia(BottleMedia)

	Metadata("swagger:generate", "false") // ← !!!

	Action("show", func() {
		Routing(GET("/:bottleID"))
		Params(func() {
			Param("bottleID", Integer, "Bottle ID")
		})
		Response(OK)
		Response(NotFound)
	})
})

var _ = Resource("public", func() {
	Metadata("swagger:generate", "false") // ← !!!
	Files("/", "./index.html")
})

var BottleMedia = MediaType("application/vnd.goa.example.bottle+json", func() {
	Description("A bottle of wine")
	Attributes(func() { // Attributes define the media type shape.
		Attribute("id", Integer, "Unique bottle ID")
		Attribute("href", String, "API href for making requests on the bottle")
		Attribute("name", String, "Name of wine")
		Required("id", "href", "name")
	})
	View("default", func() { // View defines a rendering of the media type.
		Attribute("id")   // Media types may have multiple views and must
		Attribute("href") // have a "default" view.
		Attribute("name")
	})
})
```