### PR TITLE
Generate Produces on operations when necessary

### DIFF
--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -950,6 +950,7 @@ func buildPathFromDefinition(s *Swagger, api *design.APIDefinition, route *desig
 		Extensions:   extensionsFromDefinition(route.Metadata),
 	}
 
+	computeProduces(operation, s, action)
 	applySecurity(operation, action.Security)
 
 	key := design.WildcardRegex.ReplaceAllStringFunc(
@@ -995,6 +996,38 @@ func buildPathFromDefinition(s *Swagger, api *design.APIDefinition, route *desig
 	}
 	p.Extensions = extensionsFromDefinition(route.Parent.Metadata)
 	return nil
+}
+
+func computeProduces(operation *Operation, s *Swagger, action *design.ActionDefinition) {
+	produces := make(map[string]bool)
+	action.IterateResponses(func(resp *design.ResponseDefinition) error {
+		if resp.MediaType != "" {
+			produces[resp.MediaType] = true
+		}
+		return nil
+	})
+	subset := true
+	for p := range produces {
+		found := false
+		for _, p2 := range s.Produces {
+			if p == p2 {
+				found = true
+				break
+			}
+		}
+		if !found {
+			subset = false
+			break
+		}
+	}
+	if !subset {
+		operation.Produces = make([]string, len(produces))
+		i := 0
+		for p := range produces {
+			operation.Produces[i] = p
+			i++
+		}
+	}
 }
 
 func applySecurity(operation *Operation, security *design.SecurityDefinition) {

--- a/goagen/gen_swagger/swagger_test.go
+++ b/goagen/gen_swagger/swagger_test.go
@@ -572,6 +572,7 @@ var _ = Describe("New", func() {
 				b := swagger.Paths["/base/bottles/{id}"].(*genswagger.Path)
 				Ω(b.Put).ShouldNot(BeNil())
 				Ω(b.Put.Parameters).Should(HaveLen(14))
+				Ω(b.Put.Produces).Should(Equal([]string{"application/vnd.goa.example.bottle; type=collection"}))
 			})
 
 			It("should set the inherited tag and the action tag", func() {


### PR DESCRIPTION
That is when the set of mime types corresponding to the operation
responses differs from the overall API 'Produces' set.