### PR TITLE
Prevent pointer to '*interface{}' in user types

### DIFF
--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -116,7 +116,7 @@ func goTypeDefObject(obj design.Object, def *design.AttributeDefinition, tabs in
 		WriteTabs(&buffer, tabs+1)
 		field := obj[name]
 		typedef := GoTypeDef(field, tabs+1, jsonTags, private)
-		if (field.Type.IsPrimitive() && private) || field.Type.IsObject() || def.IsPrimitivePointer(name) {
+		if (private && field.Type.IsPrimitive() && !def.IsInterface(name)) || field.Type.IsObject() || def.IsPrimitivePointer(name) {
 			typedef = "*" + typedef
 		}
 		fname := GoifyAtt(field, name, true)


### PR DESCRIPTION
    A previous patch in [#1591][1] addressed an issue where optional fields
    of kind "Any" would result in a pointer to interface. We fix an
    additional occurence of this problem in private user types, which follow
    slightly different logic than the public media types previously fixed
    and add a test case for private defs.

    [1]: https://github.com/goadesign/goa/pull/1591