### PR TITLE
add payload test to endpoint_test

### DIFF
--- a/dsl/endpoint_test.go
+++ b/dsl/endpoint_test.go
@@ -57,6 +57,40 @@ func TestEndpoint(t *testing.T) {
 				}
 			},
 		},
+		"c": {
+			func() {
+				Endpoint("c", func() {
+					Payload(func() {
+						Description(desc)
+						Attribute("required", design.String)
+						Required("required")
+					})
+				})
+			},
+			func(t *testing.T, endpoints []*design.EndpointExpr) {
+				if len(endpoints) != 1 {
+					t.Fatalf("b: expected 1 endpoint, got %d", len(endpoints))
+				}
+				endpoint := endpoints[0]
+				if endpoint == nil {
+					t.Fatalf("c: endpoint is nil")
+				}
+				payload := endpoint.Payload
+				if payload == nil {
+					t.Fatalf("c: endpoint payload is nil")
+				}
+				if payload.Attribute().Description != desc {
+					t.Errorf("c: expected payload description '%s' to match '%s' ", desc, payload.Attribute().Description)
+				}
+				attrs := design.AsObject(payload.Attribute().Type)
+				if _, ok := attrs["required"]; !ok {
+					t.Errorf("c: expected a payload field with key required")
+				}
+				if !payload.Attribute().IsRequired("required") {
+					t.Errorf("c: expected the required field to be required")
+				}
+			},
+		},
 	}
 	//Run our tests
 	for k, tc := range cases {


### PR DESCRIPTION
@raphael Expanding on your test. Is the goal to achieve having one of these tests for each type of expression that makes up an endpoint rather than build up and duplicate? In my test I did not add a description as this was already tested in a previous test. 
Or is the goal to build up to a full example by adding to it piece by piece? In which case I should add a description attribute to my test. 
Another option here would be to have individual tests for each expression and then have a single test that pulls all of it together. This may work well as we are using maps for the test cases so have no certainty on execution order.
