### PR TITLE
Force generate types from different package

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -418,6 +418,24 @@ func (d ServicesData) analyze(service *design.ServiceExpr) *Data {
 		}
 	}
 
+	for _, t := range design.Root.Types {
+		if svcs, ok := t.Attribute().Metadata["type:generate:force"]; ok {
+			att := &design.AttributeExpr{Type: t}
+			if len(svcs) > 0 {
+				// Force generate type only in the specified services
+				for _, svc := range svcs {
+					if svc == service.Name {
+						types = append(types, collectTypes(att, seen, scope)...)
+						break
+					}
+				}
+			} else {
+				// Force generate type in all the services
+				types = append(types, collectTypes(att, seen, scope)...)
+			}
+		}
+	}
+
 	var (
 		methods []*MethodData
 		schemes []*SchemeData

--- a/codegen/service/service_test.go
+++ b/codegen/service/service_test.go
@@ -26,6 +26,8 @@ func TestService(t *testing.T) {
 		{"result-collection-multiple-views", testdata.ResultCollectionMultipleViewsMethodDSL, testdata.ResultCollectionMultipleViewsMethod},
 		{"result-with-other-result", testdata.ResultWithOtherResultMethodDSL, testdata.ResultWithOtherResultMethod},
 		{"service-level-error", testdata.ServiceErrorDSL, testdata.ServiceError},
+		{"force-generate-type", testdata.ForceGenerateTypeDSL, testdata.ForceGenerateType},
+		{"force-generate-type-explicit", testdata.ForceGenerateTypeExplicitDSL, testdata.ForceGenerateTypeExplicit},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -648,3 +648,47 @@ func newMultipleViews2ViewTiny(res *MultipleViews2) *resultwithotherresultviews.
 	return vres
 }
 `
+
+const ForceGenerateType = `
+// Service is the ForceGenerateType service interface.
+type Service interface {
+	// A implements A.
+	A(context.Context) (err error)
+}
+
+// ServiceName is the name of the service as defined in the design. This is the
+// same value that is set in the endpoint request contexts under the ServiceKey
+// key.
+const ServiceName = "ForceGenerateType"
+
+// MethodNames lists the service method names as defined in the design. These
+// are the same values that are set in the endpoint request contexts under the
+// MethodKey key.
+var MethodNames = [1]string{"A"}
+
+type ForcedType struct {
+	A *string
+}
+`
+
+const ForceGenerateTypeExplicit = `
+// Service is the ForceGenerateTypeExplicit service interface.
+type Service interface {
+	// A implements A.
+	A(context.Context) (err error)
+}
+
+// ServiceName is the name of the service as defined in the design. This is the
+// same value that is set in the endpoint request contexts under the ServiceKey
+// key.
+const ServiceName = "ForceGenerateTypeExplicit"
+
+// MethodNames lists the service method names as defined in the design. These
+// are the same values that are set in the endpoint request contexts under the
+// MethodKey key.
+var MethodNames = [1]string{"A"}
+
+type ForcedType struct {
+	A *string
+}
+`

--- a/codegen/service/testdata/service_dsls.go
+++ b/codegen/service/testdata/service_dsls.go
@@ -200,3 +200,23 @@ var ResultWithOtherResultMethodDSL = func() {
 		})
 	})
 }
+
+var ForceGenerateTypeDSL = func() {
+	var _ = Type("ForcedType", func() {
+		Attribute("a", String)
+		Metadata("type:generate:force")
+	})
+	Service("ForceGenerateType", func() {
+		Method("A", func() {})
+	})
+}
+
+var ForceGenerateTypeExplicitDSL = func() {
+	var _ = Type("ForcedType", func() {
+		Attribute("a", String)
+		Metadata("type:generate:force", "ForceGenerateTypeExplicit")
+	})
+	Service("ForceGenerateTypeExplicit", func() {
+		Method("A", func() {})
+	})
+}

--- a/dsl/metadata.go
+++ b/dsl/metadata.go
@@ -12,7 +12,32 @@ import (
 // services and API definitions.
 //
 // While keys can have any value the following names are handled explicitly by
-// goa when set on attributes.
+// goa when set on attributes or types.
+//
+// type:generate:force specified on a Type will generate a Go struct in the
+// service packages specified in the value. If no services are specified, it
+// generates the type in all the services in the design package. The Type
+// definition to force generate can exist in an external package and must be
+// imported in the API design.
+//
+//        package my_package
+//
+//        var ExternalType = Type("ExternalType", func() {
+//                Attribute("name", String)
+//                Metadata("type:generate:force", service1, service2)
+//        })
+//
+//        package design
+//
+//        import _ "my_package"
+//
+//        var _ = Service("service1", func() {
+//                ...
+//        })
+//
+//        var _ = Service("service2", func() {
+//                ...
+//        })
 //
 // struct:error:name identifies the attribute of a result type used to select
 // the returned error when multiple errors are defined on the same method.

--- a/dsl/metadata.go
+++ b/dsl/metadata.go
@@ -14,22 +14,20 @@ import (
 // While keys can have any value the following names are handled explicitly by
 // goa when set on attributes or types.
 //
-// type:generate:force specified on a Type will generate a Go struct in the
-// service packages specified in the value. If no services are specified, it
-// generates the type in all the services in the design package. The Type
-// definition to force generate can exist in an external package and must be
-// imported in the API design.
+// type:generate:force forces the code generation for the type it is defined
+// on. By default goa only generates types that are used explicitly by the
+// service methods. This metadata key makes it possible to override this
+// behavior and forces goa to generate the corresponding struct. The value is
+// a slice of strings that lists the names of the services for which to
+// generate the struct. If left empty then the struct is generated for all
+// services.
 //
-//        package my_package
+//        package design
 //
 //        var ExternalType = Type("ExternalType", func() {
 //                Attribute("name", String)
 //                Metadata("type:generate:force", service1, service2)
 //        })
-//
-//        package design
-//
-//        import _ "my_package"
 //
 //        var _ = Service("service1", func() {
 //                ...


### PR DESCRIPTION
* Add "type:generate:force" in Metadata expression of a UserType to force its generation on the services even though the type is not used in the design. (#1574)