### PR TITLE
Add RFC3339 date format

### DIFF
--- a/design/apidsl/attribute.go
+++ b/design/apidsl/attribute.go
@@ -386,6 +386,7 @@ func Enum(val ...interface{}) {
 // Format DSL.
 var SupportedValidationFormats = []string{
 	"cidr",
+	"date",
 	"date-time",
 	"email",
 	"hostname",
@@ -403,6 +404,8 @@ var SupportedValidationFormats = []string{
 // Format adds a "format" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor104.
 // The formats supported by goa are:
+//
+// "date": RFC3339 date
 //
 // "date-time": RFC3339 date time
 //

--- a/design/example.go
+++ b/design/example.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/goadesign/goa"
 	regen "github.com/zach-klippenstein/goregen"
 )
 
@@ -153,8 +152,8 @@ func (eg *exampleGenerator) generateFormatExample() interface{} {
 	if res, ok := map[string]interface{}{
 		"email":     eg.r.faker.Email(),
 		"hostname":  eg.r.faker.DomainName() + "." + eg.r.faker.DomainSuffix(),
-		"date":      time.Unix(int64(eg.r.Int())%1454957045, 0).Format(goa.LayoutRFC3339Date), // to obtain a "fixed" rand
-		"date-time": time.Unix(int64(eg.r.Int())%1454957045, 0).Format(time.RFC3339),          // to obtain a "fixed" rand
+		"date":      time.Unix(int64(eg.r.Int())%1454957045, 0).Format("2006-01-02"), // to obtain a "fixed" rand
+		"date-time": time.Unix(int64(eg.r.Int())%1454957045, 0).Format(time.RFC3339), // to obtain a "fixed" rand
 		"ipv4":      eg.r.faker.IPv4Address().String(),
 		"ipv6":      eg.r.faker.IPv6Address().String(),
 		"ip":        eg.r.faker.IPv4Address().String(),

--- a/design/example.go
+++ b/design/example.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/goadesign/goa"
 	regen "github.com/zach-klippenstein/goregen"
 )
 
@@ -152,7 +153,8 @@ func (eg *exampleGenerator) generateFormatExample() interface{} {
 	if res, ok := map[string]interface{}{
 		"email":     eg.r.faker.Email(),
 		"hostname":  eg.r.faker.DomainName() + "." + eg.r.faker.DomainSuffix(),
-		"date-time": time.Unix(int64(eg.r.Int())%1454957045, 0).Format(time.RFC3339), // to obtain a "fixed" rand
+		"date":      time.Unix(int64(eg.r.Int())%1454957045, 0).Format(goa.LayoutRFC3339Date), // to obtain a "fixed" rand
+		"date-time": time.Unix(int64(eg.r.Int())%1454957045, 0).Format(time.RFC3339),          // to obtain a "fixed" rand
 		"ipv4":      eg.r.faker.IPv4Address().String(),
 		"ipv6":      eg.r.faker.IPv6Address().String(),
 		"ip":        eg.r.faker.IPv4Address().String(),

--- a/goagen/codegen/validation.go
+++ b/goagen/codegen/validation.go
@@ -452,6 +452,8 @@ func oneof(target string, vals []interface{}) string {
 // constant returns the Go constant name of the format with the given value.
 func constant(formatName string) string {
 	switch formatName {
+	case "date":
+		return "goa.FormatDate"
 	case "date-time":
 		return "goa.FormatDateTime"
 	case "email":

--- a/validation.go
+++ b/validation.go
@@ -54,9 +54,6 @@ const (
 
 	// FormatRFC1123 defines RFC1123 date time values.
 	FormatRFC1123 = "rfc1123"
-
-	// LayoutRFC3339Date is a layout of RFC3339 date for use in time.Parse.
-	LayoutRFC3339Date = "2006-01-02"
 )
 
 var (
@@ -87,7 +84,7 @@ func ValidateFormat(f Format, val string) error {
 	var err error
 	switch f {
 	case FormatDate:
-		_, err = time.Parse(LayoutRFC3339Date, val)
+		_, err = time.Parse("2006-01-02", val)
 	case FormatDateTime:
 		_, err = time.Parse(time.RFC3339, val)
 	case FormatUUID:

--- a/validation.go
+++ b/validation.go
@@ -16,6 +16,9 @@ import (
 type Format string
 
 const (
+	// FormatDate defines RFC3339 date values.
+	FormatDate Format = "date"
+
 	// FormatDateTime defines RFC3339 date time values.
 	FormatDateTime Format = "date-time"
 
@@ -51,6 +54,9 @@ const (
 
 	// FormatRFC1123 defines RFC1123 date time values.
 	FormatRFC1123 = "rfc1123"
+
+	// LayoutRFC3339Date is a layout of RFC3339 date for use in time.Parse.
+	LayoutRFC3339Date = "2006-01-02"
 )
 
 var (
@@ -67,6 +73,7 @@ var (
 // see http://json-schema.org/latest/json-schema-validation.html#anchor105
 // Supported formats are:
 //
+//     - "date": RFC3339 date value
 //     - "date-time": RFC3339 date time value
 //     - "email": RFC5322 email address
 //     - "hostname": RFC1035 Internet host name
@@ -79,6 +86,8 @@ var (
 func ValidateFormat(f Format, val string) error {
 	var err error
 	switch f {
+	case FormatDate:
+		_, err = time.Parse(LayoutRFC3339Date, val)
 	case FormatDateTime:
 		_, err = time.Parse(time.RFC3339, val)
 	case FormatUUID:

--- a/validation_test.go
+++ b/validation_test.go
@@ -19,6 +19,32 @@ var _ = Describe("ValidateFormat", func() {
 		valErr = goa.ValidateFormat(f, val)
 	})
 
+	Context("Date", func() {
+		BeforeEach(func() {
+			f = goa.FormatDate
+		})
+
+		Context("with an invalid value", func() {
+			BeforeEach(func() {
+				val = "201510-26"
+			})
+
+			It("does not validates", func() {
+				Ω(valErr).Should(HaveOccurred())
+			})
+		})
+
+		Context("with a valid value", func() {
+			BeforeEach(func() {
+				val = "2015-10-26"
+			})
+
+			It("validates", func() {
+				Ω(valErr).ShouldNot(HaveOccurred())
+			})
+		})
+	})
+
 	Context("DateTime", func() {
 		BeforeEach(func() {
 			f = goa.FormatDateTime


### PR DESCRIPTION
Hello,

I added support of RFC3339 date format. This format exists in [Swagger 2.0 Spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types).

Thanks