### PR TITLE
Fix the condition to get schemes in APIExpr

### DIFF
--- a/design/api.go
+++ b/design/api.go
@@ -86,7 +86,7 @@ type (
 func (a *APIExpr) Schemes() []string {
 	schemes := make(map[string]bool)
 	for _, s := range a.Servers {
-		if u, err := url.Parse(s.URL); err != nil {
+		if u, err := url.Parse(s.URL); err == nil && u.Scheme != "" {
 			schemes[u.Scheme] = true
 		}
 	}

--- a/design/api_test.go
+++ b/design/api_test.go
@@ -1,0 +1,28 @@
+package design
+
+import (
+	"testing"
+)
+
+func TestAPIExprSchemes(t *testing.T) {
+	cases := map[string]struct {
+		expr     APIExpr
+		expected []string
+	}{
+		"default scheme":   {expr: APIExpr{Servers: []*ServerExpr{&ServerExpr{}}}, expected: []string{"http"}},
+		"single scheme":    {expr: APIExpr{Servers: []*ServerExpr{&ServerExpr{URL: "http://example.com"}}}, expected: []string{"http"}},
+		"multiple schemes": {expr: APIExpr{Servers: []*ServerExpr{&ServerExpr{URL: "http://example.com"}, &ServerExpr{URL: "https://example.net"}}}, expected: []string{"http", "https"}},
+	}
+
+	for k, tc := range cases {
+		if actual := tc.expr.Schemes(); len(tc.expected) != len(actual) {
+			t.Errorf("%s: expected the number of scheme values to match %d got %d ", k, len(tc.expected), len(actual))
+		} else {
+			for i, v := range actual {
+				if v != tc.expected[i] {
+					t.Errorf("%s: got %#v, expected %#v at index %d", k, v, tc.expected[i], i)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
It should get only schemes which can be parsed and not empty.