### PR TITLE
Fix goagen to not call panic when API definition is missing

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -79,6 +79,10 @@ func Generate() (files []string, err error) {
 
 // Generate generats the client package and CLI.
 func (g *Generator) Generate() (_ []string, err error) {
+	if g.API == nil {
+		return nil, fmt.Errorf("missing API definition, make sure design is properly initialized")
+	}
+
 	go utils.Catch(nil, func() { g.Cleanup() })
 
 	defer func() {

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -91,15 +91,18 @@ func (g *Generator) Generate() (_ []string, err error) {
 		}
 	}()
 
-	if g.Target == "" {
-		g.Target = "client"
+	firstNonEmpty := func(args ...string) string {
+		for _, value := range args {
+			if len(value) > 0 {
+				return value
+			}
+		}
+		return ""
 	}
-	if g.ToolDirName == "" {
-		g.ToolDirName = "tool"
-	}
-	if g.Tool == "" {
-		g.Tool = defaultToolName(g.API)
-	}
+
+	g.Target = firstNonEmpty(g.Target, "client")
+	g.ToolDirName = firstNonEmpty(g.ToolDirName, "tool")
+	g.Tool = firstNonEmpty(g.Tool, defaultToolName(g.API))
 
 	codegen.Reserved[g.Target] = true
 

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -205,6 +205,9 @@ func (g *Generator) Generate() (_ []string, err error) {
 }
 
 func defaultToolName(api *design.APIDefinition) string {
+	if api == nil {
+		return ""
+	}
 	return strings.Replace(strings.ToLower(api.Name), " ", "-", -1) + "-cli"
 }
 

--- a/goagen/gen_controller/generator.go
+++ b/goagen/gen_controller/generator.go
@@ -2,6 +2,7 @@ package gencontroller
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/goadesign/goa/design"
@@ -63,6 +64,10 @@ func Generate() (files []string, err error) {
 
 // Generate produces the skeleton controller service factory.
 func (g *Generator) Generate() (_ []string, err error) {
+	if g.API == nil {
+		return nil, fmt.Errorf("missing API definition, make sure design is properly initialized")
+	}
+
 	go utils.Catch(nil, func() { g.Cleanup() })
 
 	defer func() {

--- a/goagen/gen_js/generator.go
+++ b/goagen/gen_js/generator.go
@@ -70,6 +70,10 @@ func Generate() (files []string, err error) {
 
 // Generate produces the skeleton main.
 func (g *Generator) Generate() (_ []string, err error) {
+	if g.API == nil {
+		return nil, fmt.Errorf("missing API definition, make sure design is properly initialized")
+	}
+
 	go utils.Catch(nil, func() { g.Cleanup() })
 
 	defer func() {

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -64,6 +64,10 @@ func Generate() (files []string, err error) {
 
 // Generate produces the skeleton main.
 func (g *Generator) Generate() (_ []string, err error) {
+	if g.API == nil {
+		return nil, fmt.Errorf("missing API definition, make sure design is properly initialized")
+	}
+
 	go utils.Catch(nil, func() { g.Cleanup() })
 
 	defer func() {

--- a/goagen/gen_schema/generator.go
+++ b/goagen/gen_schema/generator.go
@@ -2,6 +2,7 @@ package genschema
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -49,6 +50,10 @@ func Generate() (files []string, err error) {
 
 // Generate produces the skeleton main.
 func (g *Generator) Generate() (_ []string, err error) {
+	if g.API == nil {
+		return nil, fmt.Errorf("missing API definition, make sure design is properly initialized")
+	}
+
 	go utils.Catch(nil, func() { g.Cleanup() })
 
 	defer func() {

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -3,6 +3,7 @@ package genswagger
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -54,6 +55,10 @@ func Generate() (files []string, err error) {
 
 // Generate produces the skeleton main.
 func (g *Generator) Generate() (_ []string, err error) {
+	if g.API == nil {
+		return nil, fmt.Errorf("missing API definition, make sure design is properly initialized")
+	}
+
 	go utils.Catch(nil, func() { g.Cleanup() })
 
 	defer func() {


### PR DESCRIPTION
Generators in goagen except gen_app call panic when API definition is missing.
This patch fixes it.