### PR TITLE
Reset the http Request in the context in the generated handler.

### DIFF
--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -130,13 +130,14 @@ func (g *Generator) generateContexts() error {
 	title := fmt.Sprintf("%s: Application Contexts", g.API.Context())
 	imports := []*codegen.ImportSpec{
 		codegen.SimpleImport("fmt"),
-		codegen.SimpleImport("golang.org/x/net/context"),
+		codegen.SimpleImport("net/http"),
 		codegen.SimpleImport("strconv"),
 		codegen.SimpleImport("strings"),
 		codegen.SimpleImport("time"),
 		codegen.SimpleImport("unicode/utf8"),
 		codegen.SimpleImport("github.com/goadesign/goa"),
 		codegen.NewImport("uuid", "github.com/satori/go.uuid"),
+		codegen.SimpleImport("golang.org/x/net/context"),
 	}
 	g.genfiles = append(g.genfiles, ctxFile)
 	ctxWr.WriteHeader(title, g.Target, imports)

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -300,6 +300,7 @@ package app
 import (
 	"github.com/goadesign/goa"
 	"golang.org/x/net/context"
+	"net/http"
 )
 
 // GetWidgetContext provides the Widget get action context.
@@ -312,11 +313,12 @@ type GetWidgetContext struct {
 
 // NewGetWidgetContext parses the incoming request URL and body, performs validations and creates the
 // context used by the Widget controller get action.
-func NewGetWidgetContext(ctx context.Context, service *goa.Service) (*GetWidgetContext, error) {
+func NewGetWidgetContext(ctx context.Context, r *http.Request, service *goa.Service) (*GetWidgetContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := GetWidgetContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramID := req.Params["id"]
 	if len(paramID) > 0 {
@@ -375,7 +377,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 			return err
 		}
 		// Build the context
-		rctx, err := NewGetWidgetContext(ctx, service)
+		rctx, err := NewGetWidgetContext(ctx, req, service)
 		if err != nil {
 			return err
 		}
@@ -435,7 +437,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 			return err
 		}
 		// Build the context
-		rctx, err := NewGetWidgetContext(ctx, service)
+		rctx, err := NewGetWidgetContext(ctx, req, service)
 		if err != nil {
 			return err
 		}
@@ -474,7 +476,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 			return err
 		}
 		// Build the context
-		rctx, err := NewGetWidgetContext(ctx, service)
+		rctx, err := NewGetWidgetContext(ctx, req, service)
 		if err != nil {
 			return err
 		}

--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -366,7 +366,7 @@ func {{ $test.Name }}(t goatest.TInterface, ctx context.Context, service *goa.Se
 		ctx = context.Background()
 	}
 	goaCtx := goa.NewContext(goa.WithAction(ctx, "{{ $test.ResourceName }}Test"), rw, req, prms)
-	{{ $test.ContextVarName }}, err := {{ $test.ContextType }}(goaCtx, service)
+	{{ $test.ContextVarName }}, err := {{ $test.ContextType }}(goaCtx, req, service)
 	if err != nil {
 		panic("invalid test data " + err.Error()) // bug
 	}

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -541,11 +541,12 @@ type {{ .Name }} struct {
 	ctxNewT = `{{ define "Coerce" }}` + coerceT + `{{ end }}` + `
 // New{{ goify .Name true }} parses the incoming request URL and body, performs validations and creates the
 // context used by the {{ .ResourceName }} controller {{ .ActionName }} action.
-func New{{ .Name }}(ctx context.Context, service *goa.Service) (*{{ .Name }}, error) {
+func New{{ .Name }}(ctx context.Context, r *http.Request, service *goa.Service) (*{{ .Name }}, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := {{ .Name }}{Context: ctx, ResponseData: resp, RequestData: req}{{/*
 */}}
 {{ if .Headers }}{{ range $name, $att := .Headers.Type.ToObject }}	header{{ goify $name true }} := req.Header["{{ canonicalHeaderKey $name }}"]
@@ -701,7 +702,7 @@ func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Co
 			return err
 		}
 		// Build the context
-		rctx, err := New{{ .Context }}(ctx, service)
+		rctx, err := New{{ .Context }}(ctx, req, service)
 		if err != nil {
 			return err
 		}

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -1046,11 +1046,12 @@ type ListBottleContext struct {
 `
 
 	emptyContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	return &rctx, err
 }
@@ -1066,11 +1067,12 @@ type ListBottleContext struct {
 `
 
 	intContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
@@ -1097,11 +1099,12 @@ type ListBottleContext struct {
 `
 
 	strContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
@@ -1122,11 +1125,12 @@ type ListBottleContext struct {
 `
 
 	strHeaderContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	headerHeader := req.Header["Header"]
 	if len(headerHeader) > 0 {
@@ -1139,11 +1143,12 @@ func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottl
 `
 
 	strHeaderParamContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	headerParam := req.Header["Param"]
 	if len(headerParam) > 0 {
@@ -1170,11 +1175,12 @@ type ListBottleContext struct {
 `
 
 	numContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
@@ -1199,11 +1205,12 @@ type ListBottleContext struct {
 `
 
 	boolContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
@@ -1229,11 +1236,12 @@ type ListBottleContext struct {
 `
 
 	arrayContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
@@ -1254,11 +1262,12 @@ type ListBottleContext struct {
 `
 
 	intArrayContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramParam := req.Params["param"]
 	if len(paramParam) > 0 {
@@ -1286,11 +1295,12 @@ type ListBottleContext struct {
 `
 
 	resContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramInt := req.Params["int"]
 	if len(paramInt) > 0 {
@@ -1317,11 +1327,12 @@ type ListBottleContext struct {
 `
 
 	requiredContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramInt := req.Params["int"]
 	if len(paramInt) == 0 {
@@ -1348,11 +1359,12 @@ type ListBottleContext struct {
 `
 
 	customContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	paramInt := req.Params["int"]
 	if len(paramInt) > 0 {
@@ -1379,11 +1391,12 @@ type ListBottleContext struct {
 `
 
 	payloadContextFactory = `
-func NewListBottleContext(ctx context.Context, service *goa.Service) (*ListBottleContext, error) {
+func NewListBottleContext(ctx context.Context, r *http.Request, service *goa.Service) (*ListBottleContext, error) {
 	var err error
 	resp := goa.ContextResponse(ctx)
 	resp.Service = service
 	req := goa.ContextRequest(ctx)
+	req.Request = r
 	rctx := ListBottleContext{Context: ctx, ResponseData: resp, RequestData: req}
 	return &rctx, err
 }
@@ -1536,7 +1549,7 @@ func MountBottlesController(service *goa.Service, ctrl BottlesController) {
 			return err
 		}
 		// Build the context
-		rctx, err := NewListBottleContext(ctx, service)
+		rctx, err := NewListBottleContext(ctx, req, service)
 		if err != nil {
 			return err
 		}
@@ -1557,7 +1570,7 @@ func MountBottlesController(service *goa.Service, ctrl BottlesController) {
 			return err
 		}
 		// Build the context
-		rctx, err := NewListBottleContext(ctx, service)
+		rctx, err := NewListBottleContext(ctx, req, service)
 		if err != nil {
 			return err
 		}
@@ -1586,7 +1599,7 @@ type BottlesController interface {
 			return err
 		}
 		// Build the context
-		rctx, err := NewListBottleContext(ctx, service)
+		rctx, err := NewListBottleContext(ctx, req, service)
 		if err != nil {
 			return err
 		}
@@ -1601,7 +1614,7 @@ type BottlesController interface {
 			return err
 		}
 		// Build the context
-		rctx, err := NewShowBottleContext(ctx, service)
+		rctx, err := NewShowBottleContext(ctx, req, service)
 		if err != nil {
 			return err
 		}

--- a/service_test.go
+++ b/service_test.go
@@ -136,6 +136,7 @@ var _ = Describe("Service", func() {
 					rw.Write([]byte(err.Error()))
 					return nil
 				}
+				goa.ContextRequest(c).Request = req
 				ctx = c
 				rw.WriteHeader(respStatus)
 				rw.Write(respContent)


### PR DESCRIPTION
So that if a middleware changed the request object (e.g. to change its context)
the new request object is handed over to the controller code.