### PR TITLE
validate different wildcards only if request method is the same

### DIFF
--- a/design/validation.go
+++ b/design/validation.go
@@ -121,6 +121,9 @@ func (a *APIDefinition) Validate() error {
 			if route == other {
 				continue
 			}
+			if route.Route.Verb != other.Route.Verb {
+				continue
+			}
 			if strings.HasPrefix(route.Key, other.Key) {
 				diffs := route.DifferentWildcards(other)
 				if len(diffs) > 0 {

--- a/design/validation.go
+++ b/design/validation.go
@@ -116,8 +116,39 @@ func (a *APIDefinition) Validate() error {
 		})
 		return nil
 	})
-	for _, route := range allRoutes {
-		for _, other := range allRoutes {
+
+	a.validateRoutes(verr, allRoutes)
+
+	a.IterateMediaTypes(func(mt *MediaTypeDefinition) error {
+		verr.Merge(mt.Validate())
+		return nil
+	})
+	a.IterateUserTypes(func(t *UserTypeDefinition) error {
+		verr.Merge(t.Validate("", a))
+		return nil
+	})
+	a.IterateResponses(func(r *ResponseDefinition) error {
+		verr.Merge(r.Validate())
+		return nil
+	})
+	for _, dec := range a.Consumes {
+		verr.Merge(dec.Validate())
+	}
+	for _, enc := range a.Produces {
+		verr.Merge(enc.Validate())
+	}
+
+	err := verr.AsError()
+	if err == nil {
+		// *ValidationErrors(nil) != error(nil)
+		return nil
+	}
+	return err
+}
+
+func (a *APIDefinition) validateRoutes(verr *dslengine.ValidationErrors, routes []*routeInfo) {
+	for _, route := range routes {
+		for _, other := range routes {
 			if route == other {
 				continue
 			}
@@ -145,31 +176,6 @@ func (a *APIDefinition) Validate() error {
 			}
 		}
 	}
-	a.IterateMediaTypes(func(mt *MediaTypeDefinition) error {
-		verr.Merge(mt.Validate())
-		return nil
-	})
-	a.IterateUserTypes(func(t *UserTypeDefinition) error {
-		verr.Merge(t.Validate("", a))
-		return nil
-	})
-	a.IterateResponses(func(r *ResponseDefinition) error {
-		verr.Merge(r.Validate())
-		return nil
-	})
-	for _, dec := range a.Consumes {
-		verr.Merge(dec.Validate())
-	}
-	for _, enc := range a.Produces {
-		verr.Merge(enc.Validate())
-	}
-
-	err := verr.AsError()
-	if err == nil {
-		// *ValidationErrors(nil) != error(nil)
-		return nil
-	}
-	return err
 }
 
 func (a *APIDefinition) validateContact(verr *dslengine.ValidationErrors) {

--- a/design/validation_test.go
+++ b/design/validation_test.go
@@ -293,6 +293,25 @@ var _ = Describe("Validation", func() {
 		})
 	})
 
+	Context("actions with different http methods", func() {
+		It("should be valid because methods are different", func() {
+			dslengine.Reset()
+
+			Resource("one", func() {
+				Action("first", func() {
+					Routing(GET("/:first"))
+				})
+				Action("second", func() {
+					Routing(DELETE("/:second"))
+				})
+			})
+
+			dslengine.Run()
+
+			Ω(dslengine.Errors).ShouldNot(HaveOccurred())
+		})
+	})
+
 	Describe("EncoderDefinition", func() {
 		var (
 			enc           *EncodingDefinition


### PR DESCRIPTION
Hi. I noticed that goa design doesn't allow to use different wildcards at the same position for different methods. It's reasonable only if we check wildcard positions in URLs with the same HTTP method. But it's not reasonable to make this check if http methods are different.
My error was:
```
resource "decisions" action "list": route "/api/v1/decisions/:entity/:entityID/" conflicts with route "/api/v1/decisions/:decisionID" of decisions action delete. Make sure wildcards at the same positions have the same name. Conflicting wildcards are "entity" from route GET "/:entity/:entityID/" of resource "decisions" action "list" and "decisionID" from route DELETE "/:decisionID" of resource "decisions" action "delete".
```
So `DELETE "/:decisionID" ` was conflicting with `GET "/:entity/:entityID/"` but there are no really possible conflicts because http methods are different and mux can handle both without any problem.

I made a patch and tested it, works just fine.