### PR TITLE
gen_cli: Replace underscores by dashes for the generated cmd arguments

### DIFF
--- a/goagen/codegen/helpers.go
+++ b/goagen/codegen/helpers.go
@@ -167,35 +167,6 @@ func SnakeCase(name string) string {
 
 // KebabCase produces the kebab-case version of the given CamelCase string.
 func KebabCase(name string) string {
-	for u, l := range toLower {
-		name = strings.Replace(name, u, l, -1)
-		// Replace any potential underscore by a dash character following kebab-case alg.
-		name = strings.Replace(name, "_", "-", -1)
-	}
-	var b bytes.Buffer
-	var lastDash bool
-	ln := len(name)
-	if ln == 0 {
-		return ""
-	}
-	b.WriteRune(unicode.ToLower(rune(name[0])))
-	for i := 1; i < ln; i++ {
-		r := rune(name[i])
-		nextIsLower := false
-		if i < ln-1 {
-			n := rune(name[i+1])
-			nextIsLower = unicode.IsLower(n) && unicode.IsLetter(n)
-		}
-		if unicode.IsUpper(r) {
-			if !lastDash && nextIsLower {
-				b.WriteRune('-')
-				lastDash = true
-			}
-			b.WriteRune(unicode.ToLower(r))
-		} else {
-			b.WriteRune(r)
-			lastDash = false
-		}
-	}
-	return b.String()
+	name = SnakeCase(name)
+	return strings.Replace(name, "_", "-", -1)
 }

--- a/goagen/codegen/helpers.go
+++ b/goagen/codegen/helpers.go
@@ -164,3 +164,38 @@ func SnakeCase(name string) string {
 	}
 	return b.String()
 }
+
+// KebabCase produces the kebab-case version of the given CamelCase string.
+func KebabCase(name string) string {
+	for u, l := range toLower {
+		name = strings.Replace(name, u, l, -1)
+		// Replace any potential underscore by a dash character following kebab-case alg.
+		name = strings.Replace(name, "_", "-", -1)
+	}
+	var b bytes.Buffer
+	var lastDash bool
+	ln := len(name)
+	if ln == 0 {
+		return ""
+	}
+	b.WriteRune(unicode.ToLower(rune(name[0])))
+	for i := 1; i < ln; i++ {
+		r := rune(name[i])
+		nextIsLower := false
+		if i < ln-1 {
+			n := rune(name[i+1])
+			nextIsLower = unicode.IsLower(n) && unicode.IsLetter(n)
+		}
+		if unicode.IsUpper(r) {
+			if !lastDash && nextIsLower {
+				b.WriteRune('-')
+				lastDash = true
+			}
+			b.WriteRune(unicode.ToLower(r))
+		} else {
+			b.WriteRune(r)
+			lastDash = false
+		}
+	}
+	return b.String()
+}

--- a/goagen/codegen/helpers_test.go
+++ b/goagen/codegen/helpers_test.go
@@ -9,29 +9,11 @@ import (
 )
 
 func TestHelpers(t *testing.T) {
-	var (
-		stringTestA = "testAa"
-		stringTestB = "test-B"
-		stringTestC = "test_cA"
-		stringTestD = "test_D"
-		stringTestE = "teste"
-		stringTestF = "testABC"
-		stringTestG = "testAbc"
-
-		expectedTestA = "test-aa"
-		expectedTestB = "test-b"
-		expectedTestC = "test-ca"
-		expectedTestD = "test-d"
-		expectedTestE = "teste"
-		expectedTestF = "testabc"
-		expectedTestG = "test-abc"
-	)
-
-	Expect(codegen.KebabCase(stringTestA)).To(Equal(expectedTestA))
-	Expect(codegen.KebabCase(stringTestB)).To(Equal(expectedTestB))
-	Expect(codegen.KebabCase(stringTestC)).To(Equal(expectedTestC))
-	Expect(codegen.KebabCase(stringTestD)).To(Equal(expectedTestD))
-	Expect(codegen.KebabCase(stringTestE)).To(Equal(expectedTestE))
-	Expect(codegen.KebabCase(stringTestF)).To(Equal(expectedTestF))
-	Expect(codegen.KebabCase(stringTestG)).To(Equal(expectedTestG))
+	Expect(codegen.KebabCase("testAa")).To(Equal("test-aa"))
+	Expect(codegen.KebabCase("test-B")).To(Equal("test-b"))
+	Expect(codegen.KebabCase("test_cA")).To(Equal("test-ca"))
+	Expect(codegen.KebabCase("test_D")).To(Equal("test-d"))
+	Expect(codegen.KebabCase("teste")).To(Equal("teste"))
+	Expect(codegen.KebabCase("testABC")).To(Equal("testabc"))
+	Expect(codegen.KebabCase("testAbc")).To(Equal("test-abc"))
 }

--- a/goagen/codegen/helpers_test.go
+++ b/goagen/codegen/helpers_test.go
@@ -1,0 +1,37 @@
+package codegen_test
+
+import (
+	"testing"
+
+	"github.com/goadesign/goa/goagen/codegen"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHelpers(t *testing.T) {
+	var (
+		stringTestA = "testAa"
+		stringTestB = "test-B"
+		stringTestC = "test_cA"
+		stringTestD = "test_D"
+		stringTestE = "teste"
+		stringTestF = "testABC"
+		stringTestG = "testAbc"
+
+		expectedTestA = "test-aa"
+		expectedTestB = "test-b"
+		expectedTestC = "test-ca"
+		expectedTestD = "test-d"
+		expectedTestE = "teste"
+		expectedTestF = "testabc"
+		expectedTestG = "test-abc"
+	)
+
+	Expect(codegen.KebabCase(stringTestA)).To(Equal(expectedTestA))
+	Expect(codegen.KebabCase(stringTestB)).To(Equal(expectedTestB))
+	Expect(codegen.KebabCase(stringTestC)).To(Equal(expectedTestC))
+	Expect(codegen.KebabCase(stringTestD)).To(Equal(expectedTestD))
+	Expect(codegen.KebabCase(stringTestE)).To(Equal(expectedTestE))
+	Expect(codegen.KebabCase(stringTestF)).To(Equal(expectedTestF))
+	Expect(codegen.KebabCase(stringTestG)).To(Equal(expectedTestG))
+}

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -105,6 +105,7 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 	funcs["cmdFieldType"] = cmdFieldTypeString
 	funcs["formatExample"] = formatExample
 	funcs["shouldAddExample"] = shouldAddExample
+	funcs["kebabCase"] = codegen.KebabCase
 
 	commandTypesTmpl := template.Must(template.New("commandTypes").Funcs(funcs).Parse(commandTypesTmpl))
 	commandsTmpl := template.Must(template.New("commands").Funcs(funcs).Parse(commandsTmpl))
@@ -162,9 +163,6 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 		}
 		return res.IterateActions(func(action *design.ActionDefinition) error {
 			name := codegen.Goify(action.Name, false)
-			// To avoid underscore in the resource name, we apply the kebabCase
-			// algorithm over the action.Parent.Name property.
-			action.Parent.Name = codegen.KebabCase(action.Parent.Name)
 			if as, ok := actions[name]; ok {
 				actions[name] = append(as, action)
 			} else {
@@ -225,9 +223,6 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 	}
 	err = g.API.IterateResources(func(res *design.ResourceDefinition) error {
 		return res.IterateActions(func(action *design.ActionDefinition) error {
-			// To avoid underscore in the resource name, we apply the kebabCase
-			// algorithm over the action.Parent.Name property.
-			action.Parent.Name = codegen.KebabCase(action.Parent.Name)
 			data := map[string]interface{}{
 				"Action":          action,
 				"Resource":        action.Parent,
@@ -839,13 +834,13 @@ const registerCmdsT = `// RegisterCommands registers the resource action CLI com
 func RegisterCommands(app *cobra.Command, c *{{ .Package }}.Client) {
 {{ with .Actions }}{{ if gt (len .) 0 }}	var command, sub *cobra.Command
 {{ end }}{{ range $name, $actions := . }}	command = &cobra.Command{
-		Use:   "{{ $name }}",
+		Use:   "{{ kebabCase $name }}",
 		Short: ` + "`" + `{{ if eq (len $actions) 1 }}{{ $a := index $actions 0 }}{{ escapeBackticks $a.Description }}{{ else }}{{ $name }} action{{ end }}` + "`" + `,
 	}
-{{ range $action := $actions }}{{ $cmdName := goify (printf "%s%sCommand" $action.Name (title $action.Parent.Name)) true }}{{/*
+{{ range $action := $actions }}{{ $cmdName := goify (printf "%s%sCommand" $action.Name (title (kebabCase $action.Parent.Name))) true }}{{/*
 */}}{{ $tmp := tempvar }}	{{ $tmp }} := new({{ $cmdName }})
 	sub = &cobra.Command{
-		Use:   ` + "`" + `{{ $action.Parent.Name }} {{ routes $action }}` + "`" + `,
+		Use:   ` + "`" + `{{ kebabCase $action.Parent.Name }} {{ routes $action }}` + "`" + `,
 		Short: ` + "`" + `{{ escapeBackticks $action.Parent.Description }}` + "`" + `,{{ if shouldAddExample $action.Payload }}
 		Long:  ` + "`" + `{{ escapeBackticks $action.Parent.Description }}
 

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -162,6 +162,9 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 		}
 		return res.IterateActions(func(action *design.ActionDefinition) error {
 			name := codegen.Goify(action.Name, false)
+			// To avoid underscore in the resource name, we apply the kebabCase
+			// algorithm over the action.Parent.Name property.
+			action.Parent.Name = codegen.KebabCase(action.Parent.Name)
 			if as, ok := actions[name]; ok {
 				actions[name] = append(as, action)
 			} else {
@@ -222,6 +225,9 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 	}
 	err = g.API.IterateResources(func(res *design.ResourceDefinition) error {
 		return res.IterateActions(func(action *design.ActionDefinition) error {
+			// To avoid underscore in the resource name, we apply the kebabCase
+			// algorithm over the action.Parent.Name property.
+			action.Parent.Name = codegen.KebabCase(action.Parent.Name)
 			data := map[string]interface{}{
 				"Action":          action,
 				"Resource":        action.Parent,

--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Generate", func() {
 					},
 				},
 			}
-			fooRes := design.Design.Resources["foo"]
+			fooRes := design.Design.Resources["foo_test"]
 			showAct := fooRes.Actions["show"]
 			showAct.Parent = fooRes
 			showAct.Routes[0].Parent = showAct
@@ -183,7 +183,7 @@ var _ = Describe("Generate", func() {
 			c, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
 			content := string(c)
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(content).Should(ContainSubstring(`foo-test`))
+			Ω(content).Should(ContainSubstring("foo-test"))
 		})
 	})
 


### PR DESCRIPTION
Related to this issues: https://github.com/goadesign/goa/issues/1035

@raphael Please, have a look! I made some initial changes that works in my branch. But I believe I might miss stuff. Also, I was thinking to pass a different parameter into the map instead of modifying the `Parent.Name` property.

ping @raphael 