### PR TITLE
Properly handle Number default values defined as int.

### DIFF
--- a/goagen/codegen/finalizer.go
+++ b/goagen/codegen/finalizer.go
@@ -116,7 +116,11 @@ func PrintVal(t design.DataType, val interface{}) string {
 		s := fmt.Sprintf("%#v", val)
 		switch t {
 		case design.Number:
-			s = fmt.Sprintf("%f", val)
+			v := val
+			if i, ok := val.(int); ok {
+				v = float64(i)
+			}
+			s = fmt.Sprintf("%f", v)
 		case design.DateTime:
 			s = fmt.Sprintf("time.Parse(time.RFC3339, %s)", s)
 		}

--- a/goagen/codegen/finalizer_test.go
+++ b/goagen/codegen/finalizer_test.go
@@ -54,6 +54,24 @@ var _ = Describe("Struct finalize code generation", func() {
 		})
 	})
 
+	Context("given an object with a primitive Number field with a int default value", func() {
+		BeforeEach(func() {
+			att = &design.AttributeDefinition{
+				Type: &design.Object{
+					"foo": &design.AttributeDefinition{
+						Type:         design.Number,
+						DefaultValue: 50,
+					},
+				},
+			}
+			target = "ut"
+		})
+		It("finalizes the fields", func() {
+			code := finalizer.Code(att, target, 0)
+			Ω(code).Should(Equal(numberAssignmentCodeIntDefault))
+		})
+	})
+
 	Context("given an array field", func() {
 		BeforeEach(func() {
 			att = &design.AttributeDefinition{
@@ -169,6 +187,11 @@ var _ = Describe("Struct finalize code generation", func() {
 
 const (
 	primitiveAssignmentCode = `var defaultFoo = "bar"
+if ut.Foo == nil {
+	ut.Foo = &defaultFoo
+}`
+
+	numberAssignmentCodeIntDefault = `var defaultFoo = 50.000000
 if ut.Foo == nil {
 	ut.Foo = &defaultFoo
 }`


### PR DESCRIPTION
So that this is legal:

    Param("num", Number, func() {
        Default(50)
    })

Fix #1342 
