### PR TITLE
gen_cli: Replace underscores by dashes for the generated cmd arguments

### DIFF
--- a/goagen/codegen/helpers.go
+++ b/goagen/codegen/helpers.go
@@ -164,3 +164,9 @@ func SnakeCase(name string) string {
 	}
 	return b.String()
 }
+
+// KebabCase produces the kebab-case version of the given CamelCase string.
+func KebabCase(name string) string {
+	name = SnakeCase(name)
+	return strings.Replace(name, "_", "-", -1)
+}

--- a/goagen/codegen/helpers_test.go
+++ b/goagen/codegen/helpers_test.go
@@ -1,0 +1,19 @@
+package codegen_test
+
+import (
+	"testing"
+
+	"github.com/goadesign/goa/goagen/codegen"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHelpers(t *testing.T) {
+	Expect(codegen.KebabCase("testAa")).To(Equal("test-aa"))
+	Expect(codegen.KebabCase("test-B")).To(Equal("test-b"))
+	Expect(codegen.KebabCase("test_cA")).To(Equal("test-ca"))
+	Expect(codegen.KebabCase("test_D")).To(Equal("test-d"))
+	Expect(codegen.KebabCase("teste")).To(Equal("teste"))
+	Expect(codegen.KebabCase("testABC")).To(Equal("testabc"))
+	Expect(codegen.KebabCase("testAbc")).To(Equal("test-abc"))
+}

--- a/goagen/gen_client/cli_generator.go
+++ b/goagen/gen_client/cli_generator.go
@@ -105,6 +105,7 @@ func (g *Generator) generateCommands(commandsFile string, clientPkg string, func
 	funcs["cmdFieldType"] = cmdFieldTypeString
 	funcs["formatExample"] = formatExample
 	funcs["shouldAddExample"] = shouldAddExample
+	funcs["kebabCase"] = codegen.KebabCase
 
 	commandTypesTmpl := template.Must(template.New("commandTypes").Funcs(funcs).Parse(commandTypesTmpl))
 	commandsTmpl := template.Must(template.New("commands").Funcs(funcs).Parse(commandsTmpl))
@@ -833,13 +834,13 @@ const registerCmdsT = `// RegisterCommands registers the resource action CLI com
 func RegisterCommands(app *cobra.Command, c *{{ .Package }}.Client) {
 {{ with .Actions }}{{ if gt (len .) 0 }}	var command, sub *cobra.Command
 {{ end }}{{ range $name, $actions := . }}	command = &cobra.Command{
-		Use:   "{{ $name }}",
+		Use:   "{{ kebabCase $name }}",
 		Short: ` + "`" + `{{ if eq (len $actions) 1 }}{{ $a := index $actions 0 }}{{ escapeBackticks $a.Description }}{{ else }}{{ $name }} action{{ end }}` + "`" + `,
 	}
-{{ range $action := $actions }}{{ $cmdName := goify (printf "%s%sCommand" $action.Name (title $action.Parent.Name)) true }}{{/*
+{{ range $action := $actions }}{{ $cmdName := goify (printf "%s%sCommand" $action.Name (title (kebabCase $action.Parent.Name))) true }}{{/*
 */}}{{ $tmp := tempvar }}	{{ $tmp }} := new({{ $cmdName }})
 	sub = &cobra.Command{
-		Use:   ` + "`" + `{{ $action.Parent.Name }} {{ routes $action }}` + "`" + `,
+		Use:   ` + "`" + `{{ kebabCase $action.Parent.Name }} {{ routes $action }}` + "`" + `,
 		Short: ` + "`" + `{{ escapeBackticks $action.Parent.Description }}` + "`" + `,{{ if shouldAddExample $action.Payload }}
 		Long:  ` + "`" + `{{ escapeBackticks $action.Parent.Description }}
 

--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -142,6 +142,51 @@ var _ = Describe("Generate", func() {
 		})
 	})
 
+	Context("with a resource name with underscores characters", func() {
+		BeforeEach(func() {
+			codegen.TempCount = 0
+			design.Design = &design.APIDefinition{
+				Name:        "testapi",
+				Title:       "dummy API with no resource",
+				Description: "I told you it's dummy",
+				Resources: map[string]*design.ResourceDefinition{
+					"foo_test": {
+						Name: "foo_test",
+						Actions: map[string]*design.ActionDefinition{
+							"show": {
+								Name: "show",
+								Params: &design.AttributeDefinition{
+									Type: design.Object{
+										"nicID":     &design.AttributeDefinition{Type: design.String},
+										"ipAddress": &design.AttributeDefinition{Type: design.String},
+									},
+								},
+								Routes: []*design.RouteDefinition{
+									{
+										Verb: "GET",
+										Path: "/nics/:nicID/add/:ipAddress",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			fooRes := design.Design.Resources["foo_test"]
+			showAct := fooRes.Actions["show"]
+			showAct.Parent = fooRes
+			showAct.Routes[0].Parent = showAct
+		})
+
+		It("generate the correct command path formatting code", func() {
+			Ω(genErr).Should(BeNil())
+			c, err := ioutil.ReadFile(filepath.Join(outDir, "tool", "cli", "commands.go"))
+			content := string(c)
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(content).Should(ContainSubstring("foo-test"))
+		})
+	})
+
 	Context("with an action with an integer parameter with no default value", func() {
 		BeforeEach(func() {
 			codegen.TempCount = 0


### PR DESCRIPTION
See #1039. Backport on `v1` branch.