### PR TITLE
Added "can be used in" to the top of all DSL's

### DIFF
--- a/design/apidsl/action.go
+++ b/design/apidsl/action.go
@@ -8,6 +8,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// Files used in: Resource
 // Files defines an API endpoint that serves static assets. The logic for what to do when the
 // filename points to a file vs. a directory is the same as the standard http package ServeFile
 // function. The path may end with a wildcard that matches the rest of the URL (e.g. *filepath). If
@@ -52,6 +53,7 @@ func Files(path, filename string, dsls ...func()) {
 	}
 }
 
+// Action used in: Resource
 // Action implements the action definition DSL. Action definitions describe specific API endpoints
 // including the URL, HTTP method and request parameters (via path wildcards or query strings) and
 // payload (data structure describing the request HTTP body). An action belongs to a resource and
@@ -112,6 +114,7 @@ func Action(name string, dsl func()) {
 	}
 }
 
+// Routing used in: Action
 // Routing lists the action route. Each route is defined with a function named after the HTTP method.
 // The route function takes the path as argument. Route paths may use wildcards as described in the
 // [httptreemux](https://godoc.org/github.com/dimfeld/httptreemux) package documentation. These
@@ -126,6 +129,7 @@ func Routing(routes ...*design.RouteDefinition) {
 	}
 }
 
+// GET used in: Routing
 // GET creates a route using the GET HTTP method.
 func GET(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "GET", Path: path}
@@ -137,6 +141,7 @@ func GET(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// HEAD used in: Routing
 // HEAD creates a route using the HEAD HTTP method.
 func HEAD(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "HEAD", Path: path}
@@ -148,6 +153,7 @@ func HEAD(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// POST used in: Routing
 // POST creates a route using the POST HTTP method.
 func POST(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "POST", Path: path}
@@ -159,6 +165,7 @@ func POST(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// PUT used in: Routing
 // PUT creates a route using the PUT HTTP method.
 func PUT(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "PUT", Path: path}
@@ -170,6 +177,7 @@ func PUT(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// DELETE used in: Routing
 // DELETE creates a route using the DELETE HTTP method.
 func DELETE(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "DELETE", Path: path}
@@ -181,6 +189,7 @@ func DELETE(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// OPTIONS used in: Routing
 // OPTIONS creates a route using the OPTIONS HTTP method.
 func OPTIONS(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "OPTIONS", Path: path}
@@ -192,6 +201,7 @@ func OPTIONS(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// TRACE used in: Routing
 // TRACE creates a route using the TRACE HTTP method.
 func TRACE(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "TRACE", Path: path}
@@ -203,6 +213,7 @@ func TRACE(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// CONNECT used in: Routing
 // CONNECT creates a route using the CONNECT HTTP method.
 func CONNECT(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "CONNECT", Path: path}
@@ -214,6 +225,7 @@ func CONNECT(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// PATCH used in: Routing
 // PATCH creates a route using the PATCH HTTP method.
 func PATCH(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "PATCH", Path: path}
@@ -225,6 +237,7 @@ func PATCH(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
+// Headers can be used in: Action, Response, Resource
 // Headers implements the DSL for describing HTTP headers. The DSL syntax is identical to the one
 // of Attribute. Here is an example defining a couple of headers with validations:
 //
@@ -293,6 +306,7 @@ func Headers(params ...interface{}) {
 	}
 }
 
+// Params can be used in: Action, Resource, API
 // Params describe the action parameters, either path parameters identified via wildcards or query
 // string parameters if there is no corresponding path parameter. Each parameter is described via
 // the Param function which uses the same DSL as the Attribute DSL. Here is an example:
@@ -360,6 +374,7 @@ func Params(dsl func()) {
 	}
 }
 
+// Payload can be used in: Action
 // Payload implements the action payload DSL. An action payload describes the HTTP request body
 // data structure. The function accepts either a type or a DSL that describes the payload members
 // using the Member DSL which accepts the same syntax as the Attribute DSL. This function can be
@@ -379,6 +394,7 @@ func Payload(p interface{}, dsls ...func()) {
 	payload(false, p, dsls...)
 }
 
+// OptionalPayload can be used in: Action
 // OptionalPayload implements the action optional payload DSL. The function works identically to the
 // Payload DSL except it sets a bit in the action definition to denote that the payload is not
 // required. Example:

--- a/design/apidsl/action.go
+++ b/design/apidsl/action.go
@@ -129,7 +129,7 @@ func Routing(routes ...*design.RouteDefinition) {
 	}
 }
 
-// GET used in: Routing
+// GET is used as an argument to Routing
 // GET creates a route using the GET HTTP method.
 func GET(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "GET", Path: path}
@@ -141,7 +141,7 @@ func GET(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
-// HEAD used in: Routing
+// HEAD is used as an argument to Routing
 // HEAD creates a route using the HEAD HTTP method.
 func HEAD(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "HEAD", Path: path}
@@ -153,7 +153,7 @@ func HEAD(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
-// POST used in: Routing
+// POST is used as an argument to Routing
 // POST creates a route using the POST HTTP method.
 func POST(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "POST", Path: path}
@@ -165,7 +165,7 @@ func POST(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
-// PUT used in: Routing
+// PUT is used as an argument to Routing
 // PUT creates a route using the PUT HTTP method.
 func PUT(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "PUT", Path: path}
@@ -177,7 +177,7 @@ func PUT(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
-// DELETE used in: Routing
+// DELETE is used as an argument to Routing
 // DELETE creates a route using the DELETE HTTP method.
 func DELETE(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "DELETE", Path: path}
@@ -189,7 +189,7 @@ func DELETE(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
-// OPTIONS used in: Routing
+// OPTIONS is used as an argument to Routing
 // OPTIONS creates a route using the OPTIONS HTTP method.
 func OPTIONS(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "OPTIONS", Path: path}
@@ -201,7 +201,7 @@ func OPTIONS(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
-// TRACE used in: Routing
+// TRACE is used as an argument to Routing
 // TRACE creates a route using the TRACE HTTP method.
 func TRACE(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "TRACE", Path: path}
@@ -213,7 +213,7 @@ func TRACE(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
-// CONNECT used in: Routing
+// CONNECT is used as an argument to Routing
 // CONNECT creates a route using the CONNECT HTTP method.
 func CONNECT(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "CONNECT", Path: path}
@@ -225,7 +225,7 @@ func CONNECT(path string, dsl ...func()) *design.RouteDefinition {
 	return route
 }
 
-// PATCH used in: Routing
+// PATCH is used as an argument to Routing
 // PATCH creates a route using the PATCH HTTP method.
 func PATCH(path string, dsl ...func()) *design.RouteDefinition {
 	route := &design.RouteDefinition{Verb: "PATCH", Path: path}

--- a/design/apidsl/api.go
+++ b/design/apidsl/api.go
@@ -10,6 +10,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// API used in: (top level DSL)
 // API implements the top level API DSL. It defines the API name, default description and other
 // default global property values. Here is an example showing all the possible API sub-definitions:
 //
@@ -88,6 +89,7 @@ func API(name string, dsl func()) *design.APIDefinition {
 	return design.Design
 }
 
+// Version can be used in: API
 // Version specifies the API version. One design describes one version.
 func Version(ver string) {
 	if api, ok := apiDefinition(); ok {
@@ -95,8 +97,8 @@ func Version(ver string) {
 	}
 }
 
+// Description can be used in: API, Resource, Action, or MediaType
 // Description sets the definition description.
-// Description can be called inside API, Resource, Action or MediaType.
 func Description(d string) {
 	switch def := dslengine.CurrentDefinition().(type) {
 	case *design.APIDefinition:
@@ -122,6 +124,7 @@ func Description(d string) {
 	}
 }
 
+// BasePath used in: API
 // BasePath defines the API base path, i.e. the common path prefix to all the API actions.
 // The path may define wildcards (see Routing for a description of the wildcard syntax).
 // The corresponding parameters must be described using Params.
@@ -147,6 +150,8 @@ func BasePath(val string) {
 	}
 }
 
+// Origin can be used in: Resource, API, Action
+// TODO: check if origin can really be used in action
 // Origin defines the CORS policy for a given origin. The origin can use a wildcard prefix
 // such as "https://*.mydomain.com". The special value "*" defines the policy for all origins
 // (in which case there should be only one Origin DSL in the parent resource).
@@ -194,34 +199,39 @@ func Origin(origin string, dsl func()) {
 	cors.Parent = parent
 }
 
-// Methods sets the origin allowed methods. Used in Origin DSL.
+// Methods can be used in: Origin
+// Methods sets the origin allowed methods.
 func Methods(vals ...string) {
 	if cors, ok := corsDefinition(); ok {
 		cors.Methods = vals
 	}
 }
 
-// Expose sets the origin exposed headers. Used in Origin DSL.
+// Expose can be used in: Origin
+// Expose sets the origin exposed headers.
 func Expose(vals ...string) {
 	if cors, ok := corsDefinition(); ok {
 		cors.Exposed = vals
 	}
 }
 
-// MaxAge sets the cache expiry for preflight request responses. Used in Origin DSL.
+// MaxAge can be used in: Origin
+// MaxAge sets the cache expiry for preflight request responses.
 func MaxAge(val uint) {
 	if cors, ok := corsDefinition(); ok {
 		cors.MaxAge = val
 	}
 }
 
-// Credentials sets the allow credentials response header. Used in Origin DSL.
+// Credentials can be used in: Origin
+// Credentials sets the allow credentials response header.
 func Credentials() {
 	if cors, ok := corsDefinition(); ok {
 		cors.Credentials = true
 	}
 }
 
+// TermsOfService can be used in: Origin
 // TermsOfService describes the API terms of services or links to them.
 func TermsOfService(terms string) {
 	if a, ok := apiDefinition(); ok {
@@ -232,6 +242,7 @@ func TermsOfService(terms string) {
 // Regular expression used to validate RFC1035 hostnames*/
 var hostnameRegex = regexp.MustCompile(`^[[:alnum:]][[:alnum:]\-]{0,61}[[:alnum:]]|[[:alpha:]]$`)
 
+// Host used in: API
 // Host sets the API hostname.
 func Host(host string) {
 	if !hostnameRegex.MatchString(host) {
@@ -244,6 +255,8 @@ func Host(host string) {
 	}
 }
 
+// Scheme can be used in: API, Resource, Action
+// TODO: can it really be used in Resource (no examples in docs)
 // Scheme sets the API URL schemes.
 func Scheme(vals ...string) {
 	ok := true
@@ -269,6 +282,7 @@ func Scheme(vals ...string) {
 	}
 }
 
+// Contact can be used in: API
 // Contact sets the API contact information.
 func Contact(dsl func()) {
 	contact := new(design.ContactDefinition)
@@ -280,6 +294,7 @@ func Contact(dsl func()) {
 	}
 }
 
+// License can be used in: API
 // License sets the API license information.
 func License(dsl func()) {
 	license := new(design.LicenseDefinition)
@@ -291,6 +306,8 @@ func License(dsl func()) {
 	}
 }
 
+// Docs can be used in: API, Action, Resource, Files
+// TODO: can it really be used in Resource (no examples)
 // Docs provides external documentation pointers.
 func Docs(dsl func()) {
 	docs := new(design.DocsDefinition)
@@ -310,6 +327,7 @@ func Docs(dsl func()) {
 	}
 }
 
+// Name can be used in: Contact, License.
 // Name sets the contact or license name.
 func Name(name string) {
 	switch def := dslengine.CurrentDefinition().(type) {
@@ -322,6 +340,7 @@ func Name(name string) {
 	}
 }
 
+// Email can be used in: Contact
 // Email sets the contact email.
 func Email(email string) {
 	if c, ok := contactDefinition(); ok {
@@ -329,6 +348,7 @@ func Email(email string) {
 	}
 }
 
+// URL can be used in: Contact, License.
 // URL sets the contact or license URL.
 func URL(url string) {
 	switch def := dslengine.CurrentDefinition().(type) {
@@ -343,6 +363,7 @@ func URL(url string) {
 	}
 }
 
+// Consumes can be used in: API
 // Consumes adds a MIME type to the list of MIME types the APIs supports when accepting requests.
 // Consumes may also specify the path of the decoding package.
 // The package must expose a DecoderFactory method that returns an object which implements
@@ -355,6 +376,7 @@ func Consumes(args ...interface{}) {
 	}
 }
 
+// Produces can be used in: API
 // Produces adds a MIME type to the list of MIME types the APIs can encode responses with.
 // Produces may also specify the path of the encoding package.
 // The package must expose a EncoderFactory method that returns an object which implements
@@ -403,6 +425,7 @@ func buildEncodingDefinition(encoding bool, args ...interface{}) *design.Encodin
 	return d
 }
 
+// Package used in: Consumes, Produces.
 // Package sets the Go package path to the encoder or decoder. It must be used inside a
 // Consumes or Produces DSL.
 func Package(path string) {
@@ -411,6 +434,7 @@ func Package(path string) {
 	}
 }
 
+// TODO: where is function used?
 // Function sets the Go function name used to instantiate the encoder or decoder. Defaults to
 // NewEncoder / NewDecoder.
 func Function(fn string) {
@@ -419,6 +443,7 @@ func Function(fn string) {
 	}
 }
 
+// ResponseTemplate can be used in: API
 // ResponseTemplate defines a response template that action definitions can use to describe their
 // responses. The template may specify the HTTP response status, header specification and body media
 // type. The template consists of a name and an anonymous function. The function is called when an
@@ -522,6 +547,7 @@ func setupResponseTemplate(a *design.APIDefinition, name string, p interface{}) 
 	}
 }
 
+// Title used in: API
 // Title sets the API title used by generated documentation, JSON Hyper-schema, code comments etc.
 func Title(val string) {
 	if a, ok := apiDefinition(); ok {
@@ -529,6 +555,7 @@ func Title(val string) {
 	}
 }
 
+// Trait can be used in: API
 // Trait defines an API trait. A trait encapsulates arbitrary DSL that gets executed wherever the
 // trait is called via the UseTrait function.
 func Trait(name string, val ...func()) {
@@ -552,9 +579,9 @@ func Trait(name string, val ...func()) {
 	}
 }
 
-// UseTrait executes the API trait with the given name. UseTrait can be used inside a Resource,
-// Action, Type, MediaType or Attribute DSL. UseTrait takes a variable number
-// of trait names.
+// Trait can be used in: Resource, Action, Type, MediaType, Attribute
+// UseTrait executes the API trait with the given name. An API level DSL trait must be
+// defined first. UseTrait takes a variable number of trait names.
 func UseTrait(names ...string) {
 	var def dslengine.Definition
 

--- a/design/apidsl/api.go
+++ b/design/apidsl/api.go
@@ -10,7 +10,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
-// API used in: (top level DSL)
+// API is a top level DSL.
 // API implements the top level API DSL. It defines the API name, default description and other
 // default global property values. Here is an example showing all the possible API sub-definitions:
 //
@@ -124,7 +124,7 @@ func Description(d string) {
 	}
 }
 
-// BasePath used in: API
+// BasePath can used in: API, Resource
 // BasePath defines the API base path, i.e. the common path prefix to all the API actions.
 // The path may define wildcards (see Routing for a description of the wildcard syntax).
 // The corresponding parameters must be described using Params.
@@ -150,8 +150,7 @@ func BasePath(val string) {
 	}
 }
 
-// Origin can be used in: Resource, API, Action
-// TODO: check if origin can really be used in action
+// Origin can be used in: Resource, API
 // Origin defines the CORS policy for a given origin. The origin can use a wildcard prefix
 // such as "https://*.mydomain.com". The special value "*" defines the policy for all origins
 // (in which case there should be only one Origin DSL in the parent resource).
@@ -231,7 +230,7 @@ func Credentials() {
 	}
 }
 
-// TermsOfService can be used in: Origin
+// TermsOfService can be used in: API
 // TermsOfService describes the API terms of services or links to them.
 func TermsOfService(terms string) {
 	if a, ok := apiDefinition(); ok {
@@ -256,7 +255,6 @@ func Host(host string) {
 }
 
 // Scheme can be used in: API, Resource, Action
-// TODO: can it really be used in Resource (no examples in docs)
 // Scheme sets the API URL schemes.
 func Scheme(vals ...string) {
 	ok := true
@@ -306,8 +304,7 @@ func License(dsl func()) {
 	}
 }
 
-// Docs can be used in: API, Action, Resource, Files
-// TODO: can it really be used in Resource (no examples)
+// Docs can be used in: API, Action, Files
 // Docs provides external documentation pointers.
 func Docs(dsl func()) {
 	docs := new(design.DocsDefinition)
@@ -348,8 +345,8 @@ func Email(email string) {
 	}
 }
 
-// URL can be used in: Contact, License.
-// URL sets the contact or license URL.
+// URL can be used in: Contact, License, Docs
+// URL sets the contact, license, or Docs URL.
 func URL(url string) {
 	switch def := dslengine.CurrentDefinition().(type) {
 	case *design.ContactDefinition:
@@ -434,7 +431,7 @@ func Package(path string) {
 	}
 }
 
-// TODO: where is function used?
+// Function can be used in: Consumes, Produces
 // Function sets the Go function name used to instantiate the encoder or decoder. Defaults to
 // NewEncoder / NewDecoder.
 func Function(fn string) {
@@ -579,7 +576,7 @@ func Trait(name string, val ...func()) {
 	}
 }
 
-// Trait can be used in: Resource, Action, Type, MediaType, Attribute
+// UseTrait can be used in: Resource, Action, Type, MediaType, Attribute
 // UseTrait executes the API trait with the given name. An API level DSL trait must be
 // defined first. UseTrait takes a variable number of trait names.
 func UseTrait(names ...string) {

--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -11,6 +11,9 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// Attribute can be used in: View, Type, Attribute (nested), Attributes (child),
+// MediaType
+//
 // Attribute implements the attribute definition DSL. An attribute describes a data structure
 // recursively. Attributes are used for describing request headers, parameters and payloads -
 // response bodies and headers - media types	 and types. An attribute definition is recursive:
@@ -235,6 +238,7 @@ func parseAttributeArgs(baseAttr *design.AttributeDefinition, args ...interface{
 	return dataType, description, dsl
 }
 
+// Header can be used in: Headers, APIKeySecurity, JWTSecurity
 // Header is an alias of Attribute for the most part.
 //
 // Within an APIKeySecurity or JWTSecurity definition, Header
@@ -282,6 +286,7 @@ func Default(def interface{}) {
 	}
 }
 
+// Example can be used in: Attribute
 // Example sets the example of an attribute to be used for the documentation:
 //
 //	Attributes(func() {
@@ -304,6 +309,7 @@ func Example(exp interface{}) {
 	}
 }
 
+// NoExample can be used in: Attribute
 // NoExample sets the example of an attribute to be blank for the documentation. It is used when
 // users don't want any custom or auto-generated example
 func NoExample() {
@@ -317,6 +323,7 @@ func NoExample() {
 	}
 }
 
+// Enum can be used in: Attribute, Param
 // Enum adds a "enum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor76.
 func Enum(val ...interface{}) {
@@ -368,6 +375,7 @@ var SupportedValidationFormats = []string{
 	"uri",
 }
 
+// Format can be used in: Attribute
 // Format adds a "format" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor104.
 // The formats supported by goa are:
@@ -412,6 +420,7 @@ func Format(f string) {
 	}
 }
 
+// Pattern can be used in: HashOf, ArrayOf, Header, Attribute
 // Pattern adds a "pattern" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor33.
 func Pattern(p string) {
@@ -432,6 +441,7 @@ func Pattern(p string) {
 	}
 }
 
+// Minimum can be used in: Attribute, Header
 // Minimum adds a "minimum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor21.
 func Minimum(val interface{}) {
@@ -462,6 +472,7 @@ func Minimum(val interface{}) {
 	}
 }
 
+// Maximum can be used in: Attribute, Header
 // Maximum adds a "maximum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor17.
 func Maximum(val interface{}) {
@@ -492,6 +503,7 @@ func Maximum(val interface{}) {
 	}
 }
 
+// MinLength can be used in: Attribute, Header
 // MinLength adss a "minItems" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor45.
 func MinLength(val int) {
@@ -507,6 +519,7 @@ func MinLength(val int) {
 	}
 }
 
+// MaxLength can be used in: Attribute, Header
 // MaxLength adss a "maxItems" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor42.
 func MaxLength(val int) {
@@ -522,6 +535,7 @@ func MaxLength(val int) {
 	}
 }
 
+// Required can be used in: Attribute, Attributes, Header, Headers, Payload, Type
 // Required adds a "required" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor61.
 func Required(names ...string) {

--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -11,8 +11,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
-// Attribute can be used in: View, Type, Attribute (nested), Attributes (child),
-// MediaType
+// Attribute can be used in: View, Type, Attribute, Attributes
 //
 // Attribute implements the attribute definition DSL. An attribute describes a data structure
 // recursively. Attributes are used for describing request headers, parameters and payloads -
@@ -257,16 +256,19 @@ func Header(name string, args ...interface{}) {
 	Attribute(name, args...)
 }
 
+// Member can be used in: Payload
 // Member is an alias of Attribute.
 func Member(name string, args ...interface{}) {
 	Attribute(name, args...)
 }
 
+// Param can be used in: Params
 // Param is an alias of Attribute.
 func Param(name string, args ...interface{}) {
 	Attribute(name, args...)
 }
 
+// Default can be used in: Attribute
 // Default sets the default value for an attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor10.
 func Default(def interface{}) {
@@ -286,7 +288,7 @@ func Default(def interface{}) {
 	}
 }
 
-// Example can be used in: Attribute
+// Example can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // Example sets the example of an attribute to be used for the documentation:
 //
 //	Attributes(func() {
@@ -309,7 +311,7 @@ func Example(exp interface{}) {
 	}
 }
 
-// NoExample can be used in: Attribute
+// NoExample can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // NoExample sets the example of an attribute to be blank for the documentation. It is used when
 // users don't want any custom or auto-generated example
 func NoExample() {
@@ -323,7 +325,7 @@ func NoExample() {
 	}
 }
 
-// Enum can be used in: Attribute, Param
+// Enum can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // Enum adds a "enum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor76.
 func Enum(val ...interface{}) {
@@ -375,7 +377,7 @@ var SupportedValidationFormats = []string{
 	"uri",
 }
 
-// Format can be used in: Attribute
+// Format can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // Format adds a "format" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor104.
 // The formats supported by goa are:
@@ -420,7 +422,7 @@ func Format(f string) {
 	}
 }
 
-// Pattern can be used in: HashOf, ArrayOf, Header, Attribute
+// Pattern can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // Pattern adds a "pattern" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor33.
 func Pattern(p string) {
@@ -441,7 +443,7 @@ func Pattern(p string) {
 	}
 }
 
-// Minimum can be used in: Attribute, Header
+// Minimum can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // Minimum adds a "minimum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor21.
 func Minimum(val interface{}) {
@@ -472,7 +474,7 @@ func Minimum(val interface{}) {
 	}
 }
 
-// Maximum can be used in: Attribute, Header
+// Maximum can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // Maximum adds a "maximum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor17.
 func Maximum(val interface{}) {
@@ -503,7 +505,7 @@ func Maximum(val interface{}) {
 	}
 }
 
-// MinLength can be used in: Attribute, Header
+// MinLength can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // MinLength adss a "minItems" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor45.
 func MinLength(val int) {
@@ -519,7 +521,7 @@ func MinLength(val int) {
 	}
 }
 
-// MaxLength can be used in: Attribute, Header
+// MaxLength can be used in: Attribute, Header, Param, HashOf, ArrayOf
 // MaxLength adss a "maxItems" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor42.
 func MaxLength(val int) {
@@ -535,7 +537,7 @@ func MaxLength(val int) {
 	}
 }
 
-// Required can be used in: Attribute, Attributes, Header, Headers, Payload, Type
+// Required can be used in: Attributes, Headers, Payload, Type, Params
 // Required adds a "required" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor61.
 func Required(names ...string) {

--- a/design/apidsl/media_type.go
+++ b/design/apidsl/media_type.go
@@ -12,6 +12,7 @@ import (
 // Counter used to create unique media type names for identifier-less media types.
 var mediaTypeCount int
 
+// MediaType can be used in: ResponseTemplate, (also as a top level DSL)
 // MediaType implements the media type definition DSL. A media type definition describes the
 // representation of a resource used in a response body.
 //
@@ -113,6 +114,7 @@ func MediaType(identifier string, apidsl func()) *design.MediaTypeDefinition {
 	return mt
 }
 
+// Media can be used in: Response, ResponseTemplate
 // Media sets a response media type by name or by reference using a value returned by MediaType:
 //
 //	Response("NotFound", func() {
@@ -149,6 +151,7 @@ func Media(val interface{}, viewName ...string) {
 	}
 }
 
+// Reference can be used in: MediaType, Type
 // Reference sets a type or media type reference. The value itself can be a type or a media type.
 // The reference type attributes define the default properties for attributes with the same name in
 // the type using the reference. So for example if a type is defined as such:
@@ -187,6 +190,7 @@ func Reference(t design.DataType) {
 	}
 }
 
+// TypeName can be used in: Type, MediaType
 // TypeName makes it possible to set the Go struct name for a type or media type in the generated
 // code. By default goagen uses the name (type) or identifier (media type) given in the apidsl and
 // computes a valid Go identifier from it. This function makes it possible to override that and
@@ -202,6 +206,7 @@ func TypeName(name string) {
 	}
 }
 
+// ContentType can be used in: Type, MediaType
 // ContentType sets the value of the Content-Type response header. By default the ID of the media
 // type is used.
 //
@@ -213,6 +218,7 @@ func ContentType(typ string) {
 	}
 }
 
+// iew can be used in: MediaType
 // View adds a new view to a media type. A view has a name and lists attributes that are
 // rendered when the view is used to produce a response. The attribute names must appear in the
 // media type definition. If an attribute is itself a media type then the view may specify which
@@ -312,6 +318,7 @@ func buildView(name string, mt *design.MediaTypeDefinition, at *design.Attribute
 	}, nil
 }
 
+// Attributes can be used in: MediaType
 // Attributes implements the media type attributes apidsl. See MediaType.
 func Attributes(apidsl func()) {
 	if mt, ok := mediaTypeDefinition(); ok {
@@ -319,6 +326,7 @@ func Attributes(apidsl func()) {
 	}
 }
 
+// Links can be used in: MediaType
 // Links implements the media type links apidsl. See MediaType.
 func Links(apidsl func()) {
 	if mt, ok := mediaTypeDefinition(); ok {
@@ -326,6 +334,7 @@ func Links(apidsl func()) {
 	}
 }
 
+// Link can be used in: Links
 // Link adds a link to a media type. At the minimum a link has a name corresponding to one of the
 // media type attribute names. A link may also define the view used to render the linked-to
 // attribute. The default view used to render links is "link". Examples:
@@ -355,6 +364,8 @@ func Link(name string, view ...string) {
 	}
 }
 
+// TODO: is this correct?
+// CollectionOf can be used in: Media, Response, ResponseTemplate
 // CollectionOf creates a collection media type from its element media type. A collection media
 // type represents the content of responses that return a collection of resources such as "list"
 // actions. This function can be called from any place where a media type can be used.

--- a/design/apidsl/media_type.go
+++ b/design/apidsl/media_type.go
@@ -12,7 +12,7 @@ import (
 // Counter used to create unique media type names for identifier-less media types.
 var mediaTypeCount int
 
-// MediaType can be used in: ResponseTemplate, (also as a top level DSL)
+// MediaType is a top level DSL, which can also be used in: ResponseTemplate
 // MediaType implements the media type definition DSL. A media type definition describes the
 // representation of a resource used in a response body.
 //
@@ -130,8 +130,6 @@ func MediaType(identifier string, apidsl func()) *design.MediaTypeDefinition {
 //	})
 //
 // Specifying a media type is useful for responses that always return the same view.
-//
-// Media can be used inside Response or ResponseTemplate.
 func Media(val interface{}, viewName ...string) {
 	if r, ok := responseDefinition(); ok {
 		if m, ok := val.(*design.MediaTypeDefinition); ok {
@@ -206,7 +204,7 @@ func TypeName(name string) {
 	}
 }
 
-// ContentType can be used in: Type, MediaType
+// ContentType can be used in: MediaType
 // ContentType sets the value of the Content-Type response header. By default the ID of the media
 // type is used.
 //
@@ -218,7 +216,7 @@ func ContentType(typ string) {
 	}
 }
 
-// iew can be used in: MediaType
+// View can be used in: MediaType, Response
 // View adds a new view to a media type. A view has a name and lists attributes that are
 // rendered when the view is used to produce a response. The attribute names must appear in the
 // media type definition. If an attribute is itself a media type then the view may specify which
@@ -364,8 +362,8 @@ func Link(name string, view ...string) {
 	}
 }
 
-// TODO: is this correct?
-// CollectionOf can be used in: Media, Response, ResponseTemplate
+// CollectionOf can be used in: Wherever a MediaType can be used..
+// e.g. Attribute("foo", CollectionOf(Bar))
 // CollectionOf creates a collection media type from its element media type. A collection media
 // type represents the content of responses that return a collection of resources such as "list"
 // actions. This function can be called from any place where a media type can be used.

--- a/design/apidsl/metadata.go
+++ b/design/apidsl/metadata.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
-// Metadata can be used in: Attributes, MediaTypes, Action, Response, Resource, API
+// Metadata can be used in: Attributes, MediaType, Action, Response, Resource, API
 // Metadata is a set of key/value pairs that can be assigned to an object. Each value consists of a
 // slice of strings so that multiple invocation of the Metadata function on the same target using
 // the same key builds up the slice.

--- a/design/apidsl/metadata.go
+++ b/design/apidsl/metadata.go
@@ -5,10 +5,10 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// Metadata can be used in: Attributes, MediaTypes, Action, Response, Resource, API
 // Metadata is a set of key/value pairs that can be assigned to an object. Each value consists of a
 // slice of strings so that multiple invocation of the Metadata function on the same target using
-// the same key builds up the slice. Metadata may be set on attributes, media types, actions,
-// responses, resources and API definitions.
+// the same key builds up the slice.
 //
 // While keys can have any value the following names are handled explicitly by goagen when set on
 // attributes.

--- a/design/apidsl/resource.go
+++ b/design/apidsl/resource.go
@@ -5,6 +5,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// Resource can be used in: (it is a top level DSL)
 // Resource implements the resource definition dsl. There is one resource definition per resource
 // exposed by the API. The resource dsl allows setting the resource default media type. This media
 // type is used to render the response body of actions that return the OK response (unless the
@@ -64,6 +65,7 @@ func Resource(name string, dsl func()) *design.ResourceDefinition {
 	return resource
 }
 
+// DefaultMedia can be used in: Resource
 // DefaultMedia sets a resource default media type by identifier or by reference using a value
 // returned by MediaType:
 //
@@ -105,6 +107,7 @@ func DefaultMedia(val interface{}, viewName ...string) {
 	}
 }
 
+// Parent can be used in: Resource
 // Parent sets the resource parent. The parent resource is used to compute the path to the resource
 // actions as well as resource collection item hrefs. See Resource.
 func Parent(p string) {

--- a/design/apidsl/resource.go
+++ b/design/apidsl/resource.go
@@ -5,7 +5,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
-// Resource can be used in: (it is a top level DSL)
+// Resource is a top level DSL.
 // Resource implements the resource definition dsl. There is one resource definition per resource
 // exposed by the API. The resource dsl allows setting the resource default media type. This media
 // type is used to render the response body of actions that return the OK response (unless the

--- a/design/apidsl/response.go
+++ b/design/apidsl/response.go
@@ -5,6 +5,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// Response can be used in: Action, Resource
 // Response implements the response definition DSL. Response takes the name of the response as
 // first parameter. goa defines all the standard HTTP status name as global variables so they can be
 // readily used as response names. The response body data type can be specified as second argument.
@@ -111,6 +112,7 @@ func Response(name string, paramsAndDSL ...interface{}) {
 	}
 }
 
+// Status can be used in: Response, ResponseTemplate
 // Status sets the Response status.
 func Status(status int) {
 	if r, ok := responseDefinition(); ok {

--- a/design/apidsl/security.go
+++ b/design/apidsl/security.go
@@ -85,7 +85,7 @@ func NoSecurity() {
 	}
 }
 
-// BasicAuthSecurity can be used in: (it is a top level DSL)
+// BasicAuthSecurity is a top level DSL.
 // BasicAuthSecurity defines a "basic" security scheme for the API.
 //
 // Example:
@@ -131,7 +131,7 @@ func securitySchemeRedefined(name string) bool {
 	return false
 }
 
-// APIKeySecurity can be used in: (it is a top level DSL)
+// APIKeySecurity is a top level DSL.
 // APIKeySecurity defines an "apiKey" security scheme available throughout the API.
 //
 // Example:
@@ -168,7 +168,7 @@ func APIKeySecurity(name string, dsl ...func()) *design.SecuritySchemeDefinition
 	return def
 }
 
-// OAuth2Security can be used in: (it is a top level DSL)
+// OAuth2Security is a top level DSL.
 // OAuth2Security defines an OAuth2 security scheme. The child DSL must define one and exactly one
 // flow. One of AccessCodeFlow, ImplicitFlow, PasswordFlow or ApplicationFlow. Each flow defines
 // endpoints for retrieving OAuth2 authorization codes and/or refresh and access tokens. The
@@ -219,7 +219,7 @@ func OAuth2Security(name string, dsl ...func()) *design.SecuritySchemeDefinition
 	return def
 }
 
-// JWTSecurity can be used in: (it is a top level DSL)
+// JWTSecurity is a top level DSL.
 // JWTSecurity defines an APIKey security scheme, with support for Scopes and a TokenURL.
 //
 // Since Scopes and TokenURLs are not compatible with the Swagger specification, the swagger
@@ -307,7 +307,6 @@ func inHeader(headerName string) {
 	dslengine.IncompatibleDSL()
 }
 
-// TODO: is this correct?
 // Query can be used in: APIKeySecurity, JWTSecurity
 // Query defines that an APIKeySecurity or JWTSecurity implementation must check in the query
 // parameter named "parameterName" to get the api key.

--- a/design/apidsl/security.go
+++ b/design/apidsl/security.go
@@ -5,6 +5,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// Security can be used in: API, Action, Files, Resource
 // Security defines an authentication requirements to access a goa Action.  When defined on a
 // Resource, it applies to all Actions, unless overriden by individual actions.  When defined at the
 // API level, it will apply to all resources by default, following the same logic.
@@ -62,6 +63,7 @@ func Security(scheme interface{}, dsl ...func()) {
 	}
 }
 
+// NoSecurity can be used in: API, Action, Files, Resource
 // NoSecurity resets the authentication schemes for an Action or a Resource. It also prevents
 // fallback to Resource or API-defined Security.
 func NoSecurity() {
@@ -83,6 +85,7 @@ func NoSecurity() {
 	}
 }
 
+// BasicAuthSecurity can be used in: (it is a top level DSL)
 // BasicAuthSecurity defines a "basic" security scheme for the API.
 //
 // Example:
@@ -128,6 +131,7 @@ func securitySchemeRedefined(name string) bool {
 	return false
 }
 
+// APIKeySecurity can be used in: (it is a top level DSL)
 // APIKeySecurity defines an "apiKey" security scheme available throughout the API.
 //
 // Example:
@@ -164,6 +168,7 @@ func APIKeySecurity(name string, dsl ...func()) *design.SecuritySchemeDefinition
 	return def
 }
 
+// OAuth2Security can be used in: (it is a top level DSL)
 // OAuth2Security defines an OAuth2 security scheme. The child DSL must define one and exactly one
 // flow. One of AccessCodeFlow, ImplicitFlow, PasswordFlow or ApplicationFlow. Each flow defines
 // endpoints for retrieving OAuth2 authorization codes and/or refresh and access tokens. The
@@ -214,6 +219,7 @@ func OAuth2Security(name string, dsl ...func()) *design.SecuritySchemeDefinition
 	return def
 }
 
+// JWTSecurity can be used in: (it is a top level DSL)
 // JWTSecurity defines an APIKey security scheme, with support for Scopes and a TokenURL.
 //
 // Since Scopes and TokenURLs are not compatible with the Swagger specification, the swagger
@@ -256,6 +262,7 @@ func JWTSecurity(name string, dsl ...func()) *design.SecuritySchemeDefinition {
 	return def
 }
 
+// Scope can be used in: Security, JWTSecurity, OAuth2Security
 // Scope defines an authorization scope. Used within SecurityScheme, a description may be provided
 // explaining what the scope means. Within a Security block, only a scope is needed.
 func Scope(name string, desc ...string) {
@@ -300,6 +307,8 @@ func inHeader(headerName string) {
 	dslengine.IncompatibleDSL()
 }
 
+// TODO: is this correct?
+// Query can be used in: APIKeySecurity, JWTSecurity
 // Query defines that an APIKeySecurity or JWTSecurity implementation must check in the query
 // parameter named "parameterName" to get the api key.
 func Query(parameterName string) {
@@ -317,6 +326,7 @@ func Query(parameterName string) {
 	dslengine.IncompatibleDSL()
 }
 
+// AccessCodeFlow can be used in: OAuth2Security
 // AccessCodeFlow defines an "access code" OAuth2 flow.  Use within an OAuth2Security definition.
 func AccessCodeFlow(authorizationURL, tokenURL string) {
 	if current, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
@@ -330,6 +340,7 @@ func AccessCodeFlow(authorizationURL, tokenURL string) {
 	dslengine.IncompatibleDSL()
 }
 
+// ApplicationFlow can be used in: OAuth2Security
 // ApplicationFlow defines an "application" OAuth2 flow.  Use within an OAuth2Security definition.
 func ApplicationFlow(tokenURL string) {
 	if parent, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
@@ -342,6 +353,7 @@ func ApplicationFlow(tokenURL string) {
 	dslengine.IncompatibleDSL()
 }
 
+// PasswordFlow can be used in: OAuth2Security
 // PasswordFlow defines a "password" OAuth2 flow.  Use within an OAuth2Security definition.
 func PasswordFlow(tokenURL string) {
 	if parent, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
@@ -354,6 +366,7 @@ func PasswordFlow(tokenURL string) {
 	dslengine.IncompatibleDSL()
 }
 
+// ImplicitFlow can be used in: OAuth2Security
 // ImplicitFlow defines an "implicit" OAuth2 flow.  Use within an OAuth2Security definition.
 func ImplicitFlow(authorizationURL string) {
 	if parent, ok := dslengine.CurrentDefinition().(*design.SecuritySchemeDefinition); ok {
@@ -366,6 +379,7 @@ func ImplicitFlow(authorizationURL string) {
 	dslengine.IncompatibleDSL()
 }
 
+// TokenURL can be used in: JWTSecurity
 // TokenURL defines a URL to get an access token.  If you are defining OAuth2 flows, use
 // `ImplicitFlow`, `PasswordFlow`, `AccessCodeFlow` or `ApplicationFlow` instead. This will set an
 // endpoint where you can obtain a JWT with the JWTSecurity scheme. The URL may be a complete URL

--- a/design/apidsl/type.go
+++ b/design/apidsl/type.go
@@ -5,6 +5,10 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// TODO: are these correct? They can be used as values inline, but they can also be used
+// as top level DSL's
+
+// Type can be used in: (it is a top level DSL)
 // Type implements the type definition dsl. A type definition describes a data structure consisting
 // of attributes. Each attribute has a type which can also refer to a type definition (or use a
 // primitive type or nested attibutes). The dsl syntax for define a type definition is the
@@ -59,6 +63,7 @@ func Type(name string, dsl func()) *design.UserTypeDefinition {
 	return t
 }
 
+// ArrayOf can be used in: (it is a top level DSL)
 // ArrayOf creates an array type from its element type. The result can be used anywhere a type can.
 // Examples:
 //
@@ -114,6 +119,7 @@ func ArrayOf(v interface{}, dsl ...func()) *design.Array {
 	return &design.Array{ElemType: &at}
 }
 
+// HashOf can be used in: (it is a top level DSL)
 // HashOf creates a hash map from its key and element types. The result can be used anywhere a type
 // can. Examples:
 //

--- a/design/apidsl/type.go
+++ b/design/apidsl/type.go
@@ -5,10 +5,7 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
-// TODO: are these correct? They can be used as values inline, but they can also be used
-// as top level DSL's
-
-// Type can be used in: (it is a top level DSL)
+// Type is a top level DSL.
 // Type implements the type definition dsl. A type definition describes a data structure consisting
 // of attributes. Each attribute has a type which can also refer to a type definition (or use a
 // primitive type or nested attibutes). The dsl syntax for define a type definition is the
@@ -63,7 +60,8 @@ func Type(name string, dsl func()) *design.UserTypeDefinition {
 	return t
 }
 
-// ArrayOf can be used in: (it is a top level DSL)
+// ArrayOf can be used in: Wherever a a type can be used...
+// e.g. Attribute("foo", ArrayOf(String))
 // ArrayOf creates an array type from its element type. The result can be used anywhere a type can.
 // Examples:
 //
@@ -119,7 +117,8 @@ func ArrayOf(v interface{}, dsl ...func()) *design.Array {
 	return &design.Array{ElemType: &at}
 }
 
-// HashOf can be used in: (it is a top level DSL)
+// HashOf can be used in: Wherever a type can be used...
+// e.g. Attribute("foo", HashOf(String))
 // HashOf creates a hash map from its key and element types. The result can be used anywhere a type
 // can. Examples:
 //


### PR DESCRIPTION
Some things I was unsure about so I noted them with a TODO. I will change them and resubmit if there is extra feedback...

Todos are on the following lines so far:

```
Desktop/goa/design/apidsl/api.go|154 col 4| // TODO: check if origin can really be used in action
Desktop/goa/design/apidsl/api.go|259 col 4| // TODO: can it really be used in Resource (no examples in docs)
Desktop/goa/design/apidsl/api.go|310 col 4| // TODO: can it really be used in Resource (no examples)
Desktop/goa/design/apidsl/api.go|437 col 4| // TODO: where is function used?
Desktop/goa/design/apidsl/media_type.go|367 col 4| // TODO: is this correct?
Desktop/goa/design/apidsl/security.go|310 col 4| // TODO: is this correct?
Desktop/goa/design/apidsl/type.go|8 col 4| // TODO: are these correct? They can be used as values inline, but they can also be used
```