### PR TITLE
Fix gen_client to not crash when an array parameter is defined in an action using websocket

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -940,7 +940,7 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 {{ if .MustToString }}{{ $tmp := tempvar }}			{{ toString "p" $tmp .ElemAttribute }}
 			values.Add("{{ .Name }}", {{ $tmp }})
 {{ else }}			values.Add("{{ .Name }}", {{ .ValueName }})
-{{ end }}{{/*
+{{ end }}}{{/*
 
 // NON STRING
 */}}{{ else if .MustToString }}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}


### PR DESCRIPTION
https://github.com/goadesign/goa/commit/0e7563b1eace965bb172548f8bf3174aa45e8370 adds a test context to reproduce the issue.
Then, https://github.com/goadesign/goa/commit/14b0f8d977ee9bd590e90b9c93c5302b61befdac is a patch to fix it.