### PR TITLE
Add Use method to generated Endpoints struct

### DIFF
--- a/codegen/service/endpoint.go
+++ b/codegen/service/endpoint.go
@@ -86,7 +86,12 @@ func EndpointFile(service *design.ServiceExpr) *codegen.File {
 			Source: serviceEndpointsInitT,
 			Data:   data,
 		}
-		sections = []*codegen.SectionTemplate{header, def, init}
+		use := &codegen.SectionTemplate{
+			Name:   "endpoints-use",
+			Source: serviceEndpointsUseT,
+			Data:   data,
+		}
+		sections = []*codegen.SectionTemplate{header, def, init, use}
 		for _, m := range data.Methods {
 			sections = append(sections, &codegen.SectionTemplate{
 				Name:   "endpoint-method",
@@ -164,5 +169,14 @@ func New{{ .VarName }}Endpoint(s {{ .ServiceVarName}}) goa.Endpoint {
 		return nil, s.{{ .VarName }}(ctx{{ if .PayloadRef }}, p{{ end }})
 {{- end }}
 	}
+}
+`
+
+// input: EndpointMethodData
+const serviceEndpointsUseT = `{{ printf "Use applies the given middleware to all the %q service endpoints." .Name | comment }}
+func (e *{{ .VarName }}) Use(m func(goa.Endpoint) goa.Endpoint) {
+{{- range .Methods }}
+	e.{{ .VarName }} = m(e.{{ .VarName }})
+{{- end }}
 }
 `

--- a/codegen/service/endpoint_test.go
+++ b/codegen/service/endpoint_test.go
@@ -22,6 +22,10 @@ func NewEndpoints(s Service) *Endpoints {
 		A: NewAEndpoint(s),
 	}
 }
+// Use applies the given middleware to all the "Single" service endpoints.
+func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
+	e.A = m(e.A)
+}
 // NewAEndpoint returns an endpoint function that calls the method "A" of
 // service "Single".
 func NewAEndpoint(s Service) goa.Endpoint {
@@ -44,6 +48,11 @@ func NewEndpoints(s Service) *Endpoints {
 		B: NewBEndpoint(s),
 		C: NewCEndpoint(s),
 	}
+}
+// Use applies the given middleware to all the "Multiple" service endpoints.
+func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
+	e.B = m(e.B)
+	e.C = m(e.C)
 }
 // NewBEndpoint returns an endpoint function that calls the method "B" of
 // service "Multiple".
@@ -73,6 +82,10 @@ func NewEndpoints(s Service) *Endpoints {
 	return &Endpoints{
 		NoPayload: NewNoPayloadEndpoint(s),
 	}
+}
+// Use applies the given middleware to all the "NoPayload" service endpoints.
+func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
+	e.NoPayload = m(e.NoPayload)
 }
 // NewNoPayloadEndpoint returns an endpoint function that calls the method
 // "NoPayload" of service "NoPayload".

--- a/endpoint.go
+++ b/endpoint.go
@@ -2,6 +2,25 @@ package goa
 
 import "context"
 
+const (
+	// ContextKeyMethod is the name of the context key used to store the
+	// name of the method as defined in the design. The generated transport
+	// code initializes the corresponding value prior to invoking the
+	// endpoint.
+	ContextKeyMethod contextKey = iota + 1
+
+	// ContextKeyService is the name of the context key used to store the
+	// name of the service as defined in the design. The generated transport
+	// code initializes the corresponding value prior to invoking the
+	// endpoint.
+	ContextKeyService
+)
+
+type (
+	// private type used to define context keys.
+	contextKey int
+)
+
 // Endpoint exposes service methods to remote clients independently of the
 // underlying transport.
 type Endpoint func(ctx context.Context, request interface{}) (response interface{}, err error)

--- a/examples/cellar/gen/http/sommelier/server/server.go
+++ b/examples/cellar/gen/http/sommelier/server/server.go
@@ -85,6 +85,8 @@ func NewPickHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "pick")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "sommelier")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)

--- a/examples/cellar/gen/http/storage/server/server.go
+++ b/examples/cellar/gen/http/storage/server/server.go
@@ -110,6 +110,8 @@ func NewListHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "list")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "storage")
 		res, err := endpoint(ctx, nil)
 
 		if err != nil {
@@ -150,6 +152,8 @@ func NewShowHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "show")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "storage")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)
@@ -196,6 +200,8 @@ func NewAddHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "add")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "storage")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)
@@ -242,6 +248,8 @@ func NewRemoveHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "remove")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "storage")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)
@@ -288,6 +296,8 @@ func NewRateHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "rate")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "storage")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)
@@ -334,6 +344,8 @@ func NewMultiAddHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "multi_add")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "storage")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)

--- a/examples/cellar/gen/sommelier/endpoints.go
+++ b/examples/cellar/gen/sommelier/endpoints.go
@@ -26,6 +26,11 @@ func NewEndpoints(s Service) *Endpoints {
 	}
 }
 
+// Use applies the given middleware to all the "sommelier" service endpoints.
+func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
+	e.Pick = m(e.Pick)
+}
+
 // NewPickEndpoint returns an endpoint function that calls the method "pick" of
 // service "sommelier".
 func NewPickEndpoint(s Service) goa.Endpoint {

--- a/examples/cellar/gen/storage/endpoints.go
+++ b/examples/cellar/gen/storage/endpoints.go
@@ -36,6 +36,16 @@ func NewEndpoints(s Service) *Endpoints {
 	}
 }
 
+// Use applies the given middleware to all the "storage" service endpoints.
+func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
+	e.List = m(e.List)
+	e.Show = m(e.Show)
+	e.Add = m(e.Add)
+	e.Remove = m(e.Remove)
+	e.Rate = m(e.Rate)
+	e.MultiAdd = m(e.MultiAdd)
+}
+
 // NewListEndpoint returns an endpoint function that calls the method "list" of
 // service "storage".
 func NewListEndpoint(s Service) goa.Endpoint {

--- a/examples/cellar/gen/swagger/endpoints.go
+++ b/examples/cellar/gen/swagger/endpoints.go
@@ -8,6 +8,10 @@
 
 package swagger
 
+import (
+	goa "goa.design/goa"
+)
+
 // Endpoints wraps the "swagger" service endpoints.
 type Endpoints struct {
 }
@@ -15,4 +19,8 @@ type Endpoints struct {
 // NewEndpoints wraps the methods of the "swagger" service with endpoints.
 func NewEndpoints(s Service) *Endpoints {
 	return &Endpoints{}
+}
+
+// Use applies the given middleware to all the "swagger" service endpoints.
+func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 }

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -308,6 +308,8 @@ func {{ .HandlerInit }}(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, {{ printf "%q" .Method.Name }})
+		ctx = context.WithValue(ctx, goa.ContextKeyService, {{ printf "%q" .ServiceName }})
 
 		{{- if .Payload.Ref }}
 		payload, err := decodeRequest(r)

--- a/http/codegen/testdata/handler_init_functions.go
+++ b/http/codegen/testdata/handler_init_functions.go
@@ -16,6 +16,8 @@ func NewMethodNoPayloadNoResultHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "MethodNoPayloadNoResult")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "ServiceNoPayloadNoResult")
 		res, err := endpoint(ctx, nil)
 
 		if err != nil {
@@ -46,6 +48,8 @@ func NewMethodPayloadNoResultHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "MethodPayloadNoResult")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "ServicePayloadNoResult")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)
@@ -81,6 +85,8 @@ func NewMethodNoPayloadResultHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "MethodNoPayloadResult")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "ServiceNoPayloadResult")
 		res, err := endpoint(ctx, nil)
 
 		if err != nil {
@@ -111,6 +117,8 @@ func NewMethodPayloadResultHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "MethodPayloadResult")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "ServicePayloadResult")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)
@@ -147,6 +155,8 @@ func NewMethodPayloadResultErrorHandler(
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
 		ctx := context.WithValue(r.Context(), goahttp.ContextKeyAcceptType, accept)
+		ctx = context.WithValue(ctx, goa.ContextKeyMethod, "MethodPayloadResultError")
+		ctx = context.WithValue(ctx, goa.ContextKeyService, "ServicePayloadResultError")
 		payload, err := decodeRequest(r)
 		if err != nil {
 			encodeError(ctx, w, err)

--- a/http/encoding.go
+++ b/http/encoding.go
@@ -18,9 +18,11 @@ import (
 )
 
 const (
-	// ContextKeyAcceptType is the context key associated with the request
-	// Accept-Type header value used by the goa response encoder.
-	ContextKeyAcceptType contextKey = iota
+	// ContextKeyAcceptType is the name of the context key used to store the
+	// value of the HTTP request Accept-Type header. The value may be used
+	// by encoders and decoders to implement a content type negotiation
+	// algorithm.
+	ContextKeyAcceptType contextKey = iota + 1
 )
 
 type (


### PR DESCRIPTION
Add name of method and service to context created by transport .
This allows generic endpoint middlewares to take advantage of them.