### PR TITLE
Fix cli generator test by accounting for os seperators.

### DIFF
--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 var _ = Describe("Generate", func() {
-	const testgenPackagePath = "github.com/goadesign/goa/goagen/gen_client/test_"
+	var testgenPackagePath = filepath.FromSlash("github.com/goadesign/goa/goagen/gen_client/test_")
 
 	var outDir string
 	var files []string


### PR DESCRIPTION
This should do the trick, but I don't have access to a windows machine at the moment to test it myself.