### PR TITLE
fix xray.WrapDoer to update segment in the context

### DIFF
--- a/middleware/xray/wrap_doer.go
+++ b/middleware/xray/wrap_doer.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/goadesign/goa/client"
+	"github.com/goadesign/goa/middleware"
 )
 
 // wrapDoer is a client.Doer middleware that will create xray subsegments for traced requests.
@@ -29,6 +30,10 @@ func (r *wrapDoer) Do(ctx context.Context, req *http.Request) (*http.Response, e
 
 	sub := s.NewSubsegment(req.URL.Host)
 	defer sub.Close()
+
+	// update the context with the latest segment
+	ctx = middleware.WithTrace(ctx, sub.TraceID, sub.ID, sub.ParentID)
+	ctx = WithSegment(ctx, sub)
 
 	sub.RecordRequest(req, "remote")
 

--- a/middleware/xray/wrap_doer_test.go
+++ b/middleware/xray/wrap_doer_test.go
@@ -52,7 +52,7 @@ func TestWrapDoer(t *testing.T) {
 
 		doer.Expect("Do", func(c context.Context, r *http.Request) (*http.Response, error) {
 			Expect(r).To(Equal(req))
-			Expect(c).To(Equal(ctx))
+			Expect(ContextSegment(c).ParentID).To(Equal(segment.ID))
 			return &http.Response{StatusCode: 123}, nil
 		})
 
@@ -97,7 +97,8 @@ func TestWrapDoer(t *testing.T) {
 		var (
 			requestErr = errors.New("some request error")
 		)
-		doer.Expect("Do", func(context.Context, *http.Request) (*http.Response, error) {
+		doer.Expect("Do", func(c context.Context, r *http.Request) (*http.Response, error) {
+			Expect(ContextSegment(c).ParentID).To(Equal(segment.ID))
 			return nil, requestErr
 		})
 


### PR DESCRIPTION
This way, the `middleware.TraceDoer` will include the latest span ID in the headers of the outgoing request.

Otherwise, the X-Ray service map would misrepresent a single request from A to B as two outgoing requests:
- `A` -> `B(client-side span)`
- `A` -> `B`

Now the service map will represent the single request as:
- `A` -> `B`