### PR TITLE
Fix the encode error

### DIFF
--- a/examples/calc/gen/http/calc/server/server.go
+++ b/examples/calc/gen/http/calc/server/server.go
@@ -104,8 +104,8 @@ func NewAddHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/examples/cellar/gen/http/sommelier/server/server.go
+++ b/examples/cellar/gen/http/sommelier/server/server.go
@@ -104,8 +104,8 @@ func NewPickHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/examples/cellar/gen/http/storage/server/server.go
+++ b/examples/cellar/gen/http/storage/server/server.go
@@ -138,8 +138,8 @@ func NewListHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -188,8 +188,8 @@ func NewShowHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -238,8 +238,8 @@ func NewAddHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -288,8 +288,8 @@ func NewRemoveHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -338,8 +338,8 @@ func NewRateHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -388,8 +388,8 @@ func NewMultiAddHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -438,8 +438,8 @@ func NewMultiUpdateHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -338,8 +338,8 @@ func {{ .HandlerInit }}(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/http/codegen/testdata/handler_init_functions.go
+++ b/http/codegen/testdata/handler_init_functions.go
@@ -23,8 +23,8 @@ func NewMethodNoPayloadNoResultHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -63,8 +63,8 @@ func NewMethodPayloadNoResultHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -96,8 +96,8 @@ func NewMethodNoPayloadResultHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -136,8 +136,8 @@ func NewMethodPayloadResultHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -176,8 +176,8 @@ func NewMethodPayloadResultErrorHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)


### PR DESCRIPTION
Don't proceed to encoding the response if there was an error and
encoding the error was successful.