### PR TITLE
Various fixes

### DIFF
--- a/codegen/service/endpoint.go
+++ b/codegen/service/endpoint.go
@@ -292,14 +292,9 @@ func New{{ .VarName }}Endpoint(s {{ .ServiceVarName}}{{ range .Schemes }}, auth{
 		if err != nil {
 			return nil, err
 		}
-		var vres {{ .ViewedResult.FullRef }}
-		switch view {
-			{{- range .ViewedResult.Views }}
-		case {{ printf "%q" .Name }}{{ if eq .Name "default" }}, ""{{ end }}:
-			vres = {{ .Project.Name }}(res)
-			{{- end }}
-		default:
-			return nil, fmt.Errorf("unknown view %q", view)
+		vres := {{ $.ViewedResult.Init.Name }}(res, view)
+		if err := vres.Validate(); err != nil {
+			return nil, err
 		}
 		return vres, nil
 {{- else if .ResultRef }}

--- a/codegen/service/testdata/endpoint_code.go
+++ b/codegen/service/testdata/endpoint_code.go
@@ -133,7 +133,7 @@ func NewAEndpoint(s Service) goa.Endpoint {
 		if err != nil {
 			return nil, err
 		}
-		vres := NewViewedViewtype(res, view)
+		vres := newViewedViewtype(res, view)
 		if err := vres.Validate(); err != nil {
 			return nil, err
 		}

--- a/codegen/service/testdata/endpoint_code.go
+++ b/codegen/service/testdata/endpoint_code.go
@@ -133,14 +133,9 @@ func NewAEndpoint(s Service) goa.Endpoint {
 		if err != nil {
 			return nil, err
 		}
-		var vres *withresultmultipleviewsviews.Viewtype
-		switch view {
-		case "default", "":
-			vres = NewViewtypeDefault(res)
-		case "tiny":
-			vres = NewViewtypeTiny(res)
-		default:
-			return nil, fmt.Errorf("unknown view %q", view)
+		vres := NewViewedViewtype(res, view)
+		if err := vres.Validate(); err != nil {
+			return nil, err
 		}
 		return vres, nil
 	}

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -262,9 +262,9 @@ func NewMultipleViews(vres *multiplemethodsresultmultipleviewsviews.MultipleView
 	return res
 }
 
-// NewViewedMultipleViews initializes viewed result type MultipleViews from
+// newViewedMultipleViews initializes viewed result type MultipleViews from
 // result type MultipleViews using the given view.
-func NewViewedMultipleViews(res *MultipleViews, view string) *multiplemethodsresultmultipleviewsviews.MultipleViews {
+func newViewedMultipleViews(res *MultipleViews, view string) *multiplemethodsresultmultipleviewsviews.MultipleViews {
 	var vres *multiplemethodsresultmultipleviewsviews.MultipleViews
 	switch view {
 	case "default", "":
@@ -358,10 +358,10 @@ func NewMultipleViewsCollection(vres resultcollectionmultipleviewsmethodviews.Mu
 	return res
 }
 
-// NewViewedMultipleViewsCollection initializes viewed result type
+// newViewedMultipleViewsCollection initializes viewed result type
 // MultipleViewsCollection from result type MultipleViewsCollection using the
 // given view.
-func NewViewedMultipleViewsCollection(res MultipleViewsCollection, view string) resultcollectionmultipleviewsmethodviews.MultipleViewsCollection {
+func newViewedMultipleViewsCollection(res MultipleViewsCollection, view string) resultcollectionmultipleviewsmethodviews.MultipleViewsCollection {
 	var vres resultcollectionmultipleviewsmethodviews.MultipleViewsCollection
 	switch view {
 	case "default", "":
@@ -503,9 +503,9 @@ func NewMultipleViews(vres *resultwithotherresultviews.MultipleViews) *MultipleV
 	return res
 }
 
-// NewViewedMultipleViews initializes viewed result type MultipleViews from
+// newViewedMultipleViews initializes viewed result type MultipleViews from
 // result type MultipleViews using the given view.
-func NewViewedMultipleViews(res *MultipleViews, view string) *resultwithotherresultviews.MultipleViews {
+func newViewedMultipleViews(res *MultipleViews, view string) *resultwithotherresultviews.MultipleViews {
 	var vres *resultwithotherresultviews.MultipleViews
 	switch view {
 	case "default", "":

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -255,7 +255,7 @@ func NewMultipleViews(vres *multiplemethodsresultmultipleviewsviews.MultipleView
 	var res *MultipleViews
 	switch vres.View {
 	case "default", "":
-		res = newMultipleViewsDefault(vres.Projected)
+		res = newMultipleViews(vres.Projected)
 	case "tiny":
 		res = newMultipleViewsTiny(vres.Projected)
 	}
@@ -268,7 +268,7 @@ func NewViewedMultipleViews(res *MultipleViews, view string) *multiplemethodsres
 	var vres *multiplemethodsresultmultipleviewsviews.MultipleViews
 	switch view {
 	case "default", "":
-		p := newMultipleViewsViewDefault(res)
+		p := newMultipleViewsView(res)
 		vres = &multiplemethodsresultmultipleviewsviews.MultipleViews{p, "default"}
 	case "tiny":
 		p := newMultipleViewsViewTiny(res)
@@ -277,9 +277,9 @@ func NewViewedMultipleViews(res *MultipleViews, view string) *multiplemethodsres
 	return vres
 }
 
-// newMultipleViewsDefault converts projected type MultipleViews to service
-// type MultipleViews.
-func newMultipleViewsDefault(vres *multiplemethodsresultmultipleviewsviews.MultipleViewsView) *MultipleViews {
+// newMultipleViews converts projected type MultipleViews to service type
+// MultipleViews.
+func newMultipleViews(vres *multiplemethodsresultmultipleviewsviews.MultipleViewsView) *MultipleViews {
 	res := &MultipleViews{
 		A: vres.A,
 		B: vres.B,
@@ -296,9 +296,9 @@ func newMultipleViewsTiny(vres *multiplemethodsresultmultipleviewsviews.Multiple
 	return res
 }
 
-// newMultipleViewsViewDefault projects result type MultipleViews into
-// projected type MultipleViewsView using the default view.
-func newMultipleViewsViewDefault(res *MultipleViews) *multiplemethodsresultmultipleviewsviews.MultipleViewsView {
+// newMultipleViewsView projects result type MultipleViews into projected type
+// MultipleViewsView using the "default" view.
+func newMultipleViewsView(res *MultipleViews) *multiplemethodsresultmultipleviewsviews.MultipleViewsView {
 	vres := &multiplemethodsresultmultipleviewsviews.MultipleViewsView{
 		A: res.A,
 		B: res.B,
@@ -307,7 +307,7 @@ func newMultipleViewsViewDefault(res *MultipleViews) *multiplemethodsresultmulti
 }
 
 // newMultipleViewsViewTiny projects result type MultipleViews into projected
-// type MultipleViewsView using the tiny view.
+// type MultipleViewsView using the "tiny" view.
 func newMultipleViewsViewTiny(res *MultipleViews) *multiplemethodsresultmultipleviewsviews.MultipleViewsView {
 	vres := &multiplemethodsresultmultipleviewsviews.MultipleViewsView{
 		A: res.A,
@@ -351,7 +351,7 @@ func NewMultipleViewsCollection(vres resultcollectionmultipleviewsmethodviews.Mu
 	var res MultipleViewsCollection
 	switch vres.View {
 	case "default", "":
-		res = newMultipleViewsCollectionDefault(vres.Projected)
+		res = newMultipleViewsCollection(vres.Projected)
 	case "tiny":
 		res = newMultipleViewsCollectionTiny(vres.Projected)
 	}
@@ -365,7 +365,7 @@ func NewViewedMultipleViewsCollection(res MultipleViewsCollection, view string) 
 	var vres resultcollectionmultipleviewsmethodviews.MultipleViewsCollection
 	switch view {
 	case "default", "":
-		p := newMultipleViewsCollectionViewDefault(res)
+		p := newMultipleViewsCollectionView(res)
 		vres = resultcollectionmultipleviewsmethodviews.MultipleViewsCollection{p, "default"}
 	case "tiny":
 		p := newMultipleViewsCollectionViewTiny(res)
@@ -374,12 +374,12 @@ func NewViewedMultipleViewsCollection(res MultipleViewsCollection, view string) 
 	return vres
 }
 
-// newMultipleViewsCollectionDefault converts projected type
-// MultipleViewsCollection to service type MultipleViewsCollection.
-func newMultipleViewsCollectionDefault(vres resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView) MultipleViewsCollection {
+// newMultipleViewsCollection converts projected type MultipleViewsCollection
+// to service type MultipleViewsCollection.
+func newMultipleViewsCollection(vres resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView) MultipleViewsCollection {
 	res := make(MultipleViewsCollection, len(vres))
 	for i, n := range vres {
-		res[i] = newMultipleViewsDefault(n)
+		res[i] = newMultipleViews(n)
 	}
 	return res
 }
@@ -394,20 +394,19 @@ func newMultipleViewsCollectionTiny(vres resultcollectionmultipleviewsmethodview
 	return res
 }
 
-// newMultipleViewsCollectionViewDefault projects result type
-// MultipleViewsCollection into projected type MultipleViewsCollectionView
-// using the default view.
-func newMultipleViewsCollectionViewDefault(res MultipleViewsCollection) resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView {
+// newMultipleViewsCollectionView projects result type MultipleViewsCollection
+// into projected type MultipleViewsCollectionView using the "default" view.
+func newMultipleViewsCollectionView(res MultipleViewsCollection) resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView {
 	vres := make(resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView, len(res))
 	for i, n := range res {
-		vres[i] = newMultipleViewsViewDefault(n)
+		vres[i] = newMultipleViewsView(n)
 	}
 	return vres
 }
 
 // newMultipleViewsCollectionViewTiny projects result type
 // MultipleViewsCollection into projected type MultipleViewsCollectionView
-// using the tiny view.
+// using the "tiny" view.
 func newMultipleViewsCollectionViewTiny(res MultipleViewsCollection) resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView {
 	vres := make(resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView, len(res))
 	for i, n := range res {
@@ -416,9 +415,9 @@ func newMultipleViewsCollectionViewTiny(res MultipleViewsCollection) resultcolle
 	return vres
 }
 
-// newMultipleViewsDefault converts projected type MultipleViews to service
-// type MultipleViews.
-func newMultipleViewsDefault(vres *resultcollectionmultipleviewsmethodviews.MultipleViewsView) *MultipleViews {
+// newMultipleViews converts projected type MultipleViews to service type
+// MultipleViews.
+func newMultipleViews(vres *resultcollectionmultipleviewsmethodviews.MultipleViewsView) *MultipleViews {
 	res := &MultipleViews{}
 	if vres.A != nil {
 		res.A = *vres.A
@@ -439,9 +438,9 @@ func newMultipleViewsTiny(vres *resultcollectionmultipleviewsmethodviews.Multipl
 	return res
 }
 
-// newMultipleViewsViewDefault projects result type MultipleViews into
-// projected type MultipleViewsView using the default view.
-func newMultipleViewsViewDefault(res *MultipleViews) *resultcollectionmultipleviewsmethodviews.MultipleViewsView {
+// newMultipleViewsView projects result type MultipleViews into projected type
+// MultipleViewsView using the "default" view.
+func newMultipleViewsView(res *MultipleViews) *resultcollectionmultipleviewsmethodviews.MultipleViewsView {
 	vres := &resultcollectionmultipleviewsmethodviews.MultipleViewsView{
 		A: &res.A,
 		B: &res.B,
@@ -450,7 +449,7 @@ func newMultipleViewsViewDefault(res *MultipleViews) *resultcollectionmultiplevi
 }
 
 // newMultipleViewsViewTiny projects result type MultipleViews into projected
-// type MultipleViewsView using the tiny view.
+// type MultipleViewsView using the "tiny" view.
 func newMultipleViewsViewTiny(res *MultipleViews) *resultcollectionmultipleviewsmethodviews.MultipleViewsView {
 	vres := &resultcollectionmultipleviewsmethodviews.MultipleViewsView{
 		A: &res.A,
@@ -497,7 +496,7 @@ func NewMultipleViews(vres *resultwithotherresultviews.MultipleViews) *MultipleV
 	var res *MultipleViews
 	switch vres.View {
 	case "default", "":
-		res = newMultipleViewsDefault(vres.Projected)
+		res = newMultipleViews(vres.Projected)
 	case "tiny":
 		res = newMultipleViewsTiny(vres.Projected)
 	}
@@ -510,7 +509,7 @@ func NewViewedMultipleViews(res *MultipleViews, view string) *resultwithotherres
 	var vres *resultwithotherresultviews.MultipleViews
 	switch view {
 	case "default", "":
-		p := newMultipleViewsViewDefault(res)
+		p := newMultipleViewsView(res)
 		vres = &resultwithotherresultviews.MultipleViews{p, "default"}
 	case "tiny":
 		p := newMultipleViewsViewTiny(res)
@@ -519,15 +518,15 @@ func NewViewedMultipleViews(res *MultipleViews, view string) *resultwithotherres
 	return vres
 }
 
-// newMultipleViewsDefault converts projected type MultipleViews to service
-// type MultipleViews.
-func newMultipleViewsDefault(vres *resultwithotherresultviews.MultipleViewsView) *MultipleViews {
+// newMultipleViews converts projected type MultipleViews to service type
+// MultipleViews.
+func newMultipleViews(vres *resultwithotherresultviews.MultipleViewsView) *MultipleViews {
 	res := &MultipleViews{}
 	if vres.A != nil {
 		res.A = *vres.A
 	}
 	if vres.B != nil {
-		res.B = newMultipleViews2Default(vres.B)
+		res.B = newMultipleViews2(vres.B)
 	}
 	return res
 }
@@ -540,25 +539,25 @@ func newMultipleViewsTiny(vres *resultwithotherresultviews.MultipleViewsView) *M
 		res.A = *vres.A
 	}
 	if vres.B != nil {
-		res.B = newMultipleViews2Default(vres.B)
+		res.B = newMultipleViews2(vres.B)
 	}
 	return res
 }
 
-// newMultipleViewsViewDefault projects result type MultipleViews into
-// projected type MultipleViewsView using the default view.
-func newMultipleViewsViewDefault(res *MultipleViews) *resultwithotherresultviews.MultipleViewsView {
+// newMultipleViewsView projects result type MultipleViews into projected type
+// MultipleViewsView using the "default" view.
+func newMultipleViewsView(res *MultipleViews) *resultwithotherresultviews.MultipleViewsView {
 	vres := &resultwithotherresultviews.MultipleViewsView{
 		A: &res.A,
 	}
 	if res.B != nil {
-		vres.B = newMultipleViews2ViewDefault(res.B)
+		vres.B = newMultipleViews2View(res.B)
 	}
 	return vres
 }
 
 // newMultipleViewsViewTiny projects result type MultipleViews into projected
-// type MultipleViewsView using the tiny view.
+// type MultipleViewsView using the "tiny" view.
 func newMultipleViewsViewTiny(res *MultipleViews) *resultwithotherresultviews.MultipleViewsView {
 	vres := &resultwithotherresultviews.MultipleViewsView{
 		A: &res.A,
@@ -566,9 +565,9 @@ func newMultipleViewsViewTiny(res *MultipleViews) *resultwithotherresultviews.Mu
 	return vres
 }
 
-// newMultipleViews2Default converts projected type MultipleViews2 to service
-// type MultipleViews2.
-func newMultipleViews2Default(vres *resultwithotherresultviews.MultipleViews2View) *MultipleViews2 {
+// newMultipleViews2 converts projected type MultipleViews2 to service type
+// MultipleViews2.
+func newMultipleViews2(vres *resultwithotherresultviews.MultipleViews2View) *MultipleViews2 {
 	res := &MultipleViews2{
 		B: vres.B,
 	}
@@ -588,9 +587,9 @@ func newMultipleViews2Tiny(vres *resultwithotherresultviews.MultipleViews2View) 
 	return res
 }
 
-// newMultipleViews2ViewDefault projects result type MultipleViews2 into
-// projected type MultipleViews2View using the default view.
-func newMultipleViews2ViewDefault(res *MultipleViews2) *resultwithotherresultviews.MultipleViews2View {
+// newMultipleViews2View projects result type MultipleViews2 into projected
+// type MultipleViews2View using the "default" view.
+func newMultipleViews2View(res *MultipleViews2) *resultwithotherresultviews.MultipleViews2View {
 	vres := &resultwithotherresultviews.MultipleViews2View{
 		A: &res.A,
 		B: res.B,
@@ -599,7 +598,7 @@ func newMultipleViews2ViewDefault(res *MultipleViews2) *resultwithotherresultvie
 }
 
 // newMultipleViews2ViewTiny projects result type MultipleViews2 into projected
-// type MultipleViews2View using the tiny view.
+// type MultipleViews2View using the "tiny" view.
 func newMultipleViews2ViewTiny(res *MultipleViews2) *resultwithotherresultviews.MultipleViews2View {
 	vres := &resultwithotherresultviews.MultipleViews2View{
 		A: &res.A,

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -249,28 +249,51 @@ type SingleView struct {
 	B *string
 }
 
-// NewMultipleViews converts viewed result type MultipleViews to result type
-// MultipleViews.
+// NewMultipleViews initializes result type MultipleViews from viewed result
+// type MultipleViews.
 func NewMultipleViews(vres *multiplemethodsresultmultipleviewsviews.MultipleViews) *MultipleViews {
-	res := &MultipleViews{
-		A: vres.Projected.A,
-		B: vres.Projected.B,
+	var res *MultipleViews
+	switch vres.View {
+	case "default", "":
+		res = newMultipleViewsDefault(vres.Projected)
+	case "tiny":
+		res = newMultipleViewsTiny(vres.Projected)
 	}
 	return res
 }
 
-// NewMultipleViewsDefault projects result type MultipleViews into viewed
-// result type MultipleViews using the default view.
-func NewMultipleViewsDefault(res *MultipleViews) *multiplemethodsresultmultipleviewsviews.MultipleViews {
-	p := newMultipleViewsViewDefault(res)
-	return &multiplemethodsresultmultipleviewsviews.MultipleViews{p, "default"}
+// NewViewedMultipleViews initializes viewed result type MultipleViews from
+// result type MultipleViews using the given view.
+func NewViewedMultipleViews(res *MultipleViews, view string) *multiplemethodsresultmultipleviewsviews.MultipleViews {
+	var vres *multiplemethodsresultmultipleviewsviews.MultipleViews
+	switch view {
+	case "default", "":
+		p := newMultipleViewsViewDefault(res)
+		vres = &multiplemethodsresultmultipleviewsviews.MultipleViews{p, "default"}
+	case "tiny":
+		p := newMultipleViewsViewTiny(res)
+		vres = &multiplemethodsresultmultipleviewsviews.MultipleViews{p, "tiny"}
+	}
+	return vres
 }
 
-// NewMultipleViewsTiny projects result type MultipleViews into viewed result
-// type MultipleViews using the tiny view.
-func NewMultipleViewsTiny(res *MultipleViews) *multiplemethodsresultmultipleviewsviews.MultipleViews {
-	p := newMultipleViewsViewTiny(res)
-	return &multiplemethodsresultmultipleviewsviews.MultipleViews{p, "tiny"}
+// newMultipleViewsDefault converts projected type MultipleViews to service
+// type MultipleViews.
+func newMultipleViewsDefault(vres *multiplemethodsresultmultipleviewsviews.MultipleViewsView) *MultipleViews {
+	res := &MultipleViews{
+		A: vres.A,
+		B: vres.B,
+	}
+	return res
+}
+
+// newMultipleViewsTiny converts projected type MultipleViews to service type
+// MultipleViews.
+func newMultipleViewsTiny(vres *multiplemethodsresultmultipleviewsviews.MultipleViewsView) *MultipleViews {
+	res := &MultipleViews{
+		A: vres.A,
+	}
+	return res
 }
 
 // newMultipleViewsViewDefault projects result type MultipleViews into
@@ -322,32 +345,53 @@ type MultipleViews struct {
 	B int
 }
 
-// NewMultipleViewsCollection converts viewed result type
-// MultipleViewsCollection to result type MultipleViewsCollection.
+// NewMultipleViewsCollection initializes result type MultipleViewsCollection
+// from viewed result type MultipleViewsCollection.
 func NewMultipleViewsCollection(vres resultcollectionmultipleviewsmethodviews.MultipleViewsCollection) MultipleViewsCollection {
-	res := make([]*MultipleViews, len(vres.Projected))
-	for i, val := range vres.Projected {
-		res[i] = &MultipleViews{
-			A: *val.A,
-			B: *val.B,
-		}
+	var res MultipleViewsCollection
+	switch vres.View {
+	case "default", "":
+		res = newMultipleViewsCollectionDefault(vres.Projected)
+	case "tiny":
+		res = newMultipleViewsCollectionTiny(vres.Projected)
 	}
 	return res
 }
 
-// NewMultipleViewsCollectionDefault projects result type
-// MultipleViewsCollection into viewed result type MultipleViewsCollection
-// using the default view.
-func NewMultipleViewsCollectionDefault(res MultipleViewsCollection) resultcollectionmultipleviewsmethodviews.MultipleViewsCollection {
-	p := newMultipleViewsCollectionViewDefault(res)
-	return resultcollectionmultipleviewsmethodviews.MultipleViewsCollection{p, "default"}
+// NewViewedMultipleViewsCollection initializes viewed result type
+// MultipleViewsCollection from result type MultipleViewsCollection using the
+// given view.
+func NewViewedMultipleViewsCollection(res MultipleViewsCollection, view string) resultcollectionmultipleviewsmethodviews.MultipleViewsCollection {
+	var vres resultcollectionmultipleviewsmethodviews.MultipleViewsCollection
+	switch view {
+	case "default", "":
+		p := newMultipleViewsCollectionViewDefault(res)
+		vres = resultcollectionmultipleviewsmethodviews.MultipleViewsCollection{p, "default"}
+	case "tiny":
+		p := newMultipleViewsCollectionViewTiny(res)
+		vres = resultcollectionmultipleviewsmethodviews.MultipleViewsCollection{p, "tiny"}
+	}
+	return vres
 }
 
-// NewMultipleViewsCollectionTiny projects result type MultipleViewsCollection
-// into viewed result type MultipleViewsCollection using the tiny view.
-func NewMultipleViewsCollectionTiny(res MultipleViewsCollection) resultcollectionmultipleviewsmethodviews.MultipleViewsCollection {
-	p := newMultipleViewsCollectionViewTiny(res)
-	return resultcollectionmultipleviewsmethodviews.MultipleViewsCollection{p, "tiny"}
+// newMultipleViewsCollectionDefault converts projected type
+// MultipleViewsCollection to service type MultipleViewsCollection.
+func newMultipleViewsCollectionDefault(vres resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView) MultipleViewsCollection {
+	res := make(MultipleViewsCollection, len(vres))
+	for i, n := range vres {
+		res[i] = newMultipleViewsDefault(n)
+	}
+	return res
+}
+
+// newMultipleViewsCollectionTiny converts projected type
+// MultipleViewsCollection to service type MultipleViewsCollection.
+func newMultipleViewsCollectionTiny(vres resultcollectionmultipleviewsmethodviews.MultipleViewsCollectionView) MultipleViewsCollection {
+	res := make(MultipleViewsCollection, len(vres))
+	for i, n := range vres {
+		res[i] = newMultipleViewsTiny(n)
+	}
+	return res
 }
 
 // newMultipleViewsCollectionViewDefault projects result type
@@ -370,6 +414,29 @@ func newMultipleViewsCollectionViewTiny(res MultipleViewsCollection) resultcolle
 		vres[i] = newMultipleViewsViewTiny(n)
 	}
 	return vres
+}
+
+// newMultipleViewsDefault converts projected type MultipleViews to service
+// type MultipleViews.
+func newMultipleViewsDefault(vres *resultcollectionmultipleviewsmethodviews.MultipleViewsView) *MultipleViews {
+	res := &MultipleViews{}
+	if vres.A != nil {
+		res.A = *vres.A
+	}
+	if vres.B != nil {
+		res.B = *vres.B
+	}
+	return res
+}
+
+// newMultipleViewsTiny converts projected type MultipleViews to service type
+// MultipleViews.
+func newMultipleViewsTiny(vres *resultcollectionmultipleviewsmethodviews.MultipleViewsView) *MultipleViews {
+	res := &MultipleViews{}
+	if vres.A != nil {
+		res.A = *vres.A
+	}
+	return res
 }
 
 // newMultipleViewsViewDefault projects result type MultipleViews into
@@ -424,28 +491,58 @@ type MultipleViews2 struct {
 	B *string
 }
 
-// NewMultipleViews converts viewed result type MultipleViews to result type
-// MultipleViews.
+// NewMultipleViews initializes result type MultipleViews from viewed result
+// type MultipleViews.
 func NewMultipleViews(vres *resultwithotherresultviews.MultipleViews) *MultipleViews {
-	res := &MultipleViews{
-		A: *vres.Projected.A,
+	var res *MultipleViews
+	switch vres.View {
+	case "default", "":
+		res = newMultipleViewsDefault(vres.Projected)
+	case "tiny":
+		res = newMultipleViewsTiny(vres.Projected)
 	}
-	res.B = unmarshalMultipleViews2ViewToMultipleViews2(vres.Projected.B)
 	return res
 }
 
-// NewMultipleViewsDefault projects result type MultipleViews into viewed
-// result type MultipleViews using the default view.
-func NewMultipleViewsDefault(res *MultipleViews) *resultwithotherresultviews.MultipleViews {
-	p := newMultipleViewsViewDefault(res)
-	return &resultwithotherresultviews.MultipleViews{p, "default"}
+// NewViewedMultipleViews initializes viewed result type MultipleViews from
+// result type MultipleViews using the given view.
+func NewViewedMultipleViews(res *MultipleViews, view string) *resultwithotherresultviews.MultipleViews {
+	var vres *resultwithotherresultviews.MultipleViews
+	switch view {
+	case "default", "":
+		p := newMultipleViewsViewDefault(res)
+		vres = &resultwithotherresultviews.MultipleViews{p, "default"}
+	case "tiny":
+		p := newMultipleViewsViewTiny(res)
+		vres = &resultwithotherresultviews.MultipleViews{p, "tiny"}
+	}
+	return vres
 }
 
-// NewMultipleViewsTiny projects result type MultipleViews into viewed result
-// type MultipleViews using the tiny view.
-func NewMultipleViewsTiny(res *MultipleViews) *resultwithotherresultviews.MultipleViews {
-	p := newMultipleViewsViewTiny(res)
-	return &resultwithotherresultviews.MultipleViews{p, "tiny"}
+// newMultipleViewsDefault converts projected type MultipleViews to service
+// type MultipleViews.
+func newMultipleViewsDefault(vres *resultwithotherresultviews.MultipleViewsView) *MultipleViews {
+	res := &MultipleViews{}
+	if vres.A != nil {
+		res.A = *vres.A
+	}
+	if vres.B != nil {
+		res.B = newMultipleViews2Default(vres.B)
+	}
+	return res
+}
+
+// newMultipleViewsTiny converts projected type MultipleViews to service type
+// MultipleViews.
+func newMultipleViewsTiny(vres *resultwithotherresultviews.MultipleViewsView) *MultipleViews {
+	res := &MultipleViews{}
+	if vres.A != nil {
+		res.A = *vres.A
+	}
+	if vres.B != nil {
+		res.B = newMultipleViews2Default(vres.B)
+	}
+	return res
 }
 
 // newMultipleViewsViewDefault projects result type MultipleViews into
@@ -469,6 +566,28 @@ func newMultipleViewsViewTiny(res *MultipleViews) *resultwithotherresultviews.Mu
 	return vres
 }
 
+// newMultipleViews2Default converts projected type MultipleViews2 to service
+// type MultipleViews2.
+func newMultipleViews2Default(vres *resultwithotherresultviews.MultipleViews2View) *MultipleViews2 {
+	res := &MultipleViews2{
+		B: vres.B,
+	}
+	if vres.A != nil {
+		res.A = *vres.A
+	}
+	return res
+}
+
+// newMultipleViews2Tiny converts projected type MultipleViews2 to service type
+// MultipleViews2.
+func newMultipleViews2Tiny(vres *resultwithotherresultviews.MultipleViews2View) *MultipleViews2 {
+	res := &MultipleViews2{}
+	if vres.A != nil {
+		res.A = *vres.A
+	}
+	return res
+}
+
 // newMultipleViews2ViewDefault projects result type MultipleViews2 into
 // projected type MultipleViews2View using the default view.
 func newMultipleViews2ViewDefault(res *MultipleViews2) *resultwithotherresultviews.MultipleViews2View {
@@ -486,17 +605,5 @@ func newMultipleViews2ViewTiny(res *MultipleViews2) *resultwithotherresultviews.
 		A: &res.A,
 	}
 	return vres
-}
-
-// unmarshalMultipleViews2ViewToMultipleViews2 builds a value of type
-// *MultipleViews2 from a value of type
-// *resultwithotherresultviews.MultipleViews2View.
-func unmarshalMultipleViews2ViewToMultipleViews2(v *resultwithotherresultviews.MultipleViews2View) *MultipleViews2 {
-	res := &MultipleViews2{
-		A: *v.A,
-		B: v.B,
-	}
-
-	return res
 }
 `

--- a/codegen/service/testdata/views_code.go
+++ b/codegen/service/testdata/views_code.go
@@ -18,7 +18,7 @@ type ResultTypeView struct {
 func (result *ResultType) Validate() (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.ValidateDefault()
+		err = result.Projected.Validate()
 	case "tiny":
 		err = result.Projected.ValidateTiny()
 	default:
@@ -27,9 +27,9 @@ func (result *ResultType) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on ResultTypeView using the
-// "default" view.
-func (result *ResultTypeView) ValidateDefault() (err error) {
+// Validate runs the validations defined on ResultTypeView using the "default"
+// view.
+func (result *ResultTypeView) Validate() (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
@@ -72,7 +72,7 @@ type ResultTypeView struct {
 func (result ResultTypeCollection) Validate() (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.ValidateDefault()
+		err = result.Projected.Validate()
 	case "tiny":
 		err = result.Projected.ValidateTiny()
 	default:
@@ -81,11 +81,11 @@ func (result ResultTypeCollection) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on ResultTypeCollectionView
-// using the "default" view.
-func (result ResultTypeCollectionView) ValidateDefault() (err error) {
+// Validate runs the validations defined on ResultTypeCollectionView using the
+// "default" view.
+func (result ResultTypeCollectionView) Validate() (err error) {
 	for _, item := range result {
-		if err2 := item.ValidateDefault(); err2 != nil {
+		if err2 := item.Validate(); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -103,9 +103,9 @@ func (result ResultTypeCollectionView) ValidateTiny() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on ResultTypeView using the
-// "default" view.
-func (result *ResultTypeView) ValidateDefault() (err error) {
+// Validate runs the validations defined on ResultTypeView using the "default"
+// view.
+func (result *ResultTypeView) Validate() (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
@@ -148,7 +148,7 @@ type UserType struct {
 func (result *ResultType) Validate() (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.ValidateDefault()
+		err = result.Projected.Validate()
 	case "tiny":
 		err = result.Projected.ValidateTiny()
 	default:
@@ -157,9 +157,9 @@ func (result *ResultType) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on ResultTypeView using the
-// "default" view.
-func (result *ResultTypeView) ValidateDefault() (err error) {
+// Validate runs the validations defined on ResultTypeView using the "default"
+// view.
+func (result *ResultTypeView) Validate() (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
@@ -220,7 +220,7 @@ type RT3View struct {
 func (result *RT) Validate() (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.ValidateDefault()
+		err = result.Projected.Validate()
 	case "tiny":
 		err = result.Projected.ValidateTiny()
 	default:
@@ -229,9 +229,8 @@ func (result *RT) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on RTView using the "default"
-// view.
-func (result *RTView) ValidateDefault() (err error) {
+// Validate runs the validations defined on RTView using the "default" view.
+func (result *RTView) Validate() (err error) {
 
 	if result.B != nil {
 		if err2 := result.B.ValidateExtended(); err2 != nil {
@@ -239,7 +238,7 @@ func (result *RTView) ValidateDefault() (err error) {
 		}
 	}
 	if result.C != nil {
-		if err2 := result.C.ValidateDefault(); err2 != nil {
+		if err2 := result.C.Validate(); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -255,16 +254,15 @@ func (result *RTView) ValidateTiny() (err error) {
 		}
 	}
 	if result.C != nil {
-		if err2 := result.C.ValidateDefault(); err2 != nil {
+		if err2 := result.C.Validate(); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateDefault runs the validations defined on RT2View using the "default"
-// view.
-func (result *RT2View) ValidateDefault() (err error) {
+// Validate runs the validations defined on RT2View using the "default" view.
+func (result *RT2View) Validate() (err error) {
 	if result.C == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("c", "result"))
 	}
@@ -300,9 +298,8 @@ func (result *UserType) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on RT3View using the "default"
-// view.
-func (result *RT3View) ValidateDefault() (err error) {
+// Validate runs the validations defined on RT3View using the "default" view.
+func (result *RT3View) Validate() (err error) {
 	if result.X == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("x", "result"))
 	}
@@ -338,7 +335,7 @@ type RTView struct {
 func (result *RT) Validate() (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.ValidateDefault()
+		err = result.Projected.Validate()
 	case "tiny":
 		err = result.Projected.ValidateTiny()
 	default:
@@ -347,9 +344,8 @@ func (result *RT) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on RTView using the "default"
-// view.
-func (result *RTView) ValidateDefault() (err error) {
+// Validate runs the validations defined on RTView using the "default" view.
+func (result *RTView) Validate() (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
@@ -367,7 +363,7 @@ func (result *RTView) ValidateTiny() (err error) {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
 	if result.A != nil {
-		if err2 := result.A.ValidateDefault(); err2 != nil {
+		if err2 := result.A.Validate(); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}

--- a/codegen/service/testdata/views_code.go
+++ b/codegen/service/testdata/views_code.go
@@ -14,7 +14,7 @@ type ResultTypeView struct {
 	B *string
 }
 
-// Validate runs the validations defined on ResultType.
+// Validate runs the validations defined on the viewed result type ResultType.
 func (result *ResultType) Validate() (err error) {
 	switch result.View {
 	case "default", "":
@@ -27,7 +27,7 @@ func (result *ResultType) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on ResultType using the
+// ValidateDefault runs the validations defined on ResultTypeView using the
 // "default" view.
 func (result *ResultTypeView) ValidateDefault() (err error) {
 	if result.A == nil {
@@ -39,7 +39,7 @@ func (result *ResultTypeView) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on ResultType using the "tiny"
+// ValidateTiny runs the validations defined on ResultTypeView using the "tiny"
 // view.
 func (result *ResultTypeView) ValidateTiny() (err error) {
 	if result.A == nil {
@@ -67,7 +67,8 @@ type ResultTypeView struct {
 	B *string
 }
 
-// Validate runs the validations defined on ResultTypeCollection.
+// Validate runs the validations defined on the viewed result type
+// ResultTypeCollection.
 func (result ResultTypeCollection) Validate() (err error) {
 	switch result.View {
 	case "default", "":
@@ -80,8 +81,8 @@ func (result ResultTypeCollection) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on ResultTypeCollection using
-// the "default" view.
+// ValidateDefault runs the validations defined on ResultTypeCollectionView
+// using the "default" view.
 func (result ResultTypeCollectionView) ValidateDefault() (err error) {
 	for _, item := range result {
 		if err2 := item.ValidateDefault(); err2 != nil {
@@ -91,8 +92,8 @@ func (result ResultTypeCollectionView) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on ResultTypeCollection using the
-// "tiny" view.
+// ValidateTiny runs the validations defined on ResultTypeCollectionView using
+// the "tiny" view.
 func (result ResultTypeCollectionView) ValidateTiny() (err error) {
 	for _, item := range result {
 		if err2 := item.ValidateTiny(); err2 != nil {
@@ -102,7 +103,7 @@ func (result ResultTypeCollectionView) ValidateTiny() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on ResultType using the
+// ValidateDefault runs the validations defined on ResultTypeView using the
 // "default" view.
 func (result *ResultTypeView) ValidateDefault() (err error) {
 	if result.A == nil {
@@ -114,7 +115,7 @@ func (result *ResultTypeView) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on ResultType using the "tiny"
+// ValidateTiny runs the validations defined on ResultTypeView using the "tiny"
 // view.
 func (result *ResultTypeView) ValidateTiny() (err error) {
 	if result.A == nil {
@@ -143,7 +144,7 @@ type UserType struct {
 	A *string
 }
 
-// Validate runs the validations defined on ResultType.
+// Validate runs the validations defined on the viewed result type ResultType.
 func (result *ResultType) Validate() (err error) {
 	switch result.View {
 	case "default", "":
@@ -156,7 +157,7 @@ func (result *ResultType) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on ResultType using the
+// ValidateDefault runs the validations defined on ResultTypeView using the
 // "default" view.
 func (result *ResultTypeView) ValidateDefault() (err error) {
 	if result.A == nil {
@@ -165,7 +166,7 @@ func (result *ResultTypeView) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on ResultType using the "tiny"
+// ValidateTiny runs the validations defined on ResultTypeView using the "tiny"
 // view.
 func (result *ResultTypeView) ValidateTiny() (err error) {
 	if result.A == nil {
@@ -174,7 +175,7 @@ func (result *ResultTypeView) ValidateTiny() (err error) {
 	return
 }
 
-// Validate runs the validations defined on UserType.
+// Validate runs the validations defined on UserType
 func (result *UserType) Validate() (err error) {
 
 	return
@@ -215,7 +216,7 @@ type RT3View struct {
 	Z *string
 }
 
-// Validate runs the validations defined on RT.
+// Validate runs the validations defined on the viewed result type RT.
 func (result *RT) Validate() (err error) {
 	switch result.View {
 	case "default", "":
@@ -228,7 +229,8 @@ func (result *RT) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on RT using the "default" view.
+// ValidateDefault runs the validations defined on RTView using the "default"
+// view.
 func (result *RTView) ValidateDefault() (err error) {
 
 	if result.B != nil {
@@ -244,7 +246,7 @@ func (result *RTView) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on RT using the "tiny" view.
+// ValidateTiny runs the validations defined on RTView using the "tiny" view.
 func (result *RTView) ValidateTiny() (err error) {
 
 	if result.B != nil {
@@ -260,7 +262,8 @@ func (result *RTView) ValidateTiny() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on RT2 using the "default" view.
+// ValidateDefault runs the validations defined on RT2View using the "default"
+// view.
 func (result *RT2View) ValidateDefault() (err error) {
 	if result.C == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("c", "result"))
@@ -271,8 +274,8 @@ func (result *RT2View) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateExtended runs the validations defined on RT2 using the "extended"
-// view.
+// ValidateExtended runs the validations defined on RT2View using the
+// "extended" view.
 func (result *RT2View) ValidateExtended() (err error) {
 	if result.C == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("c", "result"))
@@ -283,7 +286,7 @@ func (result *RT2View) ValidateExtended() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on RT2 using the "tiny" view.
+// ValidateTiny runs the validations defined on RT2View using the "tiny" view.
 func (result *RT2View) ValidateTiny() (err error) {
 	if result.D == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("d", "result"))
@@ -291,13 +294,14 @@ func (result *RT2View) ValidateTiny() (err error) {
 	return
 }
 
-// Validate runs the validations defined on UserType.
+// Validate runs the validations defined on UserType
 func (result *UserType) Validate() (err error) {
 
 	return
 }
 
-// ValidateDefault runs the validations defined on RT3 using the "default" view.
+// ValidateDefault runs the validations defined on RT3View using the "default"
+// view.
 func (result *RT3View) ValidateDefault() (err error) {
 	if result.X == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("x", "result"))
@@ -308,7 +312,7 @@ func (result *RT3View) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on RT3 using the "tiny" view.
+// ValidateTiny runs the validations defined on RT3View using the "tiny" view.
 func (result *RT3View) ValidateTiny() (err error) {
 	if result.X == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("x", "result"))
@@ -330,7 +334,7 @@ type RTView struct {
 	A *RTView
 }
 
-// Validate runs the validations defined on RT.
+// Validate runs the validations defined on the viewed result type RT.
 func (result *RT) Validate() (err error) {
 	switch result.View {
 	case "default", "":
@@ -343,7 +347,8 @@ func (result *RT) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on RT using the "default" view.
+// ValidateDefault runs the validations defined on RTView using the "default"
+// view.
 func (result *RTView) ValidateDefault() (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
@@ -356,7 +361,7 @@ func (result *RTView) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on RT using the "tiny" view.
+// ValidateTiny runs the validations defined on RTView using the "tiny" view.
 func (result *RTView) ValidateTiny() (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))

--- a/codegen/service/views.go
+++ b/codegen/service/views.go
@@ -27,6 +27,13 @@ func ViewsFile(genpkg string, service *design.ServiceExpr) *codegen.File {
 		sections = []*codegen.SectionTemplate{header}
 
 		// type definitions
+		for _, t := range svc.ViewedResultTypes {
+			sections = append(sections, &codegen.SectionTemplate{
+				Name:   "viewed-result-type",
+				Source: userTypeT,
+				Data:   t.UserTypeData,
+			})
+		}
 		for _, t := range svc.ProjectedTypes {
 			sections = append(sections, &codegen.SectionTemplate{
 				Name:   "projected-type",
@@ -36,24 +43,20 @@ func ViewsFile(genpkg string, service *design.ServiceExpr) *codegen.File {
 		}
 
 		// validations
+		for _, t := range svc.ViewedResultTypes {
+			sections = append(sections, &codegen.SectionTemplate{
+				Name:   "validate-viewed-result-type",
+				Source: validateT,
+				Data:   t.Validate,
+			})
+		}
 		for _, t := range svc.ProjectedTypes {
-			if t.Validate != nil {
+			for _, v := range t.Validations {
 				sections = append(sections, &codegen.SectionTemplate{
-					Name:   "validate-type",
+					Name:   "validate-projected-type",
 					Source: validateT,
-					Data:   t.Validate,
+					Data:   v,
 				})
-			}
-			if t.Views != nil {
-				for _, v := range t.Views {
-					if v.Validate != nil {
-						sections = append(sections, &codegen.SectionTemplate{
-							Name:   "validate-type",
-							Source: validateT,
-							Data:   v.Validate,
-						})
-					}
-				}
 			}
 		}
 	}

--- a/examples/cellar/gen/http/storage/client/encode_decode.go
+++ b/examples/cellar/gen/http/storage/client/encode_decode.go
@@ -530,9 +530,9 @@ func unmarshalWineryTinyResponseBodyToWineryTiny(v *WineryTinyResponseBody) *sto
 	return res
 }
 
-// unmarshalWineryResponseBodyToWineryView builds a value of type
+// marshalWineryResponseBodyToWineryView builds a value of type
 // *storageviews.WineryView from a value of type *WineryResponseBody.
-func unmarshalWineryResponseBodyToWineryView(v *WineryResponseBody) *storageviews.WineryView {
+func marshalWineryResponseBodyToWineryView(v *WineryResponseBody) *storageviews.WineryView {
 	res := &storageviews.WineryView{
 		Name:    v.Name,
 		Region:  v.Region,

--- a/examples/cellar/gen/http/storage/client/types.go
+++ b/examples/cellar/gen/http/storage/client/types.go
@@ -249,7 +249,9 @@ func NewShowStoredBottleOK(body *ShowResponseBody) *storageviews.StoredBottleVie
 		Description: body.Description,
 		Rating:      body.Rating,
 	}
-	v.Winery = unmarshalWineryResponseBodyToWineryView(body.Winery)
+	if body.Winery != nil {
+		v.Winery = marshalWineryResponseBodyToWineryView(body.Winery)
+	}
 	if body.Composition != nil {
 		v.Composition = make([]*storageviews.Component, len(body.Composition))
 		for j, val := range body.Composition {

--- a/examples/cellar/gen/storage/endpoints.go
+++ b/examples/cellar/gen/storage/endpoints.go
@@ -10,10 +10,8 @@ package storage
 
 import (
 	"context"
-	"fmt"
 
 	goa "goa.design/goa"
-	storageviews "goa.design/goa/examples/cellar/gen/storage/views"
 )
 
 // Endpoints wraps the "storage" service endpoints.
@@ -68,14 +66,9 @@ func NewShowEndpoint(s Service) goa.Endpoint {
 		if err != nil {
 			return nil, err
 		}
-		var vres *storageviews.StoredBottle
-		switch view {
-		case "default", "":
-			vres = NewStoredBottleDefault(res)
-		case "tiny":
-			vres = NewStoredBottleTiny(res)
-		default:
-			return nil, fmt.Errorf("unknown view %q", view)
+		vres := NewViewedStoredBottle(res, view)
+		if err := vres.Validate(); err != nil {
+			return nil, err
 		}
 		return vres, nil
 	}

--- a/examples/cellar/gen/storage/endpoints.go
+++ b/examples/cellar/gen/storage/endpoints.go
@@ -66,7 +66,7 @@ func NewShowEndpoint(s Service) goa.Endpoint {
 		if err != nil {
 			return nil, err
 		}
-		vres := NewViewedStoredBottle(res, view)
+		vres := newViewedStoredBottle(res, view)
 		if err := vres.Validate(); err != nil {
 			return nil, err
 		}

--- a/examples/cellar/gen/storage/service.go
+++ b/examples/cellar/gen/storage/service.go
@@ -170,7 +170,7 @@ func NewStoredBottle(vres *storageviews.StoredBottle) *StoredBottle {
 	var res *StoredBottle
 	switch vres.View {
 	case "default", "":
-		res = newStoredBottleDefault(vres.Projected)
+		res = newStoredBottle(vres.Projected)
 	case "tiny":
 		res = newStoredBottleTiny(vres.Projected)
 	}
@@ -183,7 +183,7 @@ func NewViewedStoredBottle(res *StoredBottle, view string) *storageviews.StoredB
 	var vres *storageviews.StoredBottle
 	switch view {
 	case "default", "":
-		p := newStoredBottleViewDefault(res)
+		p := newStoredBottleView(res)
 		vres = &storageviews.StoredBottle{p, "default"}
 	case "tiny":
 		p := newStoredBottleViewTiny(res)
@@ -192,9 +192,9 @@ func NewViewedStoredBottle(res *StoredBottle, view string) *storageviews.StoredB
 	return vres
 }
 
-// newStoredBottleDefault converts projected type StoredBottle to service type
+// newStoredBottle converts projected type StoredBottle to service type
 // StoredBottle.
-func newStoredBottleDefault(vres *storageviews.StoredBottleView) *StoredBottle {
+func newStoredBottle(vres *storageviews.StoredBottleView) *StoredBottle {
 	res := &StoredBottle{
 		Description: vres.Description,
 		Rating:      vres.Rating,
@@ -239,9 +239,9 @@ func newStoredBottleTiny(vres *storageviews.StoredBottleView) *StoredBottle {
 	return res
 }
 
-// newStoredBottleViewDefault projects result type StoredBottle into projected
-// type StoredBottleView using the default view.
-func newStoredBottleViewDefault(res *StoredBottle) *storageviews.StoredBottleView {
+// newStoredBottleView projects result type StoredBottle into projected type
+// StoredBottleView using the "default" view.
+func newStoredBottleView(res *StoredBottle) *storageviews.StoredBottleView {
 	vres := &storageviews.StoredBottleView{
 		ID:          &res.ID,
 		Name:        &res.Name,
@@ -265,7 +265,7 @@ func newStoredBottleViewDefault(res *StoredBottle) *storageviews.StoredBottleVie
 }
 
 // newStoredBottleViewTiny projects result type StoredBottle into projected
-// type StoredBottleView using the tiny view.
+// type StoredBottleView using the "tiny" view.
 func newStoredBottleViewTiny(res *StoredBottle) *storageviews.StoredBottleView {
 	vres := &storageviews.StoredBottleView{
 		ID:   &res.ID,
@@ -277,8 +277,8 @@ func newStoredBottleViewTiny(res *StoredBottle) *storageviews.StoredBottleView {
 	return vres
 }
 
-// newWineryDefault converts projected type Winery to service type Winery.
-func newWineryDefault(vres *storageviews.WineryView) *Winery {
+// newWinery converts projected type Winery to service type Winery.
+func newWinery(vres *storageviews.WineryView) *Winery {
 	res := &Winery{
 		URL: vres.URL,
 	}
@@ -303,9 +303,9 @@ func newWineryTiny(vres *storageviews.WineryView) *Winery {
 	return res
 }
 
-// newWineryViewDefault projects result type Winery into projected type
-// WineryView using the default view.
-func newWineryViewDefault(res *Winery) *storageviews.WineryView {
+// newWineryView projects result type Winery into projected type WineryView
+// using the "default" view.
+func newWineryView(res *Winery) *storageviews.WineryView {
 	vres := &storageviews.WineryView{
 		Name:    &res.Name,
 		Region:  &res.Region,
@@ -316,7 +316,7 @@ func newWineryViewDefault(res *Winery) *storageviews.WineryView {
 }
 
 // newWineryViewTiny projects result type Winery into projected type WineryView
-// using the tiny view.
+// using the "tiny" view.
 func newWineryViewTiny(res *Winery) *storageviews.WineryView {
 	vres := &storageviews.WineryView{
 		Name: &res.Name,

--- a/examples/cellar/gen/storage/service.go
+++ b/examples/cellar/gen/storage/service.go
@@ -177,9 +177,9 @@ func NewStoredBottle(vres *storageviews.StoredBottle) *StoredBottle {
 	return res
 }
 
-// NewViewedStoredBottle initializes viewed result type StoredBottle from
+// newViewedStoredBottle initializes viewed result type StoredBottle from
 // result type StoredBottle using the given view.
-func NewViewedStoredBottle(res *StoredBottle, view string) *storageviews.StoredBottle {
+func newViewedStoredBottle(res *StoredBottle, view string) *storageviews.StoredBottle {
 	var vres *storageviews.StoredBottle
 	switch view {
 	case "default", "":

--- a/examples/cellar/gen/storage/service.go
+++ b/examples/cellar/gen/storage/service.go
@@ -164,41 +164,79 @@ func (e *NotFound) ErrorName() string {
 	return e.Message
 }
 
-// NewStoredBottle converts viewed result type StoredBottle to result type
+// NewStoredBottle initializes result type StoredBottle from viewed result type
 // StoredBottle.
 func NewStoredBottle(vres *storageviews.StoredBottle) *StoredBottle {
-	res := &StoredBottle{
-		ID:          *vres.Projected.ID,
-		Name:        *vres.Projected.Name,
-		Vintage:     *vres.Projected.Vintage,
-		Description: vres.Projected.Description,
-		Rating:      vres.Projected.Rating,
+	var res *StoredBottle
+	switch vres.View {
+	case "default", "":
+		res = newStoredBottleDefault(vres.Projected)
+	case "tiny":
+		res = newStoredBottleTiny(vres.Projected)
 	}
-	res.Winery = unmarshalWineryViewToWinery(vres.Projected.Winery)
-	if vres.Projected.Composition != nil {
-		res.Composition = make([]*Component, len(vres.Projected.Composition))
-		for j, val := range vres.Projected.Composition {
+	return res
+}
+
+// NewViewedStoredBottle initializes viewed result type StoredBottle from
+// result type StoredBottle using the given view.
+func NewViewedStoredBottle(res *StoredBottle, view string) *storageviews.StoredBottle {
+	var vres *storageviews.StoredBottle
+	switch view {
+	case "default", "":
+		p := newStoredBottleViewDefault(res)
+		vres = &storageviews.StoredBottle{p, "default"}
+	case "tiny":
+		p := newStoredBottleViewTiny(res)
+		vres = &storageviews.StoredBottle{p, "tiny"}
+	}
+	return vres
+}
+
+// newStoredBottleDefault converts projected type StoredBottle to service type
+// StoredBottle.
+func newStoredBottleDefault(vres *storageviews.StoredBottleView) *StoredBottle {
+	res := &StoredBottle{
+		Description: vres.Description,
+		Rating:      vres.Rating,
+	}
+	if vres.ID != nil {
+		res.ID = *vres.ID
+	}
+	if vres.Name != nil {
+		res.Name = *vres.Name
+	}
+	if vres.Vintage != nil {
+		res.Vintage = *vres.Vintage
+	}
+	if vres.Composition != nil {
+		res.Composition = make([]*Component, len(vres.Composition))
+		for j, val := range vres.Composition {
 			res.Composition[j] = &Component{
 				Varietal:   *val.Varietal,
 				Percentage: val.Percentage,
 			}
 		}
 	}
+	if vres.Winery != nil {
+		res.Winery = newWineryTiny(vres.Winery)
+	}
 	return res
 }
 
-// NewStoredBottleDefault projects result type StoredBottle into viewed result
-// type StoredBottle using the default view.
-func NewStoredBottleDefault(res *StoredBottle) *storageviews.StoredBottle {
-	p := newStoredBottleViewDefault(res)
-	return &storageviews.StoredBottle{p, "default"}
-}
-
-// NewStoredBottleTiny projects result type StoredBottle into viewed result
-// type StoredBottle using the tiny view.
-func NewStoredBottleTiny(res *StoredBottle) *storageviews.StoredBottle {
-	p := newStoredBottleViewTiny(res)
-	return &storageviews.StoredBottle{p, "tiny"}
+// newStoredBottleTiny converts projected type StoredBottle to service type
+// StoredBottle.
+func newStoredBottleTiny(vres *storageviews.StoredBottleView) *StoredBottle {
+	res := &StoredBottle{}
+	if vres.ID != nil {
+		res.ID = *vres.ID
+	}
+	if vres.Name != nil {
+		res.Name = *vres.Name
+	}
+	if vres.Winery != nil {
+		res.Winery = newWineryTiny(vres.Winery)
+	}
+	return res
 }
 
 // newStoredBottleViewDefault projects result type StoredBottle into projected
@@ -239,6 +277,32 @@ func newStoredBottleViewTiny(res *StoredBottle) *storageviews.StoredBottleView {
 	return vres
 }
 
+// newWineryDefault converts projected type Winery to service type Winery.
+func newWineryDefault(vres *storageviews.WineryView) *Winery {
+	res := &Winery{
+		URL: vres.URL,
+	}
+	if vres.Name != nil {
+		res.Name = *vres.Name
+	}
+	if vres.Region != nil {
+		res.Region = *vres.Region
+	}
+	if vres.Country != nil {
+		res.Country = *vres.Country
+	}
+	return res
+}
+
+// newWineryTiny converts projected type Winery to service type Winery.
+func newWineryTiny(vres *storageviews.WineryView) *Winery {
+	res := &Winery{}
+	if vres.Name != nil {
+		res.Name = *vres.Name
+	}
+	return res
+}
+
 // newWineryViewDefault projects result type Winery into projected type
 // WineryView using the default view.
 func newWineryViewDefault(res *Winery) *storageviews.WineryView {
@@ -258,17 +322,4 @@ func newWineryViewTiny(res *Winery) *storageviews.WineryView {
 		Name: &res.Name,
 	}
 	return vres
-}
-
-// unmarshalWineryViewToWinery builds a value of type *Winery from a value of
-// type *storageviews.WineryView.
-func unmarshalWineryViewToWinery(v *storageviews.WineryView) *Winery {
-	res := &Winery{
-		Name:    *v.Name,
-		Region:  *v.Region,
-		Country: *v.Country,
-		URL:     v.URL,
-	}
-
-	return res
 }

--- a/examples/cellar/gen/storage/views/view.go
+++ b/examples/cellar/gen/storage/views/view.go
@@ -60,7 +60,7 @@ type Component struct {
 	Percentage *uint32
 }
 
-// Validate runs the validations defined on StoredBottle.
+// Validate runs the validations defined on the viewed result type StoredBottle.
 func (result *StoredBottle) Validate() (err error) {
 	switch result.View {
 	case "default", "":
@@ -73,7 +73,7 @@ func (result *StoredBottle) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on StoredBottle using the
+// ValidateDefault runs the validations defined on StoredBottleView using the
 // "default" view.
 func (result *StoredBottleView) ValidateDefault() (err error) {
 	if result.ID == nil {
@@ -130,8 +130,8 @@ func (result *StoredBottleView) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on StoredBottle using the "tiny"
-// view.
+// ValidateTiny runs the validations defined on StoredBottleView using the
+// "tiny" view.
 func (result *StoredBottleView) ValidateTiny() (err error) {
 	if result.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
@@ -152,8 +152,8 @@ func (result *StoredBottleView) ValidateTiny() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on Winery using the "default"
-// view.
+// ValidateDefault runs the validations defined on WineryView using the
+// "default" view.
 func (result *WineryView) ValidateDefault() (err error) {
 	if result.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "result"))
@@ -176,7 +176,8 @@ func (result *WineryView) ValidateDefault() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on Winery using the "tiny" view.
+// ValidateTiny runs the validations defined on WineryView using the "tiny"
+// view.
 func (result *WineryView) ValidateTiny() (err error) {
 	if result.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "result"))
@@ -184,7 +185,7 @@ func (result *WineryView) ValidateTiny() (err error) {
 	return
 }
 
-// Validate runs the validations defined on Component.
+// Validate runs the validations defined on Component
 func (result *Component) Validate() (err error) {
 	if result.Varietal != nil {
 		err = goa.MergeErrors(err, goa.ValidatePattern("result.varietal", *result.Varietal, "[A-Za-z' ]+"))

--- a/examples/cellar/gen/storage/views/view.go
+++ b/examples/cellar/gen/storage/views/view.go
@@ -64,7 +64,7 @@ type Component struct {
 func (result *StoredBottle) Validate() (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.ValidateDefault()
+		err = result.Projected.Validate()
 	case "tiny":
 		err = result.Projected.ValidateTiny()
 	default:
@@ -73,9 +73,9 @@ func (result *StoredBottle) Validate() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on StoredBottleView using the
+// Validate runs the validations defined on StoredBottleView using the
 // "default" view.
-func (result *StoredBottleView) ValidateDefault() (err error) {
+func (result *StoredBottleView) Validate() (err error) {
 	if result.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
 	}
@@ -152,9 +152,8 @@ func (result *StoredBottleView) ValidateTiny() (err error) {
 	return
 }
 
-// ValidateDefault runs the validations defined on WineryView using the
-// "default" view.
-func (result *WineryView) ValidateDefault() (err error) {
+// Validate runs the validations defined on WineryView using the "default" view.
+func (result *WineryView) Validate() (err error) {
 	if result.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "result"))
 	}

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -410,7 +410,7 @@ func {{ .ResponseDecoder }}(decoder func(*http.Response) goahttp.Decoder, restor
 			if err = vres.Validate(); err != nil {
 				return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", err)
 			}
-			return {{ $.ServicePkgName }}.{{ $.Method.ViewedResult.ConvertToResult.Name }}(vres), nil
+			return {{ $.ServicePkgName }}.{{ $.Method.ViewedResult.ResultInit.Name }}(vres), nil
 			{{- else }}
 		return {{ .ResultInit.Name }}({{ range .ResultInit.ClientArgs }}{{ .Ref }},{{ end }}), nil
 			{{- end }}

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1253,6 +1253,18 @@ func buildResponseResultInit(resp *httpdesign.HTTPResponseExpr, e *httpdesign.En
 			Validate: vcode,
 		}}
 		var helpers []*codegen.TransformFunctionData
+		// If the method result type is a viewed result type (i.e. result type with
+		// multiple views), then we marshal the client response body to the viewed
+		// result type so that the transformation code never assumes that all the
+		// required attributes in the result type are set (a view in the viewed
+		// result type may not contain a required attribute). The client response
+		// body validation is now delegated to the viewed result type which
+		// contains view-specific validation logic.
+		// If the method result type is a user type or a result type with single
+		// view, then we unmarshal the client response body to the result type
+		// after validating the response body. Here, the transformation code must
+		// rely that the required attributes are set in the response body
+		// (otherwise validation would fail).
 		code, helpers, err = codegen.GoTypeTransform(resp.Body.Type, respBody.Type, "body", "v", "", pkg, md.ViewedResult == nil, svc.Scope)
 		if err == nil {
 			sd.ClientTransformHelpers = codegen.AppendHelpers(sd.ClientTransformHelpers, helpers)

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1253,7 +1253,7 @@ func buildResponseResultInit(resp *httpdesign.HTTPResponseExpr, e *httpdesign.En
 			Validate: vcode,
 		}}
 		var helpers []*codegen.TransformFunctionData
-		code, helpers, err = codegen.GoTypeTransform(resp.Body.Type, respBody.Type, "body", "v", "", pkg, true, svc.Scope)
+		code, helpers, err = codegen.GoTypeTransform(resp.Body.Type, respBody.Type, "body", "v", "", pkg, md.ViewedResult == nil, svc.Scope)
 		if err == nil {
 			sd.ClientTransformHelpers = codegen.AppendHelpers(sd.ClientTransformHelpers, helpers)
 		}


### PR DESCRIPTION
* Fixes a case where required attributes may not be in a view.
* In HTTP client response decode, marshal response body if method uses a viewed result type so that the transformation code checks for nil before calling the helpers.
* Fix a bug when validating security scheme in method when payload is nil
* Remove suffix "Default" from validation and init functions. (Fixes #1734)
