### PR TITLE
Backport to v1: Add support for readonly attributes (#1762)

### DIFF
--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -11,6 +11,8 @@ import (
 	"github.com/goadesign/goa/dslengine"
 )
 
+// Attribute can be used in: View, Type, Attribute, Attributes
+//
 // Attribute implements the attribute definition DSL. An attribute describes a data structure
 // recursively. Attributes are used for describing request headers, parameters and payloads -
 // response bodies and headers - media types	 and types. An attribute definition is recursive:
@@ -239,6 +241,8 @@ func parseAttributeArgs(baseAttr *design.AttributeDefinition, args ...interface{
 	return dataType, description, dsl
 }
 
+// Header can be used in: Headers, APIKeySecurity, JWTSecurity
+//
 // Header is an alias of Attribute for the most part.
 //
 // Within an APIKeySecurity or JWTSecurity definition, Header
@@ -257,16 +261,22 @@ func Header(name string, args ...interface{}) {
 	Attribute(name, args...)
 }
 
+// Member can be used in: Payload
+//
 // Member is an alias of Attribute.
 func Member(name string, args ...interface{}) {
 	Attribute(name, args...)
 }
 
+// Param can be used in: Params
+//
 // Param is an alias of Attribute.
 func Param(name string, args ...interface{}) {
 	Attribute(name, args...)
 }
 
+// Default can be used in: Attribute
+//
 // Default sets the default value for an attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor10.
 func Default(def interface{}) {
@@ -286,6 +296,8 @@ func Default(def interface{}) {
 	}
 }
 
+// Example can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // Example sets the example of an attribute to be used for the documentation:
 //
 //	Attributes(func() {
@@ -308,6 +320,17 @@ func Example(exp interface{}) {
 	}
 }
 
+// ReadOnly can be used in: Attribute
+// ReadOnly sets the readOnly property of an attribute to true. It is used when attributes are computed in the API and
+// are not expected from the client
+func ReadOnly() {
+	if a, ok := attributeDefinition(); ok {
+		a.SetReadOnly()
+	}
+}
+
+// NoExample can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // NoExample sets the example of an attribute to be blank for the documentation. It is used when
 // users don't want any custom or auto-generated example
 func NoExample() {
@@ -321,6 +344,8 @@ func NoExample() {
 	}
 }
 
+// Enum can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // Enum adds a "enum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor76.
 func Enum(val ...interface{}) {
@@ -373,6 +398,8 @@ var SupportedValidationFormats = []string{
 	"uri",
 }
 
+// Format can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // Format adds a "format" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor104.
 // The formats supported by goa are:
@@ -419,6 +446,8 @@ func Format(f string) {
 	}
 }
 
+// Pattern can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // Pattern adds a "pattern" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor33.
 func Pattern(p string) {
@@ -439,6 +468,8 @@ func Pattern(p string) {
 	}
 }
 
+// Minimum can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // Minimum adds a "minimum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor21.
 func Minimum(val interface{}) {
@@ -469,6 +500,8 @@ func Minimum(val interface{}) {
 	}
 }
 
+// Maximum can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // Maximum adds a "maximum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor17.
 func Maximum(val interface{}) {
@@ -499,6 +532,8 @@ func Maximum(val interface{}) {
 	}
 }
 
+// MinLength can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // MinLength adds a "minItems" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor45.
 func MinLength(val int) {
@@ -514,6 +549,8 @@ func MinLength(val int) {
 	}
 }
 
+// MaxLength can be used in: Attribute, Header, Param, HashOf, ArrayOf
+//
 // MaxLength adds a "maxItems" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor42.
 func MaxLength(val int) {
@@ -529,6 +566,8 @@ func MaxLength(val int) {
 	}
 }
 
+// Required can be used in: Attributes, Headers, Payload, Type, Params
+//
 // Required adds a "required" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor61.
 func Required(names ...string) {

--- a/design/apidsl/attribute_test.go
+++ b/design/apidsl/attribute_test.go
@@ -194,6 +194,24 @@ var _ = Describe("Attribute", func() {
 		})
 	})
 
+	Context("with a name and a DSL defining a 'readOnly' attribute", func() {
+		BeforeEach(func() {
+			name = "foo"
+			dsl = func() { ReadOnly() }
+		})
+
+		It("produces an attribute of type string set to readOnly", func() {
+			t := parent.Type
+			Ω(t).ShouldNot(BeNil())
+			Ω(t).Should(BeAssignableToTypeOf(Object{}))
+			o := t.(Object)
+			Ω(o).Should(HaveLen(1))
+			Ω(o).Should(HaveKey(name))
+			Ω(o[name].Type).Should(Equal(String))
+			Ω(o[name].IsReadOnly()).Should(BeTrue())
+		})
+	})
+
 	Context("with a name and a DSL defining an enum validation", func() {
 		BeforeEach(func() {
 			name = "foo"

--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1148,6 +1148,22 @@ func (a *AttributeDefinition) GenerateExample(rand *RandomGenerator, seen []stri
 	return a.Example
 }
 
+// SetReadOnly sets the attribute's ReadOnly field as true.
+func (a *AttributeDefinition) SetReadOnly() {
+	if a.Metadata == nil {
+		a.Metadata = map[string][]string{}
+	}
+	a.Metadata["swagger:read-only"] = nil
+}
+
+// IsReadOnly returns true if attribute is read-only (set using SetReadOnly() method)
+func (a *AttributeDefinition) IsReadOnly() bool {
+	if _, readOnlyMetadataIsPresent := a.Metadata["swagger:read-only"]; readOnlyMetadataIsPresent {
+		return true
+	}
+	return false
+}
+
 func (a *AttributeDefinition) arrayExample(rand *RandomGenerator, seen []string) interface{} {
 	ary := a.Type.ToArray()
 	ln := newExampleGenerator(a, rand).ExampleLength()
@@ -1304,6 +1320,18 @@ func (a *AttributeDefinition) inheritRecursive(parent *AttributeDefinition, seen
 			}
 			if att.Example == nil {
 				att.Example = patt.Example
+			}
+			if patt.Metadata != nil {
+				if att.Metadata == nil {
+					att.Metadata = patt.Metadata
+				} else {
+					// Copy all key/value pairs from parent to child that DO NOT exist in child; existing ones will remain with the same value
+					for k, v := range patt.Metadata {
+						if _, keyMetadataIsPresent := att.Metadata[k]; !keyMetadataIsPresent {
+							att.Metadata[k] = v
+						}
+					}
+				}
 			}
 		}
 	}

--- a/design/definitions_test.go
+++ b/design/definitions_test.go
@@ -61,14 +61,15 @@ var _ = Describe("Inherit", func() {
 
 		BeforeEach(func() {
 			child.Type.(design.Object)[attName] = &design.AttributeDefinition{Type: design.String}
-			parent.Type.(design.Object)[attName] = &design.AttributeDefinition{Type: design.String, DefaultValue: def}
+			parent.Type.(design.Object)[attName] = &design.AttributeDefinition{Type: design.String, DefaultValue: def, Metadata: map[string][]string{"swagger:read-only": nil}}
 		})
 
-		It("inherits the default value", func() {
+		It("inherits the default value and readOnly value", func() {
 			obj := child.Type.(design.Object)
 			Ω(obj).Should(HaveLen(1))
 			Ω(obj).Should(HaveKey(attName))
 			Ω(obj[attName].DefaultValue).Should(Equal(def))
+			Ω(obj[attName].IsReadOnly()).Should(BeTrue())
 		})
 	})
 

--- a/goagen/gen_schema/json_schema.go
+++ b/goagen/gen_schema/json_schema.go
@@ -446,6 +446,7 @@ func buildAttributeSchema(api *design.APIDefinition, s *JSONSchema, at *design.A
 	s.DefaultValue = toStringMap(at.DefaultValue)
 	s.Description = at.Description
 	s.Example = at.GenerateExample(api.RandomGenerator(), nil)
+	s.ReadOnly = at.IsReadOnly()
 	val := at.Validation
 	if val == nil {
 		return s

--- a/goagen/gen_schema/json_schema_test.go
+++ b/goagen/gen_schema/json_schema_test.go
@@ -29,7 +29,7 @@ var _ = Describe("TypeSchema", func() {
 		BeforeEach(func() {
 			MediaType("application/foo.bar", func() {
 				Attributes(func() {
-					Attribute("bar")
+					Attribute("bar", func() { ReadOnly() })
 				})
 				View("default", func() {
 					Attribute("bar")


### PR DESCRIPTION
* Add support for readonly attributes

* run go fmt

* use metadata to set readonly flag instead

# Conflicts:
#	design/apidsl/attribute.go