### PR TITLE
Allow basic auth to attach Authorization header for a websocket (#1740)

### DIFF
--- a/client/signers.go
+++ b/client/signers.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
+
+	"golang.org/x/net/websocket"
 )
 
 type (
@@ -10,6 +13,10 @@ type (
 	Signer interface {
 		// Sign adds required headers, cookies etc.
 		Sign(*http.Request) error
+	}
+
+	WebSocketSigner interface {
+		SignWebSocket(*websocket.Conn) error
 	}
 
 	// BasicSigner implements basic auth.
@@ -85,6 +92,13 @@ type (
 func (s *BasicSigner) Sign(req *http.Request) error {
 	if s.Username != "" && s.Password != "" {
 		req.SetBasicAuth(s.Username, s.Password)
+	}
+	return nil
+}
+
+func (s *BasicSigner) SignWebSocket(cfg *websocket.Config) error {
+	if s.Username != "" && s.Password != "" {
+		cfg.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(s.Username+":"+s.Password)))
 	}
 	return nil
 }

--- a/client/signers.go
+++ b/client/signers.go
@@ -8,16 +8,22 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+const (
+	// AuthHeader is the standard Authorization header name.
+	AuthHeader = "Authorization"
+)
+
 type (
-	// Signer is the common interface implemented by all signers.
+	// Signer is the common interface implemented by all http signers.
 	Signer interface {
 		// Sign adds required headers, cookies etc.
 		Sign(*http.Request) error
 	}
 
-	// WebSocketSigner is the interface implemented by all signers using websocket.
-	WebSocketSigner interface {
-		SignWebSocket(*websocket.Conn) error
+	// WsSigner is the common interface for websocket signers
+	WsSigner interface {
+		// WsSign adds required headers, cookies, etc. to websocket config
+		WsSign(*websocket.Conn) error
 	}
 
 	// BasicSigner implements basic auth.
@@ -63,6 +69,8 @@ type (
 	Token interface {
 		// SetAuthHeader sets the Authorization header to r.
 		SetAuthHeader(r *http.Request)
+		// SetWsAuthHeader sets the Authorization header to cfg.
+		SetWsAuthHeader(cfg *websocket.Config)
 		// Valid reports whether Token can be used to properly sign requests.
 		Valid() bool
 	}
@@ -89,7 +97,7 @@ type (
 	}
 )
 
-// Sign adds the basic auth header to the request.
+// Sign adds the basic auth header to the http request.
 func (s *BasicSigner) Sign(req *http.Request) error {
 	if s.Username != "" && s.Password != "" {
 		req.SetBasicAuth(s.Username, s.Password)
@@ -97,18 +105,18 @@ func (s *BasicSigner) Sign(req *http.Request) error {
 	return nil
 }
 
-// SignWebSocket adds the basic auth header to the WebSocket dial config
-func (s *WebSocketSigner) SignWebSocket(cfg *websocket.Config) error {
+// WsSign adds the basic auth header to the websocket config
+func (s *BasicSigner) WsSign(cfg *websocket.Config) error {
 	if s.Username != "" && s.Password != "" {
-		cfg.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(s.Username+":"+s.Password)))
+		cfg.Header.Set(AuthHeader, "Basic "+base64.StdEncoding.EncodeToString([]byte(s.Username+":"+s.Password)))
 	}
 	return nil
 }
 
-// Sign adds the API key header to the request.
+// Sign adds the API key header to the http request.
 func (s *APIKeySigner) Sign(req *http.Request) error {
 	if s.KeyName == "" {
-		s.KeyName = "Authorization"
+		s.KeyName = AuthHeader
 	}
 	if s.Format == "" {
 		s.Format = "Bearer %s"
@@ -126,17 +134,42 @@ func (s *APIKeySigner) Sign(req *http.Request) error {
 	return nil
 }
 
-// Sign adds the JWT auth header.
+// WsSign adds the API key header to the websocket config
+func (s *APIKeySigner) WsSign(cfg *websocket.Config) error {
+	if s.KeyName == "" {
+		s.KeyName = AuthHeader
+	}
+	if s.Format == "" {
+		s.Format = "Bearer %s"
+	}
+	name := s.KeyName
+	format := s.Format
+	val := fmt.Sprintf(format, s.KeyValue)
+	cfg.Header.Set(name, val)
+	return nil
+}
+
+// Sign adds the JWT auth header to the http request.
 func (s *JWTSigner) Sign(req *http.Request) error {
 	return signFromSource(s.TokenSource, req)
 }
 
-// Sign refreshes the access token if needed and adds the OAuth header.
+// WsSign adds the JWT auth header to the websocket config.
+func (s *JWTSigner) WsSign(cfg *websocket.Config) error {
+	return signWsFromSource(s.TokenSource, cfg)
+}
+
+// Sign refreshes the access token if needed and adds the OAuth header to the http request.
 func (s *OAuth2Signer) Sign(req *http.Request) error {
 	return signFromSource(s.TokenSource, req)
 }
 
-// signFromSource generates a token using the given source and uses it to sign the request.
+// WsSign refreshes the access token if needed and adds the OAuth header to the websocket config.
+func (s *OAuth2Signer) WsSign(cfg *websocket.Config) error {
+	return signWsFromSource(s.TokenSource, cfg)
+}
+
+// signFromSource generates a token using the given source and uses it to sign the http request.
 func signFromSource(source TokenSource, req *http.Request) error {
 	token, err := source.Token()
 	if err != nil {
@@ -149,18 +182,40 @@ func signFromSource(source TokenSource, req *http.Request) error {
 	return nil
 }
 
+// signWsFromSource generates a token using the given source and uses it to create the websocket config.
+func signWsFromSource(source TokenSource, cfg *websocket.Config) error {
+	token, err := source.Token()
+	if err != nil {
+		return err
+	}
+	if !token.Valid() {
+		return fmt.Errorf("token expired or invalid")
+	}
+	token.SetWsAuthHeader(cfg)
+	return nil
+}
+
 // Token returns the static token.
 func (s *StaticTokenSource) Token() (Token, error) {
 	return s.StaticToken, nil
 }
 
-// SetAuthHeader sets the Authorization header to r.
+// SetAuthHeader sets the Authorization header to http request.
 func (t *StaticToken) SetAuthHeader(r *http.Request) {
 	typ := t.Type
 	if typ == "" {
 		typ = "Bearer"
 	}
-	r.Header.Set("Authorization", typ+" "+t.Value)
+	r.Header.Set(AuthHeader, typ+" "+t.Value)
+}
+
+// SetWsAuthHeader sets the Authorization header to websocket config.
+func (t *StaticToken) SetWsAuthHeader(c *websocket.Config) {
+	typ := t.Type
+	if typ == "" {
+		typ = "Bearer"
+	}
+	c.Header.Set(AuthHeader, typ+" "+t.Value)
 }
 
 // Valid reports whether Token can be used to properly sign requests.

--- a/client/signers.go
+++ b/client/signers.go
@@ -23,11 +23,19 @@ type (
 	// WsSigner is the common interface for websocket signers
 	WsSigner interface {
 		// WsSign adds required headers, cookies, etc. to websocket config
-		WsSign(*websocket.Conn) error
+		WsSign(*websocket.Config) error
 	}
 
 	// BasicSigner implements basic auth.
 	BasicSigner struct {
+		// Username is the basic auth user.
+		Username string
+		// Password is err guess what? the basic auth password.
+		Password string
+	}
+
+	// WsBasicSigner implements basic auth for a websocket.
+	WsBasicSigner struct {
 		// Username is the basic auth user.
 		Username string
 		// Password is err guess what? the basic auth password.
@@ -106,7 +114,7 @@ func (s *BasicSigner) Sign(req *http.Request) error {
 }
 
 // WsSign adds the basic auth header to the websocket config
-func (s *BasicSigner) WsSign(cfg *websocket.Config) error {
+func (s *WsBasicSigner) WsSign(cfg *websocket.Config) error {
 	if s.Username != "" && s.Password != "" {
 		cfg.Header.Set(AuthHeader, "Basic "+base64.StdEncoding.EncodeToString([]byte(s.Username+":"+s.Password)))
 	}

--- a/client/signers.go
+++ b/client/signers.go
@@ -15,6 +15,7 @@ type (
 		Sign(*http.Request) error
 	}
 
+	// WebSocketSigner is the interface implemented by all signers using websocket.
 	WebSocketSigner interface {
 		SignWebSocket(*websocket.Conn) error
 	}
@@ -96,6 +97,7 @@ func (s *BasicSigner) Sign(req *http.Request) error {
 	return nil
 }
 
+// SignWebSocket adds the basic auth header to the WebSocket dial config
 func (s *BasicSigner) SignWebSocket(cfg *websocket.Config) error {
 	if s.Username != "" && s.Password != "" {
 		cfg.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(s.Username+":"+s.Password)))

--- a/client/signers.go
+++ b/client/signers.go
@@ -98,7 +98,7 @@ func (s *BasicSigner) Sign(req *http.Request) error {
 }
 
 // SignWebSocket adds the basic auth header to the WebSocket dial config
-func (s *BasicSigner) SignWebSocket(cfg *websocket.Config) error {
+func (s *WebSocketSigner) SignWebSocket(cfg *websocket.Config) error {
 	if s.Username != "" && s.Password != "" {
 		cfg.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(s.Username+":"+s.Password)))
 	}

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -347,9 +347,6 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 		codegen.SimpleImport("context"),
 		codegen.SimpleImport("golang.org/x/net/websocket"),
 		codegen.NewImport("uuid", "github.com/goadesign/goa/uuid"),
-		codegen.SimpleImport("errors"),
-		codegen.SimpleImport("encoding/base64"),
-		codegen.NewImport("goaclient", "github.com/goadesign/goa/client"),
 	}
 	title := fmt.Sprintf("%s: %s Resource Client", g.API.Context(), res.Name)
 	if err = file.WriteHeader(title, g.Target, imports); err != nil {
@@ -1014,12 +1011,8 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 	if err != nil {
 		return nil, err
 	}
-	if c.BasicAuthSigner != nil {
-		wsSigner, ok := c.BasicAuthSigner.(*goaclient.BasicSigner)
-		if !ok {
-			return nil, errors.New("BasicAuthSigner type conversion failed.")
-		}
-		wsSigner.SignWebSocket(cfg)
+	if c.BasicAuthWsSigner != nil {
+		c.BasicAuthWsSigner.WsSign(cfg)
 	}
 {{ range $header := .Headers }}{{ $tmp := tempvar }}	{{ toString $header.VarName $tmp $header.Attribute }}
 	cfg.Header["{{ $header.Name }}"] = []string{ {{ $tmp }} }

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -347,6 +347,9 @@ func (g *Generator) generateResourceClient(pkgDir string, res *design.ResourceDe
 		codegen.SimpleImport("context"),
 		codegen.SimpleImport("golang.org/x/net/websocket"),
 		codegen.NewImport("uuid", "github.com/goadesign/goa/uuid"),
+		codegen.SimpleImport("errors"),
+		codegen.SimpleImport("encoding/base64"),
+		codegen.NewImport("goaclient", "github.com/goadesign/goa/client"),
 	}
 	title := fmt.Sprintf("%s: %s Resource Client", g.API.Context(), res.Name)
 	if err = file.WriteHeader(title, g.Target, imports); err != nil {
@@ -1010,6 +1013,13 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 	cfg, err := websocket.NewConfig(url_, url_)
 	if err != nil {
 		return nil, err
+	}
+	if c.BasicAuthSigner != nil {
+		wsSigner, ok := c.BasicAuthSigner.(*goaclient.BasicSigner)
+		if !ok {
+			return nil, errors.New("BasicAuthSigner type conversion failed.")
+		}
+		wsSigner.SignWebSocket(cfg)
 	}
 {{ range $header := .Headers }}{{ $tmp := tempvar }}	{{ toString $header.VarName $tmp $header.Attribute }}
 	cfg.Header["{{ $header.Name }}"] = []string{ {{ $tmp }} }


### PR DESCRIPTION
Currently if the cli client is making a websocket request then any supplied user/pass values will not be added as a basic auth header. This change causes the generated client code to add the Authorization header.

Developed together with @slaterx