### PR TITLE
Fix MuxHandler initialization race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ cyclo:
 	fi
 
 test:
-	@ginkgo -r --randomizeAllSpecs --failOnPending --randomizeSuites -skipPackage vendor
+	@ginkgo -r --randomizeAllSpecs --failOnPending --randomizeSuites -race -skipPackage vendor
 	go test ./_integration_tests
 
 goagen:

--- a/service.go
+++ b/service.go
@@ -310,7 +310,8 @@ func (ctrl *Controller) MuxHandler(name string, hdlr Handler, unm Unmarshaler) M
 				}
 				return nil
 			}
-			chain := append(ctrl.Service.middleware, ctrl.middleware...)
+			mwLen := len(ctrl.Service.middleware)
+			chain := append(ctrl.Service.middleware[:mwLen:mwLen], ctrl.middleware...)
 			ml := len(chain)
 			for i := range chain {
 				handler = chain[ml-i-1](handler)


### PR DESCRIPTION
Fix race condition that can occur when calling handlers returned from
Controller.MuxHandler where the Service's slice of middleware functions
is written to in a way that is not thread-safe.

The race will only occur when the capacity of the Service's middleware
slice is greater than its length and when the number of Controller
middlewares is more than 0. The functions returned by MuxHandler (that
are all from the same Controller object), if called in parallel, could
cause the race to occur.

(cherry picked from commit cfffe9c)