### PR TITLE
Fix gzip middleware so that headers are written properly.

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -126,11 +126,7 @@ func (decoder *HTTPDecoder) Decode(v interface{}, body io.Reader, contentType st
 	// the decoderPool will handle whether or not a pool is actually in use
 	d := p.Get(body)
 	defer p.Put(d)
-	if err := d.Decode(v); err != nil {
-		return err
-	}
-
-	return nil
+	return d.Decode(v)
 }
 
 // Register sets a specific decoder to be used for the specified content types. If a decoder is

--- a/encoding/gogoprotobuf/encoding.go
+++ b/encoding/gogoprotobuf/encoding.go
@@ -54,10 +54,7 @@ func (dec *ProtoDecoder) Decode(v interface{}) error {
 	}
 	dec.pBuf.SetBuf(dec.bBuf.Bytes())
 
-	if err = dec.pBuf.Unmarshal(msg); err != nil {
-		return err
-	}
-	return nil
+	return dec.pBuf.Unmarshal(msg)
 }
 
 // Reset stores the new reader and resets its bytes.Buffer and proto.Buffer

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -312,10 +312,7 @@ func (w *ControllersWriter) WriteInitService(encoders, decoders []*EncoderTempla
 		"Encoders": encoders,
 		"Decoders": decoders,
 	}
-	if err := w.ExecuteTemplate("service", serviceT, nil, ctx); err != nil {
-		return err
-	}
-	return nil
+	return w.ExecuteTemplate("service", serviceT, nil, ctx)
 }
 
 // Execute writes the handlers GoGenerator
@@ -400,10 +397,7 @@ func (w *MediaTypesWriter) Execute(mt *design.MediaTypeDefinition) error {
 		if err != nil {
 			return err
 		}
-		if err := w.ExecuteTemplate("mediatype", mediaTypeT, fn, p); err != nil {
-			return err
-		}
-		return nil
+		return w.ExecuteTemplate("mediatype", mediaTypeT, fn, p)
 	})
 	if err != nil {
 		return err

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -608,10 +608,7 @@ func (g *Generator) generateMediaTypes(pkgDir string, funcs template.FuncMap) (e
 			if err != nil {
 				return err
 			}
-			if err := typeDecodeTmpl.Execute(mtWr.SourceFile, p); err != nil {
-				return err
-			}
-			return nil
+			return typeDecodeTmpl.Execute(mtWr.SourceFile, p)
 		})
 		return err
 	})

--- a/middleware/gzip/middleware_test.go
+++ b/middleware/gzip/middleware_test.go
@@ -67,8 +67,8 @@ var _ = Describe("Gzip", func() {
 
 		gzr, err := gzip.NewReader(bytes.NewReader(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, gzr)
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, gzr)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -89,8 +89,8 @@ var _ = Describe("Gzip", func() {
 
 		gzr, err := gzip.NewReader(bytes.NewReader(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, gzr)
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, gzr)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -111,8 +111,8 @@ var _ = Describe("Gzip", func() {
 
 		gzr, err := gzip.NewReader(bytes.NewReader(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, gzr)
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, gzr)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -134,8 +134,8 @@ var _ = Describe("Gzip", func() {
 
 		gzr, err := gzip.NewReader(bytes.NewReader(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, gzr)
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, gzr)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -162,8 +162,8 @@ var _ = Describe("Gzip", func() {
 
 		gzr, err := gzip.NewReader(bytes.NewReader(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, gzr)
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, gzr)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal(strings.Repeat("gzip me!", 128)))
 	})
@@ -201,8 +201,8 @@ var _ = Describe("NotGzip", func() {
 		Ω(resp.Status).Should(Equal(http.StatusOK))
 		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
 
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, bytes.NewBuffer(rw.Body))
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip data"))
 	})
@@ -221,8 +221,8 @@ var _ = Describe("NotGzip", func() {
 		Ω(resp.Status).Should(Equal(http.StatusOK))
 		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
 
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, bytes.NewBuffer(rw.Body))
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -241,8 +241,8 @@ var _ = Describe("NotGzip", func() {
 		Ω(resp.Status).Should(Equal(http.StatusBadRequest))
 		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
 
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, bytes.NewBuffer(rw.Body))
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -261,8 +261,8 @@ var _ = Describe("NotGzip", func() {
 		Ω(resp.Status).Should(Equal(http.StatusOK))
 		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
 
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, bytes.NewBuffer(rw.Body))
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -282,8 +282,8 @@ var _ = Describe("NotGzip", func() {
 		Ω(resp.Status).Should(Equal(http.StatusOK))
 		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
 
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, bytes.NewBuffer(rw.Body))
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -302,8 +302,8 @@ var _ = Describe("NotGzip", func() {
 		Ω(resp.Status).Should(Equal(http.StatusOK))
 		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
 
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, bytes.NewBuffer(rw.Body))
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})
@@ -340,8 +340,8 @@ var _ = Describe("NotGzip", func() {
 		Ω(resp.Status).Should(Equal(http.StatusOK))
 		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
 
-		buf := bytes.NewBuffer(nil)
-		io.Copy(buf, bytes.NewBuffer(rw.Body))
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
 	})

--- a/service.go
+++ b/service.go
@@ -206,10 +206,7 @@ func (service *Service) ListenAndServeTLS(addr, certFile, keyFile string) error 
 
 // Serve accepts incoming HTTP connections on the listener l, invoking the service mux handler for each.
 func (service *Service) Serve(l net.Listener) error {
-	if err := http.Serve(l, service.Mux); err != nil {
-		return err
-	}
-	return nil
+	return http.Serve(l, service.Mux)
 }
 
 // NewController returns a controller for the given resource. This method is mainly intended for


### PR DESCRIPTION
* Need to buffer gzip content to compute proper content length
* Do not write headers prior to compressing so that content type and content
  encoding headers can be written properly.