### PR TITLE
Cleanup processing of parameters and headers in requests and responses.

### DIFF
--- a/design/method.go
+++ b/design/method.go
@@ -78,10 +78,21 @@ func (m *MethodExpr) EvalName() string {
 	return prefix + suffix
 }
 
+// Prepare makes sure the payload and result types are initialized (to the Empty
+// type if nil).
+func (m *MethodExpr) Prepare() {
+	if m.Payload == nil {
+		m.Payload = &AttributeExpr{Type: Empty}
+	}
+	if m.Result == nil {
+		m.Result = &AttributeExpr{Type: Empty}
+	}
+}
+
 // Validate validates the method payloads, results, and errors (if any).
 func (m *MethodExpr) Validate() error {
 	verr := new(eval.ValidationErrors)
-	if m.Payload != nil {
+	if m.Payload.Type != Empty {
 		verr.Merge(m.Payload.Validate("payload", m))
 		// validate security scheme requirements
 		for _, r := range m.Requirements {
@@ -127,7 +138,7 @@ func (m *MethodExpr) Validate() error {
 			}
 		}
 	}
-	if m.Result != nil {
+	if m.Result.Type != Empty {
 		verr.Merge(m.Result.Validate("result", m))
 	}
 	for _, e := range m.Errors {

--- a/design/method_test.go
+++ b/design/method_test.go
@@ -12,6 +12,11 @@ func TestMethodExprValidate(t *testing.T) {
 		identifier = "result"
 	)
 	var (
+		attributeTypeEmpty = func() *AttributeExpr {
+			return &AttributeExpr{
+				Type: Empty,
+			}
+		}
 		attributeTypeNil = func() *AttributeExpr {
 			return &AttributeExpr{
 				Type: nil,
@@ -76,17 +81,23 @@ func TestMethodExprValidate(t *testing.T) {
 		expected *eval.ValidationErrors
 	}{
 		"no error": {
+			payload:  attributeTypeEmpty(),
+			result:   attributeTypeEmpty(),
 			expected: &eval.ValidationErrors{},
 		},
 		"error only in payload": {
 			payload:  attributeTypeNil(),
+			result:   attributeTypeEmpty(),
 			expected: &eval.ValidationErrors{Errors: []error{errAttributeTypeNil}},
 		},
 		"error only in result": {
+			payload:  attributeTypeEmpty(),
 			result:   attributeTypeNil(),
 			expected: &eval.ValidationErrors{Errors: []error{errAttributeTypeNil}},
 		},
 		"errors only in errors": {
+			payload: attributeTypeEmpty(),
+			result:  attributeTypeEmpty(),
 			errors: []*ErrorExpr{
 				{
 					AttributeExpr: errorDuplicatedMetadata(),

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -40,6 +40,9 @@ func RunDSL() error {
 		return Context.Errors
 	}
 	for _, root := range roots {
+		root.WalkSets(prepareSet)
+	}
+	for _, root := range roots {
 		root.WalkSets(validateSet)
 	}
 	if Context.Errors != nil {
@@ -70,6 +73,20 @@ func runSet(set ExpressionSet) error {
 		}
 		if recursed > 100 {
 			return fmt.Errorf("too many generated expressions, infinite loop?")
+		}
+	}
+	return nil
+}
+
+// prepareSet runs the pre validation steps on all the set expressions that
+// define one.
+func prepareSet(set ExpressionSet) error {
+	for _, def := range set {
+		if def == nil {
+			continue
+		}
+		if p, ok := def.(Preparer); ok {
+			p.Prepare()
 		}
 	}
 	return nil

--- a/eval/expression.go
+++ b/eval/expression.go
@@ -37,10 +37,20 @@ type (
 		DSL() func()
 	}
 
+	// A Preparer expression requires an additional pass after the DSL has
+	// executed and BEFORE it is validated (e.g. to flatten inheritance)
+	Preparer interface {
+		// Prepare is run by the engine right after the DSL has run.
+		// Prepare cannot fail, any potential failure should be returned
+		// by implementing Validator instead.
+		Prepare()
+	}
+
 	// A Validator expression can be validated.
 	Validator interface {
-		// Validate returns nil if the expression contains no validation
-		// error.  The Validate implementation may take advantage of
+		// Validate runs after Prepare if the expression is a Preparer.
+		// It returns nil if the expression contains no validation
+		// error. The Validate implementation may take advantage of
 		// ValidationErrors to report more than one errors at a time.
 		Validate() error
 	}

--- a/http/codegen/openapi/json_schema.go
+++ b/http/codegen/openapi/json_schema.go
@@ -167,19 +167,9 @@ func GenerateServiceDefinition(api *design.APIExpr, res *httpdesign.ServiceExpr)
 	Definitions[res.Name()] = s
 	for _, a := range res.HTTPEndpoints {
 		var requestSchema *Schema
-		if a.MethodExpr.Payload != nil {
+		if a.MethodExpr.Payload.Type != design.Empty {
 			requestSchema = AttributeTypeSchema(api, a.MethodExpr.Payload)
 			requestSchema.Description = a.Name() + " payload"
-		}
-		if a.Params() != nil {
-			params := a.MappedParams()
-			// We don't want to keep the path params, these are
-			// defined inline in the href
-			for _, r := range a.Routes {
-				for _, p := range r.Params() {
-					design.AsObject(params.Type).Delete(p)
-				}
-			}
 		}
 		var targetSchema *Schema
 		var identifier string

--- a/http/codegen/openapi/openapi_v2_builder.go
+++ b/http/codegen/openapi/openapi_v2_builder.go
@@ -31,7 +31,7 @@ func NewV2(root *httpdesign.RootExpr) (*V2, error) {
 	if hasAbsoluteRoutes(root) {
 		basePath = ""
 	}
-	params, err := paramsFromExpr(root.MappedParams(), basePath)
+	params, err := paramsFromExpr(root.Params, basePath)
 	if err != nil {
 		return nil, err
 	}
@@ -361,8 +361,8 @@ func paramsFromExpr(params *design.MappedAttributeExpr, path string) ([]*Paramet
 func paramsFromHeaders(endpoint *httpdesign.EndpointExpr) []*Parameter {
 	params := []*Parameter{}
 	var (
-		rma = endpoint.Service.MappedParams()
-		ma  = endpoint.MappedHeaders()
+		rma = endpoint.Service.Params
+		ma  = endpoint.Headers
 
 		merged *design.MappedAttributeExpr
 	)
@@ -442,7 +442,7 @@ func responseSpecFromExpr(s *V2, root *httpdesign.RootExpr, r *httpdesign.HTTPRe
 	} else if r.Body.Type != design.Empty {
 		schema = AttributeTypeSchema(root.Design.API, r.Body)
 	}
-	headers, err := headersFromExpr(r.MappedHeaders())
+	headers, err := headersFromExpr(r.Headers)
 	if err != nil {
 		return nil, err
 	}
@@ -553,11 +553,10 @@ func buildPathFromExpr(s *V2, root *httpdesign.RootExpr, route *httpdesign.Route
 		tagNames = []string{route.Endpoint.Service.Name()}
 	}
 	for _, key := range route.FullPaths() {
-		params, err := paramsFromExpr(endpoint.AllParams(), key)
+		params, err := paramsFromExpr(endpoint.Params, key)
 		if err != nil {
 			return err
 		}
-
 		params = append(params, paramsFromHeaders(endpoint)...)
 
 		responses := make(map[string]*Response, len(endpoint.Responses))

--- a/http/codegen/openapi_test.go
+++ b/http/codegen/openapi_test.go
@@ -49,6 +49,7 @@ func newService(endpoints ...*httpdesign.EndpointExpr) *httpdesign.ServiceExpr {
 	for _, ep := range endpoints {
 		ep.MethodExpr.Service = s
 		ep.Service = res
+		ep.Prepare()
 		ep.Finalize()
 		s.Methods = append(s.Methods, ep.MethodExpr)
 	}
@@ -71,6 +72,8 @@ func newSimpleEndpoint() *httpdesign.EndpointExpr {
 	ep := &httpdesign.EndpointExpr{
 		MethodExpr: method,
 		Routes:     []*httpdesign.RouteExpr{route},
+		Headers:    design.NewEmptyMappedAttributeExpr(),
+		Params:     design.NewEmptyMappedAttributeExpr(),
 	}
 	route.Endpoint = ep
 	return ep

--- a/http/design/response_test.go
+++ b/http/design/response_test.go
@@ -20,7 +20,7 @@ func TestResponseValidation(t *testing.T) {
 		{"object result", testdata.ObjectResultResponseWithHeadersDSL, ""},
 		{"array result", testdata.ArrayResultResponseWithHeadersDSL, ""},
 		{"map result", testdata.MapResultResponseWithHeadersDSL, ""},
-		{"invalid", testdata.EmptyResultResponseWithHeadersDSL, `HTTP response of service "EmptyResultResponseWithHeaders" HTTP endpoint "Method": response define headers but result is empty`},
+		{"invalid", testdata.EmptyResultResponseWithHeadersDSL, `HTTP response of service "EmptyResultResponseWithHeaders" HTTP endpoint "Method": response defines headers but result is empty`},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/design/root.go
+++ b/http/design/root.go
@@ -26,26 +26,6 @@ var (
 )
 
 type (
-	// ParamHolder is the interface implemented by the design data structures
-	// that represent HTTP constructs with path and query string parameters.
-	ParamHolder interface {
-		eval.Expression
-		// Params returns the attribute holding the parameters. It takes
-		// care of initializing the underlying struct field so that it
-		// never returns nil.
-		Params() *design.AttributeExpr
-	}
-
-	// HeaderHolder is the interface implemented by the design data
-	// structures that represent HTTP constructs with HTTP headers.
-	HeaderHolder interface {
-		eval.Expression
-		// Headers returns the attribute holding the headers. It takes
-		// care of initializing the underlying struct field so that it
-		// never returns nil.
-		Headers() *design.AttributeExpr
-	}
-
 	// RootExpr is the data structure built by the top level HTTP DSL.
 	RootExpr struct {
 		// Design is the transport agnostic root expression.
@@ -53,6 +33,12 @@ type (
 		// Path is the common request path prefix to all the service
 		// HTTP endpoints.
 		Path string
+		// Params defines the HTTP request path and query parameters
+		// common to all the API endpoints.
+		Params *design.MappedAttributeExpr
+		// Headers defines the HTTP request headers common to to all the
+		// API endpoints.
+		Headers *design.MappedAttributeExpr
 		// Consumes lists the mime types supported by the API
 		// controllers.
 		Consumes []string
@@ -66,16 +52,6 @@ type (
 		// Metadata is a set of key/value pairs with semantic that is
 		// specific to each generator.
 		Metadata design.MetadataExpr
-		// params defines common request parameters to all the service
-		// HTTP endpoints. The keys may use the "attribute:param" syntax
-		// where "attribute" is the name of the attribute and "param"
-		// the name of the HTTP parameter.
-		params *design.AttributeExpr
-		// headers defines common headers to all the service HTTP
-		// endpoints. The keys may use the "attribute:header" syntax
-		// where "attribute" is the name of the attribute and "header"
-		// the name of the HTTP header.
-		headers *design.AttributeExpr
 	}
 )
 
@@ -124,32 +100,6 @@ func (r *RootExpr) ServiceFor(s *design.ServiceExpr) *ServiceExpr {
 	}
 	r.HTTPServices = append(r.HTTPServices, res)
 	return res
-}
-
-// Headers initializes and returns the attribute holding the API headers.
-func (r *RootExpr) Headers() *design.AttributeExpr {
-	if r.headers == nil {
-		r.headers = &design.AttributeExpr{Type: &design.Object{}}
-	}
-	return r.headers
-}
-
-// MappedHeaders computes the mapped attribute expression from Headers.
-func (r *RootExpr) MappedHeaders() *design.MappedAttributeExpr {
-	return design.NewMappedAttributeExpr(r.headers)
-}
-
-// Params initializes and returns the attribute holding the API parameters.
-func (r *RootExpr) Params() *design.AttributeExpr {
-	if r.params == nil {
-		r.params = &design.AttributeExpr{Type: &design.Object{}}
-	}
-	return r.params
-}
-
-// MappedParams computes the mapped attribute expression from Params.
-func (r *RootExpr) MappedParams() *design.MappedAttributeExpr {
-	return design.NewMappedAttributeExpr(r.params)
 }
 
 // EvalName is the expression name used by the evaluation engine to display


### PR DESCRIPTION
Added a new "Prepare" phase during code generation.
The endpoint expression flattens params and headers during "Prepare".
This alleviates the need for separating between values set at design
and values used to validate and generate the code.
This also helps in making the use of the "a:b" notation handling more
consistent as the code now always uses mapped attributes.