### PR TITLE
gzip middleware updates

### DIFF
--- a/middleware/gzip/middleware.go
+++ b/middleware/gzip/middleware.go
@@ -62,6 +62,7 @@ func (grw *gzipResponseWriter) Write(b []byte) (int, error) {
 		s := grw.o.shouldCompress(grw.Header().Get(headerContentType), grw.statusCode)
 		grw.shouldCompress = &s
 		if !s {
+			grw.ResponseWriter.WriteHeader(grw.statusCode)
 			return grw.ResponseWriter.Write(b)
 		}
 	}
@@ -325,8 +326,8 @@ func Middleware(level int, o ...Option) goa.Middleware {
 				gzipPool.Put(grw.gzw)
 				return
 			}
-			// No writes, set status code if ok.
-			if grw.statusCode != 0 {
+			// No writes, set status code.
+			if grw.shouldCompress == nil {
 				w.WriteHeader(grw.statusCode)
 			}
 			return

--- a/middleware/gzip/middleware_test.go
+++ b/middleware/gzip/middleware_test.go
@@ -3,11 +3,11 @@ package gzip_test
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
-
-	"context"
 
 	"github.com/goadesign/goa"
 	gzm "github.com/goadesign/goa/middleware/gzip"
@@ -44,6 +44,7 @@ var _ = Describe("Gzip", func() {
 		var err error
 		req, err = http.NewRequest("POST", "/foo/bar", strings.NewReader(`{"payload":42}`))
 		req.Header.Set("Accept-Encoding", "gzip")
+		req.Header.Set("Range", "bytes=0-1023")
 		Ω(err).ShouldNot(HaveOccurred())
 		rw = &TestResponseWriter{ParentHeader: make(http.Header)}
 
@@ -71,6 +72,7 @@ var _ = Describe("Gzip", func() {
 		_, err = io.Copy(&buf, gzr)
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
+		Ω(resp.Header().Get("Content-Length")).Should(Equal(""))
 	})
 
 	It("encodes response using gzip (custom status)", func() {
@@ -167,6 +169,36 @@ var _ = Describe("Gzip", func() {
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal(strings.Repeat("gzip me!", 128)))
 	})
+
+	It("removes Accept-Ranges header", func() {
+		h := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			resp := goa.ContextResponse(ctx)
+			resp.Header().Add("Accept-Ranges", "some value")
+			resp.WriteHeader(http.StatusOK)
+			// Use multiple writes.
+			for i := 0; i < 128; i++ {
+				_, err := resp.Write([]byte("gzip me!"))
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		t := gzm.Middleware(gzip.BestCompression, gzm.MinSize(512))(h)
+		err := t(ctx, rw, req)
+		Ω(err).ShouldNot(HaveOccurred())
+		resp := goa.ContextResponse(ctx)
+		Ω(resp.Status).Should(Equal(http.StatusOK))
+		Ω(resp.Header().Get("Content-Encoding")).Should(Equal("gzip"))
+		Ω(resp.Header().Get("Accept-Ranges")).Should(Equal(""))
+
+		gzr, err := gzip.NewReader(bytes.NewReader(rw.Body))
+		Ω(err).ShouldNot(HaveOccurred())
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, gzr)
+		Ω(err).ShouldNot(HaveOccurred())
+		Ω(buf.String()).Should(Equal(strings.Repeat("gzip me!", 128)))
+	})
 })
 
 var _ = Describe("NotGzip", func() {
@@ -179,6 +211,7 @@ var _ = Describe("NotGzip", func() {
 		var err error
 		req, err = http.NewRequest("POST", "/foo/bar", strings.NewReader(`{"payload":42}`))
 		req.Header.Set("Accept-Encoding", "gzip")
+		req.Header.Set("Range", "bytes=0-10")
 		Ω(err).ShouldNot(HaveOccurred())
 		rw = &TestResponseWriter{ParentHeader: make(http.Header)}
 
@@ -222,9 +255,11 @@ var _ = Describe("NotGzip", func() {
 		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
 
 		var buf bytes.Buffer
-		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
+		n, err := io.Copy(&buf, bytes.NewBuffer(rw.Body))
 		Ω(err).ShouldNot(HaveOccurred())
 		Ω(buf.String()).Should(Equal("gzip me!"))
+		Ω(resp.Header().Get("Content-Length")).Should(Equal(strconv.Itoa(int(n))))
+		Ω(resp.Header().Get("Content-Length")).Should(Equal(strconv.Itoa(len("gzip me!"))))
 	})
 
 	It("does not encode response (wrong status code)", func() {
@@ -296,6 +331,26 @@ var _ = Describe("NotGzip", func() {
 			return nil
 		}
 		t := gzm.Middleware(gzip.BestCompression, gzm.MinSize(0), gzm.OnlyContentTypes("some/type"))(h)
+		err := t(ctx, rw, req)
+		Ω(err).ShouldNot(HaveOccurred())
+		resp := goa.ContextResponse(ctx)
+		Ω(resp.Status).Should(Equal(http.StatusOK))
+		Ω(resp.Header().Get("Content-Encoding")).ShouldNot(Equal("gzip"))
+
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, bytes.NewBuffer(rw.Body))
+		Ω(err).ShouldNot(HaveOccurred())
+		Ω(buf.String()).Should(Equal("gzip me!"))
+	})
+
+	It("does not encode response (has Range header)", func() {
+		h := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			resp := goa.ContextResponse(ctx)
+			resp.WriteHeader(http.StatusOK)
+			resp.Write([]byte("gzip me!"))
+			return nil
+		}
+		t := gzm.Middleware(gzip.BestCompression, gzm.MinSize(0), gzm.IgnoreRange(false))(h)
 		err := t(ctx, rw, req)
 		Ω(err).ShouldNot(HaveOccurred())
 		resp := goa.ContextResponse(ctx)


### PR DESCRIPTION
I have tried to re-enable the unbuffered writes, so gzipped content doesn't have to be buffered. The problem before was that headers could be written after bytes had been written. This should no longer be possible. "Content-Length" is optional, so unless we already have it by accident, we just keep it out.

I have also made an option to Disable "Range" requests since they are unclear in compressed context. This includes removing the "Accept-Ranges" header on responses.

I have added an option if users would prefer "Range" requests to go through but disable compression instead.