### PR TITLE
update logrus import path

### DIFF
--- a/logging/logrus/adapter.go
+++ b/logging/logrus/adapter.go
@@ -18,8 +18,8 @@ import (
 
 	"context"
 
-	"github.com/sirupsen/logrus"
 	"github.com/goadesign/goa"
+	"github.com/sirupsen/logrus"
 )
 
 // adapter is the logrus goa logger adapter.

--- a/logging/logrus/adapter.go
+++ b/logging/logrus/adapter.go
@@ -18,7 +18,7 @@ import (
 
 	"context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/goadesign/goa"
 )
 

--- a/logging/logrus/adapter_test.go
+++ b/logging/logrus/adapter_test.go
@@ -5,7 +5,7 @@ import (
 
 	"context"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/logging/logrus"
 	. "github.com/onsi/ginkgo"

--- a/logging/logrus/adapter_test.go
+++ b/logging/logrus/adapter_test.go
@@ -5,11 +5,11 @@ import (
 
 	"context"
 
-	"github.com/sirupsen/logrus"
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/logging/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("goalogrus", func() {


### PR DESCRIPTION
Recently Sirpsen/logrus renamed to sirpsen/logrus. 
According to READ.me of sirpsen/logrus, I fixed the import path of logrus.
refs https://github.com/sirupsen/logrus