### PR TITLE
Support HTTP DSL in API for defining common errors across services

### DIFF
--- a/http/dsl/http.go
+++ b/http/dsl/http.go
@@ -80,6 +80,8 @@ import (
 //
 func HTTP(fn func()) {
 	switch actual := eval.Current().(type) {
+	case *design.APIExpr:
+		eval.Execute(fn, httpdesign.Root)
 	case *design.ServiceExpr:
 		res := httpdesign.Root.ServiceFor(actual)
 		res.DSLFunc = fn


### PR DESCRIPTION
Allow HTTP DSL to be defined at API level to define common errors across services.