### PR TITLE
Add appengine context middleware

### DIFF
--- a/middleware/with_appengine_context.go
+++ b/middleware/with_appengine_context.go
@@ -1,0 +1,19 @@
+// +build appengine
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/goadesign/goa"
+	"google.golang.org/appengine"
+)
+
+// AppEngineContext is a middleware that ensures that the goa contexts are valid App Engine contexts
+// It is safe to use in a non-appengine environment
+func AppEngineContext(h goa.Handler) goa.Handler {
+	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		return h(appengine.WithContext(ctx, req), rw, req)
+	}
+}

--- a/middleware/without_appengine_context.go
+++ b/middleware/without_appengine_context.go
@@ -1,0 +1,18 @@
+// +build !appengine
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/goadesign/goa"
+)
+
+// AppEngineContext is a middleware that ensures that the goa contexts are valid App Engine contexts
+// It is safe to use in a non-appengine environment
+func AppEngineContext(h goa.Handler) goa.Handler {
+	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		return h(ctx, rw, req)
+	}
+}

--- a/middleware/without_appengine_context.go
+++ b/middleware/without_appengine_context.go
@@ -12,7 +12,5 @@ import (
 // AppEngineContext is a middleware that ensures that the goa contexts are valid App Engine contexts
 // It is safe to use in a non-appengine environment
 func AppEngineContext(h goa.Handler) goa.Handler {
-	return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-		return h(ctx, rw, req)
-	}
+	return h
 }


### PR DESCRIPTION
Adds a middleware that makes sure that the goa contexts are also App Engine contexts. If the user is not on App Engine, the middleware will do nothing.