### PR TITLE
use_x_request_id

### DIFF
--- a/http/middleware/requestid.go
+++ b/http/middleware/requestid.go
@@ -5,13 +5,59 @@ import (
 	"net/http"
 )
 
+type (
+	// RequestIDOption uses a constructor pattern to customize middleware
+	RequestIDOption func(*requestIDOption) *requestIDOption
+
+	// requestIDOption is the struct storing all the options.
+	requestIDOption struct {
+		// useXRequestIDHeader is true to use incoming "X-Request-Id" headers,
+		// instead of always generating unique IDs, when present in request.
+		// defaults to always-generate.
+		useXRequestIDHeader bool
+		// xRequestHeaderLimit is positive to truncate incoming "X-Request-Id"
+		// headers at the specified length. defaults to no limit.
+		xRequestHeaderLimit int
+	}
+)
+
 // RequestID returns a middleware which initializes the context with a unique value under the
 // RequestIDKey key.
-func RequestID() func(http.Handler) http.Handler {
+func RequestID(options ...RequestIDOption) func(http.Handler) http.Handler {
+	o := new(requestIDOption)
+	for _, option := range options {
+		o = option(o)
+	}
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := context.WithValue(r.Context(), RequestIDKey, shortID())
+			var id string
+			if o.useXRequestIDHeader {
+				id = r.Header.Get("X-Request-Id")
+				if o.xRequestHeaderLimit > 0 && len(id) > o.xRequestHeaderLimit {
+					id = id[:o.xRequestHeaderLimit]
+				}
+			}
+			if id == "" {
+				id = shortID()
+			}
+			ctx := context.WithValue(r.Context(), RequestIDKey, id)
 			h.ServeHTTP(w, r.WithContext(ctx))
 		})
+	}
+}
+
+// UseXRequestIDHeaderOption enables/disables using "X-Request-Id" header.
+func UseXRequestIDHeaderOption(f bool) RequestIDOption {
+	return func(o *requestIDOption) *requestIDOption {
+		o.useXRequestIDHeader = f
+		return o
+	}
+}
+
+// XRequestHeaderLimitOption sets the option for using "X-Request-Id" header.
+func XRequestHeaderLimitOption(limit int) RequestIDOption {
+	return func(o *requestIDOption) *requestIDOption {
+		o.xRequestHeaderLimit = limit
+		return o
 	}
 }

--- a/http/middleware/requestid_test.go
+++ b/http/middleware/requestid_test.go
@@ -1,0 +1,89 @@
+package middleware_test
+
+import (
+	"net/http"
+	"testing"
+
+	"goa.design/goa/http/middleware"
+)
+
+type (
+	requestIDTestHandler struct {
+		handler http.HandlerFunc
+	}
+
+	requestIDTestCase struct {
+		name    string
+		options []middleware.RequestIDOption
+		request *http.Request
+		handler http.HandlerFunc
+	}
+)
+
+func TestRequestID(t *testing.T) {
+	var (
+		getRequestID = func(r *http.Request) (id string) {
+			id, _ = r.Context().Value(middleware.RequestIDKey).(string)
+			return
+		}
+		makeRequest = func(xRequestIDValue string) (r *http.Request) {
+			r = &http.Request{
+				Header: make(http.Header),
+			}
+			if len(xRequestIDValue) > 0 {
+				r.Header.Set("X-Request-Id", xRequestIDValue)
+			}
+			return
+		}
+		ignored http.ResponseWriter
+	)
+	for _, tc := range []*requestIDTestCase{
+		&requestIDTestCase{"default without header", nil, makeRequest(""),
+			func(_ http.ResponseWriter, r *http.Request) {
+				id := getRequestID(r)
+				if len(id) != 8 {
+					t.Errorf("unexpected request ID length: %d != 8", len(id))
+				}
+			},
+		},
+		&requestIDTestCase{"default ignores header", nil, makeRequest("ignore this header"),
+			func(_ http.ResponseWriter, r *http.Request) {
+				id := getRequestID(r)
+				if len(id) != 8 {
+					t.Errorf("unexpected request ID length: %d != 8", len(id))
+				}
+			},
+		},
+		&requestIDTestCase{"accept header",
+			[]middleware.RequestIDOption{middleware.UseXRequestIDHeaderOption(true)},
+			makeRequest("accepted"),
+			func(_ http.ResponseWriter, r *http.Request) {
+				id := getRequestID(r)
+				if id != "accepted" {
+					t.Errorf("unexpected request ID length: %s != accepted", id)
+				}
+			},
+		},
+		&requestIDTestCase{"truncate header",
+			[]middleware.RequestIDOption{
+				middleware.UseXRequestIDHeaderOption(true),
+				middleware.XRequestHeaderLimitOption(3),
+			},
+			makeRequest("too long for length limit"),
+			func(_ http.ResponseWriter, r *http.Request) {
+				id := getRequestID(r)
+				if id != "too" {
+					t.Errorf("unexpected request ID length: %s != too", id)
+				}
+			},
+		},
+	} {
+		middleware.RequestID(tc.options...)(
+			&requestIDTestHandler{tc.handler}).ServeHTTP(ignored, tc.request)
+	}
+}
+
+// ServeHTTP implements http.Handler#ServeHTTP
+func (h *requestIDTestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.handler(w, r)
+}


### PR DESCRIPTION
added options for RequestID middleware
same default behavior but with options to use incoming "X-Request-Id" header
added unit tests
