### PR TITLE
Make X-Ray segment RecordError method public

### DIFF
--- a/middleware/xray/client.go
+++ b/middleware/xray/client.go
@@ -47,7 +47,9 @@ func (r *httpTracer) Do(req *http.Request) (*http.Response, error) {
 	resp, err := r.client.Do(req)
 
 	if err != nil {
-		sub.recordError(err, resp.StatusCode < 500)
+		sub.Fault = resp.StatusCode < http.StatusInternalServerError &&
+			resp.StatusCode != http.StatusTooManyRequests
+		sub.RecordError(err)
 		return nil, err
 	}
 	sub.HTTP.Response = responseData(resp)

--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -152,9 +152,11 @@ func record(ctx context.Context, s *Segment, err error) {
 	if err != nil {
 		fault := false
 		if gerr, ok := err.(goa.ServiceError); ok {
-			fault = gerr.ResponseStatus() < 500
+			fault = gerr.ResponseStatus() < http.StatusInternalServerError &&
+				gerr.ResponseStatus() != http.StatusTooManyRequests
 		}
-		s.recordError(err, fault)
+		s.Fault = fault
+		s.RecordError(err)
 	}
 	s.Close()
 }

--- a/middleware/xray/middleware_test.go
+++ b/middleware/xray/middleware_test.go
@@ -140,7 +140,7 @@ func TestMiddleware(t *testing.T) {
 			ctx    = goa.NewContext(context.Background(), rw, req, nil)
 			h      = func(ctx context.Context, rw http.ResponseWriter, _ *http.Request) error {
 				if c.Segment.Exception != "" {
-					ContextSegment(ctx).recordError(errors.New(c.Segment.Exception), false)
+					ContextSegment(ctx).RecordError(errors.New(c.Segment.Exception))
 				}
 				rw.WriteHeader(c.Response.Status)
 				return nil

--- a/middleware/xray/segment.go
+++ b/middleware/xray/segment.go
@@ -45,9 +45,9 @@ type (
 		// automatically set by Close when the response status code is
 		// 500 or more.
 		Error bool `json:"error"`
-		// Fault is true when a request results in an error. It is
-		// automatically set by Close when the response status code is
-		// between 400 and 500 (but not 429).
+		// Fault is true when a request results in an error that is due
+		// to the user. Typically it should be set when the response
+		// status code is between 400 and 500 (but not 429).
 		Fault bool `json:"fault"`
 		// Throttle is true when a request is throttled. It is set to
 		// true when the segment closes and the response status code is
@@ -143,13 +143,13 @@ type (
 	}
 )
 
-// recordError traces an error. fault denotes whether the error is unexpected
-// (a bug) or whether it is due to invalid data (e.g. bad request).
+// RecordError traces an error. The client may also want to initialize the
+// fault field of s.
 //
 // The trace contains a stack trace and a cause for the error if the argument
 // was created using one of the New, Errorf, Wrap or Wrapf functions of the
 // github.com/pkg/errors package. Otherwise the Stack and Cause fields are empty.
-func (s *Segment) recordError(e error, fault bool) {
+func (s *Segment) RecordError(e error) {
 	var xerr *Exception
 	if c, ok := e.(causer); ok {
 		xerr = &Exception{Message: c.Cause().Error()}

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -28,7 +28,7 @@ func TestRecordError(t *testing.T) {
 	}
 	for k, c := range cases {
 		s := Segment{Mutex: &sync.Mutex{}}
-		s.recordError(c.Error, false)
+		s.RecordError(c.Error)
 		w := s.Cause.Exceptions[0]
 		if w.Message != c.Message {
 			t.Errorf("%s: invalid message, expected %s got %s", k, c.Message, w.Message)


### PR DESCRIPTION
So it can be used by code that does not rely on the
middleware to report errors.