### PR TITLE
added ability to suppress sensitive headers from log. closes #1676

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ _integration_tests/*/**/*.*
 
 # OSes cruft
 .DS_Store
+
+# vim
+*.swp
+*.swo


### PR DESCRIPTION
Minor change to `middleware/log_request.go` that allows the user to suppress sensitive headers from the log. Closes #1676.