### PR TITLE
Fix gen_client to not crash when an array parameter is defined in an action using websocket

### DIFF
--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -940,7 +940,7 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 {{ if .MustToString }}{{ $tmp := tempvar }}			{{ toString "p" $tmp .ElemAttribute }}
 			values.Add("{{ .Name }}", {{ $tmp }})
 {{ else }}			values.Add("{{ .Name }}", {{ .ValueName }})
-{{ end }}{{/*
+{{ end }}}{{/*
 
 // NON STRING
 */}}{{ else if .MustToString }}{{ $tmp := tempvar }}	{{ toString .ValueName $tmp .Attribute }}


### PR DESCRIPTION
This is a backporting of #1054 to v1.