### PR TITLE
Append a newline to the errors from goa

### DIFF
--- a/cmd/goa/main.go
+++ b/cmd/goa/main.go
@@ -99,7 +99,7 @@ func generate(cmd, path, output string, debug bool) {
 	fmt.Println(strings.Join(files, "\n"))
 	return
 fail:
-	fmt.Fprint(os.Stderr, err.Error())
+	fmt.Fprintln(os.Stderr, err.Error())
 	if !debug && tmp != nil {
 		tmp.Remove()
 	}


### PR DESCRIPTION
Now `goa` prints an error without a newline. The next prompt is printed to the same line like below.

```console
$ goa gen adder
no buildable Go source files in adder  $ 
```

This patch append a newline to the errors from `goa`.

```console
$ goa gen adder
no buildable Go source files in adder
$ 
```