### PR TITLE
Fix example generation

### DIFF
--- a/codegen/service/auth_funcs.go
+++ b/codegen/service/auth_funcs.go
@@ -25,6 +25,7 @@ func AuthFuncsFile(genpkg string, root *design.RootExpr) *codegen.File {
 
 	var (
 		sections []*codegen.SectionTemplate
+		generate bool
 	)
 	{
 		specs := []*codegen.ImportSpec{
@@ -46,6 +47,7 @@ func AuthFuncsFile(genpkg string, root *design.RootExpr) *codegen.File {
 		for _, s := range root.Services {
 			svc := Services.Get(s.Name)
 			if len(svc.Schemes) > 0 {
+				generate = true
 				sections = append(sections, &codegen.SectionTemplate{
 					Name:   "security-authfuncs",
 					Source: dummyAuthFuncsT,
@@ -54,10 +56,9 @@ func AuthFuncsFile(genpkg string, root *design.RootExpr) *codegen.File {
 			}
 		}
 	}
-	if len(sections) == 0 {
+	if len(sections) == 0 || !generate {
 		return nil
 	}
-
 	return &codegen.File{
 		Path:             "auth.go",
 		SectionTemplates: sections,

--- a/codegen/service/auth_funcs.go
+++ b/codegen/service/auth_funcs.go
@@ -42,7 +42,7 @@ func AuthFuncsFile(genpkg string, root *design.RootExpr) *codegen.File {
 				Name: pkgName,
 			})
 		}
-		header := codegen.Header(root.API.Name+" authentication logic.", apiPkg, specs)
+		header := codegen.Header("", apiPkg, specs)
 		sections = []*codegen.SectionTemplate{header}
 		for _, s := range root.Services {
 			svc := Services.Get(s.Name)

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -143,12 +143,14 @@ func New{{ .Service.StructName }}(logger *log.Logger) {{ .Service.PkgName }}.Ser
 
 // input: EndpointData
 const dummyEndpointImplT = `{{ comment .Method.Description }}
-func (s *{{ .ServiceVarName }}Svc) {{ .Method.VarName }}(ctx context.Context{{ if .Payload.Ref }}, p {{ .Payload.Ref }}{{ end }}) ({{ if .Result.Ref }}res {{ .Result.Ref }}, {{ if .Method.ViewedResult }}view string, {{ end }} {{ end }}err error) {
+func (s *{{ .ServiceVarName }}Svc) {{ .Method.VarName }}(ctx context.Context{{ if .Payload.Ref }}, p {{ .Payload.Ref }}{{ end }}) ({{ if .Result.Ref }}res {{ .Result.Ref }}, {{ if .Method.ViewedResult }}{{ if not .Method.ViewedResult.ViewName }}view string, {{ end }}{{ end }} {{ end }}err error) {
 {{- if and .Result.Ref .Result.IsStruct }}
 	res = &{{ .Result.Name }}{}
 {{- end }}
 {{- if .Method.ViewedResult }}
+	{{- if not .Method.ViewedResult.ViewName }}
 	view = {{ printf "%q" .Result.View }}
+	{{- end }}
 {{- end }}
 	s.logger.Print("{{ .ServiceVarName }}.{{ .Method.Name }}")
 	return


### PR DESCRIPTION
* Fixes #1770 
* auth.go is generated only if security schemes are defined in DSL
* Remove "DO NOT EDIT" comment from auth.go