### PR TITLE
Form encoding (application/x-www-form-urlencoded) for requests

### DIFF
--- a/http/encoding.go
+++ b/http/encoding.go
@@ -10,6 +10,8 @@ import (
 	"mime"
 	"net/http"
 	"strings"
+
+	"github.com/ajg/form"
 )
 
 const (
@@ -70,6 +72,8 @@ func RequestDecoder(r *http.Request) Decoder {
 		return gob.NewDecoder(r.Body)
 	case "application/xml":
 		return xml.NewDecoder(r.Body)
+	case "application/x-www-form-urlencoded":
+		return form.NewDecoder(r.Body)
 	default:
 		return json.NewDecoder(r.Body)
 	}


### PR DESCRIPTION
Allows requests with `Content-Type: application/x-www-form-urlencoded`. 

It is only useful for HTTP encoding but it is a very important feature for some legacy, non-json and non-xml HTTP forms. It shouldn't cause any trouble because it will use this encoder only for requests with explicit `application/x-www-form-urlencoded` Content-Type.

multipart/form-data may need some special treating but it would be good to at least have this application/x-www-form-urlencoded in for now.