### PR TITLE
Use "main" as default controller package name

### DIFF
--- a/goagen/gen_controller/generator.go
+++ b/goagen/gen_controller/generator.go
@@ -47,7 +47,7 @@ func Generate() (files []string, err error) {
 	set.StringVar(&outDir, "out", "", "")
 	set.StringVar(&designPkg, "design", "", "")
 	set.StringVar(&appPkg, "app-pkg", "app", "")
-	set.StringVar(&pkg, "pkg", "controller", "")
+	set.StringVar(&pkg, "pkg", "main", "")
 	set.StringVar(&res, "res", "", "")
 	set.StringVar(&ver, "version", "", "")
 	set.BoolVar(&force, "force", false, "")


### PR DESCRIPTION
So that the default behavior matches the `main` and `bootstrap` commands.