### PR TITLE
Add Tracer and AWS X-Ray middlewares.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ lint:
 	fi
 
 cyclo:
-	@if [ "`gocyclo -over 20 . | grep -v _integration_tests | tee /dev/stderr`" ]; then \
+	@if [ "`gocyclo -over 20 . | grep -v _integration_tests | grep -v _test.go | tee /dev/stderr`" ]; then \
 		echo "^ - Cyclomatic complexity exceeds 20, refactor the code!" && echo && exit 1; \
 	fi
 

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -4,5 +4,12 @@ package middleware
 // It is private to avoid possible collisions with keys used by other packages.
 type middlewareKey int
 
-// ReqIDKey is the context key used by the RequestID middleware to store the request ID value.
-const reqIDKey middlewareKey = 1
+const (
+	// ReqIDKey is the context key used by the RequestID middleware to store the request ID value.
+	reqIDKey middlewareKey = iota + 1
+
+	// Keys used to record trace in context.
+	traceKey
+	spanKey
+	parentSpanKey
+)

--- a/middleware/tracer.go
+++ b/middleware/tracer.go
@@ -1,0 +1,143 @@
+package middleware
+
+import (
+	rd "math/rand"
+	"net/http"
+
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/client"
+	"golang.org/x/net/context"
+)
+
+var (
+	// TraceIDHeader is the name of the HTTP request header containing the
+	// current TraceID if any.
+	TraceIDHeader = "TraceID"
+
+	// ParentSpanIDHeader is the name of the HTTP request header containing
+	// the parent span ID if any.
+	ParentSpanIDHeader = "ParentSpanID"
+)
+
+type (
+	// IDFunc is a function that produces span and trace IDs for cosumption by
+	// tracing systems such as Zipkin or AWS X-Ray.
+	IDFunc func() string
+
+	// tracedDoer is a goa client Doer that inserts the tracing headers for
+	// each request it makes.
+	tracedDoer struct {
+		doer    client.Doer
+		traceID string
+		spanID  string
+	}
+)
+
+// Tracer returns a middleware that initializes the trace information in the
+// context. The information can be retrieved using any of the ContextXXX
+// functions.
+//
+// sampleRate must be a value between 0 and 100. It represents the percentage of
+// requests that should be traced.
+//
+// spanIDFunc and traceIDFunc are the functions used to create Span and Trace
+// IDs respectively. This is configurable so that the created IDs are compatible
+// with the various backend tracing systems. The xray package provides
+// implementations that produce AWS X-Ray compatible IDs.
+//
+// If the incoming request has a TraceIDHeader header then the sample rate is
+// disregarded and the tracing is enabled.
+func Tracer(sampleRate int, spanIDFunc, traceIDFunc IDFunc) goa.Middleware {
+	if sampleRate < 0 || sampleRate > 100 {
+		panic("tracing: sample rate must be between 0 and 100")
+	}
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			// Compute trace info.
+			var (
+				traceID  = req.Header.Get(TraceIDHeader)
+				parentID = req.Header.Get(ParentSpanIDHeader)
+				spanID   = spanIDFunc()
+			)
+			if traceID == "" {
+				// Avoid computing a random value if unnecessary.
+				if sampleRate == 0 || rd.Intn(100) > sampleRate {
+					return h(ctx, rw, req)
+				}
+				traceID = traceIDFunc()
+			}
+
+			// Setup context.
+			ctx = WithTrace(ctx, traceID, spanID, parentID)
+
+			// Call next handler.
+			return h(ctx, rw, req)
+		}
+	}
+}
+
+// TraceDoer wraps a goa client Doer and sets the trace headers so that the
+// downstream service may properly retrieve the parent span ID and trace ID.
+//
+// ctx must contain the current request segment as set by the xray middleware or
+// the doer passed as argument is returned.
+func TraceDoer(ctx context.Context, doer client.Doer) client.Doer {
+	var (
+		traceID = ContextTraceID(ctx)
+		spanID  = ContextSpanID(ctx)
+	)
+	if traceID == "" {
+		return doer
+	}
+	return &tracedDoer{
+		doer:    doer,
+		traceID: traceID,
+		spanID:  spanID,
+	}
+}
+
+// ContextTraceID returns the trace ID extracted from the given context if any,
+// the empty string otherwise.
+func ContextTraceID(ctx context.Context) string {
+	if t := ctx.Value(traceKey); t != nil {
+		return t.(string)
+	}
+	return ""
+}
+
+// ContextSpanID returns the span ID extracted from the given context if any,
+// the empty string otherwise.
+func ContextSpanID(ctx context.Context) string {
+	if s := ctx.Value(spanKey); s != nil {
+		return s.(string)
+	}
+	return ""
+}
+
+// ContextParentSpanID returns the parent span ID extracted from the given
+// context if any, the empty string otherwise.
+func ContextParentSpanID(ctx context.Context) string {
+	if p := ctx.Value(parentSpanKey); p != nil {
+		return p.(string)
+	}
+	return ""
+}
+
+// WithTrace returns a context containing the given trace, span and parent span
+// IDs.
+func WithTrace(ctx context.Context, traceID, spanID, parentID string) context.Context {
+	if parentID != "" {
+		ctx = context.WithValue(ctx, parentSpanKey, parentID)
+	}
+	ctx = context.WithValue(ctx, traceKey, traceID)
+	ctx = context.WithValue(ctx, spanKey, spanID)
+	return ctx
+}
+
+// Do adds the tracing headers to the requests before making it.
+func (d *tracedDoer) Do(ctx context.Context, req *http.Request) (*http.Response, error) {
+	req.Header.Set(TraceIDHeader, d.traceID)
+	req.Header.Set(ParentSpanIDHeader, d.spanID)
+
+	return d.doer.Do(ctx, req)
+}

--- a/middleware/tracer_test.go
+++ b/middleware/tracer_test.go
@@ -1,0 +1,104 @@
+package middleware
+
+import (
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestNew(t *testing.T) {
+	cases := map[string]struct{ Rate int }{
+		"zero":  {0},
+		"one":   {1},
+		"fifty": {50},
+		"100":   {100},
+	}
+
+	for k, c := range cases {
+		m := Tracer(c.Rate, nil, nil)
+		if m == nil {
+			t.Errorf("%s: Tracer return nil", k)
+		}
+	}
+
+	cases = map[string]struct{ Rate int }{
+		"negative":  {-1},
+		"one-o-one": {101},
+		"maxint":    {math.MaxInt64},
+	}
+
+	for k, c := range cases {
+		func() {
+			defer func() {
+				r := recover()
+				if r != "tracing: sample rate must be between 0 and 100" {
+					t.Errorf("%s: Tracer did *not* panic", k)
+				}
+			}()
+			Tracer(c.Rate, nil, nil)
+		}()
+	}
+}
+
+func TestMiddleware(t *testing.T) {
+	var (
+		traceID    = "testTraceID"
+		spanID     = "testSpanID"
+		newTraceID = func() string { return traceID }
+		newID      = func() string { return spanID }
+	)
+
+	cases := map[string]struct {
+		Rate                  int
+		TraceID, ParentSpanID string
+		// output
+		CtxTraceID, CtxSpanID, CtxParentID string
+	}{
+		"no-trace": {100, "", "", traceID, spanID, ""},
+		"trace":    {100, "trace", "", "trace", spanID, ""},
+		"parent":   {100, "trace", "parent", "trace", spanID, "parent"},
+
+		"zero-rate-no-trace": {0, "", "", "", "", ""},
+		"zero-rate-trace":    {0, "trace", "", "trace", spanID, ""},
+		"zero-rate-parent":   {0, "trace", "parent", "trace", spanID, "parent"},
+	}
+
+	for k, c := range cases {
+		var (
+			ctxTraceID, ctxSpanID, ctxParentID string
+
+			m = Tracer(c.Rate, newID, newTraceID)
+			h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+				ctxTraceID = ContextTraceID(ctx)
+				ctxSpanID = ContextSpanID(ctx)
+				ctxParentID = ContextParentSpanID(ctx)
+				return nil
+			}
+			headers = make(http.Header)
+			ctx     = context.Background()
+		)
+		if c.TraceID != "" {
+			headers.Set(TraceIDHeader, c.TraceID)
+		}
+		if c.ParentSpanID != "" {
+			headers.Set(ParentSpanIDHeader, c.ParentSpanID)
+		}
+		req, _ := http.NewRequest("GET", "/", nil)
+		req.Header = headers
+
+		m(h)(ctx, httptest.NewRecorder(), req)
+
+		if ctxTraceID != c.CtxTraceID {
+			t.Errorf("%s: invalid TraceID, expected %v - got %v", k, c.CtxTraceID, ctxTraceID)
+		}
+		if ctxSpanID != c.CtxSpanID {
+			t.Errorf("%s: invalid SpanID, expected %v - got %v", k, c.CtxSpanID, ctxSpanID)
+		}
+		if ctxParentID != c.CtxParentID {
+			t.Errorf("%s: invalid ParentSpanID, expected %v - got %v", k, c.CtxParentID, ctxParentID)
+		}
+	}
+}

--- a/middleware/xray/client.go
+++ b/middleware/xray/client.go
@@ -1,0 +1,56 @@
+package xray
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+type (
+	// Doer is the http Client interface.
+	Doer interface {
+		Do(*http.Request) (*http.Response, error)
+	}
+
+	// httpTracer is a http client that creates subsegments for each request
+	// it makes.
+	httpTracer struct {
+		client  *http.Client
+		segment *Segment
+	}
+)
+
+// WrapClient wraps a http client and creates subsegments of the segment in the
+// context for each request it makes. The subsegments created this way have
+// their namespace set to "remote".
+//
+// ctx must contain the current request segment as set by the xray middleware or
+// the client passed as argument is returned.
+func WrapClient(ctx context.Context, c *http.Client) Doer {
+	s := ContextSegment(ctx)
+	if s == nil {
+		return c
+	}
+	return &httpTracer{
+		client:  c,
+		segment: s,
+	}
+}
+
+// Do reates a subsegment and makes the request.
+func (r *httpTracer) Do(req *http.Request) (*http.Response, error) {
+	sub := r.segment.NewSubsegment(req.URL.Host)
+	defer sub.Close()
+	sub.Namespace = "remote"
+	sub.HTTP = &HTTP{Request: requestData(req)}
+
+	resp, err := r.client.Do(req)
+
+	if err != nil {
+		sub.recordError(err, resp.StatusCode < 500)
+		return nil, err
+	}
+	sub.HTTP.Response = responseData(resp)
+
+	return resp, err
+}

--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -1,0 +1,218 @@
+package xray
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/middleware"
+	"golang.org/x/net/context"
+)
+
+const (
+	// segKey is the key used to store the segments in the context.
+	segKey key = iota + 1
+)
+
+// New returns a middleware that sends AWS X-Ray segments to the daemon running
+// at the given address.
+//
+// service is the name of the service reported to X-Ray. daemon is the hostname
+// (including port) of the X-Ray daemon collecting the segments.
+//
+// The middleware works by extracting the trace information from the context
+// using the tracing middleware package. The tracing middleware must be mounted
+// first on the service.
+//
+// The middleware stores the request segment in the context. Use ContextSegment
+// to retrieve it. User code can further configure the segment for example to set
+// a service version or record an error.
+//
+// User code may create child segments using the Segment NewSubsegment method
+// for tracing requests to external services. Such segments should be closed via
+// the Close method once the request completes. The middleware takes care of
+// closing the top level segment. Typical usage:
+//
+//     segment := xray.ContextSegment(ctx)
+//     sub := segment.NewSubsegment("external-service")
+//     defer sub.Close()
+//     err := client.MakeRequest()
+//     if err != nil {
+//         sub.Error = xray.Wrap(err)
+//     }
+//     return
+//
+func New(service, daemon string) (goa.Middleware, error) {
+	c, err := net.Dial("udp", daemon)
+	if err != nil {
+		return nil, fmt.Errorf("xray: failed to connect to daemon - %s", err)
+	}
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			var (
+				err     error
+				traceID = middleware.ContextTraceID(ctx)
+			)
+			if traceID == "" {
+				// No tracing
+				return h(ctx, rw, req)
+			}
+
+			s := newSegment(ctx, traceID, service, req, c)
+			ctx = WithSegment(ctx, s)
+
+			defer func() {
+				go record(ctx, s, err)
+			}()
+
+			err = h(ctx, rw, req)
+
+			return err
+		}
+	}, nil
+}
+
+// NewID is a span ID creation algorithm which produces values that are
+// compatible with AWS X-Ray.
+func NewID() string {
+	b := make([]byte, 8)
+	rand.Read(b)
+	return fmt.Sprintf("%x", b)
+}
+
+// NewTraceID is a trace ID creation algorithm which produces values that are
+// compatible with AWS X-Ray.
+func NewTraceID() string {
+	b := make([]byte, 12)
+	rand.Read(b)
+	return fmt.Sprintf("%d-%x-%s", 1, time.Now().Unix(), fmt.Sprintf("%x", b))
+}
+
+// WithSegment creates a context containing the given segment. Use ContextSegment
+// to retrieve it.
+func WithSegment(ctx context.Context, s *Segment) context.Context {
+	return context.WithValue(ctx, segKey, s)
+}
+
+// ContextSegment extracts the segment set in the context with WithSegment.
+func ContextSegment(ctx context.Context) *Segment {
+	if s := ctx.Value(segKey); s != nil {
+		return s.(*Segment)
+	}
+	return nil
+}
+
+// newSegment creates a new segment for the incoming request.
+func newSegment(ctx context.Context, traceID, name string, req *http.Request, c net.Conn) *Segment {
+	var (
+		spanID   = middleware.ContextSpanID(ctx)
+		parentID = middleware.ContextParentSpanID(ctx)
+		h        = &HTTP{Request: requestData(req)}
+	)
+
+	s := &Segment{
+		Mutex:      &sync.Mutex{},
+		ID:         spanID,
+		HTTP:       h,
+		Name:       name,
+		TraceID:    traceID,
+		StartTime:  now(),
+		InProgress: true,
+		conn:       c,
+	}
+
+	if parentID != "" {
+		s.ParentID = parentID
+		s.Type = "subsegment"
+	}
+
+	return s
+}
+
+// record finalizes and sends the segment to the X-Ray daemon.
+func record(ctx context.Context, s *Segment, err error) {
+	resp := goa.ContextResponse(ctx)
+	if resp != nil {
+		s.Lock()
+		switch {
+		case resp.Status == 429:
+			s.Throttle = true
+		case resp.Status >= 500:
+			s.Error = true
+		}
+		s.HTTP.Response = &Response{resp.Status, resp.Length}
+		s.Unlock()
+	}
+	if err != nil {
+		fault := false
+		if gerr, ok := err.(goa.ServiceError); ok {
+			fault = gerr.ResponseStatus() < 500
+		}
+		s.recordError(err, fault)
+	}
+	s.Close()
+}
+
+// requestData creates a Request from a http.Request.
+func requestData(req *http.Request) *Request {
+	var (
+		scheme = "http"
+		host   = req.Host
+	)
+	if len(req.URL.Scheme) > 0 {
+		scheme = req.URL.Scheme
+	}
+	if len(req.URL.Host) > 0 {
+		host = req.URL.Host
+	}
+	return &Request{
+		Method:    req.Method,
+		URL:       fmt.Sprintf("%s://%s%s", scheme, host, req.URL.Path),
+		ClientIP:  getIP(req),
+		UserAgent: req.UserAgent(),
+	}
+}
+
+// responseData creates a Response from a http.Response.
+func responseData(resp *http.Response) *Response {
+	var ln int
+	if lh := resp.Header.Get("Content-Length"); lh != "" {
+		ln, _ = strconv.Atoi(lh)
+	}
+
+	return &Response{
+		Status:        resp.StatusCode,
+		ContentLength: ln,
+	}
+}
+
+// getIP implements a heuristic that returns an origin IP address for a request.
+func getIP(req *http.Request) string {
+	for _, h := range []string{"X-Forwarded-For", "X-Real-Ip"} {
+		for _, ip := range strings.Split(req.Header.Get(h), ",") {
+			if len(ip) == 0 {
+				continue
+			}
+			realIP := net.ParseIP(strings.Replace(ip, " ", "", -1))
+			return realIP.String()
+		}
+	}
+
+	// not found in header
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+	if err != nil {
+		return req.RemoteAddr
+	}
+	return host
+}
+
+// now returns the current time as a float appropriate for X-Ray processing.
+func now() float64 {
+	return float64(time.Now().Truncate(time.Millisecond).UnixNano()) / 1e9
+}

--- a/middleware/xray/middleware_test.go
+++ b/middleware/xray/middleware_test.go
@@ -1,0 +1,294 @@
+package xray
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/middleware"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	// udp host:port used to run test server
+	udplisten = "127.0.0.1:62111"
+)
+
+func TestNew(t *testing.T) {
+	cases := map[string]struct {
+		Daemon  string
+		Success bool
+	}{
+		"ok":     {udplisten, true},
+		"not-ok": {"1002.0.0.0:62111", false},
+	}
+	for k, c := range cases {
+		m, err := New("", c.Daemon)
+		if err == nil && !c.Success {
+			t.Errorf("%s: expected failure but err is nil", k)
+		}
+		if err != nil && c.Success {
+			t.Errorf("%s: unexpected error %s", k, err)
+		}
+		if m == nil && c.Success {
+			t.Errorf("%s: middleware is nil", k)
+		}
+	}
+}
+
+func TestMiddleware(t *testing.T) {
+	type (
+		Tra struct {
+			TraceID, SpanID, ParentID string
+		}
+		Req struct {
+			Method, Host, IP, RemoteAddr string
+			RemoteHost, UserAgent        string
+			URL                          *url.URL
+		}
+		Res struct {
+			Status int
+		}
+		Seg struct {
+			Exception string
+			Error     bool
+		}
+	)
+	var (
+		traceID      = "traceID"
+		spanID       = "spanID"
+		parentID     = "parentID"
+		host         = "goa.design"
+		method       = "GET"
+		ip           = "104.18.42.42"
+		remoteAddr   = "104.18.43.42:443"
+		remoteNoPort = "104.18.43.42"
+		remoteHost   = "104.18.43.42"
+		agent        = "user agent"
+		url, _       = url.Parse("https://goa.design/path?query#fragment")
+	)
+	cases := map[string]struct {
+		Trace    Tra
+		Request  Req
+		Response Res
+		Segment  Seg
+	}{
+		"no-trace": {
+			Trace:    Tra{"", "", ""},
+			Request:  Req{"", "", "", "", "", "", nil},
+			Response: Res{0},
+			Segment:  Seg{"", false},
+		},
+		"basic": {
+			Trace:    Tra{traceID, spanID, ""},
+			Request:  Req{method, host, ip, remoteAddr, remoteHost, agent, url},
+			Response: Res{http.StatusOK},
+			Segment:  Seg{"", false},
+		},
+		"with-parent": {
+			Trace:    Tra{traceID, spanID, parentID},
+			Request:  Req{method, host, ip, remoteAddr, remoteHost, agent, url},
+			Response: Res{http.StatusOK},
+			Segment:  Seg{"", false},
+		},
+		"without-ip": {
+			Trace:    Tra{traceID, spanID, parentID},
+			Request:  Req{method, host, "", remoteAddr, remoteHost, agent, url},
+			Response: Res{http.StatusOK},
+			Segment:  Seg{"", false},
+		},
+		"without-ip-remote-port": {
+			Trace:    Tra{traceID, spanID, parentID},
+			Request:  Req{method, host, "", remoteNoPort, remoteHost, agent, url},
+			Response: Res{http.StatusOK},
+			Segment:  Seg{"", false},
+		},
+		"error": {
+			Trace:    Tra{traceID, spanID, ""},
+			Request:  Req{method, host, ip, remoteAddr, remoteHost, agent, url},
+			Response: Res{http.StatusBadRequest},
+			Segment:  Seg{"error", false},
+		},
+		"fault": {
+			Trace:    Tra{traceID, spanID, ""},
+			Request:  Req{method, host, ip, remoteAddr, remoteHost, agent, url},
+			Response: Res{http.StatusInternalServerError},
+			Segment:  Seg{"", true},
+		},
+	}
+	for k, c := range cases {
+		m, err := New("service", udplisten)
+		if err != nil {
+			t.Fatalf("%s: failed to create middleware: %s", k, err)
+		}
+		if c.Response.Status == 0 {
+			continue
+		}
+
+		var (
+			req, _ = http.NewRequest(c.Request.Method, c.Request.URL.String(), nil)
+			rw     = httptest.NewRecorder()
+			ctx    = goa.NewContext(context.Background(), rw, req, nil)
+			h      = func(ctx context.Context, rw http.ResponseWriter, _ *http.Request) error {
+				if c.Segment.Exception != "" {
+					ContextSegment(ctx).recordError(errors.New(c.Segment.Exception), false)
+				}
+				rw.WriteHeader(c.Response.Status)
+				return nil
+			}
+		)
+		ctx = middleware.WithTrace(ctx, c.Trace.TraceID, c.Trace.SpanID, c.Trace.ParentID)
+		if c.Request.UserAgent != "" {
+			req.Header.Set("User-Agent", c.Request.UserAgent)
+		}
+		if c.Request.IP != "" {
+			req.Header.Set("X-Forwarded-For", c.Request.IP)
+		}
+		if c.Request.RemoteAddr != "" {
+			req.RemoteAddr = c.Request.RemoteAddr
+		}
+		if c.Request.Host != "" {
+			req.Host = c.Request.Host
+		}
+
+		js := readUDP(t, func() {
+			m(h)(ctx, goa.ContextResponse(ctx), req)
+		})
+
+		var s *Segment
+		elems := strings.Split(js, "\n")
+		if len(elems) != 2 {
+			t.Fatalf("%s: invalid number of lines, expected 2 got %d: %v", k, len(elems), elems)
+		}
+		if elems[0] != udpHeader[:len(udpHeader)-1] {
+			t.Errorf("%s: invalid header, got %s", k, elems[0])
+		}
+		err = json.Unmarshal([]byte(elems[1]), &s)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if s.Name != "service" {
+			t.Errorf("%s: unexpected segment name, expected service - got %s", k, s.Name)
+		}
+		if c.Trace.ParentID == "" && s.Type != "" {
+			t.Errorf("%s: expected Type to be empty but got %s", k, s.Type)
+		}
+		if c.Trace.ParentID != "" && s.Type != "subsegment" {
+			t.Errorf("%s: expected Type to subsegment but got %s", k, s.Type)
+		}
+		if s.ID != c.Trace.SpanID {
+			t.Errorf("%s: unexpected segment ID, expected %s - got %s", k, c.Trace.SpanID, s.ID)
+		}
+		if s.TraceID != c.Trace.TraceID {
+			t.Errorf("%s: unexpected trace ID, expected %s - got %s", k, c.Trace.TraceID, s.TraceID)
+		}
+		if s.ParentID != c.Trace.ParentID {
+			t.Errorf("%s: unexpected parent ID, expected %s - got %s", k, c.Trace.ParentID, s.ParentID)
+		}
+		if s.StartTime == 0 {
+			t.Errorf("%s: StartTime is 0", k)
+		}
+		if s.EndTime == 0 {
+			t.Errorf("%s: EndTime is 0", k)
+		}
+		if s.StartTime > s.EndTime {
+			t.Errorf("%s: StartTime (%v) is after EndTime (%v)", k, s.StartTime, s.EndTime)
+		}
+		if s.HTTP == nil {
+			t.Fatalf("%s: HTTP field is nil", k)
+		}
+		if s.HTTP.Request == nil {
+			t.Fatalf("%s: HTTP Request field is nil", k)
+		}
+		if c.Request.IP != "" && s.HTTP.Request.ClientIP != c.Request.IP {
+			t.Errorf("%s: HTTP Request ClientIP is invalid, expected %#v got %#v", k, c.Request.IP, s.HTTP.Request.ClientIP)
+		}
+		if c.Request.IP == "" && s.HTTP.Request.ClientIP != c.Request.RemoteHost {
+			t.Errorf("%s: HTTP Request ClientIP is invalid, expected host %#v got %#v", k, c.Request.RemoteHost, s.HTTP.Request.ClientIP)
+		}
+		if s.HTTP.Request.Method != c.Request.Method {
+			t.Errorf("%s: HTTP Request Method is invalid, expected %#v got %#v", k, c.Request.Method, s.HTTP.Request.Method)
+		}
+		expected := strings.Split(c.Request.URL.String(), "?")[0]
+		if s.HTTP.Request.URL != expected {
+			t.Errorf("%s: HTTP Request URL is invalid, expected %#v got %#v", k, expected, s.HTTP.Request.URL)
+		}
+		if s.HTTP.Request.UserAgent != c.Request.UserAgent {
+			t.Errorf("%s: HTTP Request UserAgent is invalid, expected %#v got %#v", k, c.Request.UserAgent, s.HTTP.Request.UserAgent)
+		}
+		if (s.Cause == nil && c.Segment.Exception != "") || (s.Cause != nil && s.Cause.Exceptions[0].Message != c.Segment.Exception) {
+			t.Errorf("%s: Exception is invalid, expected %v got %v", k, c.Segment.Exception, s.Cause.Exceptions[0].Message)
+		}
+		if s.Error != c.Segment.Error {
+			t.Errorf("%s: Error is invalid, expected %v got %v", k, c.Segment.Error, s.Error)
+		}
+	}
+}
+
+func TestNewID(t *testing.T) {
+	id := NewID()
+	if len(id) != 16 {
+		t.Errorf("invalid ID length, expected 16 got %d", len(id))
+	}
+	if !regexp.MustCompile("[0-9a-f]{16}").MatchString(id) {
+		t.Errorf("invalid ID format, should be hexadecimal, got %s", id)
+	}
+	if id == NewID() {
+		t.Errorf("ids not unique")
+	}
+}
+
+func TestNewTraceID(t *testing.T) {
+	id := NewTraceID()
+	if len(id) != 35 {
+		t.Errorf("invalid ID length, expected 35 got %d", len(id))
+	}
+	if !regexp.MustCompile("1-[0-9a-f]{8}-[0-9a-f]{16}").MatchString(id) {
+		t.Errorf("invalid Trace ID format, got %s", id)
+	}
+	if id == NewTraceID() {
+		t.Errorf("trace ids not unique")
+	}
+}
+
+// readUDP calls sender, reads and returns UDP messages received on udplisten.
+func readUDP(t *testing.T, sender func()) string {
+	var (
+		readChan = make(chan string)
+		msg      = make([]byte, 1024*32)
+	)
+	resAddr, err := net.ResolveUDPAddr("udp", udplisten)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.ListenUDP("udp", resAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		listener.SetReadDeadline(time.Now().Add(time.Second))
+		n, _, _ := listener.ReadFrom(msg)
+		readChan <- string(msg[0:n])
+	}()
+
+	sender()
+
+	defer func() {
+		if err := listener.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	return <-readChan
+}

--- a/middleware/xray/segment.go
+++ b/middleware/xray/segment.go
@@ -1,0 +1,306 @@
+package xray
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type (
+	// Segment represents a AWS X-Ray segment document.
+	Segment struct {
+		// Mutex used to synchronize access to segment.
+		*sync.Mutex
+		// Name is the name of the service reported to X-Ray.
+		Name string `json:"name"`
+		// Namespace identifies the source that created the segment.
+		Namespace string `json:"namespace"`
+		// Type is either the empty string or "subsegment".
+		Type string `json:"type,omitempty"`
+		// ID is a unique ID for the segment.
+		ID string `json:"id"`
+		// TraceID is the ID of the root trace.
+		TraceID string `json:"trace_id,omitempty"`
+		// ParentID is the ID of the parent segment when it is from a
+		// remote service. It is only initialized for the root segment.
+		ParentID string `json:"parent_id,omitempty"`
+		// StartTime is the segment start time.
+		StartTime float64 `json:"start_time,omitempty"`
+		// EndTime is the segment end time.
+		EndTime float64 `json:"end_time,omitempty"`
+		// InProgress is true if the segment hasn't completed yet.
+		InProgress bool `json:"in_progress"`
+		// HTTP contains the HTTP request and response information and is
+		// only initialized for the root segment.
+		HTTP *HTTP `json:"http,omitempty"`
+		// Cause contains information about an error that occurred while
+		// processing the request.
+		Cause *Cause `json:"cause,omitempty"`
+		// Error is true when a request causes an internal error. It is
+		// automatically set by Close when the response status code is
+		// 500 or more.
+		Error bool `json:"error"`
+		// Fault is true when a request results in an error. It is
+		// automatically set by Close when the response status code is
+		// between 400 and 500 (but not 429).
+		Fault bool `json:"fault"`
+		// Throttle is true when a request is throttled. It is set to
+		// true when the segment closes and the response status code is
+		// 429. Client code may set it to true manually as well.
+		Throttle bool `json:"throttle"`
+		// Annotations contains the segment annotations.
+		Annotations map[string]interface{} `json:"annotations,omitempty"`
+		// Metadata contains the segment metadata.
+		Metadata map[string]map[string]interface{} `json:"metadata,omitempty"`
+		// Subsegments contains all the subsegments.
+		Subsegments []*Segment `json:"subsegments,omitempty"`
+		// Parent is the subsegment parent, it's nil for the root
+		// segment.
+		Parent *Segment `json:"-"`
+		// conn is the UDP client to the X-Ray daemon.
+		conn net.Conn
+		// counter keeps track of the number of subsegments that have not
+		// completed yet.
+		counter int
+	}
+
+	// HTTP describes a HTTP request.
+	HTTP struct {
+		// Request contains the data reported about the incoming request.
+		Request *Request `json:"request,omitempty"`
+		// Response contains the data reported about the HTTP response.
+		Response *Response `json:"response,omitempty"`
+	}
+
+	// Request describes a HTTP request.
+	Request struct {
+		Method    string `json:"method,omitempty"`
+		URL       string `json:"url,omitempty"`
+		UserAgent string `json:"user_agent,omitempty"`
+		ClientIP  string `json:"client_ip,omitempty"`
+	}
+
+	// Response describes a HTTP response.
+	Response struct {
+		Status        int `json:"status"`
+		ContentLength int `json:"content_length"`
+	}
+
+	// Cause list errors that happens during the request.
+	Cause struct {
+		// ID to segment where error originated, exclusive with other
+		// fields.
+		ID string `json:"id,omitempty"`
+		// WorkingDirectory when error occurred. Exclusive with ID.
+		WorkingDirectory string `json:"working_directory,omitempty"`
+		// Exceptions contains the details on the error(s) that occurred
+		// when the request as processing.
+		Exceptions []*Exception `json:"exceptions,omitempty"`
+	}
+
+	// Exception describes an error.
+	Exception struct {
+		// Message contains the error message.
+		Message string `json:"message"`
+		// Stack is the error stack trace as initialized via the
+		// github.com/pkg/errors package.
+		Stack []*StackEntry `json:"stack"`
+	}
+
+	// StackEntry represents an entry in a error stacktrace.
+	StackEntry struct {
+		// Path to code file
+		Path string `json:"path"`
+		// Line number
+		Line int `json:"line"`
+		// Label is the line label if any
+		Label string `json:"label,omitempty"`
+	}
+
+	// key is the type used for context keys.
+	key int
+)
+
+const (
+	// udpHeader is the header of each segment sent to the daemon.
+	udpHeader = "{\"format\": \"json\", \"version\": 1}\n"
+
+	// maxStackDepth is the maximum number of stack frames reported.
+	maxStackDepth = 100
+)
+
+type (
+	causer interface {
+		Cause() error
+	}
+	stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+)
+
+// recordError traces an error. fault denotes whether the error is unexpected
+// (a bug) or whether it is due to invalid data (e.g. bad request).
+//
+// The trace contains a stack trace and a cause for the error if the argument
+// was created using one of the New, Errorf, Wrap or Wrapf functions of the
+// github.com/pkg/errors package. Otherwise the Stack and Cause fields are empty.
+func (s *Segment) recordError(e error, fault bool) {
+	var xerr *Exception
+	if c, ok := e.(causer); ok {
+		xerr = &Exception{Message: c.Cause().Error()}
+	} else {
+		xerr = &Exception{Message: e.Error()}
+	}
+	if s, ok := e.(stackTracer); ok {
+		st := s.StackTrace()
+		ln := len(st)
+		if ln > maxStackDepth {
+			ln = maxStackDepth
+		}
+		frames := make([]*StackEntry, ln)
+		for i := 0; i < ln; i++ {
+			f := st[i]
+			line, _ := strconv.Atoi(fmt.Sprintf("%d", f))
+			frames[i] = &StackEntry{
+				Path:  fmt.Sprintf("%s", f),
+				Line:  line,
+				Label: fmt.Sprintf("%n", f),
+			}
+		}
+		xerr.Stack = frames
+	}
+	if s.Cause == nil {
+		wd, _ := os.Getwd()
+		s.Cause = &Cause{WorkingDirectory: wd}
+	}
+	s.Cause.Exceptions = append(s.Cause.Exceptions, xerr)
+	p := s.Parent
+	for p != nil {
+		if p.Cause == nil {
+			p.Cause = &Cause{ID: s.ID}
+		}
+		p = p.Parent
+	}
+}
+
+// NewSubsegment creates a subsegment of s.
+func (s *Segment) NewSubsegment(name string) *Segment {
+	s.Lock()
+	defer s.Unlock()
+	sub := &Segment{
+		Mutex:      &sync.Mutex{},
+		ID:         NewID(),
+		TraceID:    s.TraceID,
+		ParentID:   s.ID,
+		Type:       "subsegment",
+		Name:       name,
+		StartTime:  now(),
+		InProgress: true,
+		Parent:     s,
+		conn:       s.conn,
+	}
+	s.Subsegments = append(s.Subsegments, sub)
+	s.counter++
+	return sub
+}
+
+// Capture creates a subsegment to record the execution of the given function.
+// Usage:
+//
+//     s := xray.ContextSegment(ctx)
+//     s.Capture("slow-func", func() {
+//         // ... some long executing code
+//     })
+//
+func (s *Segment) Capture(name string, fn func()) {
+	sub := s.NewSubsegment(name)
+	defer sub.Close()
+	fn()
+}
+
+// AddAnnotation adds a key-value pair that can be queried by AWS X-Ray.
+func (s *Segment) AddAnnotation(key string, value string) {
+	s.addAnnotation(key, value)
+}
+
+// AddInt64Annotation adds a key-value pair that can be queried by AWS X-Ray.
+func (s *Segment) AddInt64Annotation(key string, value int64) {
+	s.addAnnotation(key, value)
+}
+
+// AddBoolAnnotation adds a key-value pair that can be queried by AWS X-Ray.
+func (s *Segment) AddBoolAnnotation(key string, value bool) {
+	s.addAnnotation(key, value)
+}
+
+// addAnnotation adds a key-value pair that can be queried by AWS X-Ray.
+// AWS X-Ray only supports annotations of type string, integer or boolean.
+func (s *Segment) addAnnotation(key string, value interface{}) {
+	if s.Annotations == nil {
+		s.Annotations = make(map[string]interface{})
+	}
+	s.Annotations[key] = value
+}
+
+// AddMetadata adds a key-value pair to the metadata.default attribute.
+// Metadata is not queryable, but is recorded.
+func (s *Segment) AddMetadata(key string, value string) {
+	s.addMetadata(key, value)
+}
+
+// AddInt64Metadata adds a key-value pair that can be queried by AWS X-Ray.
+func (s *Segment) AddInt64Metadata(key string, value int64) {
+	s.addMetadata(key, value)
+}
+
+// AddBoolMetadata adds a key-value pair that can be queried by AWS X-Ray.
+func (s *Segment) AddBoolMetadata(key string, value bool) {
+	s.addMetadata(key, value)
+}
+
+// addMetadata adds a key-value pair that can be queried by AWS X-Ray.
+// AWS X-Ray only supports annotations of type string, integer or boolean.
+func (s *Segment) addMetadata(key string, value interface{}) {
+	if s.Metadata == nil {
+		s.Metadata = make(map[string]map[string]interface{})
+		s.Metadata["default"] = make(map[string]interface{})
+	}
+	s.Metadata["default"][key] = value
+}
+
+// Close closes the segment by setting its EndTime.
+func (s *Segment) Close() {
+	s.Lock()
+	defer s.Unlock()
+	s.EndTime = now()
+	s.InProgress = false
+	if s.Parent != nil {
+		s.Parent.decrementCounter()
+	}
+	if s.counter <= 0 {
+		s.flush()
+	}
+}
+
+// flush sends the segment to the AWS X-Ray daemon.
+func (s *Segment) flush() {
+	b, _ := json.Marshal(s)
+	// append so we make only one call to Write to be goroutine-safe
+	s.conn.Write(append([]byte(udpHeader), b...))
+}
+
+// decrementCounter decrements the segment counter and flushes it if it's 0.
+func (s *Segment) decrementCounter() {
+	s.Lock()
+	defer s.Unlock()
+	s.counter--
+	if s.counter <= 0 && s.EndTime != 0 {
+		// Segment is closed and last subsegment closed, flush it
+		s.flush()
+	}
+}

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -1,0 +1,76 @@
+package xray
+
+import (
+	"regexp"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+func TestRecordError(t *testing.T) {
+	var (
+		errMsg       = "foo"
+		cause        = "cause"
+		inner        = "inner"
+		err          = errors.New(errMsg)
+		wrapped      = errors.Wrap(err, cause)
+		wrappedTwice = errors.Wrap(wrapped, inner)
+	)
+	cases := map[string]struct {
+		Error    error
+		Message  string
+		HasCause bool
+	}{
+		"go-error":     {err, errMsg, false},
+		"wrapped":      {wrapped, cause + ": " + errMsg, true},
+		"wrappedTwice": {wrappedTwice, inner + ": " + cause + ": " + errMsg, true},
+	}
+	for k, c := range cases {
+		s := Segment{}
+		s.recordError(c.Error, false)
+		w := s.Cause.Exceptions[0]
+		if w.Message != c.Message {
+			t.Errorf("%s: invalid message, expected %s got %s", k, c.Message, w.Message)
+		}
+		if c.HasCause && len(w.Stack) < 2 {
+			t.Errorf("%s: stack too small: %v", k, w.Stack)
+		}
+	}
+}
+
+func TestNewSubsegment(t *testing.T) {
+	var (
+		name   = "sub"
+		s      = &Segment{Mutex: &sync.Mutex{}}
+		before = now()
+		ss     = s.NewSubsegment(name)
+	)
+	if s.counter != 1 {
+		t.Errorf("counter not incremented after call to Subsegment")
+	}
+	if len(s.Subsegments) != 1 {
+		t.Fatalf("invalid count of subsegments, expected 1 got %d", len(s.Subsegments))
+	}
+	if s.Subsegments[0] != ss {
+		t.Errorf("invalid subsegments element, expected %v - got %v", name, s.Subsegments[0])
+	}
+	if ss.ID == "" {
+		t.Errorf("subsegment ID not initialized")
+	}
+	if !regexp.MustCompile("[0-9a-f]{16}").MatchString(ss.ID) {
+		t.Errorf("invalid subsegment ID, got %v", ss.ID)
+	}
+	if ss.Name != name {
+		t.Errorf("invalid subsegemnt name, expected %s got %s", name, ss.Name)
+	}
+	if ss.StartTime < before {
+		t.Errorf("invalid subsegment StartAt, expected at least %v, got %v", before, ss.StartTime)
+	}
+	if !ss.InProgress {
+		t.Errorf("subsegemnt not in progress")
+	}
+	if ss.Parent != s {
+		t.Errorf("invalid subsegment parent, expected %v, got %v", s, ss.Parent)
+	}
+}


### PR DESCRIPTION
The Tracer middleware retrieves the trace ID and parent span ID from the
incoming request if present and stores the in the context. The middleware
provides a goa Doer wrapper function that extract the values from the context
and sets them in the outgoing request.

The middleware constructor accepts a percentage as argument which specifies the
sampling value. This value is used when the incoming request does *not* include
tracing headers to determine whether a new trace ID should be computed and set
in the context.

The xray middleware leverages the values set in the context by the Tracer
middleware to report tracing information to the AWS X-Ray service. The package
also makes it possible to attach further information to the traces such as
annotations and metadata. The middleware also reports errors to the service.

The xray package also provides a WrapClient function for wrapping an instance
of http.Client to trace requests made to external services.