### PR TITLE
Add a primitive type File

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1035,7 +1035,7 @@ func (a *AttributeDefinition) IsPrimitivePointer(attName string) bool {
 		return false
 	}
 	if att.Type.IsPrimitive() {
-		return !a.IsRequired(attName) && !a.HasDefaultValue(attName) && !a.IsNonZero(attName) && !a.IsInterface(attName)
+		return (!a.IsRequired(attName) && !a.HasDefaultValue(attName) && !a.IsNonZero(attName) && !a.IsInterface(attName)) || a.IsFile(attName)
 	}
 	return false
 }
@@ -1052,6 +1052,20 @@ func (a *AttributeDefinition) IsInterface(attName string) bool {
 		return false
 	}
 	return att.Type.Kind() == AnyKind
+}
+
+// IsFile returns true if the field generated for the given attribute has
+// an file type that should not be referenced as a "*multipart.File" pointer.
+// The target attribute must be an object.
+func (a *AttributeDefinition) IsFile(attName string) bool {
+	if !a.Type.IsObject() {
+		panic("checking pointer field on non-object") // bug
+	}
+	att := a.Type.ToObject()[attName]
+	if att == nil {
+		return false
+	}
+	return att.Type.Kind() == FileKind
 }
 
 // SetExample sets the custom example. SetExample also handles the case when the user doesn't

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1054,9 +1054,7 @@ func (a *AttributeDefinition) IsInterface(attName string) bool {
 	return att.Type.Kind() == AnyKind
 }
 
-// IsFile returns true if the field generated for the given attribute has
-// an file type that should not be referenced as a "*multipart.File" pointer.
-// The target attribute must be an object.
+// IsFile returns true if the attribute is of type File or if any its children attributes (if any) is.
 func (a *AttributeDefinition) IsFile(attName string) bool {
 	if !a.Type.IsObject() {
 		panic("checking pointer field on non-object") // bug

--- a/design/random.go
+++ b/design/random.go
@@ -3,6 +3,7 @@ package design
 import (
 	"crypto/md5"
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -71,4 +72,9 @@ func (r *RandomGenerator) Bool() bool {
 // Float64 produces a random float64 value.
 func (r *RandomGenerator) Float64() float64 {
 	return r.rand.Float64()
+}
+
+// File produces a random file.
+func (r *RandomGenerator) File() string {
+	return fmt.Sprintf("%sjpg", r.faker.Sentence(1, false))
 }

--- a/design/types.go
+++ b/design/types.go
@@ -163,6 +163,8 @@ const (
 	UserTypeKind
 	// MediaTypeKind represents a media type.
 	MediaTypeKind
+	// FileKind represents a file.
+	FileKind
 )
 
 const (
@@ -188,6 +190,9 @@ const (
 
 	// Any is the type for an arbitrary JSON value (interface{} in Go).
 	Any = Primitive(AnyKind)
+
+	// File is the type for a file.
+	File = Primitive(FileKind)
 )
 
 // DataType implementation
@@ -208,6 +213,8 @@ func (p Primitive) Name() string {
 		return "string"
 	case Any:
 		return "any"
+	case File:
+		return "file"
 	default:
 		panic("unknown primitive type") // bug
 	}
@@ -297,6 +304,8 @@ func (p Primitive) GenerateExample(r *RandomGenerator, seen []string) interface{
 	case Any:
 		// to not make it too complicated, pick one of the primitive types
 		return anyPrimitive[r.Int()%len(anyPrimitive)].GenerateExample(r, seen)
+	case File:
+		return r.File()
 	default:
 		panic("unknown primitive type") // bug
 	}

--- a/design/types.go
+++ b/design/types.go
@@ -600,6 +600,37 @@ func UserTypes(dt DataType) map[string]*UserTypeDefinition {
 	}
 }
 
+// HasFile returns true if the underlying type has any file attributes.
+func HasFile(dt DataType) bool {
+	if dt == nil {
+		return false
+	}
+	switch {
+	case dt.IsPrimitive():
+		return dt.Kind() == FileKind
+	case dt.IsArray():
+		if HasFile(dt.ToArray().ElemType.Type) {
+			return true
+		}
+	case dt.IsHash():
+		if HasFile(dt.ToHash().KeyType.Type) {
+			return true
+		}
+		if HasFile(dt.ToHash().ElemType.Type) {
+			return true
+		}
+	case dt.IsObject():
+		for _, att := range dt.ToObject() {
+			if HasFile(att.Type) {
+				return true
+			}
+		}
+	default:
+		panic("unknown type")
+	}
+	return false
+}
+
 // ToSlice converts an ArrayVal to a slice.
 func (a ArrayVal) ToSlice() []interface{} {
 	arr := make([]interface{}, len(a))

--- a/design/types.go
+++ b/design/types.go
@@ -191,7 +191,7 @@ const (
 	// Any is the type for an arbitrary JSON value (interface{} in Go).
 	Any = Primitive(AnyKind)
 
-	// File is the type for a file.
+	// File is the type for a file. This type can only be used in a multipart definition.
 	File = Primitive(FileKind)
 )
 

--- a/design/validation.go
+++ b/design/validation.go
@@ -336,10 +336,16 @@ func (a *ActionDefinition) Validate() *dslengine.ValidationErrors {
 			}
 		}
 		verr.Merge(r.Validate())
+		if HasFile(r.Type) {
+			verr.Add(a, "Response %s contains an invalid type, action responses cannot contain a file", i)
+		}
 	}
 	verr.Merge(a.ValidateParams())
 	if a.Payload != nil {
 		verr.Merge(a.Payload.Validate("action payload", a))
+		if HasFile(a.Payload.Type) && a.PayloadMultipart != true {
+			verr.Add(a, "Payload %s contains an invalid type, action payloads cannot contain a file", a.Payload.TypeName)
+		}
 	}
 	if a.Parent == nil {
 		verr.Add(a, "missing parent resource")
@@ -347,10 +353,16 @@ func (a *ActionDefinition) Validate() *dslengine.ValidationErrors {
 	if a.Params != nil {
 		for n, p := range a.Params.Type.ToObject() {
 			if p.Type.IsPrimitive() {
+				if HasFile(p.Type) {
+					verr.Add(a, "Param %s has an invalid type, action params cannot be a file", n)
+				}
 				continue
 			}
 			if p.Type.IsArray() {
 				if p.Type.ToArray().ElemType.Type.IsPrimitive() {
+					if HasFile(p.Type.ToArray().ElemType.Type) {
+						verr.Add(a, "Param %s has an invalid type, action params cannot be a file array", n)
+					}
 					continue
 				}
 			}

--- a/goagen/codegen/types.go
+++ b/goagen/codegen/types.go
@@ -241,6 +241,8 @@ func GoNativeType(t design.DataType) string {
 			return "uuid.UUID"
 		case design.AnyKind:
 			return "interface{}"
+		case design.FileKind:
+			return "multipart.FileHeader"
 		default:
 			panic(fmt.Sprintf("goa bug: unknown primitive type %#v", actual))
 		}

--- a/goagen/gen_app/generator.go
+++ b/goagen/gen_app/generator.go
@@ -492,6 +492,7 @@ func (g *Generator) generateUserTypes() (err error) {
 	title := fmt.Sprintf("%s: Application User Types", g.API.Context())
 	imports := []*codegen.ImportSpec{
 		codegen.SimpleImport("fmt"),
+		codegen.SimpleImport("mime/multipart"),
 		codegen.SimpleImport("time"),
 		codegen.SimpleImport("unicode/utf8"),
 		codegen.SimpleImport("github.com/goadesign/goa"),

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -247,11 +247,13 @@ var _ = Describe("Generate", func() {
 
 		Context("with a multipart payload", func() {
 			BeforeEach(func() {
-				elemType := &design.AttributeDefinition{Type: design.Integer}
+				elemTypeInt := &design.AttributeDefinition{Type: design.Integer}
+				elemTypeFile := &design.AttributeDefinition{Type: design.File}
 				payload = &design.UserTypeDefinition{
 					AttributeDefinition: &design.AttributeDefinition{
 						Type: design.Object{
-							"int": elemType,
+							"int":  elemTypeInt,
+							"file": elemTypeFile,
 						},
 					},
 					TypeName: "Collection",
@@ -560,6 +562,12 @@ func MountWidgetController(service *goa.Service, ctrl WidgetController) {
 func unmarshalGetWidgetPayload(ctx context.Context, service *goa.Service, req *http.Request) error {
 	var err error
 	var payload collection
+	_, rawFile, err2 := req.FormFile("file")
+	if err2 == nil {
+		payload.File = rawFile
+	} else {
+		err = goa.MergeErrors(err, goa.InvalidParamTypeError("file", "file", "file"))
+	}
 	rawInt := req.FormValue("int")
 	if int_, err2 := strconv.Atoi(rawInt); err2 == nil {
 		tmp2 := int_

--- a/goagen/gen_app/writers.go
+++ b/goagen/gen_app/writers.go
@@ -531,7 +531,15 @@ type {{ .Name }} struct {
 */}}{{ if .Pointer }}{{ $tmp := tempvar }}{{ tabs .Depth }}{{ $tmp }} := interface{}(raw{{ goify .Name true }})
 {{ tabs .Depth }}{{ .Pkg }} = &{{ $tmp }}
 {{ else }}{{ tabs .Depth }}{{ .Pkg }} = raw{{ goify .Name true }}
-{{ end }}{{ end }}`
+{{ end }}{{ end }}{{ if eq .Attribute.Type.Kind 13 }}{{/*
+
+*/}}{{/* FileType */}}{{/*
+*/}}{{ tabs .Depth }}if err2 == nil {
+{{ tabs .Depth }}	{{ .Pkg }} = {{ printf "raw%s" (goify .VarName true) }}
+{{ tabs .Depth }}} else {
+{{ tabs .Depth }}	err = goa.MergeErrors(err, goa.InvalidParamTypeError("{{ .Name }}", "{{ .Name }}", "file"))
+{{ tabs .Depth }}}
+{{ end }}`
 
 	// ctxNewT generates the code for the context factory method.
 	// template input: *ContextTemplateData
@@ -775,8 +783,9 @@ func {{ .Unmarshal }}(ctx context.Context, service *goa.Service, req *http.Reque
 	{{ if .PayloadMultipart}}var err error
 	var payload {{ gotypename .Payload nil 1 true }}
 	{{ $o := .Payload.ToObject }}{{ range $name, $att := $o -}}
-	raw{{ goify $name true }} := req.FormValue("{{ $name }}")
-	{{ template "Coerce" (newCoerceData $name $att true (printf "payload.%s" (goifyatt $att $name true)) 0) }}{{ end }}{{/*
+	{{ if eq $att.Type.Kind 13 }}_, raw{{ goify $name true }}, err2 := req.FormFile("{{ $name }}"){{ else }}{{/*
+*/}}	raw{{ goify $name true }} := req.FormValue("{{ $name }}"){{ end }}
+{{ template "Coerce" (newCoerceData $name $att true (printf "payload.%s" (goifyatt $att $name true)) 1) }}{{ end }}{{/*
 */}}	if err != nil {
 		return err
 	}{{ else if .Payload.IsObject }}payload := &{{ gotypename .Payload nil 1 true }}{}

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -1171,6 +1171,9 @@ var _ = Describe("ControllersWriter", func() {
 									"id": &design.AttributeDefinition{
 										Type: design.String,
 									},
+									"icon": &design.AttributeDefinition{
+										Type: design.File,
+									},
 								},
 								Validation: required,
 							},
@@ -2318,6 +2321,12 @@ func unmarshalListBottlePayload(ctx context.Context, service *goa.Service, req *
 func unmarshalListBottlePayload(ctx context.Context, service *goa.Service, req *http.Request) error {
 	var err error
 	var payload listBottlePayload
+	_, rawIcon, err2 := req.FormFile("icon")
+	if err2 == nil {
+		payload.Icon = rawIcon
+	} else {
+		err = goa.MergeErrors(err, goa.InvalidParamTypeError("icon", "icon", "file"))
+	}
 	rawID := req.FormValue("id")
 	payload.ID = &rawID
 	if err != nil {


### PR DESCRIPTION
This pull request adds a new primitive type FIle.

It represents the `file` type of the Swagger specification.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types

> An additional primitive data type "file" is used by the Parameter Object and the Response Object to set the parameter type or the response as being a file.

It can be used with `MultipartForm` and It makes it possible to create a service that can be uploaded a file.