### PR TITLE
Add in validation error type for consistency

### DIFF
--- a/examples/cellar/gen/http/sommelier/client/encode_decode.go
+++ b/examples/cellar/gen/http/sommelier/client/encode_decode.go
@@ -11,7 +11,6 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -84,7 +83,7 @@ func DecodePickResponse(decoder func(*http.Response) goahttp.Decoder, restoreBod
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("sommelier", "pick", err)
 			}
 
 			return NewPickStoredBottleCollectionOK(body), nil

--- a/examples/cellar/gen/http/storage/client/encode_decode.go
+++ b/examples/cellar/gen/http/storage/client/encode_decode.go
@@ -11,7 +11,6 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
@@ -66,7 +65,7 @@ func DecodeListResponse(decoder func(*http.Response) goahttp.Decoder, restoreBod
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("storage", "list", err)
 			}
 
 			return NewListStoredBottleCollectionOK(body), nil
@@ -151,7 +150,7 @@ func DecodeShowResponse(decoder func(*http.Response) goahttp.Decoder, restoreBod
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("storage", "show", err)
 			}
 
 			return NewShowStoredBottleOK(&body), nil
@@ -166,7 +165,7 @@ func DecodeShowResponse(decoder func(*http.Response) goahttp.Decoder, restoreBod
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("storage", "show", err)
 			}
 
 			return nil, NewShowNotFound(&body)

--- a/examples/error/gen/http/divider/client/encode_decode.go
+++ b/examples/error/gen/http/divider/client/encode_decode.go
@@ -11,7 +11,6 @@ package client
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -92,7 +91,7 @@ func DecodeIntegerDivideResponse(decoder func(*http.Response) goahttp.Decoder, r
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("divider", "integer_divide", err)
 			}
 
 			return nil, NewIntegerDivideHasRemainder(&body)
@@ -107,7 +106,7 @@ func DecodeIntegerDivideResponse(decoder func(*http.Response) goahttp.Decoder, r
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("divider", "integer_divide", err)
 			}
 
 			return nil, NewIntegerDivideDivByZero(&body)
@@ -122,7 +121,7 @@ func DecodeIntegerDivideResponse(decoder func(*http.Response) goahttp.Decoder, r
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("divider", "integer_divide", err)
 			}
 
 			return nil, NewIntegerDivideTimeout(&body)
@@ -204,7 +203,7 @@ func DecodeDivideResponse(decoder func(*http.Response) goahttp.Decoder, restoreB
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("divider", "divide", err)
 			}
 
 			return nil, NewDivideDivByZero(&body)
@@ -219,7 +218,7 @@ func DecodeDivideResponse(decoder func(*http.Response) goahttp.Decoder, restoreB
 			}
 			err = body.Validate()
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("divider", "divide", err)
 			}
 
 			return nil, NewDivideTimeout(&body)

--- a/http/client.go
+++ b/http/client.go
@@ -168,6 +168,13 @@ func ErrDecodingError(svc, m string, err error) error {
 	return &ClientError{Name: "decoding_error", Message: msg, Service: svc, Method: m}
 }
 
+// ErrValidationError is the error returned when the response body is properly
+// received and decoded but fails validation.
+func ErrValidationError(svc, m string, err error) error {
+	msg := fmt.Sprintf("invalid response: %s", err)
+	return &ClientError{Name: "validation_error", Message: msg, Service: svc, Method: m}
+}
+
 // ErrInvalidResponse is the error returned when the service responded with an
 // unexpected response status code.
 func ErrInvalidResponse(svc, m string, code int, body string) error {

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -75,7 +75,6 @@ func clientEncodeDecode(genpkg string, svc *httpdesign.ServiceExpr) *codegen.Fil
 		codegen.Header(title, "client", []*codegen.ImportSpec{
 			{Path: "bytes"},
 			{Path: "context"},
-			{Path: "fmt"},
 			{Path: "io"},
 			{Path: "io/ioutil"},
 			{Path: "mime/multipart"},
@@ -401,7 +400,7 @@ const singleResponseT = `case {{ .StatusCode }}:
 		{{- if .ClientBody.ValidateRef }}
 			{{ .ClientBody.ValidateRef }}
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", err)
 			}
 		{{- end }}
 	{{ end }}
@@ -450,7 +449,7 @@ const singleResponseT = `case {{ .StatusCode }}:
 		{{- else if .Slice }}
 			{{ .VarName }}Raw := resp.Header["{{ .CanonicalName }}"]
 				{{ if .Required }} if {{ .VarName }}Raw == nil {
-				return nil, fmt.Errorf("invalid response: %s", goa.MissingFieldError("{{ .Name }}", "header"))
+				return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", goa.MissingFieldError("{{ .Name }}", "header"))
 			}
 			{{- else if .DefaultValue }}
 			if {{ .VarName }}Raw == nil {
@@ -471,7 +470,7 @@ const singleResponseT = `case {{ .StatusCode }}:
 			{{ .VarName }}Raw := resp.Header.Get("{{ .Name }}")
 			{{- if .Required }}
 			if {{ .VarName }}Raw == "" {
-				return nil, fmt.Errorf("invalid response: %s", goa.MissingFieldError("{{ .Name }}", "header"))
+				return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", goa.MissingFieldError("{{ .Name }}", "header"))
 			}
 			{{- else if .DefaultValue }}
 			if {{ .VarName }}Raw == "" {
@@ -496,7 +495,7 @@ const singleResponseT = `case {{ .StatusCode }}:
 
 	{{- if .MustValidate }}
 			if err != nil {
-				return nil, fmt.Errorf("invalid response: %s", err)
+				return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", err)
 			}
 	{{- end }}
 `


### PR DESCRIPTION
Not necessarily a bug but every other error returned from the http client seems to be a goahttp.ErrXXX error so this helps keeps things consistent.