### PR TITLE
Avoid setting empty view metadata on attributes when building views

### DIFF
--- a/design/attribute.go
+++ b/design/attribute.go
@@ -179,7 +179,7 @@ func (a *AttributeExpr) Validate(ctx string, parent eval.Expression) *eval.Valid
 	if views, ok := a.Metadata["view"]; ok {
 		rt, ok := a.Type.(*ResultTypeExpr)
 		if !ok {
-			verr.Add(parent, "%sdefines a view but is not a result type", ctx)
+			verr.Add(parent, "%sdefines a view %v but is not a result type", ctx, views)
 		}
 		if rt != nil {
 			found := false

--- a/dsl/result_type.go
+++ b/dsl/result_type.go
@@ -440,7 +440,9 @@ func buildView(name string, mt *design.ResultTypeExpr, at *design.AttributeExpr)
 			if dup.Metadata == nil {
 				dup.Metadata = make(map[string][]string)
 			}
-			dup.Metadata["view"] = cat.Metadata["view"]
+			if len(cat.Metadata["view"]) > 0 {
+				dup.Metadata["view"] = cat.Metadata["view"]
+			}
 			o.Set(n, dup)
 		} else if n != "links" {
 			return nil, fmt.Errorf("unknown attribute %#v", n)


### PR DESCRIPTION
This is so that checks that merely check for the presence of the metadata rather than whether the value is empty don't end up returning true.

Fixes #1554