### PR TITLE
Fix problem not starting with appengine

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,4 +1,4 @@
-// +build !js
+// +build !js,!appengine
 
 package goa
 

--- a/metrics.go
+++ b/metrics.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/armon/go-metrics"
+	"github.com/tikasan/go-metrics"
 )
 
 const (

--- a/metrics_appengine.go
+++ b/metrics_appengine.go
@@ -1,0 +1,17 @@
+// +build appengine
+
+package goa
+
+import (
+	"time"
+)
+
+// Not supported in Google App Engine
+func IncrCounter(key []string, val float32) {
+	// Do nothing
+}
+
+// Not supported in Google App Engine
+func MeasureSince(key []string, start time.Time) {
+	// Do nothing
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/armon/go-metrics"
+	"github.com/tikasan/go-metrics"
 )
 
 // mock metrics


### PR DESCRIPTION
for https://github.com/armon/go-metrics/pull/47

goa are using packages that are not permitted by GAE of GCP PaaS and can not be used.
This can be solved by not including the syscall containing code of the problem package in compilation.
I like goa, so I would like to use it on GAE as well. So I requested it