### PR TITLE
Generate Valid OpenAPI When JWTSecurity is Used

### DIFF
--- a/dsl/security.go
+++ b/dsl/security.go
@@ -164,6 +164,8 @@ func JWTSecurity(name string, fn ...func()) *design.SchemeExpr {
 	expr := &design.SchemeExpr{
 		SchemeName: name,
 		Kind:       design.JWTKind,
+		In:         "header",
+		Name:       "Authorization",
 	}
 
 	if len(fn) != 0 {


### PR DESCRIPTION
Adding the "In" and "Name" field to the JWTSecurity scheme expression so it generates a valid OpenAPI securityDefinitions section.

Before this change, a design with the following security scheme would generate an invalid OpenAPI securityDefinitions section.

Design:
```
var jwtSecurity = dsl.JWTSecurity("jwt", func() {
	dsl.Description(`Secures endpoint by requiring a valid JWT token.`)
})
```

Output OpenAPI without these changes:
```
securityDefinitions:
  jwt:
    type: apiKey
    description: |
      Secures endpoint by requiring a valid JWT token.
      **Security Scopes**:
```

When copy pasted to https://editor.swagger.io/, the OpenAPI causes:
```
Schema error at securityDefinitions['jwt']
should have required property 'flow'
missingProperty: flow

Schema error at securityDefinitions['jwt'].type
should be equal to one of the allowed values
allowedValues: basic, oauth2
```

This change populates the required `in` and `name` fields when specifying an apiKey securityDefinitions and gets rid of the https://editor.swagger.io/ errors.

Output OpenAPI with these changes:
```
securityDefinitions:
  jwt:
    type: apiKey
    description: |
      Secures endpoint by requiring a valid JWT token.
      **Security Scopes**:
    name: Authorization
    in: header
```

For more information please see:
- https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityDefinitionsObject
- https://github.com/OAI/OpenAPI-Specification/issues/583
