### PR TITLE
Fix bootstrap pkg, tooldir and regen flag

### DIFF
--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -37,8 +37,8 @@ type Generator struct {
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
 	var (
-		outDir, target, ver string
-		notest              bool
+		outDir, toolDir, target, ver string
+		notest, regen                bool
 	)
 
 	set := flag.NewFlagSet("app", flag.PanicOnError)
@@ -46,7 +46,9 @@ func Generate() (files []string, err error) {
 	set.StringVar(&outDir, "out", "", "")
 	set.StringVar(&target, "pkg", "app", "")
 	set.StringVar(&ver, "version", "", "")
+	set.StringVar(&toolDir, "tooldir", "tool", "")
 	set.BoolVar(&notest, "notest", false, "")
+	set.BoolVar(&regen, "regen", false, "")
 	set.Bool("force", false, "")
 	set.Parse(os.Args[1:])
 	outDir = filepath.Join(outDir, target)

--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -440,7 +440,7 @@ func {{ $test.Name }}(t goatest.TInterface, ctx context.Context, service *goa.Se
 		var {{ $ok := $test.Escape "ok" }}{{ $ok }} bool
 		mt, {{ $ok }} = {{ $resp }}.({{ $test.ReturnType.Pointer }}{{ $test.ReturnType.Type }})
 		if !{{ $ok }} {
-			t.Fatalf("invalid response media: got %+v, expected instance of {{ $test.ReturnType.Type }}", {{ $resp }})
+			t.Fatalf("invalid response media: got variable of type %T, value %+v, expected instance of {{ $test.ReturnType.Type }}", {{ $resp }}, {{ $resp }})
 		}
 {{ if $test.ReturnType.Validatable }}		{{ $err }} = mt.Validate()
 		if {{ $err }} != nil {

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -49,7 +49,7 @@ type Generator struct {
 func Generate() (files []string, err error) {
 	var (
 		outDir, target, toolDir, tool, ver string
-		notool                             bool
+		notool, regen                      bool
 	)
 	dtool := defaultToolName(design.Design)
 
@@ -60,6 +60,7 @@ func Generate() (files []string, err error) {
 	set.StringVar(&tool, "tool", dtool, "")
 	set.StringVar(&ver, "version", "", "")
 	set.BoolVar(&notool, "notool", false, "")
+	set.BoolVar(&regen, "regen", false, "")
 	set.String("design", "", "")
 	set.Bool("force", false, "")
 	set.Bool("notest", false, "")

--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -45,8 +45,8 @@ type Generator struct {
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
 	var (
-		outDir, designPkg, target, ver string
-		force, regen                   bool
+		outDir, toolDir, designPkg, target, ver string
+		force, regen                            bool
 	)
 
 	set := flag.NewFlagSet("main", flag.PanicOnError)
@@ -54,6 +54,7 @@ func Generate() (files []string, err error) {
 	set.StringVar(&designPkg, "design", "", "")
 	set.StringVar(&target, "pkg", "app", "")
 	set.StringVar(&ver, "version", "", "")
+	set.StringVar(&toolDir, "tooldir", "tool", "")
 	set.BoolVar(&force, "force", false, "")
 	set.BoolVar(&regen, "regen", false, "")
 	set.Bool("notest", false, "")

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -35,11 +35,18 @@ type Generator struct {
 
 // Generate is the generator entry point called by the meta generator.
 func Generate() (files []string, err error) {
-	var outDir, ver string
+	var (
+		outDir, toolDir, target, ver string
+		regen                        bool
+	)
+
 	set := flag.NewFlagSet("swagger", flag.PanicOnError)
 	set.StringVar(&outDir, "out", "", "")
 	set.StringVar(&ver, "version", "", "")
 	set.String("design", "", "")
+	set.StringVar(&toolDir, "tooldir", "tool", "")
+	set.StringVar(&target, "pkg", "app", "")
+	set.BoolVar(&regen, "regen", false, "")
 	set.Bool("force", false, "")
 	set.Bool("notest", false, "")
 	set.Parse(os.Args[1:])


### PR DESCRIPTION
Some generators just ignore the flag but they must still define it so that bootstrap can use it.

Fixes #1308 