### PR TITLE
Remove the unused valiable

### DIFF
--- a/goagen/gen_app/test_generator.go
+++ b/goagen/gen_app/test_generator.go
@@ -369,9 +369,9 @@ func {{ $test.Name }}(t goatest.TInterface, ctx context.Context, service *goa.Se
 	// Setup service
 	var (
 		{{ $logBuf := $test.Escape "logBuf" }}{{ $logBuf }} bytes.Buffer
-		{{ $resp := $test.Escape "resp" }}{{ $resp }}   interface{}
+		{{ $resp := $test.Escape "resp" }}{{ if $test.ReturnType }}{{ $resp }}   interface{}{{ end }}
 
-		{{ $respSetter := $test.Escape "respSetter" }}{{ $respSetter }} goatest.ResponseSetterFunc = func(r interface{}) { {{ $resp }} = r }
+		{{ $respSetter := $test.Escape "respSetter" }}{{ $respSetter }} goatest.ResponseSetterFunc = func(r interface{}) { {{ if $test.ReturnType }}{{ $resp }} = r{{ end }} }
 	)
 	if service == nil {
 		service = goatest.Service(&{{ $logBuf }}, {{ $respSetter }})


### PR DESCRIPTION
Go version 1.10,  `go vet` command strictly detects not used variables in tests as follows:

```
$ go vet ./app/test/
# cellar/app/test
app/test/bottle_testing.go:36:3: resp declared but not used
```
```go
func ShowBottleNotFound(t goatest.TInterface, ctx context.Context, service *goa.Service, ctrl app.BottleController, bottleID interface{}) http.ResponseWriter {
        // Setup service
        var (
                logBuf bytes.Buffer
                resp   interface{} // ← ★

                respSetter goatest.ResponseSetterFunc = func(r interface{}) { resp = r }
```

This patch fix it to generate it only when the `resp` is used.