### PR TITLE
Fix problem not starting with appengine

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,4 +1,4 @@
-// +build !js
+// +build !js,!appengine
 
 package goa
 

--- a/metrics_appengine.go
+++ b/metrics_appengine.go
@@ -1,0 +1,17 @@
+// +build appengine
+
+package goa
+
+import (
+	"time"
+)
+
+// Not supported in Google App Engine
+func IncrCounter(key []string, val float32) {
+	// Do nothing
+}
+
+// Not supported in Google App Engine
+func MeasureSince(key []string, start time.Time) {
+	// Do nothing
+}


### PR DESCRIPTION
for https://github.com/armon/go-metrics/pull/47

goa uses packages not permitted by GAE of GCP PaaS and can not be used on GAE.
This can be solved by not including syscall containing the code of the package in question in the compilation.
I like Gore, so I would like to use it on GAE. So I requested it.

There is a problem with the dependency package, but if it is solved by goa it will be usable, so please consider.