### PR TITLE
Fix the code generation for ConvertTo/CreateFrom when the source/target types contains an attribute with an external name

### DIFF
--- a/codegen/service/convert_test.go
+++ b/codegen/service/convert_test.go
@@ -157,6 +157,16 @@ func TestConvertFile(t *testing.T) {
 		{"create-string-required", testdata.CreateStringRequiredDSL, 1, testdata.CreateStringRequiredCode},
 		{"create-string-pointer", testdata.CreateStringPointerDSL, 1, testdata.CreateStringPointerCode},
 		{"create-string-pointer-required", testdata.CreateStringPointerRequiredDSL, 1, testdata.CreateStringPointerRequiredCode},
+
+		{"convert-external-name", testdata.ConvertExternalNameDSL, 1, testdata.ConvertExternalNameCode},
+		{"convert-external-name-required", testdata.ConvertExternalNameRequiredDSL, 1, testdata.ConvertExternalNameRequiredCode},
+		{"convert-external-name-pointer", testdata.ConvertExternalNamePointerDSL, 1, testdata.ConvertExternalNamePointerCode},
+		{"convert-external-name-pointer-required", testdata.ConvertExternalNamePointerRequiredDSL, 1, testdata.ConvertExternalNamePointerRequiredCode},
+		{"create-external-name", testdata.CreateExternalNameDSL, 1, testdata.CreateExternalNameCode},
+		{"create-external-name-required", testdata.CreateExternalNameRequiredDSL, 1, testdata.CreateExternalNameRequiredCode},
+		{"create-external-name-pointer", testdata.CreateExternalNamePointerDSL, 1, testdata.CreateExternalNamePointerCode},
+		{"create-external-name-pointer-required", testdata.CreateExternalNamePointerRequiredDSL, 1, testdata.CreateExternalNamePointerRequiredCode},
+
 		{"convert-array-string", testdata.ConvertArrayStringDSL, 1, testdata.ConvertArrayStringCode},
 		{"convert-array-string-required", testdata.ConvertArrayStringRequiredDSL, 1, testdata.ConvertArrayStringRequiredCode},
 		{"create-array-string", testdata.CreateArrayStringDSL, 1, testdata.CreateArrayStringCode},

--- a/codegen/service/testdata/convert_dsls.go
+++ b/codegen/service/testdata/convert_dsls.go
@@ -1,10 +1,10 @@
 package testdata
 
 import (
+	"goa.design/goa/codegen/service/testdata/alias-external"
+	"goa.design/goa/codegen/service/testdata/external"
 	. "goa.design/goa/design"
 	. "goa.design/goa/dsl"
-	"goa.design/goa/codegen/service/testdata/external"
-	"goa.design/goa/codegen/service/testdata/alias-external"
 )
 
 var ConvertStringDSL = func() {
@@ -53,6 +53,56 @@ var ConvertStringPointerRequiredDSL = func() {
 	Service("Service", func() {
 		Method("Method", func() {
 			Payload(StringPointerType)
+		})
+	})
+}
+
+var ConvertExternalNameDSL = func() {
+	var ExternalNameType = Type("ExternalNameType", func() {
+		ConvertTo(ExternalNameT{})
+		Attribute("string", String)
+	})
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(ExternalNameType)
+		})
+	})
+}
+
+var ConvertExternalNameRequiredDSL = func() {
+	var ExternalNameType = Type("ExternalNameType", func() {
+		ConvertTo(ExternalNameT{})
+		Attribute("string", String)
+		Required("string")
+	})
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(ExternalNameType)
+		})
+	})
+}
+
+var ConvertExternalNamePointerDSL = func() {
+	var ExternalNamePointerType = Type("ExternalNamePointerType", func() {
+		ConvertTo(ExternalNamePointerT{})
+		Attribute("string", String)
+	})
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(ExternalNamePointerType)
+		})
+	})
+}
+
+var ConvertExternalNamePointerRequiredDSL = func() {
+	var ExternalNamePointerType = Type("ExternalNamePointerType", func() {
+		ConvertTo(ExternalNamePointerT{})
+		Attribute("string", String)
+		Required("string")
+	})
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(ExternalNamePointerType)
 		})
 	})
 }

--- a/codegen/service/testdata/convert_functions.go
+++ b/codegen/service/testdata/convert_functions.go
@@ -39,6 +39,47 @@ func (t *StringPointerType) ConvertToStringPointerT() *testdata.StringPointerT {
 }
 `
 
+var ConvertExternalNameCode = `// ConvertToExternalNameT creates an instance of ExternalNameT initialized from
+// t.
+func (t *ExternalNameType) ConvertToExternalNameT() *testdata.ExternalNameT {
+	v := &testdata.ExternalNameT{}
+	if t.String != nil {
+		v.String = *t.String
+	}
+	return v
+}
+`
+
+var ConvertExternalNameRequiredCode = `// ConvertToExternalNameT creates an instance of ExternalNameT initialized from
+// t.
+func (t *ExternalNameType) ConvertToExternalNameT() *testdata.ExternalNameT {
+	v := &testdata.ExternalNameT{
+		String: t.String,
+	}
+	return v
+}
+`
+
+var ConvertExternalNamePointerCode = `// ConvertToExternalNamePointerT creates an instance of ExternalNamePointerT
+// initialized from t.
+func (t *ExternalNamePointerType) ConvertToExternalNamePointerT() *testdata.ExternalNamePointerT {
+	v := &testdata.ExternalNamePointerT{
+		String: t.String,
+	}
+	return v
+}
+`
+
+var ConvertExternalNamePointerRequiredCode = `// ConvertToExternalNamePointerT creates an instance of ExternalNamePointerT
+// initialized from t.
+func (t *ExternalNamePointerType) ConvertToExternalNamePointerT() *testdata.ExternalNamePointerT {
+	v := &testdata.ExternalNamePointerT{
+		String: &t.String,
+	}
+	return v
+}
+`
+
 var ConvertArrayStringCode = `// ConvertToArrayStringT creates an instance of ArrayStringT initialized from t.
 func (t *ArrayStringType) ConvertToArrayStringT() *testdata.ArrayStringT {
 	v := &testdata.ArrayStringT{}

--- a/codegen/service/testdata/create_dsls.go
+++ b/codegen/service/testdata/create_dsls.go
@@ -1,10 +1,10 @@
 package testdata
 
 import (
+	"goa.design/goa/codegen/service/testdata/alias-external"
+	"goa.design/goa/codegen/service/testdata/external"
 	. "goa.design/goa/design"
 	. "goa.design/goa/dsl"
-	"goa.design/goa/codegen/service/testdata/external"
-	"goa.design/goa/codegen/service/testdata/alias-external"
 )
 
 var CreateStringDSL = func() {
@@ -53,6 +53,56 @@ var CreateStringPointerRequiredDSL = func() {
 	Service("Service", func() {
 		Method("Method", func() {
 			Payload(StringType)
+		})
+	})
+}
+
+var CreateExternalNameDSL = func() {
+	var ExternalNameType = Type("ExternalNameType", func() {
+		CreateFrom(ExternalNameT{})
+		Attribute("string", String)
+	})
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(ExternalNameType)
+		})
+	})
+}
+
+var CreateExternalNameRequiredDSL = func() {
+	var ExternalNameType = Type("ExternalNameType", func() {
+		CreateFrom(ExternalNameT{})
+		Attribute("string", String)
+		Required("string")
+	})
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(ExternalNameType)
+		})
+	})
+}
+
+var CreateExternalNamePointerDSL = func() {
+	var ExternalNamePointerType = Type("ExternalNamePointerType", func() {
+		CreateFrom(ExternalNamePointerT{})
+		Attribute("string", String)
+	})
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(ExternalNamePointerType)
+		})
+	})
+}
+
+var CreateExternalNamePointerRequiredDSL = func() {
+	var ExternalNamePointerType = Type("ExternalNamePointerType", func() {
+		CreateFrom(ExternalNamePointerT{})
+		Attribute("string", String)
+		Required("string")
+	})
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(ExternalNamePointerType)
 		})
 	})
 }

--- a/codegen/service/testdata/create_functions.go
+++ b/codegen/service/testdata/create_functions.go
@@ -37,6 +37,43 @@ func (t *StringType) CreateFromStringPointerT(v *testdata.StringPointerT) {
 }
 `
 
+var CreateExternalNameCode = `// CreateFromExternalNameT initializes t from the fields of v
+func (t *ExternalNameType) CreateFromExternalNameT(v *testdata.ExternalNameT) {
+	temp := &ExternalNameType{
+		String: &v.String,
+	}
+	*t = *temp
+}
+`
+
+var CreateExternalNameRequiredCode = `// CreateFromExternalNameT initializes t from the fields of v
+func (t *ExternalNameType) CreateFromExternalNameT(v *testdata.ExternalNameT) {
+	temp := &ExternalNameType{
+		String: v.String,
+	}
+	*t = *temp
+}
+`
+
+var CreateExternalNamePointerCode = `// CreateFromExternalNamePointerT initializes t from the fields of v
+func (t *ExternalNamePointerType) CreateFromExternalNamePointerT(v *testdata.ExternalNamePointerT) {
+	temp := &ExternalNamePointerType{
+		String: v.String,
+	}
+	*t = *temp
+}
+`
+
+var CreateExternalNamePointerRequiredCode = `// CreateFromExternalNamePointerT initializes t from the fields of v
+func (t *ExternalNamePointerType) CreateFromExternalNamePointerT(v *testdata.ExternalNamePointerT) {
+	temp := &ExternalNamePointerType{}
+	if v.String != nil {
+		temp.String = *v.String
+	}
+	*t = *temp
+}
+`
+
 var CreateArrayStringCode = `// CreateFromArrayStringT initializes t from the fields of v
 func (t *ArrayStringType) CreateFromArrayStringT(v *testdata.ArrayStringT) {
 	temp := &ArrayStringType{}

--- a/codegen/service/testdata/types.go
+++ b/codegen/service/testdata/types.go
@@ -10,6 +10,14 @@ type StringPointerT struct {
 	String *string
 }
 
+type ExternalNameT struct {
+	String string
+}
+
+type ExternalNamePointerT struct {
+	String *string
+}
+
 type ArrayStringT struct {
 	ArrayString []string
 }

--- a/codegen/transform.go
+++ b/codegen/transform.go
@@ -163,8 +163,8 @@ func transformObject(source, target *design.AttributeExpr, newVar bool, a targs)
 		if !design.IsPrimitive(srcAtt.Type) {
 			return
 		}
-		srcPtr := a.unmarshal || source.IsPrimitivePointer(n, !a.unmarshal)
-		tgtPtr := target.IsPrimitivePointer(n, true)
+		srcPtr := a.unmarshal || src.IsPrimitivePointer(n, !a.unmarshal)
+		tgtPtr := tgt.IsPrimitivePointer(n, true)
 		deref := ""
 		srcField := a.sourceVar + "." + Goify(src.ElemName(n), true)
 		if srcPtr && !tgtPtr {

--- a/codegen/transform_test.go
+++ b/codegen/transform_test.go
@@ -31,6 +31,9 @@ var (
 	DefaultPointerObj = pointer(defaulta(object("Int64", design.Int64, "Uint32", design.UInt32, "Float64", design.Float64, "String", design.String, "Bytes", design.Bytes), "Int64", 100, "Uint32", 1, "Float64", 1.0, "String", "foo", "Bytes", []byte{0, 1, 2}))
 	NonRequiredObj    = object("Int64", design.Int64, "Uint32", design.UInt32, "Float64", design.Float64, "String", design.String, "Bytes", design.Bytes)
 
+	ExternalAttrsSource = object("Int64", design.Int64, "Foo", design.String)
+	ExternalAttrsTarget = object("Int64", design.Int64, "Foo:Bar", design.String)
+
 	ObjWithMetadata = withMetadata(object("a", SimpleMap.Type, "b", design.Int), "a", metadata("struct:field:name", "Apple"))
 
 	recursiveObjMap = mapa(design.String, objRecursive(&design.UserTypeExpr{TypeName: "Recursive", AttributeExpr: object("a", design.String, "b", design.Int)}).Type)
@@ -58,6 +61,9 @@ func TestGoTypeTransform(t *testing.T) {
 		{"required-marshal", RequiredObj, RequiredObj, false, "", requiredCode},
 		{"default-marshal", DefaultObj, DefaultObj, false, "", defaultCode},
 		{"default-pointer-marshal", NonRequiredObj, DefaultPointerObj, false, "", defaultPointerMarshalCode},
+
+		// // external name of attribute
+		{"external-attr-marshal", ExternalAttrsSource, ExternalAttrsTarget, false, "", externalAgttrMarshalCode},
 
 		// non match field ignore
 		{"super-unmarshal", SuperObj, SimpleObj, true, "", objUnmarshalCode},
@@ -747,6 +753,14 @@ const defaultPointerUnmarshalCode = `func transform() {
 	if source.Bytes == nil {
 		var tmp []byte = []byte{0x0, 0x1, 0x2}
 		target.Bytes = &tmp
+	}
+}
+`
+
+const externalAgttrMarshalCode = `func transform() {
+	target := &TargetType{
+		Int64: source.Int64,
+		Bar:   source.Foo,
 	}
 }
 `


### PR DESCRIPTION
Proposed fix for issue #1874