### PR TITLE
DMO-1294 xray: request-level segment shouldn't be marked "subsegment"

### DIFF
--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -127,7 +127,6 @@ func newSegment(ctx context.Context, traceID, name string, req *http.Request, c 
 
 	if parentID != "" {
 		s.ParentID = parentID
-		s.Type = "subsegment"
 	}
 
 	return s

--- a/middleware/xray/middleware_test.go
+++ b/middleware/xray/middleware_test.go
@@ -181,11 +181,8 @@ func TestMiddleware(t *testing.T) {
 		if s.Name != "service" {
 			t.Errorf("%s: unexpected segment name, expected service - got %s", k, s.Name)
 		}
-		if c.Trace.ParentID == "" && s.Type != "" {
+		if s.Type != "" {
 			t.Errorf("%s: expected Type to be empty but got %s", k, s.Type)
-		}
-		if c.Trace.ParentID != "" && s.Type != "subsegment" {
-			t.Errorf("%s: expected Type to subsegment but got %s", k, s.Type)
 		}
 		if s.ID != c.Trace.SpanID {
 			t.Errorf("%s: unexpected segment ID, expected %s - got %s", k, c.Trace.SpanID, s.ID)


### PR DESCRIPTION
This was causing an X-Ray trace through multiple services to show up as a tree of subsegments under a single service. So queries like `service("xyz")` wouldn't show anything, even though the trace did flow through that service.