### PR TITLE
Process resource without a parent first

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -903,7 +903,7 @@ type byParent []*ResourceDefinition
 
 func (p byParent) Len() int           { return len(p) }
 func (p byParent) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p byParent) Less(i, j int) bool { return p[j].ParentName == p[i].Name }
+func (p byParent) Less(i, j int) bool { return p[j].ParentName == p[i].Name || p[i].ParentName == "" }
 
 // Context returns the generic definition name used in error messages.
 func (cors *CORSDefinition) Context() string {

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -901,9 +901,18 @@ func (r *ResourceDefinition) UserTypes() map[string]*UserTypeDefinition {
 // byParent makes it possible to sort resources - parents first the children.
 type byParent []*ResourceDefinition
 
-func (p byParent) Len() int           { return len(p) }
-func (p byParent) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p byParent) Less(i, j int) bool { return p[j].ParentName == p[i].Name || p[i].ParentName == "" }
+func (p byParent) Len() int      { return len(p) }
+func (p byParent) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p byParent) Less(i, j int) bool {
+	for k := 0; k < i; k++ {
+		// We need to inspect _all_ previous fields to see if they are a parent. Sort doesn't do this.
+		if p[i].Name == p[k].ParentName {
+			return true
+		}
+	}
+
+	return false
+}
 
 // Context returns the generic definition name used in error messages.
 func (cors *CORSDefinition) Context() string {


### PR DESCRIPTION
Resources without a parent may be parents of other resources. For
deeper levels of nesting this is a problem.

E.g. Z -> Y -> X isn't sorted properly, but X needs to be processed first.