### PR TITLE
Validate viewed result only if client body exists

### DIFF
--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -407,9 +407,11 @@ func {{ .ResponseDecoder }}(decoder func(*http.Response) goahttp.Decoder, restor
 			p := {{ .ResultInit.Name }}({{ range .ResultInit.ClientArgs }}{{ .Ref }},{{ end }})
 			view := resp.Header.Get("goa-view")
 			vres := {{ if not $.Method.ViewedResult.IsCollection }}&{{ end }}{{ $.Method.ViewedResult.ViewsPkg}}.{{ $.Method.ViewedResult.VarName }}{p, view}
-			if err = vres.Validate(); err != nil {
-				return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", err)
-			}
+			{{- if .ClientBody }}
+				if err = vres.Validate(); err != nil {
+					return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", err)
+				}
+			{{- end }}
 			return {{ $.ServicePkgName }}.{{ $.Method.ViewedResult.ResultInit.Name }}(vres), nil
 			{{- else }}
 		return {{ .ResultInit.Name }}({{ range .ResultInit.ClientArgs }}{{ .Ref }},{{ end }}), nil

--- a/http/codegen/testdata/result_decode_functions.go
+++ b/http/codegen/testdata/result_decode_functions.go
@@ -109,9 +109,6 @@ func DecodeMethodEmptyBodyResultMultipleViewResponse(decoder func(*http.Response
 			p := NewMethodEmptyBodyResultMultipleViewResulttypemultipleviewsOK(c)
 			view := resp.Header.Get("goa-view")
 			vres := &serviceemptybodyresultmultipleviewviews.Resulttypemultipleviews{p, view}
-			if err = vres.Validate(); err != nil {
-				return nil, goahttp.ErrValidationError("ServiceEmptyBodyResultMultipleView", "MethodEmptyBodyResultMultipleView", err)
-			}
 			return serviceemptybodyresultmultipleview.NewResulttypemultipleviews(vres), nil
 		default:
 			body, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Fixes an issue in client response decode where it tries to validate the viewed result type even if the response body is empty.