### PR TITLE
Fix Project for seen user types

### DIFF
--- a/design/result_type.go
+++ b/design/result_type.go
@@ -280,7 +280,11 @@ func projectSingle(m *ResultTypeExpr, view string, seen ...map[string]*Attribute
 		s := seen[0]
 		if att, ok := s[m.Identifier]; ok {
 			if rt, ok2 := att.Type.(*ResultTypeExpr); ok2 {
-				ut = rt.UserTypeExpr
+				ut = &UserTypeExpr{
+					AttributeExpr: DupAtt(rt.Attribute()),
+					TypeName:      rt.TypeName,
+					Service:       rt.Service,
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
When a seen result type is projected again using a different view, the code [inadvertently modifies the type of the original seen result type](https://github.com/goadesign/goa/blob/3b65d562232cb3c28c971119e27ac3b1075dc191/design/result_type.go#L302) instead of modifying a copy.