### PR TITLE
examples/code_regen, but built in to goagen (#1246)

### DIFF
--- a/goagen/gen_controller/generator.go
+++ b/goagen/gen_controller/generator.go
@@ -30,6 +30,7 @@ type Generator struct {
 	DesignPkg string                // Path to design package, only used to mark generated files.
 	AppPkg    string                // Name of generated "app" package
 	Force     bool                  // Whether to override existing files
+	Regen     bool                  // Whether to regenerate scaffolding in place, retaining controller impls
 	Pkg       string                // Name of the generated package
 	Resource  string                // Name of the generated file
 	genfiles  []string              // Generated files
@@ -39,7 +40,7 @@ type Generator struct {
 func Generate() (files []string, err error) {
 	var (
 		outDir, designPkg, appPkg, ver, res, pkg string
-		force                                    bool
+		force, regen                             bool
 	)
 
 	set := flag.NewFlagSet("controller", flag.PanicOnError)
@@ -50,6 +51,7 @@ func Generate() (files []string, err error) {
 	set.StringVar(&res, "res", "", "")
 	set.StringVar(&ver, "version", "", "")
 	set.BoolVar(&force, "force", false, "")
+	set.BoolVar(&regen, "regen", false, "")
 	set.Bool("notest", false, "")
 	set.Parse(os.Args[1:])
 
@@ -57,7 +59,7 @@ func Generate() (files []string, err error) {
 		return nil, err
 	}
 
-	g := &Generator{OutDir: outDir, DesignPkg: designPkg, AppPkg: appPkg, Force: force, API: design.Design, Pkg: pkg, Resource: res}
+	g := &Generator{OutDir: outDir, DesignPkg: designPkg, AppPkg: appPkg, Force: force, Regen: regen, API: design.Design, Pkg: pkg, Resource: res}
 
 	return g.Generate()
 }
@@ -89,7 +91,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 			err      error
 		)
 		if g.Resource == "" || g.Resource == r.Name {
-			filename, err = genmain.GenerateController(g.Force, g.AppPkg, g.OutDir, g.Pkg, r.Name, r)
+			filename, err = genmain.GenerateController(g.Force, g.Regen, g.AppPkg, g.OutDir, g.Pkg, r.Name, r)
 		}
 
 		if err != nil {

--- a/goagen/gen_controller/generator_test.go
+++ b/goagen/gen_controller/generator_test.go
@@ -83,6 +83,7 @@ var _ = Describe("NewGenerator", func() {
 		designPkg string
 		appPkg    string
 		force     bool
+		regen     bool
 		pkg       string
 		resource  string
 		noExample bool
@@ -109,6 +110,7 @@ var _ = Describe("NewGenerator", func() {
 				gencontroller.Pkg(args.pkg),
 				gencontroller.Resource(args.resource),
 				gencontroller.Force(args.force),
+				gencontroller.Regen(args.regen),
 			)
 		})
 
@@ -121,6 +123,7 @@ var _ = Describe("NewGenerator", func() {
 			Ω(generator.Pkg).Should(Equal(args.pkg))
 			Ω(generator.Resource).Should(Equal(args.resource))
 			Ω(generator.Force).Should(Equal(args.force))
+			Ω(generator.Regen).Should(Equal(args.regen))
 		})
 
 	})

--- a/goagen/gen_controller/options.go
+++ b/goagen/gen_controller/options.go
@@ -40,6 +40,13 @@ func Force(force bool) Option {
 	}
 }
 
+//Regen Whether to regenerate scaffolding while maintaining controller impls
+func Regen(regen bool) Option {
+	return func(g *Generator) {
+		g.Regen = regen
+	}
+}
+
 //Pkg sets the name of generated package
 func Pkg(name string) Option {
 	return func(g *Generator) {

--- a/goagen/gen_main/options.go
+++ b/goagen/gen_main/options.go
@@ -39,3 +39,10 @@ func Force(force bool) Option {
 		g.Force = force
 	}
 }
+
+//Regen Whether to regenerate scaffolding in place, maintaining existing controller implementation
+func Regen(regen bool) Option {
+	return func(g *Generator) {
+		g.Regen = regen
+	}
+}

--- a/goagen/main.go
+++ b/goagen/main.go
@@ -75,7 +75,7 @@ package and tool and the Swagger specification for the API.
 
 	// mainCmd implements the "main" command.
 	var (
-		force bool
+		force, regen bool
 	)
 	mainCmd := &cobra.Command{
 		Use:   "main",
@@ -83,6 +83,7 @@ package and tool and the Swagger specification for the API.
 		Run:   func(c *cobra.Command, _ []string) { files, err = run("genmain", c) },
 	}
 	mainCmd.Flags().BoolVar(&force, "force", false, "overwrite existing files")
+	mainCmd.Flags().BoolVar(&regen, "regen", false, "regenerate scaffolding, maintaining controller implementations")
 	rootCmd.AddCommand(mainCmd)
 
 	// clientCmd implements the "client" command.
@@ -192,6 +193,7 @@ package and tool and the Swagger specification for the API.
 		Run:   func(c *cobra.Command, _ []string) { files, err = run("gencontroller", c) },
 	}
 	controllerCmd.Flags().BoolVar(&force, "force", false, "overwrite existing files")
+	controllerCmd.Flags().BoolVar(&regen, "regen", false, "regenerate scaffolding, maintaining controller implementations")
 	controllerCmd.Flags().StringVar(&res, "res", "", "name of the `resource` to generate the controller for, generate all if not specified")
 	controllerCmd.Flags().StringVar(&pkg, "pkg", "controller", "name of the generated controller `package`")
 	controllerCmd.Flags().StringVar(&appPkg, "app-pkg", "app", "`import path` of Go package generated with 'goagen app', may be relative to output")


### PR DESCRIPTION
Add `--regen` goagen flag for `main` and `controller` commands.