### PR TITLE
examples/code_regen, but built in to goagen

### DIFF
--- a/goagen/gen_controller/generator.go
+++ b/goagen/gen_controller/generator.go
@@ -30,6 +30,7 @@ type Generator struct {
 	DesignPkg string                // Path to design package, only used to mark generated files.
 	AppPkg    string                // Name of generated "app" package
 	Force     bool                  // Whether to override existing files
+	Regen     bool                  // Whether to regenerate scaffolding in place, retaining controller impls
 	Pkg       string                // Name of the generated package
 	Resource  string                // Name of the generated file
 	genfiles  []string              // Generated files
@@ -39,7 +40,7 @@ type Generator struct {
 func Generate() (files []string, err error) {
 	var (
 		outDir, designPkg, appPkg, ver, res, pkg string
-		force                                    bool
+		force, regen                             bool
 	)
 
 	set := flag.NewFlagSet("controller", flag.PanicOnError)
@@ -50,6 +51,7 @@ func Generate() (files []string, err error) {
 	set.StringVar(&res, "res", "", "")
 	set.StringVar(&ver, "version", "", "")
 	set.BoolVar(&force, "force", false, "")
+	set.BoolVar(&regen, "regen", false, "")
 	set.Bool("notest", false, "")
 	set.Parse(os.Args[1:])
 
@@ -57,7 +59,7 @@ func Generate() (files []string, err error) {
 		return nil, err
 	}
 
-	g := &Generator{OutDir: outDir, DesignPkg: designPkg, AppPkg: appPkg, Force: force, API: design.Design, Pkg: pkg, Resource: res}
+	g := &Generator{OutDir: outDir, DesignPkg: designPkg, AppPkg: appPkg, Force: force, Regen: regen, API: design.Design, Pkg: pkg, Resource: res}
 
 	return g.Generate()
 }
@@ -89,7 +91,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 			err      error
 		)
 		if g.Resource == "" || g.Resource == r.Name {
-			filename, err = genmain.GenerateController(g.Force, g.AppPkg, g.OutDir, g.Pkg, r.Name, r)
+			filename, err = genmain.GenerateController(g.Force, g.Regen, g.AppPkg, g.OutDir, g.Pkg, r.Name, r)
 		}
 
 		if err != nil {

--- a/goagen/gen_controller/generator_test.go
+++ b/goagen/gen_controller/generator_test.go
@@ -83,6 +83,7 @@ var _ = Describe("NewGenerator", func() {
 		designPkg string
 		appPkg    string
 		force     bool
+		regen     bool
 		pkg       string
 		resource  string
 		noExample bool
@@ -109,6 +110,7 @@ var _ = Describe("NewGenerator", func() {
 				gencontroller.Pkg(args.pkg),
 				gencontroller.Resource(args.resource),
 				gencontroller.Force(args.force),
+				gencontroller.Regen(args.regen),
 			)
 		})
 
@@ -121,6 +123,7 @@ var _ = Describe("NewGenerator", func() {
 			Ω(generator.Pkg).Should(Equal(args.pkg))
 			Ω(generator.Resource).Should(Equal(args.resource))
 			Ω(generator.Force).Should(Equal(args.force))
+			Ω(generator.Regen).Should(Equal(args.regen))
 		})
 
 	})

--- a/goagen/gen_controller/options.go
+++ b/goagen/gen_controller/options.go
@@ -40,6 +40,13 @@ func Force(force bool) Option {
 	}
 }
 
+//Regen Whether to regenerate scaffolding while maintaining controller impls
+func Regen(regen bool) Option {
+	return func(g *Generator) {
+		g.Regen = regen
+	}
+}
+
 //Pkg sets the name of generated package
 func Pkg(name string) Option {
 	return func(g *Generator) {

--- a/goagen/gen_main/generator_test.go
+++ b/goagen/gen_main/generator_test.go
@@ -86,6 +86,7 @@ var _ = Describe("NewGenerator", func() {
 		designPkg string
 		target    string
 		force     bool
+		regen     bool
 		noExample bool
 	}{
 		api: &design.APIDefinition{
@@ -95,6 +96,7 @@ var _ = Describe("NewGenerator", func() {
 		designPkg: "design",
 		target:    "app",
 		force:     false,
+		regen:     false,
 	}
 
 	Context("with options all options set", func() {
@@ -106,6 +108,7 @@ var _ = Describe("NewGenerator", func() {
 				genmain.DesignPkg(args.designPkg),
 				genmain.Target(args.target),
 				genmain.Force(args.force),
+				genmain.Regen(args.regen),
 			)
 		})
 
@@ -116,6 +119,7 @@ var _ = Describe("NewGenerator", func() {
 			Ω(generator.DesignPkg).Should(Equal(args.designPkg))
 			Ω(generator.Target).Should(Equal(args.target))
 			Ω(generator.Force).Should(Equal(args.force))
+			Ω(generator.Regen).Should(Equal(args.regen))
 		})
 
 	})

--- a/goagen/gen_main/generator_test.go
+++ b/goagen/gen_main/generator_test.go
@@ -1,6 +1,7 @@
 package genmain_test
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -74,6 +75,116 @@ var _ = Describe("Generate", func() {
 			})
 
 		})
+	})
+
+	Context("with resources", func() {
+		var resource *design.ResourceDefinition
+
+		BeforeEach(func() {
+			resource = &design.ResourceDefinition{
+				Name:        "first",
+				Description: "first stuff",
+				Actions:     map[string]*design.ActionDefinition{},
+			}
+			alpha := &design.ActionDefinition{
+				Parent:      resource,
+				Name:        "alpha",
+				Schemes:     []string{"http"},
+				Description: "Alpha-like things",
+			}
+			resource.Actions[alpha.Name] = alpha
+			design.Design = &design.APIDefinition{
+				Name:        "whatever",
+				Title:       "test API",
+				Description: "Ain't matter none",
+				Resources: map[string]*design.ResourceDefinition{
+					"first": resource,
+				},
+			}
+		})
+
+		It("generates controllers ready for regeneration", func() {
+			Ω(genErr).Should(BeNil())
+			Ω(files).Should(HaveLen(2))
+			content, err := ioutil.ReadFile(filepath.Join(outDir, "first.go"))
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(content).Should(MatchRegexp("FirstController_Alpha: start_implement"))
+			Ω(content).Should(MatchRegexp(`// FirstController_Alpha: start_implement\s*// Put your logic here\s*// FirstController_Alpha: end_implement`))
+		})
+
+		Context("regenerated with a new resource", func() {
+			BeforeEach(func() {
+				// Perform a first generation
+				files, genErr = genmain.Generate()
+
+				// Put some impl in the existing controller
+				existing, err := ioutil.ReadFile(filepath.Join(outDir, "first.go"))
+				Ω(err).ShouldNot(HaveOccurred())
+
+				// First add an import for fmt, to make sure it remains
+				existing = bytes.Replace(existing, []byte("import ("), []byte("import (\n\t\"fmt\")"), 1)
+
+				// Next add some body that uses fmt
+				existing = bytes.Replace(existing, []byte("// Put your logic here"), []byte("fmt.Println(\"I did it first\")"), 1)
+
+				err = ioutil.WriteFile(filepath.Join(outDir, "first.go"), existing, os.ModePerm)
+				Ω(err).ShouldNot(HaveOccurred())
+
+				// Add an action to the existing resource
+				beta := &design.ActionDefinition{
+					Parent:      resource,
+					Name:        "beta",
+					Schemes:     []string{"http"},
+					Description: "Beta-like things",
+				}
+				resource.Actions[beta.Name] = beta
+
+				// Add a new resource
+				resource2 := &design.ResourceDefinition{
+					Name:        "second",
+					Description: "second stuff",
+					Actions:     map[string]*design.ActionDefinition{},
+				}
+				gamma := &design.ActionDefinition{
+					Parent:      resource2,
+					Name:        "gamma",
+					Schemes:     []string{"http"},
+					Description: "Gamma-like things",
+				}
+				resource2.Actions[gamma.Name] = gamma
+
+				design.Design.Resources[resource2.Name] = resource2
+
+				// Set up the regeneration for the JustBeforeEach
+				os.Args = append(os.Args, "--regen")
+			})
+
+			It("generates scaffolding for new and existing resources", func() {
+				Ω(genErr).Should(BeNil())
+				Ω(files).Should(HaveLen(2))
+				Ω(files).Should(ConsistOf(filepath.Join(outDir, "first.go"), filepath.Join(outDir, "second.go")))
+
+				content, err := ioutil.ReadFile(filepath.Join(outDir, "second.go"))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(content).Should(ContainSubstring("SecondController_Gamma: start_implement"))
+
+			})
+
+			It("regenerates controllers without modifying existing impls", func() {
+				content, err := ioutil.ReadFile(filepath.Join(outDir, "first.go"))
+				Ω(err).ShouldNot(HaveOccurred())
+
+				// First make sure the new controller is in place
+				Ω(content).Should(ContainSubstring("FirstController_Beta: start_implement"))
+
+				// Check the fmt import
+				Ω(string(content)).Should(MatchRegexp(`import \(\s*[^)]*\"fmt\"`))
+
+				// Check the body is in place
+				Ω(content).Should(MatchRegexp(`// FirstController_Alpha: start_implement\s*fmt.Println\("I did it first"\)\s*// FirstController_Alpha: end_implement`))
+			})
+		})
+
 	})
 })
 

--- a/goagen/gen_main/options.go
+++ b/goagen/gen_main/options.go
@@ -39,3 +39,10 @@ func Force(force bool) Option {
 		g.Force = force
 	}
 }
+
+//Regen Whether to regenerate scaffolding in place, maintaining existing controller implementation
+func Regen(regen bool) Option {
+	return func(g *Generator) {
+		g.Regen = regen
+	}
+}

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -75,7 +75,7 @@ package and tool and the Swagger specification for the API.
 
 	// mainCmd implements the "main" command.
 	var (
-		force bool
+		force, regen bool
 	)
 	mainCmd := &cobra.Command{
 		Use:   "main",
@@ -83,6 +83,7 @@ package and tool and the Swagger specification for the API.
 		Run:   func(c *cobra.Command, _ []string) { files, err = run("genmain", c) },
 	}
 	mainCmd.Flags().BoolVar(&force, "force", false, "overwrite existing files")
+	mainCmd.Flags().BoolVar(&regen, "regen", false, "regenerate scaffolding, maintaining controller implementations")
 	rootCmd.AddCommand(mainCmd)
 
 	// clientCmd implements the "client" command.

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -193,6 +193,7 @@ package and tool and the Swagger specification for the API.
 		Run:   func(c *cobra.Command, _ []string) { files, err = run("gencontroller", c) },
 	}
 	controllerCmd.Flags().BoolVar(&force, "force", false, "overwrite existing files")
+	controllerCmd.Flags().BoolVar(&regen, "regen", false, "regenerate scaffolding, maintaining controller implementations")
 	controllerCmd.Flags().StringVar(&res, "res", "", "name of the `resource` to generate the controller for, generate all if not specified")
 	controllerCmd.Flags().StringVar(&pkg, "pkg", "controller", "name of the generated controller `package`")
 	controllerCmd.Flags().StringVar(&appPkg, "app-pkg", "app", "`import path` of Go package generated with 'goagen app', may be relative to output")


### PR DESCRIPTION
This PR adds a `--regen` arg to `goagen main` and `goagen controller`, which has the same effect as [the code_regen example](https://github.com/goadesign/examples/blob/master/code_regen), but without an external script or Makefile. It works fine with code generated using existing goagen (that is, uses the same `// Controller_action: start_implement` indicator).