### PR TITLE
Backport to v1: Fix client tests when GOPATH is /go (#1766)

### DIFF
--- a/goagen/codegen/helpers.go
+++ b/goagen/codegen/helpers.go
@@ -38,8 +38,9 @@ func CommandLine() string {
 		gopaths := filepath.SplitList(os.Getenv("GOPATH"))
 		for i, a := range os.Args[1:] {
 			for _, p := range gopaths {
+				p = "=" + p
 				if strings.Contains(a, p) {
-					args[i] = strings.Replace(a, p, "$(GOPATH)", -1)
+					args[i] = strings.Replace(a, p, "=$(GOPATH)", 1)
 					break
 				}
 			}

--- a/goagen/codegen/helpers_test.go
+++ b/goagen/codegen/helpers_test.go
@@ -1,19 +1,62 @@
 package codegen_test
 
 import (
-	"testing"
+	"os"
 
 	"github.com/goadesign/goa/goagen/codegen"
 
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-func TestHelpers(t *testing.T) {
-	Expect(codegen.KebabCase("testAa")).To(Equal("test-aa"))
-	Expect(codegen.KebabCase("test-B")).To(Equal("test-b"))
-	Expect(codegen.KebabCase("test_cA")).To(Equal("test-ca"))
-	Expect(codegen.KebabCase("test_D")).To(Equal("test-d"))
-	Expect(codegen.KebabCase("teste")).To(Equal("teste"))
-	Expect(codegen.KebabCase("testABC")).To(Equal("testabc"))
-	Expect(codegen.KebabCase("testAbc")).To(Equal("test-abc"))
-}
+var _ = Describe("Helpers", func() {
+	Describe("KebabCase", func() {
+		It("should change uppercase letters to lowercase letters", func() {
+			Expect(codegen.KebabCase("test-B")).To(Equal("test-b"))
+			Expect(codegen.KebabCase("teste")).To(Equal("teste"))
+		})
+
+		It("should not add a dash before an abbreviation or acronym", func() {
+			Expect(codegen.KebabCase("testABC")).To(Equal("testabc"))
+		})
+
+		It("should add a dash before a title", func() {
+			Expect(codegen.KebabCase("testAa")).To(Equal("test-aa"))
+			Expect(codegen.KebabCase("testAbc")).To(Equal("test-abc"))
+		})
+
+		It("should replace underscores to dashes", func() {
+			Expect(codegen.KebabCase("test_cA")).To(Equal("test-ca"))
+			Expect(codegen.KebabCase("test_D")).To(Equal("test-d"))
+		})
+	})
+
+	Describe("CommandLine", func() {
+		oldGOPATH, oldArgs := os.Getenv("GOPATH"), os.Args
+		BeforeEach(func() {
+			os.Setenv("GOPATH", "/xx")
+		})
+		AfterEach(func() {
+			os.Setenv("GOPATH", oldGOPATH)
+			os.Args = oldArgs
+		})
+
+		It("should not touch free arguments", func() {
+			os.Args = []string{"foo", "/xx/bar/xx/42"}
+
+			Expect(codegen.CommandLine()).To(Equal("$ foo /xx/bar/xx/42"))
+		})
+
+		It("should replace GOPATH one match only in a long option", func() {
+			os.Args = []string{"foo", "--opt=/xx/bar/xx/42"}
+
+			Expect(codegen.CommandLine()).To(Equal("$ foo\n\t--opt=$(GOPATH)/bar/xx/42"))
+		})
+
+		It("should not replace GOPATH if a match is not at the beginning of a long option", func() {
+			os.Args = []string{"foo", "--opt=/bar/xx/42"}
+
+			Expect(codegen.CommandLine()).To(Equal("$ foo\n\t--opt=/bar/xx/42"))
+		})
+	})
+})


### PR DESCRIPTION
Hello,

It's a backport of #1766.

Thanks