### PR TITLE
added import aliases to external packages in convert.go

### DIFF
--- a/codegen/service/convert.go
+++ b/codegen/service/convert.go
@@ -85,19 +85,27 @@ func ConvertFile(root *design.RootExpr, service *design.ServiceExpr) (*codegen.F
 	}
 
 	// Retrieve external packages info
-	ppm := make(map[string]struct{})
+	ppm := make(map[string]string)
 	for _, c := range conversions {
-		pkg := reflect.TypeOf(c.External).PkgPath()
-		ppm[pkg] = struct{}{}
+		pkg := reflect.TypeOf(c.External)
+		p := pkg.PkgPath()
+
+		alias := strings.Split(pkg.String(), ".")[0]
+
+		ppm[p] = alias
 	}
 	for _, c := range creations {
-		pkg := reflect.TypeOf(c.External).PkgPath()
-		ppm[pkg] = struct{}{}
+		pkg := reflect.TypeOf(c.External)
+		p := pkg.PkgPath()
+
+		alias := strings.Split(pkg.String(), ".")[0]
+
+		ppm[p] = alias
 	}
 	pkgs := make([]*codegen.ImportSpec, len(ppm))
 	i := 0
-	for pp := range ppm {
-		pkgs[i] = &codegen.ImportSpec{Path: pp}
+	for pp, alias := range ppm {
+		pkgs[i] = &codegen.ImportSpec{Name: alias, Path: pp}
 		i++
 	}
 

--- a/codegen/service/convert_test.go
+++ b/codegen/service/convert_test.go
@@ -180,7 +180,7 @@ func TestConvertFile(t *testing.T) {
 
 				if c.SectionIndex == 0 {
 					methodSection := sections[1]
-					code = codegen.SectionCodeFromInputAndMethods(t, sections[c.SectionIndex], methodSection)
+					code = codegen.SectionCodeFromImportsAndMethods(t, sections[c.SectionIndex], methodSection)
 				} else {
 					code = codegen.SectionCode(t, sections[c.SectionIndex])
 				}

--- a/codegen/service/convert_test.go
+++ b/codegen/service/convert_test.go
@@ -157,6 +157,8 @@ func TestConvertFile(t *testing.T) {
 		{"create-object", testdata.CreateObjectDSL, 1, testdata.CreateObjectCode},
 		{"create-object-required", testdata.CreateObjectRequiredDSL, 1, testdata.CreateObjectRequiredCode},
 		{"create-object-extra", testdata.CreateObjectExtraDSL, 1, testdata.CreateObjectExtraCode},
+		{"create-external-convert", testdata.CreateExternalDSL, 0, testdata.CreateExternalConvert},
+		{"create-alias-convert", testdata.CreateAliasDSL, 0, testdata.CreateAliasConvert},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -173,7 +175,16 @@ func TestConvertFile(t *testing.T) {
 				if len(sections) <= c.SectionIndex {
 					t.Fatalf("got %d sections, expected at least %d", len(sections), c.SectionIndex+1)
 				}
-				code := codegen.SectionCode(t, sections[c.SectionIndex])
+
+				var code string
+
+				if c.SectionIndex == 0 {
+					methodSection := sections[1]
+					code = codegen.SectionCodeNoPackageDef(t, sections[c.SectionIndex], methodSection)
+				} else {
+					code = codegen.SectionCode(t, sections[c.SectionIndex])
+				}
+
 				if code != c.Code {
 					t.Errorf("invalid code, got:\n%s\ngot vs. expected:\n%s", code, codegen.Diff(t, code, c.Code))
 				}

--- a/codegen/service/convert_test.go
+++ b/codegen/service/convert_test.go
@@ -180,7 +180,7 @@ func TestConvertFile(t *testing.T) {
 
 				if c.SectionIndex == 0 {
 					methodSection := sections[1]
-					code = codegen.SectionCodeNoPackageDef(t, sections[c.SectionIndex], methodSection)
+					code = codegen.SectionCodeFromInputAndMethods(t, sections[c.SectionIndex], methodSection)
 				} else {
 					code = codegen.SectionCode(t, sections[c.SectionIndex])
 				}

--- a/codegen/service/testdata/alias-external/alias.go
+++ b/codegen/service/testdata/alias-external/alias.go
@@ -1,0 +1,5 @@
+package aliasd
+
+type ConvertModel struct {
+	Bar string
+}

--- a/codegen/service/testdata/convert_dsls.go
+++ b/codegen/service/testdata/convert_dsls.go
@@ -3,6 +3,8 @@ package testdata
 import (
 	. "goa.design/goa/design"
 	. "goa.design/goa/dsl"
+	"goa.design/goa/codegen/service/testdata/external"
+	"goa.design/goa/codegen/service/testdata/alias-external"
 )
 
 var ConvertStringDSL = func() {
@@ -138,6 +140,32 @@ var ConvertObjectRequiredDSL = func() {
 	Service("Service", func() {
 		Method("Method", func() {
 			Payload(ObjectType)
+		})
+	})
+}
+
+var ConvertExternalDSL = func() {
+	var StringType = Type("StringType", func() {
+		CreateFrom(external.ConvertModel{})
+		Attribute("Foo", String)
+	})
+
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(StringType)
+		})
+	})
+}
+
+var ConvertAliasDSL = func() {
+	var StringType = Type("StringType", func() {
+		CreateFrom(aliasd.ConvertModel{})
+		Attribute("Bar", String)
+	})
+
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(StringType)
 		})
 	})
 }

--- a/codegen/service/testdata/convert_functions.go
+++ b/codegen/service/testdata/convert_functions.go
@@ -174,3 +174,23 @@ func marshalObjectFieldToObjectFieldT(v *ObjectField) *testdata.ObjectFieldT {
 	return res
 }
 `
+
+var CreateExternalConvert = `// Service service type conversion functions
+//
+// Command:
+// $ goa
+
+package service
+
+import (
+	external "goa.design/goa/codegen/service/testdata/external"
+)
+
+// CreateFromConvertModel initializes t from the fields of v
+func (t *StringType) CreateFromConvertModel(v *external.ConvertModel) {
+	temp := &StringType{
+		Foo: &v.Foo,
+	}
+	*t = *temp
+}
+`

--- a/codegen/service/testdata/create_dsls.go
+++ b/codegen/service/testdata/create_dsls.go
@@ -3,6 +3,8 @@ package testdata
 import (
 	. "goa.design/goa/design"
 	. "goa.design/goa/dsl"
+	"goa.design/goa/codegen/service/testdata/external"
+	"goa.design/goa/codegen/service/testdata/alias-external"
 )
 
 var CreateStringDSL = func() {
@@ -168,6 +170,32 @@ var CreateObjectExtraDSL = func() {
 	Service("Service", func() {
 		Method("Method", func() {
 			Payload(ObjectType)
+		})
+	})
+}
+
+var CreateExternalDSL = func() {
+	var StringType = Type("StringType", func() {
+		CreateFrom(external.ConvertModel{})
+		Attribute("Foo", String)
+	})
+
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(StringType)
+		})
+	})
+}
+
+var CreateAliasDSL = func() {
+	var StringType = Type("StringType", func() {
+		CreateFrom(aliasd.ConvertModel{})
+		Attribute("Bar", String)
+	})
+
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(StringType)
 		})
 	})
 }

--- a/codegen/service/testdata/create_functions.go
+++ b/codegen/service/testdata/create_functions.go
@@ -92,3 +92,23 @@ func (t *ObjectType) CreateFromObjectExtraT(v *testdata.ObjectExtraT) {
 	*t = *temp
 }
 `
+
+var CreateAliasConvert = `// Service service type conversion functions
+//
+// Command:
+// $ goa
+
+package service
+
+import (
+	aliasd "goa.design/goa/codegen/service/testdata/alias-external"
+)
+
+// CreateFromConvertModel initializes t from the fields of v
+func (t *StringType) CreateFromConvertModel(v *aliasd.ConvertModel) {
+	temp := &StringType{
+		Bar: &v.Bar,
+	}
+	*t = *temp
+}
+`

--- a/codegen/service/testdata/external/external.go
+++ b/codegen/service/testdata/external/external.go
@@ -1,0 +1,5 @@
+package external
+
+type ConvertModel struct {
+	Foo string
+}

--- a/codegen/testing.go
+++ b/codegen/testing.go
@@ -63,7 +63,8 @@ func SectionCode(t *testing.T, section *SectionTemplate) string {
 	return sectionCodeWithPrefix(t, section, "package foo\n")
 }
 
-func SectionCodeNoPackageDef(t *testing.T, importSection *SectionTemplate, methodSection *SectionTemplate) string {
+// SectionCodeFromInputAndMethods generates and formats the code for given import and method definition sections.
+func SectionCodeFromInputAndMethods(t *testing.T, importSection *SectionTemplate, methodSection *SectionTemplate) string {
 	var code bytes.Buffer
 	if err := importSection.Write(&code); err != nil {
 		t.Fatal(err)

--- a/codegen/testing.go
+++ b/codegen/testing.go
@@ -63,8 +63,8 @@ func SectionCode(t *testing.T, section *SectionTemplate) string {
 	return sectionCodeWithPrefix(t, section, "package foo\n")
 }
 
-// SectionCodeFromInputAndMethods generates and formats the code for given import and method definition sections.
-func SectionCodeFromInputAndMethods(t *testing.T, importSection *SectionTemplate, methodSection *SectionTemplate) string {
+// SectionCodeFromImportsAndMethods generates and formats the code for given import and method definition sections.
+func SectionCodeFromImportsAndMethods(t *testing.T, importSection *SectionTemplate, methodSection *SectionTemplate) string {
 	var code bytes.Buffer
 	if err := importSection.Write(&code); err != nil {
 		t.Fatal(err)

--- a/codegen/testing.go
+++ b/codegen/testing.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"fmt"
 	"bytes"
 	"io/ioutil"
 	"os"
@@ -59,11 +60,31 @@ func RunDSLWithFunc(t *testing.T, dsl func(), fn func()) *design.RootExpr {
 
 // SectionCode generates and formats the code for the given section.
 func SectionCode(t *testing.T, section *SectionTemplate) string {
+	return sectionCodeWithPrefix(t, section, "package foo\n")
+}
+
+func SectionCodeNoPackageDef(t *testing.T, importSection *SectionTemplate, methodSection *SectionTemplate) string {
+	var code bytes.Buffer
+	if err := importSection.Write(&code); err != nil {
+		t.Fatal(err)
+	}
+
+	return sectionCodeWithPrefix(t, methodSection, code.String())
+}
+
+func sectionCodeWithPrefix(t *testing.T, section *SectionTemplate, prefix string) string {
 	var code bytes.Buffer
 	if err := section.Write(&code); err != nil {
 		t.Fatal(err)
 	}
-	return FormatTestCode(t, "package foo\n"+code.String())
+
+	codestr := code.String()
+
+	if len(prefix) > 0 {
+		codestr = fmt.Sprintf("%s\n%s", prefix, codestr)
+	}
+
+	return FormatTestCode(t, codestr)
 }
 
 // FormatTestCode formats the given Go code. The code must correspond to the


### PR DESCRIPTION
convert.go external imports where being omitted if the package name didn't match the file name.