### PR TITLE
Update help for Description function

### DIFF
--- a/design/apidsl/api.go
+++ b/design/apidsl/api.go
@@ -99,7 +99,7 @@ func Version(ver string) {
 	}
 }
 
-// Description can be used in: API, Resource, Action, or MediaType
+// Description can be used in: API, Resource, Action, MediaType, Attribute, Response or ResponseTemplate
 //
 // Description sets the definition description.
 func Description(d string) {


### PR DESCRIPTION
Description can be added to almost anything (not sure how to describe secirity, docs and fileserver definitians)

Actually when I tried to open generated swagger in the online swagger editor (https://editor.swagger.io/) it complained that Response should have Description. And it was not mentioned in the docs that Description can be inside ResponseTemplate yet it indeed worked so I decided this help should be updated. :)