### PR TITLE
v2:  Fix goagen to buildable

### DIFF
--- a/cmd/goagen/generator.go
+++ b/cmd/goagen/generator.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"fmt"

--- a/cmd/goagen/main.go
+++ b/cmd/goagen/main.go
@@ -1,4 +1,4 @@
-package cmd
+package main
 
 import (
 	"encoding/json"

--- a/codegen/file.go
+++ b/codegen/file.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/goadesign/goa/version"
+	"github.com/goadesign/goa/pkg"
 
 	"golang.org/x/tools/go/ast/astutil"
 )
@@ -159,7 +159,7 @@ func (p *Package) CreateSourceFile(name string) *SourceFile {
 func (f *SourceFile) WriteHeader(title, pack string, imports []*ImportSpec) error {
 	ctx := map[string]interface{}{
 		"Title":       title,
-		"ToolVersion": version.String(),
+		"ToolVersion": pkg.Version(),
 		"Pkg":         pack,
 		"Imports":     imports,
 	}

--- a/codegen/funcs.go
+++ b/codegen/funcs.go
@@ -8,19 +8,19 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/goadesign/goa/version"
+	"github.com/goadesign/goa/pkg"
 )
 
 // CheckVersion returns an error if the ver is empty, contains an incorrect value or
 // a version number that is not compatible with the version of this repo.
 func CheckVersion(ver string) error {
-	compat, err := version.Compatible(ver)
+	compat, err := pkg.Compatible(ver)
 	if err != nil {
 		return err
 	}
 	if !compat {
 		return fmt.Errorf("version mismatch: using goagen %s to generate code that compiles with goa %s",
-			ver, version.String())
+			ver, pkg.Version())
 	}
 	return nil
 }


### PR DESCRIPTION
This patch fixes some renamed packages and functions, and change goagen's package to `main`.