### PR TITLE
Make sure to generate strings when generating UUID examples.

### DIFF
--- a/design/types.go
+++ b/design/types.go
@@ -293,7 +293,7 @@ func (p Primitive) GenerateExample(r *RandomGenerator, seen []string) interface{
 	case DateTime:
 		return r.DateTime()
 	case UUID:
-		return r.UUID()
+		return r.UUID().String() // Generate string to can be JSON marshaled
 	case Any:
 		// to not make it too complicated, pick one of the primitive types
 		return anyPrimitive[r.Int()%len(anyPrimitive)].GenerateExample(r, seen)
@@ -1029,7 +1029,7 @@ func toReflectType(dtype DataType) reflect.Type {
 		return reflect.TypeOf(int(0))
 	case NumberKind:
 		return reflect.TypeOf(float64(0))
-	case StringKind:
+	case UUIDKind, StringKind:
 		return reflect.TypeOf("")
 	case DateTimeKind:
 		return reflect.TypeOf(time.Time{})

--- a/design/types_test.go
+++ b/design/types_test.go
@@ -565,3 +565,27 @@ var _ = Describe("Finalize", func() {
 		}).ShouldNot(HaveOccurred())
 	})
 })
+
+var _ = Describe("GenerateExample", func() {
+
+	Context("Given a UUID", func() {
+		It("generates a string example", func() {
+			rand := NewRandomGenerator("foo")
+			Ω(UUID.GenerateExample(rand, nil)).Should(BeAssignableToTypeOf("foo"))
+		})
+	})
+
+	Context("Given a Hash keyed by UUIDs", func() {
+		var h *Hash
+		BeforeEach(func() {
+			h = &Hash{
+				KeyType:  &AttributeDefinition{Type: UUID},
+				ElemType: &AttributeDefinition{Type: String},
+			}
+		})
+		It("generates a serializable example", func() {
+			rand := NewRandomGenerator("foo")
+			Ω(h.GenerateExample(rand, nil)).Should(BeAssignableToTypeOf(map[string]string{"foo": "bar"}))
+		})
+	})
+})


### PR DESCRIPTION
Fix #1301 