### PR TITLE
Changeable FileSystem for FileHandler

### DIFF
--- a/service_test.go
+++ b/service_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Service", func() {
 			}
 		})
 
-		It("creates a handle", func() {
+		It("creates a handler", func() {
 			Ω(muxHandler).ShouldNot(BeNil())
 		})
 
@@ -341,7 +341,7 @@ var _ = Describe("Service", func() {
 			os.RemoveAll(outDir)
 		})
 
-		It("creates a handle", func() {
+		It("creates a handler", func() {
 			Ω(muxHandler).ShouldNot(BeNil())
 		})
 


### PR DESCRIPTION
goa can serve static assets via the DSL `Files` but it always uses the native file system. This patch makes it possible to use another `FileSystem` for that.