### PR TITLE
Inherit query string parameters defined in API

### DIFF
--- a/design/definitions.go
+++ b/design/definitions.go
@@ -1517,9 +1517,8 @@ func (a *ActionDefinition) AllParams() *AttributeDefinition {
 		res = res.Merge(p.CanonicalAction().PathParams())
 	} else {
 		res = res.Merge(a.Parent.PathParams())
-		res = res.Merge(Design.PathParams())
 	}
-	return res
+	return res.Merge(Design.Params)
 }
 
 // HasAbsoluteRoutes returns true if all the action routes are absolute.

--- a/design/definitions_test.go
+++ b/design/definitions_test.go
@@ -365,9 +365,15 @@ var _ = Describe("AllParams", func() {
 			}
 		})
 
-		It("AllParams does NOT return the query parameters of the parent resource canonical action or the API", func() {
-			for _, p := range []string{"canquery", "pbasequery", "apiquery"} {
+		It("AllParams does NOT return the query parameters of the parent resource canonical action", func() {
+			for _, p := range []string{"canquery", "pbasequery"} {
 				Ω(allParams).ShouldNot(HaveKey(p))
+			}
+		})
+
+		It("AllParams does return the query parameters of the parent API", func() {
+			for _, p := range []string{"apiquery"} {
+				Ω(allParams).Should(HaveKey(p))
 			}
 		})
 


### PR DESCRIPTION
In all actions.

Fix #1805 