### PR TITLE
fix index out of bounds error

### DIFF
--- a/http/middleware/logging/log.go
+++ b/http/middleware/logging/log.go
@@ -39,7 +39,7 @@ func (a *adapter) Log(_ context.Context, keyvals ...interface{}) {
 	for i := 0; i < len(keyvals); i += 2 {
 		k := keyvals[i]
 		v := keyvals[i+1]
-		vals[i/2+1] = v
+		vals[i/2] = v
 		fm.WriteString(fmt.Sprintf(" %s=%%+v", k))
 	}
 	a.Logger.Printf(fm.String(), vals...)


### PR DESCRIPTION
This is a minor fix to address a bug introduced in https://github.com/goadesign/goa/pull/1585. The old logger's log definition was `func (a *adapter) log(lvl string, keyvals ...interface{})`. so we initialized the vals to be of size n+1 and set the lvl at 0th index https://github.com/goadesign/goa/pull/1585/files#diff-c569e732b7a9e4f2486a8c37f7b06c98L42.