### PR TITLE
Added Method Not Allowed default handler

### DIFF
--- a/error.go
+++ b/error.go
@@ -69,8 +69,8 @@ var (
 	// ErrNotFound is the error returned to requests that don't match a registered handler.
 	ErrNotFound = NewErrorClass("not_found", 404)
 
-	// ErrMethodNotAllowed is the error returned to requests that have a registered handler
-	// but the used HTTP method does not match.
+	// ErrMethodNotAllowed is the error returned to requests that match the path of a registered
+	// handler but not the HTTP method.
 	ErrMethodNotAllowed = NewErrorClass("method_not_allowed", 405)
 
 	// ErrInternal is the class of error used for uncaught errors.
@@ -249,8 +249,8 @@ func NoAuthMiddleware(schemeName string) error {
 	return ErrNoAuthMiddleware(msg, "scheme", schemeName)
 }
 
-// MethodNotAllowedError is the error produced to requests that have a registered handler
-// but the used HTTP method does not match.
+// MethodNotAllowedError is the error produced to requests that match the path of a registered
+// handler but not the HTTP method.
 func MethodNotAllowedError(method string, allowed []string) error {
 	msg := fmt.Sprintf("Method %s must be one of %s", method, strings.Join(allowed, ", "))
 	return ErrMethodNotAllowed(msg, "method", method, "allowed", strings.Join(allowed, ", "))

--- a/error.go
+++ b/error.go
@@ -252,7 +252,11 @@ func NoAuthMiddleware(schemeName string) error {
 // MethodNotAllowedError is the error produced to requests that match the path of a registered
 // handler but not the HTTP method.
 func MethodNotAllowedError(method string, allowed []string) error {
-	msg := fmt.Sprintf("Method %s must be one of %s", method, strings.Join(allowed, ", "))
+	var plural string
+	if len(allowed) > 1 {
+		plural = " one of"
+	}
+	msg := fmt.Sprintf("Method %s must be%s %s", method, plural, strings.Join(allowed, ", "))
 	return ErrMethodNotAllowed(msg, "method", method, "allowed", strings.Join(allowed, ", "))
 }
 

--- a/error.go
+++ b/error.go
@@ -69,6 +69,10 @@ var (
 	// ErrNotFound is the error returned to requests that don't match a registered handler.
 	ErrNotFound = NewErrorClass("not_found", 404)
 
+	// ErrMethodNotAllowed is the error returned to requests that have a registered handler
+	// but the used HTTP method does not match.
+	ErrMethodNotAllowed = NewErrorClass("method_not_allowed", 405)
+
 	// ErrInternal is the class of error used for uncaught errors.
 	ErrInternal = NewErrorClass("internal", 500)
 )
@@ -243,6 +247,13 @@ func InvalidLengthError(ctx string, target interface{}, ln, value int, min bool)
 func NoAuthMiddleware(schemeName string) error {
 	msg := fmt.Sprintf("Auth middleware for security scheme %s is not mounted", schemeName)
 	return ErrNoAuthMiddleware(msg, "scheme", schemeName)
+}
+
+// MethodNotAllowedError is the error produced to requests that have a registered handler
+// but the used HTTP method does not match.
+func MethodNotAllowedError(method string, allowed []string) error {
+	msg := fmt.Sprintf("Method %s must be one of %s", method, strings.Join(allowed, ", "))
+	return ErrMethodNotAllowed(msg, "method", method, "allowed", strings.Join(allowed, ", "))
 }
 
 // Error returns the error occurrence details.

--- a/error_test.go
+++ b/error_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -118,6 +119,24 @@ var _ = Describe("MissingHeaderError", func() {
 		Ω(valErr).Should(BeAssignableToTypeOf(&ErrorResponse{}))
 		err := valErr.(*ErrorResponse)
 		Ω(err.Detail).Should(ContainSubstring(name))
+	})
+})
+
+var _ = Describe("MethodNotAllowedError", func() {
+	var valErr error
+	method := "POST"
+	allowed := []string{"OPTIONS", "GET"}
+
+	JustBeforeEach(func() {
+		valErr = MethodNotAllowedError(method, allowed)
+	})
+
+	It("creates a http error", func() {
+		Ω(valErr).ShouldNot(BeNil())
+		Ω(valErr).Should(BeAssignableToTypeOf(&ErrorResponse{}))
+		err := valErr.(*ErrorResponse)
+		Ω(err.Detail).Should(ContainSubstring(method))
+		Ω(err.Detail).Should(ContainSubstring(strings.Join(allowed, ", ")))
 	})
 })
 

--- a/error_test.go
+++ b/error_test.go
@@ -125,10 +125,14 @@ var _ = Describe("MissingHeaderError", func() {
 var _ = Describe("MethodNotAllowedError", func() {
 	var valErr error
 	method := "POST"
-	allowed := []string{"OPTIONS", "GET"}
+	var allowed []string
 
 	JustBeforeEach(func() {
 		valErr = MethodNotAllowedError(method, allowed)
+	})
+
+	BeforeEach(func() {
+		allowed = []string{"OPTIONS", "GET"}
 	})
 
 	It("creates a http error", func() {
@@ -137,6 +141,24 @@ var _ = Describe("MethodNotAllowedError", func() {
 		err := valErr.(*ErrorResponse)
 		Ω(err.Detail).Should(ContainSubstring(method))
 		Ω(err.Detail).Should(ContainSubstring(strings.Join(allowed, ", ")))
+	})
+
+	Context("multiple allowed methods", func() {
+		It("should use plural", func() {
+			err := valErr.(*ErrorResponse)
+			Ω(err.Detail).Should(ContainSubstring("one of"))
+		})
+	})
+
+	Context("single allowed method", func() {
+		BeforeEach(func() {
+			allowed = []string{"GET"}
+		})
+
+		It("should not use plural", func() {
+			err := valErr.(*ErrorResponse)
+			Ω(err.Detail).ShouldNot(ContainSubstring("one of"))
+		})
 	})
 })
 

--- a/mux.go
+++ b/mux.go
@@ -12,6 +12,12 @@ type (
 	// The values argument includes both the querystring and path parameter values.
 	MuxHandler func(http.ResponseWriter, *http.Request, url.Values)
 
+	// MethodNotAllowedHandler provides the implementation for an MethodNotAllowed
+	// handler. The values argument includes both the querystring and path parameter
+	// values. The methods argument includes both the allowed method identifier
+	// and the registered handler.
+	MethodNotAllowedHandler func(http.ResponseWriter, *http.Request, url.Values, map[string]httptreemux.HandlerFunc)
+
 	// ServeMux is the interface implemented by the service request muxes.
 	// It implements http.Handler and makes it possible to register request handlers for
 	// specific HTTP methods and request path via the Handle method.
@@ -23,6 +29,10 @@ type (
 		// handler registered with Handle. The values argument given to the handler is
 		// always nil.
 		HandleNotFound(handle MuxHandler)
+		// HandleMethodNotAllowed sets the MethodNotAllowedHandler invoked for requests
+		// that match the path of a handler but not its HTTP method. The values argument
+		// given to the Handler is always nil.
+		HandleMethodNotAllowed(handle MethodNotAllowedHandler)
 		// Lookup returns the MuxHandler associated with the given HTTP method and path.
 		Lookup(method, path string) MuxHandler
 	}
@@ -69,8 +79,13 @@ func (m *mux) HandleNotFound(handle MuxHandler) {
 		handle(rw, req, nil)
 	}
 	m.router.NotFoundHandler = nfh
+}
+
+// HandleMethodNotAllowed sets the MuxHandler invoked for requests that match
+// the path of a handler but not its HTTP method.
+func (m *mux) HandleMethodNotAllowed(handle MethodNotAllowedHandler) {
 	mna := func(rw http.ResponseWriter, req *http.Request, methods map[string]httptreemux.HandlerFunc) {
-		handle(rw, req, nil)
+		handle(rw, req, nil, methods)
 	}
 	m.router.MethodNotAllowedHandler = mna
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -66,4 +66,21 @@ var _ = Describe("Mux", func() {
 		})
 	})
 
+	Context("with registered handlers and wrong method", func() {
+		const handlerMeth = "POST"
+		const reqMeth = "GET"
+		const reqPath = "/foo"
+
+		BeforeEach(func() {
+			var err error
+			req, err = http.NewRequest(reqMeth, reqPath, nil)
+			Ω(err).ShouldNot(HaveOccurred())
+			mux.Handle(handlerMeth, reqPath, func(rw http.ResponseWriter, req *http.Request, vals url.Values) {})
+		})
+
+		It("returns 405 to not allowed method", func() {
+			Ω(rw.Status).Should(Equal(405))
+		})
+	})
+
 })

--- a/service.go
+++ b/service.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 
 	"context"
+
+	"github.com/dimfeld/httptreemux"
 )
 
 type (
@@ -100,7 +102,8 @@ func New(name string) *Service {
 
 			cancel: cancel,
 		}
-		notFoundHandler Handler
+		notFoundHandler         Handler
+		methodNotAllowedHandler Handler
 	)
 
 	// Setup default NotFound handler
@@ -124,6 +127,37 @@ func New(name string) *Service {
 		err := notFoundHandler(ctx, ContextResponse(ctx), req)
 		if !ContextResponse(ctx).Written() {
 			service.Send(ctx, 404, err)
+		}
+	})
+
+	// Setup default MethodNotAllowed handler
+	mux.HandleMethodNotAllowed(func(rw http.ResponseWriter, req *http.Request, params url.Values, methods map[string]httptreemux.HandlerFunc) {
+		if resp := ContextResponse(ctx); resp != nil && resp.Written() {
+			return
+		}
+		// Use closure to do lazy computation of middleware chain so all middlewares are
+		// registered.
+		if methodNotAllowedHandler == nil {
+			methodNotAllowedHandler = func(_ context.Context, rw http.ResponseWriter, req *http.Request) error {
+				allowedMethods := make([]string, len(methods))
+				i := 0
+				for k := range methods {
+					allowedMethods[i] = k
+					i++
+				}
+				rw.Header().Set("Allow", strings.Join(allowedMethods, ", "))
+				return MethodNotAllowedError(req.Method, allowedMethods)
+			}
+			chain := service.middleware
+			ml := len(chain)
+			for i := range chain {
+				methodNotAllowedHandler = chain[ml-i-1](methodNotAllowedHandler)
+			}
+		}
+		ctx := NewContext(service.Context, rw, req, params)
+		err := methodNotAllowedHandler(ctx, ContextResponse(ctx), req)
+		if !ContextResponse(ctx).Written() {
+			service.Send(ctx, 405, err)
 		}
 	})
 


### PR DESCRIPTION
This PR changes the the way how goa handles not existent HTTP methods on existing endpoints and resolve #1372.

The new public `HandleMethodNotAllowed` is able to take a self defined handler. Therefore it was necessary to introduce a new `MethodNotAllowedHandler` which extends the the `MuxHandler` arguments by `map[string]httptreemux.HandlerFunc`. This allows to retrieve the allowed methods and handler by the MethodNotAllowed handler.

A default handler is included, which sets the appropriate status code, `Allow` header and a new error class.

This changes can be breaking in some edge cases, but introduce the correct behaviour described in https://tools.ietf.org/html/rfc7231#section-6.5.5