### PR TITLE
Fix new go vet cancel function context leak issue

### DIFF
--- a/examples/calc/cmd/calcsvc/main.go
+++ b/examples/calc/cmd/calcsvc/main.go
@@ -130,7 +130,8 @@ func main() {
 	logger.Printf("exiting (%v)", <-errc)
 
 	// Shutdown gracefully with a 30s timeout.
-	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	srv.Shutdown(ctx)
 
 	logger.Println("exited")

--- a/examples/cellar/cmd/cellarsvc/main.go
+++ b/examples/cellar/cmd/cellarsvc/main.go
@@ -161,7 +161,8 @@ func main() {
 	logger.Printf("exiting (%v)", <-errc)
 
 	// Shutdown gracefully with a 30s timeout.
-	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	srv.Shutdown(ctx)
 
 	logger.Println("exited")

--- a/examples/tracing/cmd/calcsvc/main.go
+++ b/examples/tracing/cmd/calcsvc/main.go
@@ -140,7 +140,8 @@ func main() {
 	logger.Printf("exiting (%v)", <-errc)
 
 	// Shutdown gracefully with a 30s timeout.
-	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	srv.Shutdown(ctx)
 
 	logger.Println("exited")

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -309,7 +309,8 @@ const mainT = `func main() {
 	logger.Printf("exiting (%v)", <-errc)
 
 	// Shutdown gracefully with a 30s timeout.
-	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 	srv.Shutdown(ctx)
 
 	logger.Println("exited")


### PR DESCRIPTION
- With Go 1.10 there is now a `go vet` error on the generated and
  example server commands: `the cancel function returned by
  context.WithTimeout should be called, not discarded, to avoid a context
  leak`