### PR TITLE
Add generic conflict error. Closes #1100

### DIFF
--- a/error.go
+++ b/error.go
@@ -44,6 +44,9 @@ var (
 	// ErrBadRequest is a generic bad request error.
 	ErrBadRequest = NewErrorClass("bad_request", 400)
 
+	// ErrConflict is a generic conflict error.
+	ErrConflict = NewErrorClass("conflict", 409)
+
 	// ErrUnauthorized is a generic unauthorized error.
 	ErrUnauthorized = NewErrorClass("unauthorized", 401)
 


### PR DESCRIPTION
I frequently find myself writing 409 Conflict errors when data doesn't validate as it should. Having a generic conflict error could be handy. What do you think?