### PR TITLE
Fail validation if params, headers, or body present but Payload is not defined

### DIFF
--- a/http/design/endpoint.go
+++ b/http/design/endpoint.go
@@ -337,6 +337,12 @@ func (e *EndpointExpr) Validate() error {
 		if e.MultipartRequest {
 			verr.Add(e, "MultipartRequest is set but Payload is not defined")
 		}
+		if !e.Params.IsEmpty() {
+			verr.Add(e, "Params are set but Payload is not defined.")
+		}
+		if !e.Headers.IsEmpty() {
+			verr.Add(e, "Headers are set but Payload is not defined.")
+		}
 		return verr
 	}
 	if design.IsArray(e.MethodExpr.Payload.Type) {

--- a/http/dsl/http.go
+++ b/http/dsl/http.go
@@ -684,6 +684,10 @@ func Body(args ...interface{}) {
 		}
 	case func():
 		fn = a
+		if ref == nil {
+			eval.ReportError("Body is set but Payload is not defined")
+			return
+		}
 		attr = ref
 	default:
 		eval.InvalidArgError("attribute name, user type or DSL", a)


### PR DESCRIPTION
Fixes #1822 