### PR TITLE
Do not close/open files on every write (10x speedup).

### DIFF
--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -172,6 +172,7 @@ func (m *Generator) generateToolSourceCode(pkg *codegen.Package) {
 	if err != nil {
 		panic(err) // bug
 	}
+	file.Close()
 }
 
 // spawn runs the compiled generator using the arguments initialized by Kingpin


### PR DESCRIPTION
Especially on Windows this is really painful.

A rather hacky way to not constantly open/close files. However, this speeds up generation by a factor of 10. So even though this isn't perfect, it should at least prove that it is worth pursuing. I hope someone with a bit more knowledge on the "back-end" can pick this up.

Example with `goagen bootstrap -d github.com/klauspost/someapi/design`:

Before: 53.56s
After: 5.38s