### PR TITLE
Apply ContentType DSL to override Content-Type of the response

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1198,6 +1198,9 @@ const responseT = `{{ define "response" -}}
 	{{- if .ErrorHeader }}
 	w.Header().Set("goa-error", {{ printf "%q" .ErrorHeader }})
 	{{- end }}
+	{{- if .ContentType }}
+	w.Header().Set("Content-Type", "{{ .ContentType }}")
+	{{- end }}
 	w.WriteHeader({{ .StatusCode }})
 {{- end }}
 

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -262,6 +262,8 @@ type (
 	ResponseData struct {
 		// StatusCode is the return code of the response.
 		StatusCode string
+		// Content-Type of the response
+		ContentType string
 		// Description is the response description.
 		Description string
 		// Headers provides information about the headers in the
@@ -1452,6 +1454,7 @@ func buildResponses(e *httpdesign.EndpointExpr, result *design.AttributeExpr, vi
 				}
 				responses = append(responses, &ResponseData{
 					StatusCode:   statusCodeToHTTPConst(resp.StatusCode),
+					ContentType:  resp.ContentType,
 					Description:  resp.Description,
 					Headers:      headersData,
 					ServerBody:   serverBodyData,

--- a/http/codegen/testdata/result_encode_functions.go
+++ b/http/codegen/testdata/result_encode_functions.go
@@ -642,6 +642,7 @@ func EncodeMethodBodyMultipleViewResponse(encoder func(context.Context, http.Res
 		if res.Projected.C != nil {
 			w.Header().Set("Location", *res.Projected.C)
 		}
+		w.Header().Set("Content-Type", "resulttypemultipleviews")
 		w.WriteHeader(http.StatusOK)
 		return enc.Encode(body)
 	}
@@ -662,6 +663,7 @@ func EncodeMethodBodyCollectionResponse(encoder func(context.Context, http.Respo
 		case "tiny":
 			body = NewResulttypecollectionResponseBodyTinyCollection(res.Projected)
 		}
+		w.Header().Set("Content-Type", "resulttypecollection; type=collection")
 		w.WriteHeader(http.StatusOK)
 		return enc.Encode(body)
 	}
@@ -676,6 +678,7 @@ func EncodeMethodBodyCollectionExplicitViewResponse(encoder func(context.Context
 		res := v.(servicebodycollectionexplicitviewviews.ResulttypecollectionCollection)
 		enc := encoder(ctx, w)
 		body := NewResulttypecollectionResponseBodyTinyCollection(res.Projected)
+		w.Header().Set("Content-Type", "resulttypecollection; type=collection")
 		w.WriteHeader(http.StatusOK)
 		return enc.Encode(body)
 	}
@@ -914,6 +917,7 @@ func EncodeMethodTagMultipleViewsResponse(encoder func(context.Context, http.Res
 				body = NewMethodTagMultipleViewsAcceptedResponseBodyTiny(res.Projected)
 			}
 			w.Header().Set("c", *res.Projected.C)
+			w.Header().Set("Content-Type", "resulttypemultipleviews")
 			w.WriteHeader(http.StatusAccepted)
 			return enc.Encode(body)
 		}
@@ -925,6 +929,7 @@ func EncodeMethodTagMultipleViewsResponse(encoder func(context.Context, http.Res
 		case "tiny":
 			body = NewMethodTagMultipleViewsOKResponseBodyTiny(res.Projected)
 		}
+		w.Header().Set("Content-Type", "resulttypemultipleviews")
 		w.WriteHeader(http.StatusOK)
 		return enc.Encode(body)
 	}


### PR DESCRIPTION
This change is to make the following design work:

```
		Result(String)
		HTTP(func() {
			GET("txt")
			Response(StatusOK, func() {
				ContentType("text/plain") 
			})
		})
```

Content-Type is set in the generated encoder like this
```
func EncodeGetTxtResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
		res := v.(string)
		enc := encoder(ctx, w)
		body := res
		w.Header().Set("Content-Type", "text/plain")
		w.WriteHeader(http.StatusOK)
		return enc.Encode(body)
	}
}
```
