### PR TITLE
Fix handling of type Bytes in OpenAPI

### DIFF
--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -81,15 +81,15 @@ func HasValidations(att *design.AttributeExpr, ignoreRequired bool) bool {
 // def indicates whether non required attributes that have a default value should
 // not be pointers.
 //
-// req | ptr | def | pointer?
-//  T  |  F  |  F  | F
-//  T  |  F  |  T  | F
-//  T  |  T  |  F  | T
-//  T  |  T  |  T  | T
-//  F  |  F  |  F  | T
-//  F  |  F  |  T  | F if has default value, T otherwise
-//  F  |  T  |  F  | T
-//  F  |  T  |  T  | T
+//    req | ptr | def | pointer?
+//     T  |  F  |  F  | F
+//     T  |  F  |  T  | F
+//     T  |  T  |  F  | T
+//     T  |  T  |  T  | T
+//     F  |  F  |  F  | T
+//     F  |  F  |  T  | F if has default value, T otherwise
+//     F  |  T  |  F  | T
+//     F  |  T  |  T  | T
 //
 // context is used to produce helpful messages in case of error.
 //

--- a/http/codegen/openapi/json_schema.go
+++ b/http/codegen/openapi/json_schema.go
@@ -292,6 +292,9 @@ func TypeSchema(api *design.APIExpr, t design.DataType) *Schema {
 		case design.Float64Kind:
 			s.Type = Type("number")
 			s.Format = "double"
+		case design.BytesKind:
+			s.Type = Type("string")
+			s.Format = "byte"
 		}
 	case *design.Array:
 		s.Type = Array

--- a/http/codegen/openapi/openapi_v2_builder.go
+++ b/http/codegen/openapi/openapi_v2_builder.go
@@ -390,6 +390,9 @@ func paramFor(at *design.AttributeExpr, name, in string, required bool) *Paramet
 	case design.Float64:
 		p.Type = "number"
 		p.Format = "double"
+	case design.Bytes:
+		p.Type = "string"
+		p.Format = "byte"
 	}
 	p.Extensions = ExtensionsFromExpr(at.Metadata)
 	initValidations(at, p)


### PR DESCRIPTION
Use type 'string' with format 'byte' instead of invalid type 'bytes'.

Fixes #1692 