### PR TITLE
support_custom_request_id_in_client_master

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -244,3 +244,8 @@ func ContextWithRequestID(ctx context.Context) (context.Context, string) {
 	}
 	return ctx, reqID
 }
+
+// SetContextRequestID sets a request ID in the given context and returns a new context.
+func SetContextRequestID(ctx context.Context, reqID string) context.Context {
+	return context.WithValue(ctx, reqIDKey, reqID)
+}

--- a/client/client_suite_test.go
+++ b/client/client_suite_test.go
@@ -1,0 +1,13 @@
+package client_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestDesign(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Client Suite")
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,47 @@
+package client_test
+
+import (
+	"github.com/goadesign/goa/client"
+	"golang.org/x/net/context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("client", func() {
+	Context("with background context", func() {
+		var ctx context.Context
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		Context("ContextRequestID", func() {
+			It("should have empty request ID", func() {
+				Expect(client.ContextRequestID(ctx)).To(BeEmpty())
+			})
+		})
+
+		Context("ContextWithRequestID", func() {
+			It("should generate a new request ID", func() {
+				newCtx, reqID := client.ContextWithRequestID(ctx)
+				Expect(reqID).ToNot(BeEmpty())
+				Expect(client.ContextRequestID(newCtx)).To(Equal(reqID))
+			})
+		})
+
+		Context("SetContextRequestID", func() {
+			It("should set a custom request ID", func() {
+				const customID = "foo"
+				newCtx := client.SetContextRequestID(ctx, customID)
+				Expect(newCtx).ToNot(Equal(ctx))
+				Expect(client.ContextRequestID(newCtx)).To(Equal(customID))
+
+				// request ID should not need to be generated again. the same context should be returned instead.
+				newCtx2, reqID := client.ContextWithRequestID(newCtx)
+				Expect(newCtx).To(Equal(newCtx2))
+				Expect(reqID).To(Equal(customID))
+			})
+		})
+	})
+})


### PR DESCRIPTION
@raphael added client.SetContextRequestID() to allow for sending a custom "X-Request-Id" header with client requests
added client/*_test.go files