### PR TITLE
Fix code generation when error response defined in service-level

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -212,6 +212,14 @@ func (d ServicesData) analyze(service *design.ServiceExpr) *Data {
 				}
 			}
 		}
+		for _, er := range service.Errors {
+			errTypes = append(errTypes, collectTypes(er.AttributeExpr, seen, scope, false)...)
+			if _, ok := seenErrors[er.Name]; ok {
+				continue
+			}
+			seenErrors[er.Name] = struct{}{}
+			errorInits = append(errorInits, buildErrorInitData(er, scope))
+		}
 	}
 
 	var (

--- a/design/method.go
+++ b/design/method.go
@@ -31,7 +31,7 @@ type (
 )
 
 // Error returns the error with the given name. It looks up recursively in the
-// enpoint then the service and finally the root expression.
+// endpoint then the service and finally the root expression.
 func (m *MethodExpr) Error(name string) *ErrorExpr {
 	for _, err := range m.Errors {
 		if err.Name == name {

--- a/http/codegen/server_error_encoder_test.go
+++ b/http/codegen/server_error_encoder_test.go
@@ -16,6 +16,7 @@ func TestEncodeError(t *testing.T) {
 	}{
 		{"primitive-error-response", testdata.PrimitiveErrorResponseDSL, testdata.PrimitiveErrorResponseEncoderCode},
 		{"default-error-response", testdata.DefaultErrorResponseDSL, testdata.DefaultErrorResponseEncoderCode},
+		{"service-error-response", testdata.ServiceErrorResponseDSL, testdata.ServiceErrorResponseEncoderCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/testdata/error_encoder_code.go
+++ b/http/codegen/testdata/error_encoder_code.go
@@ -49,3 +49,33 @@ func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.Re
 	}
 }
 `
+
+var ServiceErrorResponseEncoderCode = `// EncodeMethodServiceErrorResponseError returns an encoder for errors returned
+// by the MethodServiceErrorResponse ServiceServiceErrorResponse endpoint.
+func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) {
+	encodeError := goahttp.ErrorEncoder(encoder)
+	return func(ctx context.Context, w http.ResponseWriter, v error) {
+		switch res := v.(type) {
+		case *serviceserviceerrorresponse.Error:
+			if res.Code == "internal_error" {
+				enc := encoder(ctx, w)
+				body := NewMethodServiceErrorResponseInternalErrorResponseBody(res)
+				w.WriteHeader(http.StatusInternalServerError)
+				if err := enc.Encode(body); err != nil {
+					encodeError(ctx, w, err)
+				}
+			}
+			if res.Code == "bad_request" {
+				enc := encoder(ctx, w)
+				body := NewMethodServiceErrorResponseBadRequestResponseBody(res)
+				w.WriteHeader(http.StatusBadRequest)
+				if err := enc.Encode(body); err != nil {
+					encodeError(ctx, w, err)
+				}
+			}
+		default:
+			encodeError(ctx, w, v)
+		}
+	}
+}
+`

--- a/http/codegen/testdata/error_response_dsls.go
+++ b/http/codegen/testdata/error_response_dsls.go
@@ -30,3 +30,19 @@ var PrimitiveErrorResponseDSL = func() {
 		})
 	})
 }
+
+var ServiceErrorResponseDSL = func() {
+	Service("ServiceServiceErrorResponse", func() {
+		Error("bad_request")
+		HTTP(func() {
+			Response("bad_request", StatusBadRequest)
+		})
+		Method("MethodServiceErrorResponse", func() {
+			Error("internal_error")
+			HTTP(func() {
+				GET("/one/two")
+				Response("internal_error", StatusInternalServerError)
+			})
+		})
+	})
+}

--- a/http/design/endpoint.go
+++ b/http/design/endpoint.go
@@ -554,19 +554,17 @@ func (e *EndpointExpr) Finalize() {
 		}
 	}
 
-	// Make sure error types are user types and have a body.
-	for _, herr := range e.HTTPErrors {
-		herr.Finalize(e)
-	}
-
 	// Inherit HTTP errors from service and root
 	for _, r := range e.Service.HTTPErrors {
-		r.Finalize(e)
 		e.HTTPErrors = append(e.HTTPErrors, r.Dup())
 	}
 	for _, r := range Root.HTTPErrors {
-		r.Finalize(e)
 		e.HTTPErrors = append(e.HTTPErrors, r.Dup())
+	}
+
+	// Make sure all error types are user types and have a body.
+	for _, herr := range e.HTTPErrors {
+		herr.Finalize(e)
 	}
 }
 

--- a/http/design/endpoint.go
+++ b/http/design/endpoint.go
@@ -554,17 +554,19 @@ func (e *EndpointExpr) Finalize() {
 		}
 	}
 
+	// Make sure error types are user types and have a body.
+	for _, herr := range e.HTTPErrors {
+		herr.Finalize(e)
+	}
+
 	// Inherit HTTP errors from service and root
 	for _, r := range e.Service.HTTPErrors {
+		r.Finalize(e)
 		e.HTTPErrors = append(e.HTTPErrors, r.Dup())
 	}
 	for _, r := range Root.HTTPErrors {
+		r.Finalize(e)
 		e.HTTPErrors = append(e.HTTPErrors, r.Dup())
-	}
-
-	// Make sure all error types are user types and have a body.
-	for _, herr := range e.HTTPErrors {
-		herr.Finalize(e)
 	}
 }
 

--- a/http/design/response.go
+++ b/http/design/response.go
@@ -147,7 +147,7 @@ func (r *HTTPResponseExpr) Finalize(a *EndpointExpr, svcAtt *design.AttributeExp
 
 	// Initialize the headers with the corresponding result attributes.
 	svcObj := design.AsObject(svcAtt.Type)
-	if r.headers != nil {
+	if r.Headers() != nil {
 		for _, nat := range *design.AsObject(r.headers.Type) {
 			n := nat.Name
 			att := nat.Attribute

--- a/http/design/response.go
+++ b/http/design/response.go
@@ -147,7 +147,7 @@ func (r *HTTPResponseExpr) Finalize(a *EndpointExpr, svcAtt *design.AttributeExp
 
 	// Initialize the headers with the corresponding result attributes.
 	svcObj := design.AsObject(svcAtt.Type)
-	if r.Headers() != nil {
+	if r.headers != nil {
 		for _, nat := range *design.AsObject(r.headers.Type) {
 			n := nat.Name
 			att := nat.Attribute
@@ -202,15 +202,20 @@ func (r *HTTPResponseExpr) Finalize(a *EndpointExpr, svcAtt *design.AttributeExp
 
 // Dup creates a copy of the response expression.
 func (r *HTTPResponseExpr) Dup() *HTTPResponseExpr {
-	return &HTTPResponseExpr{
+	res := HTTPResponseExpr{
 		StatusCode:  r.StatusCode,
 		Description: r.Description,
-		Body:        design.DupAtt(r.Body),
 		ContentType: r.ContentType,
 		Parent:      r.Parent,
 		Metadata:    r.Metadata,
-		headers:     design.DupAtt(r.headers),
 	}
+	if r.Body != nil {
+		res.Body = design.DupAtt(r.Body)
+	}
+	if r.headers != nil {
+		res.headers = design.DupAtt(r.headers)
+	}
+	return &res
 }
 
 // bodyAllowedForStatus reports whether a given response status code

--- a/http/dsl/response.go
+++ b/http/dsl/response.go
@@ -298,7 +298,7 @@ func parseResponseArgs(val interface{}, args ...interface{}) (code int, fn func(
 
 func httpError(n string, p eval.Expression, args ...interface{}) *httpdesign.ErrorExpr {
 	if len(args) == 0 {
-		eval.ReportError("not enough arguments, use Error(name, status), Error(name, status, func()) or Error(name, func())")
+		eval.ReportError("not enough arguments, use Response(name, status), Response(name, status, func()) or Response(name, func())")
 		return nil
 	}
 	var (


### PR DESCRIPTION
* Fixes an issue where the error struct is not initialized in `service.go` if `Error` is defined at the service level (#1526)
* Fixes segfault when error response is defined at the service level (#1527)