### PR TITLE
Fix how headers are retrieved to build test context

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -2,6 +2,7 @@ package genapp
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -269,6 +270,7 @@ func headers(action *design.ActionDefinition, headers *design.AttributeDefinitio
 	objs := make([]*ObjectType, len(headrs))
 	for i, name := range headrs {
 		objs[i] = attToObject(name, hds, hds.Type.ToObject()[name])
+		objs[i].Label = http.CanonicalHeaderKey(objs[i].Label)
 	}
 	return objs
 }

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -230,10 +230,10 @@ var _ = Describe("Generate", func() {
 
 			Ω(content).Should(ContainSubstring(`if optionalHeader != nil`))
 			Ω(content).ShouldNot(ContainSubstring(`if requiredHeader != nil`))
-			Ω(content).Should(ContainSubstring(`req.Header["requiredHeader"] = sliceVal`))
+			Ω(content).Should(ContainSubstring(`req.Header["Requiredheader"] = sliceVal`))
 			Ω(content).Should(ContainSubstring(`if optionalResourceHeader != nil`))
 			Ω(content).ShouldNot(ContainSubstring(`if requiredResourceHeader != nil`))
-			Ω(content).Should(ContainSubstring(`req.Header["requiredResourceHeader"] = sliceVal`))
+			Ω(content).Should(ContainSubstring(`req.Header["Requiredresourceheader"] = sliceVal`))
 		})
 
 		It("generates calls to new Context ", func() {


### PR DESCRIPTION
So that the canonical key is used instead of the attribute name.

Fix #1242