### PR TITLE
Make request header logging order consistent

### DIFF
--- a/middleware/log_request.go
+++ b/middleware/log_request.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -43,7 +44,15 @@ func LogRequest(verbose bool, sensitiveHeaders ...string) goa.Middleware {
 				if len(r.Header) > 0 {
 					logCtx := make([]interface{}, 2*len(r.Header))
 					i := 0
-					for k, v := range r.Header {
+					keys := make([]string, len(r.Header))
+					for k := range r.Header {
+						keys[i] = k
+						i++
+					}
+					sort.Strings(keys)
+					i = 0
+					for _, k := range keys {
+						v := r.Header[k]
 						logCtx[i] = k
 						if _, ok := suppressed[strings.ToLower(k)]; ok {
 							logCtx[i+1] = "<hidden>"

--- a/middleware/log_request_test.go
+++ b/middleware/log_request_test.go
@@ -117,10 +117,11 @@ var _ = Describe("LogRequest", func() {
 		Ω(lg(ctx, rw, req)).ShouldNot(HaveOccurred())
 		Ω(logger.InfoEntries).Should(HaveLen(5))
 
-		Ω(logger.InfoEntries[1].Data[2]).Should(Equal("Secret"))
-		Ω(logger.InfoEntries[1].Data[3]).Should(Equal("<hidden>"))
+		Ω(logger.InfoEntries[1].Data[2]).Should(Equal("Not so secret"))
+		Ω(logger.InfoEntries[1].Data[3]).Should(Equal("public"))
 
-		Ω(logger.InfoEntries[1].Data[4]).Should(Equal("Not so secret"))
-		Ω(logger.InfoEntries[1].Data[5]).Should(Equal("public"))
+		Ω(logger.InfoEntries[1].Data[4]).Should(Equal("Secret"))
+		Ω(logger.InfoEntries[1].Data[5]).Should(Equal("<hidden>"))
+
 	})
 })


### PR DESCRIPTION
across multiple generation