### PR TITLE
Store exact design action name in request context ContextAction

### DIFF
--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -275,6 +275,7 @@ func (g *Generator) generateControllers() error {
 			unmarshal := fmt.Sprintf("unmarshal%s%sPayload", codegen.Goify(a.Name, true), codegen.Goify(r.Name, true))
 			action := map[string]interface{}{
 				"Name":            codegen.Goify(a.Name, true),
+				"DesignName":      a.Name,
 				"Routes":          a.Routes,
 				"Context":         context,
 				"Unmarshal":       unmarshal,

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -383,7 +383,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 		}
 		return ctrl.Get(rctx)
 	}
-	service.Mux.Handle("GET", "/:id", ctrl.MuxHandler("Get", h, nil))
+	service.Mux.Handle("GET", "/:id", ctrl.MuxHandler("get", h, nil))
 	service.LogInfo("mount", "ctrl", "Widget", "action", "Get", "route", "GET /:id")
 }
 `
@@ -449,7 +449,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 		}
 		return ctrl.Get(rctx)
 	}
-	service.Mux.Handle("GET", "/:id", ctrl.MuxHandler("Get", h, unmarshalGetWidgetPayload))
+	service.Mux.Handle("GET", "/:id", ctrl.MuxHandler("get", h, unmarshalGetWidgetPayload))
 	service.LogInfo("mount", "ctrl", "Widget", "action", "Get", "route", "GET /:id")
 }
 
@@ -486,7 +486,7 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 		}
 		return ctrl.Get(rctx)
 	}
-	service.Mux.Handle("GET", "/:id", ctrl.MuxHandler("Get", h, unmarshalGetWidgetPayload))
+	service.Mux.Handle("GET", "/:id", ctrl.MuxHandler("get", h, unmarshalGetWidgetPayload))
 	service.LogInfo("mount", "ctrl", "Widget", "action", "Get", "route", "GET /:id")
 }
 

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -91,7 +91,7 @@ type (
 	ControllerTemplateData struct {
 		API            *design.APIDefinition          // API definition
 		Resource       string                         // Lower case plural resource name, e.g. "bottles"
-		Actions        []map[string]interface{}       // Array of actions, each action has keys "Name", "Routes", "Context" and "Unmarshal"
+		Actions        []map[string]interface{}       // Array of actions, each action has keys "Name", "DesignName", "Routes", "Context" and "Unmarshal"
 		FileServers    []*design.FileServerDefinition // File servers
 		Encoders       []*EncoderTemplateData         // Encoder data
 		Decoders       []*EncoderTemplateData         // Decoder data
@@ -721,7 +721,7 @@ func Mount{{ .Resource }}Controller(service *goa.Service, ctrl {{ .Resource }}Co
 	}
 {{ if .Security }}	h = handleSecurity({{ printf "%q" .Security.Scheme.SchemeName }}, h{{ range .Security.Scopes }}, {{ printf "%q" . }}{{ end }})
 {{ end }}{{ if $.Origins }}	h = handle{{ $res }}Origin(h)
-{{ end }}{{ range .Routes }}	service.Mux.Handle("{{ .Verb }}", {{ printf "%q" .FullPath }}, ctrl.MuxHandler({{ printf "%q" $action.Name }}, h, {{ if $action.Payload }}{{ $action.Unmarshal }}{{ else }}nil{{ end }}))
+{{ end }}{{ range .Routes }}	service.Mux.Handle("{{ .Verb }}", {{ printf "%q" .FullPath }}, ctrl.MuxHandler({{ printf "%q" $action.DesignName }}, h, {{ if $action.Payload }}{{ $action.Unmarshal }}{{ else }}nil{{ end }}))
 	service.LogInfo("mount", "ctrl", {{ printf "%q" $res }}, "action", {{ printf "%q" $action.Name }}, "route", {{ printf "%q" (printf "%s %s" .Verb .FullPath) }}{{ with $action.Security }}, "security", {{ printf "%q" .Scheme.SchemeName }}{{ end }})
 {{ end }}{{ end }}{{ range .FileServers }}
 	h = ctrl.FileHandler({{ printf "%q" .RequestPath }}, {{ printf "%q" .FilePath }})

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -1007,7 +1007,8 @@ var _ = Describe("ControllersWriter", func() {
 						payload = payloads[i]
 					}
 					as[i] = map[string]interface{}{
-						"Name": a,
+						"Name":       codegen.Goify(a, true),
+						"DesignName": a,
 						"Routes": []*design.RouteDefinition{
 							{
 								Verb: verbs[i],
@@ -1042,7 +1043,7 @@ var _ = Describe("ControllersWriter", func() {
 
 			Context("with a simple controller", func() {
 				BeforeEach(func() {
-					actions = []string{"List"}
+					actions = []string{"list"}
 					verbs = []string{"GET"}
 					paths = []string{"/accounts/:accountID/bottles"}
 					contexts = []string{"ListBottleContext"}
@@ -1062,7 +1063,7 @@ var _ = Describe("ControllersWriter", func() {
 
 			Context("with actions that take a payload", func() {
 				BeforeEach(func() {
-					actions = []string{"List"}
+					actions = []string{"list"}
 					verbs = []string{"GET"}
 					paths = []string{"/accounts/:accountID/bottles"}
 					contexts = []string{"ListBottleContext"}
@@ -1092,7 +1093,7 @@ var _ = Describe("ControllersWriter", func() {
 			})
 			Context("with actions that take a payload with a required validation", func() {
 				BeforeEach(func() {
-					actions = []string{"List"}
+					actions = []string{"list"}
 					required := &dslengine.ValidationDefinition{
 						Required: []string{"id"},
 					}
@@ -1127,7 +1128,7 @@ var _ = Describe("ControllersWriter", func() {
 
 			Context("with multiple controllers", func() {
 				BeforeEach(func() {
-					actions = []string{"List", "Show"}
+					actions = []string{"list", "show"}
 					verbs = []string{"GET", "GET"}
 					paths = []string{"/accounts/:accountID/bottles", "/accounts/:accountID/bottles/:id"}
 					contexts = []string{"ListBottleContext", "ShowBottleContext"}
@@ -1147,7 +1148,7 @@ var _ = Describe("ControllersWriter", func() {
 
 			Context("with encoder and decoder maps", func() {
 				BeforeEach(func() {
-					actions = []string{"List"}
+					actions = []string{"list"}
 					verbs = []string{"GET"}
 					paths = []string{"/accounts/:accountID/bottles"}
 					contexts = []string{"ListBottleContext"}
@@ -1180,7 +1181,7 @@ var _ = Describe("ControllersWriter", func() {
 
 			Context("with multiple origins", func() {
 				BeforeEach(func() {
-					actions = []string{"List"}
+					actions = []string{"list"}
 					verbs = []string{"GET"}
 					paths = []string{"/accounts"}
 					contexts = []string{"ListBottleContext"}
@@ -1215,7 +1216,7 @@ var _ = Describe("ControllersWriter", func() {
 
 			Context("with regexp origins", func() {
 				BeforeEach(func() {
-					actions = []string{"List"}
+					actions = []string{"list"}
 					verbs = []string{"GET"}
 					paths = []string{"/accounts"}
 					contexts = []string{"ListBottleContext"}
@@ -2358,7 +2359,7 @@ func MountBottlesController(service *goa.Service, ctrl BottlesController) {
 		}
 		return ctrl.List(rctx)
 	}
-	service.Mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", h, nil))
+	service.Mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("list", h, nil))
 	service.LogInfo("mount", "ctrl", "Bottles", "action", "List", "route", "GET /accounts/:accountID/bottles")
 }
 `
@@ -2379,7 +2380,7 @@ func MountBottlesController(service *goa.Service, ctrl BottlesController) {
 		}
 		return ctrl.List(rctx)
 	}
-	service.Mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", h, nil))
+	service.Mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("list", h, nil))
 	service.LogInfo("mount", "ctrl", "Bottles", "action", "List", "route", "GET /accounts/:accountID/bottles")
 }
 `
@@ -2408,7 +2409,7 @@ type BottlesController interface {
 		}
 		return ctrl.List(rctx)
 	}
-	service.Mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("List", h, nil))
+	service.Mux.Handle("GET", "/accounts/:accountID/bottles", ctrl.MuxHandler("list", h, nil))
 	service.LogInfo("mount", "ctrl", "Bottles", "action", "List", "route", "GET /accounts/:accountID/bottles")
 
 	h = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
@@ -2423,7 +2424,7 @@ type BottlesController interface {
 		}
 		return ctrl.Show(rctx)
 	}
-	service.Mux.Handle("GET", "/accounts/:accountID/bottles/:id", ctrl.MuxHandler("Show", h, nil))
+	service.Mux.Handle("GET", "/accounts/:accountID/bottles/:id", ctrl.MuxHandler("show", h, nil))
 	service.LogInfo("mount", "ctrl", "Bottles", "action", "Show", "route", "GET /accounts/:accountID/bottles/:id")
 }
 `


### PR DESCRIPTION
Instead of the goified version. This is so that the names appearing in the logs
reflect the design. This also helps with other types of instrumentation (e.g.
Prometheus graph names).