### PR TITLE
Allow JWT scopes claim to be named 'scope' or 'scopes'

### DIFF
--- a/middleware/security/jwt/jwt.go
+++ b/middleware/security/jwt/jwt.go
@@ -21,8 +21,9 @@ import (
 //
 //     1. Validate the "Bearer" token present in the "Authorization" header against the key(s)
 //        given to New
-//     2. If scopes are defined in the design for the action validate them against the "scopes" JWT
-//        claim
+//     2. If scopes are defined in the design for the action, validate them
+//        against the scopes presented by the JWT in the claim "scope", or if
+//        that's not defined, "scopes".
 //
 // The `exp` (expiration) and `nbf` (not before) date checks are validated by the JWT library.
 //
@@ -119,7 +120,7 @@ func New(resolver KeyResolver, validationFunc goa.Middleware, scheme *goa.JWTSec
 
 			for _, scope := range requiredScopes {
 				if !scopesInClaim[scope] {
-					msg := "authorization failed: required 'scopes' not present in JWT claim"
+					msg := "authorization failed: required 'scope' or 'scopes' not present in JWT claim"
 					return ErrJWTError(msg, "required", requiredScopes, "scopes", scopesInClaimList)
 				}
 			}
@@ -157,11 +158,17 @@ func partitionKeys(keys []Key) ([]*rsa.PublicKey, []*ecdsa.PublicKey, [][]byte) 
 	return rsaKeys, ecdsaKeys, hmacKeys
 }
 
-// parseClaimScopes parses the "scopes" parameter in the Claims. It supports two formats:
+// validScopeClaimKeys are the claims under which scopes may be found in a token
+var validScopeClaimKeys = []string{"scope", "scopes"}
+
+// parseClaimScopes parses the "scope" or "scopes" parameter in the Claims. It
+// supports two formats:
 //
-// * a list of string
+// * a list of strings
 //
 // * a single string with space-separated scopes (akin to OAuth2's "scope").
+//
+// An empty string is an explicit claim of no scopes.
 func parseClaimScopes(token *jwt.Token) (map[string]bool, []string, error) {
 	scopesInClaim := make(map[string]bool)
 	var scopesInClaimList []string
@@ -169,22 +176,25 @@ func parseClaimScopes(token *jwt.Token) (map[string]bool, []string, error) {
 	if !ok {
 		return nil, nil, fmt.Errorf("unsupported claims shape")
 	}
-	if claims["scopes"] != nil {
-		switch scopes := claims["scopes"].(type) {
-		case string:
-			for _, scope := range strings.Split(scopes, " ") {
-				scopesInClaim[scope] = true
-				scopesInClaimList = append(scopesInClaimList, scope)
-			}
-		case []interface{}:
-			for _, scope := range scopes {
-				if val, ok := scope.(string); ok {
-					scopesInClaim[val] = true
-					scopesInClaimList = append(scopesInClaimList, val)
+	for _, k := range validScopeClaimKeys {
+		if rawscopes, ok := claims[k]; ok && rawscopes != nil {
+			switch scopes := rawscopes.(type) {
+			case string:
+				for _, scope := range strings.Split(scopes, " ") {
+					scopesInClaim[scope] = true
+					scopesInClaimList = append(scopesInClaimList, scope)
 				}
+			case []interface{}:
+				for _, scope := range scopes {
+					if val, ok := scope.(string); ok {
+						scopesInClaim[val] = true
+						scopesInClaimList = append(scopesInClaimList, val)
+					}
+				}
+			default:
+				return nil, nil, fmt.Errorf("unsupported scope format in incoming JWT claim, was type %T", scopes)
 			}
-		default:
-			return nil, nil, fmt.Errorf("unsupported 'scopes' format in incoming JWT claim, was type %T", scopes)
+			break
 		}
 	}
 	sort.Strings(scopesInClaimList)

--- a/middleware/security/jwt/jwt_test.go
+++ b/middleware/security/jwt/jwt_test.go
@@ -93,6 +93,49 @@ var _ = Describe("Middleware", func() {
 			}
 		})
 
+		Context("and valid scopes", func() {
+
+			var ctx context.Context
+
+			BeforeEach(func() {
+				keyResolver, err := jwt.NewResolver(nil, "keyname")
+				Ω(err).ShouldNot(HaveOccurred())
+				err = keyResolver.AddKeys("mykeys", "keys")
+				Ω(err).ShouldNot(HaveOccurred())
+				middleware = jwt.New(keyResolver, nil, securityScheme)
+				ctx = goa.WithRequiredScopes(context.Background(), []string{"scope1"})
+			})
+
+			It("should accept scopes specified using the 'scope' claim", func() {
+				// HS256 {"scopes":"scope1","admin":true}, signed with "keys"
+				request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOiJzY29wZTEiLCJhZG1pbiI6dHJ1ZX0.UCvEfbD_yuS5dCZidxZgogVi2yF0ZVecMsQQbY1HJy0")
+				dispatchResult = middleware(handler)(ctx, respRecord, request)
+				Ω(dispatchResult).ShouldNot(HaveOccurred())
+			})
+
+			It("should accept scopes specified using the 'scopes' claim", func() {
+				// HS256 {"scope":"scope1","admin":true}, signed with "keys"
+				request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InNjb3BlMSIsImFkbWluIjp0cnVlfQ.EwMZtpTUPUoKsiCHqH659JQeMLf3-KdboStmQKjv2IU")
+				dispatchResult = middleware(handler)(ctx, respRecord, request)
+				Ω(dispatchResult).ShouldNot(HaveOccurred())
+			})
+
+			It("should fall back to 'scopes' if 'scope' is null", func() {
+				// HS256 {"scope":null, "scopes":"scope1", "admin":true}, signed with "keys"
+				request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6bnVsbCwic2NvcGVzIjoic2NvcGUxIiwiYWRtaW4iOnRydWV9.h8L_MlWWyB0RnwaUBDVu8nGPn5wPSVPMEm42iH8Jxmg")
+				dispatchResult = middleware(handler)(ctx, respRecord, request)
+				Ω(dispatchResult).ShouldNot(HaveOccurred())
+			})
+
+			It("should not fall back to 'scopes' if 'scope' is an empty string", func() {
+				// HS256 {"scope":"", "scopes":"scope1", "admin":true}, signed with "keys"
+				request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6IiIsInNjb3BlcyI6InNjb3BlMSIsImFkbWluIjp0cnVlfQ.U5r-gAvk8SWRYBK3Hmj7zqHSQ0lSQO1wAAk0soyHkoU")
+				dispatchResult = middleware(handler)(ctx, respRecord, request)
+				Ω(dispatchResult).Should(HaveOccurred())
+			})
+
+		})
+
 		Context("and a malformed request", func() {
 			BeforeEach(func() {
 				key := []byte("keys")

--- a/middleware/security/jwt/jwt_test.go
+++ b/middleware/security/jwt/jwt_test.go
@@ -107,15 +107,15 @@ var _ = Describe("Middleware", func() {
 			})
 
 			It("should accept scopes specified using the 'scope' claim", func() {
-				// HS256 {"scopes":"scope1","admin":true}, signed with "keys"
-				request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOiJzY29wZTEiLCJhZG1pbiI6dHJ1ZX0.UCvEfbD_yuS5dCZidxZgogVi2yF0ZVecMsQQbY1HJy0")
+				// HS256 {"scope":"scope1","admin":true}, signed with "keys"
+				request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InNjb3BlMSIsImFkbWluIjp0cnVlfQ.EwMZtpTUPUoKsiCHqH659JQeMLf3-KdboStmQKjv2IU")
 				dispatchResult = middleware(handler)(ctx, respRecord, request)
 				Ω(dispatchResult).ShouldNot(HaveOccurred())
 			})
 
 			It("should accept scopes specified using the 'scopes' claim", func() {
-				// HS256 {"scope":"scope1","admin":true}, signed with "keys"
-				request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InNjb3BlMSIsImFkbWluIjp0cnVlfQ.EwMZtpTUPUoKsiCHqH659JQeMLf3-KdboStmQKjv2IU")
+				// HS256 {"scopes":"scope1","admin":true}, signed with "keys"
+				request.Header.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZXMiOiJzY29wZTEiLCJhZG1pbiI6dHJ1ZX0.UCvEfbD_yuS5dCZidxZgogVi2yF0ZVecMsQQbY1HJy0")
 				dispatchResult = middleware(handler)(ctx, respRecord, request)
 				Ω(dispatchResult).ShouldNot(HaveOccurred())
 			})


### PR DESCRIPTION
This fixes #1398 and #1228.