### PR TITLE
sort the "produces" section of the swagger.yaml, swagger.json

### DIFF
--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -1000,9 +1000,11 @@ func buildPathFromDefinition(s *Swagger, api *design.APIDefinition, route *desig
 
 func computeProduces(operation *Operation, s *Swagger, action *design.ActionDefinition) {
 	produces := make(map[string]bool)
+	producesSorted := make([]string, 0)
 	action.IterateResponses(func(resp *design.ResponseDefinition) error {
 		if resp.MediaType != "" {
 			produces[resp.MediaType] = true
+			producesSorted = append(producesSorted, resp.MediaType)
 		}
 		return nil
 	})
@@ -1021,9 +1023,9 @@ func computeProduces(operation *Operation, s *Swagger, action *design.ActionDefi
 		}
 	}
 	if !subset {
-		operation.Produces = make([]string, len(produces))
+		operation.Produces = make([]string, len(producesSorted))
 		i := 0
-		for p := range produces {
+		for _, p := range producesSorted {
 			operation.Produces[i] = p
 			i++
 		}


### PR DESCRIPTION
Currently the "produces" section is generated non-deterministically.
For example, sometimes like this:
```yaml
produces:
- application/vnd.goa.error
- application/vnd.my.object+json
```
...sometimes in another order:
```yaml
produces:
- application/vnd.my.object+json
- application/vnd.goa.error
```

This change preserves the order of the elements provided by `action.IterateResponses`.