### PR TITLE
Prevent Any fields from pointing to *interface{}

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1033,9 +1033,23 @@ func (a *AttributeDefinition) IsPrimitivePointer(attName string) bool {
 		return false
 	}
 	if att.Type.IsPrimitive() {
-		return !a.IsRequired(attName) && !a.HasDefaultValue(attName) && !a.IsNonZero(attName)
+		return !a.IsRequired(attName) && !a.HasDefaultValue(attName) && !a.IsNonZero(attName) && !a.IsInterface(attName)
 	}
 	return false
+}
+
+// IsInterface returns true if the field generated for the given attribute has
+// an interface type that should not be referenced as a "*interface{}" pointer.
+// The target attribute must be an object.
+func (a *AttributeDefinition) IsInterface(attName string) bool {
+	if !a.Type.IsObject() {
+		panic("checking pointer field on non-object") // bug
+	}
+	att := a.Type.ToObject()[attName]
+	if att == nil {
+		return false
+	}
+	return att.Type.Kind() == AnyKind
 }
 
 // SetExample sets the custom example. SetExample also handles the case when the user doesn't

--- a/goagen/codegen/publicizer.go
+++ b/goagen/codegen/publicizer.go
@@ -57,7 +57,7 @@ func RecursivePublicizer(att *design.AttributeDefinition, source, target string,
 				catt,
 				fmt.Sprintf("%s.%s", source, Goify(n, true)),
 				fmt.Sprintf("%s.%s", target, Goify(n, true)),
-				catt.Type.IsPrimitive() && !att.IsPrimitivePointer(n),
+				catt.Type.IsPrimitive() && !att.IsPrimitivePointer(n) && !att.IsInterface(n),
 				depth+1,
 				false,
 			)

--- a/goagen/codegen/publicizer_test.go
+++ b/goagen/codegen/publicizer_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/goadesign/goa/design"
+	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -37,6 +38,11 @@ var _ = Describe("Struct publicize code generation", func() {
 				att = &design.AttributeDefinition{
 					Type: design.Object{
 						"foo": &design.AttributeDefinition{Type: design.String},
+						"bar": &design.AttributeDefinition{Type: design.Any},
+						"baz": &design.AttributeDefinition{Type: design.Any},
+					},
+					Validation: &dslengine.ValidationDefinition{
+						Required: []string{"bar"},
 					},
 				}
 				sourceField = "source"
@@ -171,8 +177,16 @@ var _ = Describe("Struct publicize code generation", func() {
 
 const (
 	objectPublicizeCode = `target = &struct {
+	Bar interface{} ` + "`" + `form:"bar" json:"bar" xml:"bar"` + "`" + `
+	Baz interface{} ` + "`" + `form:"baz,omitempty" json:"baz,omitempty" xml:"baz,omitempty"` + "`" + `
 	Foo *string ` + "`" + `form:"foo,omitempty" json:"foo,omitempty" xml:"foo,omitempty"` + "`" + `
 }{}
+if source.Bar != nil {
+	target.Bar = source.Bar
+}
+if source.Baz != nil {
+	target.Baz = source.Baz
+}
 if source.Foo != nil {
 	target.Foo = source.Foo
 }`

--- a/goagen/codegen/types_test.go
+++ b/goagen/codegen/types_test.go
@@ -198,6 +198,7 @@ var _ = Describe("code generation", func() {
 						"bar": &AttributeDefinition{Type: String},
 						"baz": &AttributeDefinition{Type: DateTime},
 						"qux": &AttributeDefinition{Type: UUID},
+						"quz": &AttributeDefinition{Type: Any},
 					}
 					required = nil
 				})
@@ -208,6 +209,7 @@ var _ = Describe("code generation", func() {
 						"	Baz *time.Time `form:\"baz,omitempty\" json:\"baz,omitempty\" xml:\"baz,omitempty\"`\n" +
 						"	Foo *int `form:\"foo,omitempty\" json:\"foo,omitempty\" xml:\"foo,omitempty\"`\n" +
 						"	Qux *uuid.UUID `form:\"qux,omitempty\" json:\"qux,omitempty\" xml:\"qux,omitempty\"`\n" +
+						"	Quz interface{} `form:\"quz,omitempty\" json:\"quz,omitempty\" xml:\"quz,omitempty\"`\n" +
 						"}"
 					Ω(st).Should(Equal(expected))
 				})
@@ -232,6 +234,7 @@ var _ = Describe("code generation", func() {
 							"	Baz *time.Time `form:\"baz,omitempty\" json:\"baz,omitempty\" xml:\"baz,omitempty\"`\n"+
 							"	Foo *int `%s:\"%s,%s\" %s:\"%s\"`\n"+
 							"	Qux *uuid.UUID `form:\"qux,omitempty\" json:\"qux,omitempty\" xml:\"qux,omitempty\"`\n"+
+							"	Quz interface{} `form:\"quz,omitempty\" json:\"quz,omitempty\" xml:\"quz,omitempty\"`\n"+
 							"}", tn1[11:], tv11, tv12, tn2[11:], tv21)
 						Ω(st).Should(Equal(expected))
 					})
@@ -250,6 +253,7 @@ var _ = Describe("code generation", func() {
 							"	Baz *time.Time `form:\"baz,omitempty\" json:\"baz,omitempty\" xml:\"baz,omitempty\"`\n" +
 							"	ServiceName *int `form:\"foo,omitempty\" json:\"foo,omitempty\" xml:\"foo,omitempty\"`\n" +
 							"	Qux *uuid.UUID `form:\"qux,omitempty\" json:\"qux,omitempty\" xml:\"qux,omitempty\"`\n" +
+							"	Quz interface{} `form:\"quz,omitempty\" json:\"quz,omitempty\" xml:\"quz,omitempty\"`\n" +
 							"}"
 						Ω(st).Should(Equal(expected))
 					})
@@ -268,6 +272,25 @@ var _ = Describe("code generation", func() {
 							"	Baz *time.Time `form:\"baz,omitempty\" json:\"baz,omitempty\" xml:\"baz,omitempty\"`\n" +
 							"	Foo *[]byte `form:\"foo,omitempty\" json:\"foo,omitempty\" xml:\"foo,omitempty\"`\n" +
 							"	Qux *uuid.UUID `form:\"qux,omitempty\" json:\"qux,omitempty\" xml:\"qux,omitempty\"`\n" +
+							"	Quz interface{} `form:\"quz,omitempty\" json:\"quz,omitempty\" xml:\"quz,omitempty\"`\n" +
+							"}"
+						Ω(st).Should(Equal(expected))
+					})
+				})
+
+				Context("that are required", func() {
+					BeforeEach(func() {
+						required = &dslengine.ValidationDefinition{
+							Required: []string{"foo", "bar", "baz", "qux", "quz"},
+						}
+					})
+					It("produces the struct go code", func() {
+						expected := "struct {\n" +
+							"	Bar string `form:\"bar\" json:\"bar\" xml:\"bar\"`\n" +
+							"	Baz time.Time `form:\"baz\" json:\"baz\" xml:\"baz\"`\n" +
+							"	Foo int `form:\"foo\" json:\"foo\" xml:\"foo\"`\n" +
+							"	Qux uuid.UUID `form:\"qux\" json:\"qux\" xml:\"qux\"`\n" +
+							"	Quz interface{} `form:\"quz\" json:\"quz\" xml:\"quz\"`\n" +
 							"}"
 						Ω(st).Should(Equal(expected))
 					})


### PR DESCRIPTION
We fix an issue where non-required fields of kind Any were generated as
a pointer to *interface{}. This broke the Go compiler which failed with
the error "type *interface {} is pointer to interface, not interface".

To prevent this, we teach AttributeDefinition.IsPrimitivePointer that
AnyKind should never be converted to a pointer, since it already is an
interface.

The change also adds a test case.

## Example of the problem

```go
var NullAny = Type("NullAny", func() {
	Attribute("value", Any)
})
```

```go
// nullAny user type.
type nullAny struct {
	Value *interface{} `form:"value,omitempty" json:"value,omitempty" xml:"value,omitempty" bson:"value,omitempty"`
}

// Publicize creates NullAny from nullAny
func (ut *nullAny) Publicize() *NullAny {
	var pub NullAny
	if ut.Value != nil {
		pub.Value = ut.Value
	}
	return &pub
}

// NullAny user type.
type NullAny struct {
	Value *interface{} `form:"value,omitempty" json:"value,omitempty" xml:"value,omitempty" bson:"value,omitempty"`
}
```