### PR TITLE
Bump Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
 - 1.10.x
+- 1.11.x
 sudo: false
 install:
 - export PATH=${PATH}:${HOME}/gopath/bin

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ DEPEND=\
 	github.com/goadesign/goa-cellar \
 	github.com/goadesign/goa.design/tools/godoc2md \
 	github.com/goadesign/goa.design/tools/mdc \
-	github.com/golang/lint/golint \
 	github.com/fzipp/gocyclo \
 	github.com/onsi/ginkgo \
 	github.com/onsi/ginkgo/ginkgo \
 	github.com/onsi/gomega \
 	github.com/pkg/errors \
+	golang.org/x/lint/golint \
 	golang.org/x/tools/cmd/cover \
 	golang.org/x/tools/cmd/goimports
 


### PR DESCRIPTION
Also appears the the fetching of `lint` was recently changed, see https://github.com/golang/lint/issues/415.