### PR TITLE
Escape '%' to avoid "%A(MISSING)" strings in log

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -73,7 +73,8 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, err
 	}
 	startedAt := time.Now()
 	ctx, id := ContextWithRequestID(ctx)
-	goa.LogInfo(ctx, "started", "id", id, req.Method, req.URL.String())
+	// escape '%' because underlying logger implementation parses as a format string
+	goa.LogInfo(ctx, "started", "id", id, req.Method, strings.Replace(req.URL.String(), "%", "%%", -1))
 	if c.Dump {
 		c.dumpRequest(ctx, req)
 	}


### PR DESCRIPTION
URLs with query strings often have those queries escaped with '%'.
The underlying logger implementation eventually calls log.Info(msg), which will parse the message as a format string, and then not find any values to format.