### PR TITLE
Avoid using keywords for arguments in TestHelpers

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -49,7 +49,7 @@ type TestMethod struct {
 // Escape escapes given string.
 func (t *TestMethod) Escape(s string) string {
 	if ok := t.reservedNames[s]; ok {
-		s = t.Escape(s + "_")
+		s = t.Escape("_" + s)
 	}
 	t.reservedNames[s] = true
 	return s

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -103,6 +103,7 @@ var _ = Describe("Generate", func() {
 										"uuid":     &design.AttributeDefinition{Type: design.UUID},
 										"optional": &design.AttributeDefinition{Type: design.Integer},
 										"required": &design.AttributeDefinition{Type: design.DateTime},
+										"query":    &design.AttributeDefinition{Type: design.String},
 									},
 									Validation: &dslengine.ValidationDefinition{Required: []string{"required"}},
 								},
@@ -117,6 +118,7 @@ var _ = Describe("Generate", func() {
 									Type: design.Object{
 										"optional": &design.AttributeDefinition{Type: design.Integer},
 										"required": &design.AttributeDefinition{Type: design.DateTime},
+										"query":    &design.AttributeDefinition{Type: design.String},
 									},
 									Validation: &dslengine.ValidationDefinition{Required: []string{"required"}},
 								},
@@ -211,6 +213,7 @@ var _ = Describe("Generate", func() {
 
 			Ω(content).Should(ContainSubstring(`if optional != nil`))
 			Ω(content).ShouldNot(ContainSubstring(`if required != nil`))
+			Ω(content).Should(ContainSubstring(`if query != nil`))
 		})
 
 		It("properly handles headers", func() {


### PR DESCRIPTION
Fix #1083.