### PR TITLE
Fix create and convert

### DIFF
--- a/codegen/service/convert_test.go
+++ b/codegen/service/convert_test.go
@@ -12,6 +12,16 @@ import (
 	"goa.design/goa/eval"
 )
 
+type (
+	inner struct {
+		foo string
+	}
+
+	hasNonPtrFields struct {
+		inner inner
+	}
+)
+
 func TestDesignType(t *testing.T) {
 	var f bool
 	cases := []struct {
@@ -40,6 +50,7 @@ func TestDesignType(t *testing.T) {
 		{"invalid-array", []*bool{&f}, nil, "*(<value>[0]): only pointer to struct can be converted"},
 		{"invalid-map-key", map[*bool]string{&f: ""}, nil, "*(<value>.key): only pointer to struct can be converted"},
 		{"invalid-map-val", map[string]*bool{"": &f}, nil, "*(<value>.value): only pointer to struct can be converted"},
+		{"invalid-struct", hasNonPtrFields{inner: inner{foo: "foo"}}, nil, "<value>.inner: fields of type struct must use pointers"},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/codegen/service/testdata/convert_functions.go
+++ b/codegen/service/testdata/convert_functions.go
@@ -69,7 +69,7 @@ var ConvertObjectCode = `// ConvertToObjectT creates an instance of ObjectT init
 func (t *ObjectType) ConvertToObjectT() *testdata.ObjectT {
 	v := &testdata.ObjectT{}
 	if t.Object != nil {
-		v.Object = marshalObjectFieldToObjectFieldT(t.Object)
+		v.Object = marshalObjectFieldToObjectFieldTExt(t.Object)
 	}
 	return v
 }
@@ -79,15 +79,15 @@ var ConvertObjectRequiredCode = `// ConvertToObjectT creates an instance of Obje
 func (t *ObjectType) ConvertToObjectT() *testdata.ObjectT {
 	v := &testdata.ObjectT{}
 	if t.Object != nil {
-		v.Object = marshalObjectFieldToObjectFieldT(t.Object)
+		v.Object = marshalObjectFieldToObjectFieldTExt(t.Object)
 	}
 	return v
 }
 `
 
-var ConvertObjectHelperCode = `// marshalObjectFieldToObjectFieldT builds a value of type
+var ConvertObjectHelperCode = `// marshalObjectFieldToObjectFieldTExt builds a value of type
 // *testdata.ObjectFieldT from a value of type *ObjectField.
-func marshalObjectFieldToObjectFieldT(v *ObjectField) *testdata.ObjectFieldT {
+func marshalObjectFieldToObjectFieldTExt(v *ObjectField) *testdata.ObjectFieldT {
 	res := &testdata.ObjectFieldT{
 		Bytes: v.Bytes,
 	}
@@ -140,9 +140,9 @@ func marshalObjectFieldToObjectFieldT(v *ObjectField) *testdata.ObjectFieldT {
 }
 `
 
-var ConvertObjectRequiredHelperCode = `// marshalObjectFieldToObjectFieldT builds a value of type
+var ConvertObjectRequiredHelperCode = `// marshalObjectFieldToObjectFieldTExt builds a value of type
 // *testdata.ObjectFieldT from a value of type *ObjectField.
-func marshalObjectFieldToObjectFieldT(v *ObjectField) *testdata.ObjectFieldT {
+func marshalObjectFieldToObjectFieldTExt(v *ObjectField) *testdata.ObjectFieldT {
 	res := &testdata.ObjectFieldT{
 		Bool:    v.Bool,
 		Int:     v.Int,

--- a/codegen/service/testdata/create_functions.go
+++ b/codegen/service/testdata/create_functions.go
@@ -67,7 +67,7 @@ var CreateObjectCode = `// CreateFromObjectT initializes t from the fields of v
 func (t *ObjectType) CreateFromObjectT(v *testdata.ObjectT) {
 	temp := &ObjectType{}
 	if v.Object != nil {
-		temp.Object = marshalObjectFieldTToObjectField(v.Object)
+		temp.Object = marshalObjectFieldTExtToObjectField(v.Object)
 	}
 	*t = *temp
 }
@@ -77,7 +77,7 @@ var CreateObjectRequiredCode = `// CreateFromObjectT initializes t from the fiel
 func (t *ObjectType) CreateFromObjectT(v *testdata.ObjectT) {
 	temp := &ObjectType{}
 	if v.Object != nil {
-		temp.Object = marshalObjectFieldTToObjectField(v.Object)
+		temp.Object = marshalObjectFieldTExtToObjectField(v.Object)
 	}
 	*t = *temp
 }
@@ -87,7 +87,7 @@ var CreateObjectExtraCode = `// CreateFromObjectExtraT initializes t from the fi
 func (t *ObjectType) CreateFromObjectExtraT(v *testdata.ObjectExtraT) {
 	temp := &ObjectType{}
 	if v.Object != nil {
-		temp.Object = marshalObjectFieldTToObjectField(v.Object)
+		temp.Object = marshalObjectFieldTExtToObjectField(v.Object)
 	}
 	*t = *temp
 }

--- a/codegen/service/testdata/types.go
+++ b/codegen/service/testdata/types.go
@@ -20,7 +20,7 @@ type ObjectT struct {
 
 type ObjectExtraT struct {
 	Object *ObjectFieldT
-	t      time.Time
+	t      *time.Time
 }
 
 type ObjectFieldT struct {

--- a/codegen/transform.go
+++ b/codegen/transform.go
@@ -222,11 +222,9 @@ func transformObject(source, target *design.AttributeExpr, newVar bool, a targs)
 			return
 		}
 
-		// Nil check handling.
-		//
 		// We need to check for a nil source if it holds a reference
 		// (pointer to primitive or an object, array or map) and is not
-		// required. We also want to always check when unmarshaling is
+		// required. We also want to always check when unmarshaling if
 		// the attribute type is not a primitive: either it's a user
 		// type and we want to avoid calling transform helper functions
 		// with nil value (if unmarshaling then requiredness has been
@@ -596,7 +594,15 @@ func transformHelperName(satt, tatt *design.AttributeExpr, a targs) string {
 	)
 	{
 		sname = a.scope.GoTypeName(satt)
+		if _, ok := satt.Metadata["goa.external"]; ok {
+			// type belongs to external package so name could clash
+			sname += "Ext"
+		}
 		tname = a.scope.GoTypeName(tatt)
+		if _, ok := tatt.Metadata["goa.external"]; ok {
+			// type belongs to external package so name could clash
+			tname += "Ext"
+		}
 		prefix = "marshal"
 		if a.unmarshal {
 			prefix = "unmarshal"

--- a/design/root.go
+++ b/design/root.go
@@ -1,6 +1,8 @@
 package design
 
-import "goa.design/goa/eval"
+import (
+	"goa.design/goa/eval"
+)
 
 // Root is the root object built by the DSL.
 var Root = &RootExpr{GeneratedTypes: &GeneratedRoot{}}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -43,6 +43,7 @@ func RunDSL() error {
 		root.WalkSets(prepareSet)
 	}
 	for _, root := range roots {
+		validateSet(ExpressionSet{root})
 		root.WalkSets(validateSet)
 	}
 	if Context.Errors != nil {

--- a/examples/chatter/gen/http/openapi.yaml
+++ b/examples/chatter/gen/http/openapi.yaml
@@ -180,13 +180,13 @@ definitions:
       sent_at:
         type: string
         description: Time at which the message was sent
-        example: 1983-06-06T03:57:42Z
+        example: "1983-06-06T03:57:42Z"
         format: date-time
     description: ChatSummaryResponseBody result type (default view)
     example:
       length: 9188469515160886076
       message: Quibusdam voluptate nulla autem quisquam dolorum.
-      sent_at: 2009-06-14T08:11:36Z
+      sent_at: "2009-06-14T08:11:36Z"
     required:
     - message
   ChatterChatSummaryResponseBodyCollection:
@@ -199,13 +199,13 @@ definitions:
     example:
     - length: 3915772424247758741
       message: Sequi tenetur.
-      sent_at: 2009-01-25T10:15:11Z
+      sent_at: "2009-01-25T10:15:11Z"
     - length: 3915772424247758741
       message: Sequi tenetur.
-      sent_at: 2009-01-25T10:15:11Z
+      sent_at: "2009-01-25T10:15:11Z"
     - length: 3915772424247758741
       message: Sequi tenetur.
-      sent_at: 2009-01-25T10:15:11Z
+      sent_at: "2009-01-25T10:15:11Z"
   ChatterHistoryResponseBody:
     title: 'Mediatype identifier: application/vnd.goa.summary; view=default'
     type: object
@@ -222,13 +222,13 @@ definitions:
       sent_at:
         type: string
         description: Time at which the message was sent
-        example: 1978-02-25T14:12:07Z
+        example: "1978-02-25T14:12:07Z"
         format: date-time
     description: HistoryResponseBody result type (default view)
     example:
       length: 8447087998172944251
       message: A et soluta.
-      sent_at: 1992-03-13T17:19:43Z
+      sent_at: "1992-03-13T17:19:43Z"
     required:
     - message
   EchoerInvalidScopesResponseBody:

--- a/http/design/endpoint.go
+++ b/http/design/endpoint.go
@@ -584,8 +584,8 @@ func (e *EndpointExpr) validateParams() *eval.ValidationErrors {
 	if e.MethodExpr.Payload == nil {
 		verr.Add(e, "Parameters are defined but Payload is not defined")
 	} else {
-		switch e.MethodExpr.Payload.Type.(type) {
-		case *design.Object:
+		p := e.MethodExpr.Payload.Type
+		if design.IsObject(p) {
 			for _, nat := range pparams {
 				name := strings.Split(nat.Name, ":")[0]
 				if e.MethodExpr.Payload.Find(name) == nil {
@@ -598,11 +598,11 @@ func (e *EndpointExpr) validateParams() *eval.ValidationErrors {
 					verr.Add(e, "Querys string parameter %q not found in payload.", nat.Name)
 				}
 			}
-		case *design.Array:
+		} else if design.IsArray(p) {
 			if len(pparams)+len(qparams) > 1 {
 				verr.Add(e, "Payload type is array but HTTP endpoint defines multiple parameters. At most one parameter must be defined and it must be an array.")
 			}
-		case *design.Map:
+		} else if design.IsMap(p) {
 			if len(pparams)+len(qparams) > 1 {
 				verr.Add(e, "Payload type is map but HTTP endpoint defines multiple parameters. At most one query string parameter must be defined and it must be a map.")
 			}


### PR DESCRIPTION
Fix multiple issues with validations and CreateFrom/ConvertTo:

* Validate that fields used on external types that are of type struct use a pointer.
* Fix potential name clash in conversion helper function names in case external and design types have identical names.
* Properly validate that HTTP path and query parameters have corresponding payload attributes.

Fix #1853 