### PR TITLE
fix current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ versions with the same `X` component without having to make changes.
 Releases are tagged with the corresponding version number. There is also a branch for each major
 version (only `v1` at the moment). The recommended practice is to vendor the stable branch.
 
-Current Release: `v1.3.1`
+Current Release: `v1.4.0`
 Stable Branch: `v1`
 
 ## Teaser


### PR DESCRIPTION
it seems to not be changed when v1.4.0 released.

and, this is just a little opinion.

I think v1 "stable" branch will update to 1.4.1 with when some bugfix merged.

I did not think the branch is managing the stable version ( sorry, I did not realize when I send previous PR ), so I merged the fix. But the stable branch, I think, should merge bunch of fixes when the next release comes. not every time PR comes.

someone may think the "v1 stable" branch is same as last released v1.x version.

so its current state should released with 1.4.1 as soon as possible or revert to v1.4.0 taged version and make other working branch for next update.