### PR TITLE
Don't delete .svn directories

### DIFF
--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -79,8 +79,9 @@ func (g *Generator) Generate() (_ []string, err error) {
 
 	codegen.Reserved[g.Target] = true
 
-	os.RemoveAll(g.OutDir)
-
+	if err := utils.RemoveFiles(g.OutDir); err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(g.OutDir, 0755); err != nil {
 		return nil, err
 	}

--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -12,12 +12,11 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/utils"
 )
 
 func makeTestDir(g *Generator, apiName string) (outDir string, err error) {
 	outDir = filepath.Join(g.OutDir, "test")
-	if err = utils.RemoveFiles(outDir); err != nil {
+	if err = os.RemoveAll(outDir); err != nil {
 		return
 	}
 	if err = os.MkdirAll(outDir, 0755); err != nil {

--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
+	"github.com/goadesign/goa/goagen/utils"
 )
 
 func makeTestDir(g *Generator, apiName string) (outDir string, err error) {
 	outDir = filepath.Join(g.OutDir, "test")
-	if err = os.RemoveAll(outDir); err != nil {
+	if err = utils.RemoveFiles(outDir); err != nil {
 		return
 	}
 	if err = os.MkdirAll(outDir, 0755); err != nil {

--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -17,7 +17,7 @@ import (
 
 func makeTestDir(g *Generator, apiName string) (outDir string, err error) {
 	outDir = filepath.Join(g.OutDir, "test")
-	if err = utils.RemoveFiles(g.OutDir); err != nil {
+	if err = utils.RemoveFiles(outDir); err != nil {
 		return
 	}
 	if err = os.MkdirAll(outDir, 0755); err != nil {

--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -12,11 +12,12 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
+	"github.com/goadesign/goa/goagen/utils"
 )
 
 func makeTestDir(g *Generator, apiName string) (outDir string, err error) {
 	outDir = filepath.Join(g.OutDir, "test")
-	if err = os.RemoveAll(outDir); err != nil {
+	if err = utils.RemoveFiles(g.OutDir); err != nil {
 		return
 	}
 	if err = os.MkdirAll(outDir, 0755); err != nil {

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -119,7 +119,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 			}
 
 			cliDir = filepath.Join(g.OutDir, g.ToolDirName, "cli")
-			if err = os.RemoveAll(cliDir); err != nil {
+			if err = utils.RemoveFiles(cliDir); err != nil {
 				return
 			}
 			if err = os.MkdirAll(cliDir, 0755); err != nil {
@@ -128,7 +128,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 		}
 
 		pkgDir = filepath.Join(g.OutDir, g.Target)
-		if err = os.RemoveAll(pkgDir); err != nil {
+		if err = utils.RemoveFiles(pkgDir); err != nil {
 			return
 		}
 		if err = os.MkdirAll(pkgDir, 0755); err != nil {

--- a/goagen/gen_js/generator.go
+++ b/goagen/gen_js/generator.go
@@ -99,7 +99,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 	}
 
 	g.OutDir = filepath.Join(g.OutDir, "js")
-	if err := os.RemoveAll(g.OutDir); err != nil {
+	if err := utils.RemoveFiles(g.OutDir); err != nil {
 		return nil, err
 	}
 	if err := os.MkdirAll(g.OutDir, 0755); err != nil {

--- a/goagen/gen_schema/generator.go
+++ b/goagen/gen_schema/generator.go
@@ -69,7 +69,9 @@ func (g *Generator) Generate() (_ []string, err error) {
 	}
 
 	g.OutDir = filepath.Join(g.OutDir, "schema")
-	os.RemoveAll(g.OutDir)
+	if err := utils.RemoveFiles(g.OutDir); err != nil {
+		return nil, err
+	}
 	os.MkdirAll(g.OutDir, 0755)
 	g.genfiles = append(g.genfiles, g.OutDir)
 	schemaFile := filepath.Join(g.OutDir, "schema.json")

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -80,7 +80,9 @@ func (g *Generator) Generate() (_ []string, err error) {
 	}
 
 	swaggerDir := filepath.Join(g.OutDir, "swagger")
-	os.RemoveAll(swaggerDir)
+	if err := utils.RemoveFiles(swaggerDir); err != nil {
+		return nil, err
+	}
 	if err = os.MkdirAll(swaggerDir, 0755); err != nil {
 		return nil, err
 	}

--- a/goagen/utils/files.go
+++ b/goagen/utils/files.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+// RemoveFiles deletes all files in given directory, except those directories on ignore list.
+func RemoveFiles(dir string) (err error) {
+
+	dirContents, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, fileOrDir := range dirContents {
+		fileOrDirFullPath := dir + string(os.PathSeparator) + fileOrDir.Name()
+		if fileOrDir.IsDir() {
+			if allowDeleteDir(fileOrDir.Name()) {
+				err = RemoveFiles(fileOrDirFullPath)
+			}
+		} else {
+			err = os.Remove(fileOrDirFullPath)
+		}
+	}
+
+	return err
+}
+
+// Check if directory can be deleted.
+func allowDeleteDir(dir string) bool {
+	allowed := true
+
+	switch {
+	case dir == ".svn":
+		allowed = false
+		// Here add cases for other directories, which contents should not be deleted.
+	}
+
+	return allowed
+}

--- a/goagen/utils/files_test.go
+++ b/goagen/utils/files_test.go
@@ -7,8 +7,6 @@ import (
 	"time"
 )
 
-var sep = string(os.PathSeparator)
-
 // Test RemoveFiles. Creates new directories and files in temp directory.
 // Expects that RemoveFiles delete only files, and leaving directory structure intact.
 // Files from .svn directory should not be deleted.
@@ -19,20 +17,20 @@ func TestRemoveFiles(t *testing.T) {
 	currentDir := testDir
 	createDir(currentDir, t)
 
-	currentDir = testDir + sep + "app"
+	currentDir = filepath.Join(testDir, "app")
 	createDir(currentDir, t)
 	createFile(currentDir, "app_file.go", t)
 
-	currentDir += sep + "test"
+	currentDir = filepath.Join(currentDir, "test")
 	createDir(currentDir, t)
 	createFile(currentDir, "bookings_testing.go", t)
 
-	currentDir = testDir + sep + "client"
+	currentDir = filepath.Join(testDir, "client")
 	createDir(currentDir, t)
 	createFile(currentDir, "bookings.go", t)
 
 	// Add .svn ignore directory, which is not allowed to be deleted.
-	currentDir = testDir + sep + "client" + sep + ".svn"
+	currentDir = filepath.Join(testDir, "client", ".svn")
 	createDir(currentDir, t)
 	createFile(currentDir, "all-wcprops", t)
 
@@ -42,19 +40,19 @@ func TestRemoveFiles(t *testing.T) {
 	}
 
 	// Check if directories were deleted.
-	if !exists(testDir+sep+"app") || !exists(testDir+sep+"app"+sep+"test") || !exists(testDir+sep+"client") {
+	if !exists(filepath.Join(testDir, "app")) || !exists(filepath.Join(testDir, "app", "test")) || !exists(filepath.Join(testDir, "client")) {
 		t.Fatalf("Directories where deleted, expected to be not deleted.")
 	}
 
 	// Check if files were deleted.
-	if exists(testDir+sep+"app"+sep+"app_file.go") ||
-		exists(testDir+sep+"app"+sep+"test"+sep+"bookings_testing.go") ||
-		exists(testDir+sep+"app"+sep+"test"+sep+"bookings") {
+	if exists(filepath.Join(testDir, "app", "app_file.go")) ||
+		exists(filepath.Join(testDir, "app", "test", "bookings_testing.go")) ||
+		exists(filepath.Join(testDir, "app", "test", "bookings")) {
 		t.Fatalf("Files where not deleted, expected to be deleted.")
 	}
 
 	// Check if .svn directory was deleted.
-	if !exists(testDir + sep + "client" + sep + ".svn" + sep + "all-wcprops") {
+	if !exists(filepath.Join(testDir, "client", ".svn", "all-wcprops")) {
 		t.Fatalf("File in .svn folder was deleted, expected to be not deleted.")
 	}
 
@@ -69,7 +67,7 @@ func createDir(d string, t *testing.T) {
 }
 
 func createFile(d, f string, t *testing.T) {
-	file, err := os.OpenFile(d+sep+f, os.O_RDONLY|os.O_CREATE, 0666)
+	file, err := os.OpenFile(filepath.Join(d, f), os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
 		t.Fatalf("Can't create temp file " + d)
 	}

--- a/goagen/utils/files_test.go
+++ b/goagen/utils/files_test.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+var sep = string(os.PathSeparator)
+
+// Test RemoveFiles. Creates new directories and files in temp directory.
+// Expects that RemoveFiles delete only files, and leaving directory structure intact.
+// Files from .svn directory should not be deleted.
+func TestRemoveFiles(t *testing.T) {
+
+	//Creating temp directory. When error occures, temp directory would remain, for visual check.
+	testDir := filepath.Join(".", time.Now().Format("20060102150405"))
+	currentDir := testDir
+	createDir(currentDir, t)
+
+	currentDir = testDir + sep + "app"
+	createDir(currentDir, t)
+	createFile(currentDir, "app_file.go", t)
+
+	currentDir += sep + "test"
+	createDir(currentDir, t)
+	createFile(currentDir, "bookings_testing.go", t)
+
+	currentDir = testDir + sep + "client"
+	createDir(currentDir, t)
+	createFile(currentDir, "bookings.go", t)
+
+	// Add .svn ignore directory, which is not allowed to be deleted.
+	currentDir = testDir + sep + "client" + sep + ".svn"
+	createDir(currentDir, t)
+	createFile(currentDir, "all-wcprops", t)
+
+	// Call function RemoveFiles to be tested.
+	if err := RemoveFiles(testDir); err != nil {
+		t.Fatalf("Error when calling RemoveFiles %s", err)
+	}
+
+	// Check if directories were deleted.
+	if !exists(testDir+sep+"app") || !exists(testDir+sep+"app"+sep+"test") || !exists(testDir+sep+"client") {
+		t.Fatalf("Directories where deleted, expected to be not deleted.")
+	}
+
+	// Check if files were deleted.
+	if exists(testDir+sep+"app"+sep+"app_file.go") ||
+		exists(testDir+sep+"app"+sep+"test"+sep+"bookings_testing.go") ||
+		exists(testDir+sep+"app"+sep+"test"+sep+"bookings") {
+		t.Fatalf("Files where not deleted, expected to be deleted.")
+	}
+
+	// Check if .svn directory was deleted.
+	if !exists(testDir + sep + "client" + sep + ".svn" + sep + "all-wcprops") {
+		t.Fatalf("File in .svn folder was deleted, expected to be not deleted.")
+	}
+
+	// Delete temp directory only when no error occured.
+	os.RemoveAll(testDir)
+}
+
+func createDir(d string, t *testing.T) {
+	if err := os.MkdirAll(d, os.ModePerm); err != nil {
+		t.Fatalf("Can't create temp directory " + d)
+	}
+}
+
+func createFile(d, f string, t *testing.T) {
+	file, err := os.OpenFile(d+sep+f, os.O_RDONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("Can't create temp file " + d)
+	}
+	file.Close()
+}
+
+func exists(f string) bool {
+	if _, err := os.Stat(f); err == nil {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
As described in #1454, goagen is not simply deleting all files and directories, but leaving directories and deleting only files. Files in .svn files are not deleted. In function allowDeleteDir is possible to add other directories, from which files should not be deleted.