### PR TITLE
Fix ResponseData.Write behavior to match net/http.ResponseWriter.Write.

### DIFF
--- a/context.go
+++ b/context.go
@@ -45,8 +45,6 @@ type (
 		Status int
 		// Length is the response body length.
 		Length int
-		// Flag if WriteHeader has been called.
-		wroteHeader bool
 	}
 
 	// key is the type used to store internal values in the context.
@@ -152,20 +150,19 @@ func (r *ResponseData) SwitchWriter(rw http.ResponseWriter) http.ResponseWriter 
 
 // Written returns true if the response was written, false otherwise.
 func (r *ResponseData) Written() bool {
-	return r.wroteHeader
+	return r.Status != 0
 }
 
 // WriteHeader records the response status code and calls the underlying writer.
 func (r *ResponseData) WriteHeader(status int) {
 	go IncrCounter([]string{"goa", "response", strconv.Itoa(status)}, 1.0)
-	r.wroteHeader = true
 	r.Status = status
 	r.ResponseWriter.WriteHeader(status)
 }
 
 // Write records the amount of data written and calls the underlying writer.
 func (r *ResponseData) Write(b []byte) (int, error) {
-	if !r.wroteHeader {
+	if !r.Written() {
 		r.WriteHeader(http.StatusOK)
 	}
 	r.Length += len(b)

--- a/context_test.go
+++ b/context_test.go
@@ -39,4 +39,20 @@ var _ = Describe("ResponseData", func() {
 			Ω(trw.Status).Should(Equal(42))
 		})
 	})
+
+	Context("Write", func() {
+		It("should call WriteHeader(http.StatusOK) if WriteHeader has not yet been called", func() {
+			_, err := data.Write(nil)
+			Ω(err).Should(BeNil())
+			Ω(data.Status).Should(Equal(http.StatusOK))
+		})
+
+		It("should not affect Status if WriteHeader has been called", func() {
+			status := http.StatusBadRequest
+			data.WriteHeader(status)
+			_, err := data.Write(nil)
+			Ω(err).Should(BeNil())
+			Ω(data.Status).Should(Equal(status))
+		})
+	})
 })


### PR DESCRIPTION
From documentation of net/http.ResponseWriter.Write

    If WriteHeader has not yet been called, Write calls
    WriteHeader(http.StatusOK) before writing the data.

Without this fix, ResponseData which went through middleware which depends
on documented behavior of net/http.ResponseWriter.Write, basically which doesn't
call net/http.ResponseWriter.WriteHeader explicitly, ended in non Written
state. This leads into situation that NotFound handler will write into
ResponseData although middleware did the write already.