### PR TITLE
Make sure default output dir is set

### DIFF
--- a/goagen/gen_main/generator.go
+++ b/goagen/gen_main/generator.go
@@ -22,7 +22,7 @@ import (
 
 //NewGenerator returns an initialized instance of a JavaScript Client Generator
 func NewGenerator(options ...Option) *Generator {
-	g := &Generator{}
+	g := &Generator{OutDir: "."}
 
 	for _, option := range options {
 		option(g)


### PR DESCRIPTION
when using goagen programmatically.

Fix #1728 