### PR TITLE
Fix encoding multiple empty responses

### DIFF
--- a/http/codegen/server_encode_test.go
+++ b/http/codegen/server_encode_test.go
@@ -74,6 +74,7 @@ func TestEncode(t *testing.T) {
 		{"tag-result-multiple-views", testdata.ResultMultipleViewsTagDSL, testdata.ResultMultipleViewsTagEncodeCode},
 
 		{"empty-server-response", testdata.EmptyServerResponseDSL, testdata.EmptyServerResponseEncodeCode},
+		{"empty-server-response-with-tags", testdata.EmptyServerResponseWithTagsDSL, testdata.EmptyServerResponseWithTagsEncodeCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -576,23 +576,6 @@ func (svc *ServiceData) Endpoint(name string) *EndpointData {
 	return nil
 }
 
-// NeedServerResponse returns true if server response has a body or a header.
-// It is used when initializing the result in the server response encoding.
-func (e *EndpointData) NeedServerResponse() bool {
-	if e.Result == nil {
-		return false
-	}
-	for _, r := range e.Result.Responses {
-		if len(r.ServerBody) > 0 {
-			return true
-		}
-		if len(r.Headers) > 0 {
-			return true
-		}
-	}
-	return false
-}
-
 // analyze creates the data necessary to render the code of the given service.
 // It records the user types needed by the service definition in userTypes.
 func (d ServicesData) analyze(hs *httpdesign.ServiceExpr) *ServiceData {

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -201,6 +201,11 @@ type (
 		Responses []*ResponseData
 		// View is the view used to render the result.
 		View string
+		// MustInit indicates if a variable holding the result type must be
+		// initialized. It is used by server response encoder to initialize
+		// the result variable only if there are multiple responses, or the
+		// response has a body or a header.
+		MustInit bool
 	}
 
 	// ErrorGroupData contains the error information required to generate
@@ -1207,14 +1212,13 @@ func buildResultData(e *httpdesign.EndpointExpr, sd *ServiceData) *ResultData {
 		svc    = sd.Service
 		ep     = svc.Method(e.MethodExpr.Name)
 
-		name   string
-		ref    string
-		pkg    string
-		view   string
-		viewed bool
+		name      string
+		ref       string
+		view      string
+		mustInit  bool
+		responses []*ResponseData
 	)
 	{
-		pkg = svc.PkgName
 		view = "default"
 		if result.Metadata != nil {
 			if v, ok := result.Metadata["view"]; ok {
@@ -1225,18 +1229,28 @@ func buildResultData(e *httpdesign.EndpointExpr, sd *ServiceData) *ResultData {
 			name = svc.Scope.GoFullTypeName(result, svc.PkgName)
 			ref = svc.Scope.GoFullTypeRef(result, svc.PkgName)
 		}
+		viewed := false
+		pkg := svc.PkgName
 		if ep.ViewedResult != nil {
 			result = design.AsObject(ep.ViewedResult.Type).Attribute("projected")
 			pkg = svc.ViewsPkg
 			viewed = true
+		}
+		responses = buildResponses(e, result, viewed, sd, pkg)
+		for _, r := range responses {
+			// response has a body or headers or tag
+			if len(r.ServerBody) > 0 || len(r.Headers) > 0 || r.TagName != "" {
+				mustInit = true
+			}
 		}
 	}
 	return &ResultData{
 		IsStruct:  design.IsObject(result.Type),
 		Name:      name,
 		Ref:       ref,
-		Responses: buildResponses(e, result, viewed, sd, pkg),
+		Responses: responses,
 		View:      view,
+		MustInit:  mustInit,
 	}
 }
 

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -993,3 +993,24 @@ var EmptyServerResponseDSL = func() {
 		})
 	})
 }
+
+var EmptyServerResponseWithTagsDSL = func() {
+	Service("ServiceEmptyServerResponseWithTags", func() {
+		Method("MethodEmptyServerResponseWithTags", func() {
+			Result(func() {
+				Attribute("h", String)
+				Required("h")
+			})
+			HTTP(func() {
+				GET("/")
+				Response(StatusNoContent, func() {
+					Body(Empty)
+				})
+				Response(StatusNotModified, func() {
+					Tag("h", "true")
+					Body(Empty)
+				})
+			})
+		})
+	})
+}

--- a/http/codegen/testdata/result_encode_functions.go
+++ b/http/codegen/testdata/result_encode_functions.go
@@ -941,3 +941,19 @@ func EncodeMethodEmptyServerResponseResponse(encoder func(context.Context, http.
 	}
 }
 `
+
+var EmptyServerResponseWithTagsEncodeCode = `// EncodeMethodEmptyServerResponseWithTagsResponse returns an encoder for
+// responses returned by the ServiceEmptyServerResponseWithTags
+// MethodEmptyServerResponseWithTags endpoint.
+func EncodeMethodEmptyServerResponseWithTagsResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
+	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+		res := v.(*serviceemptyserverresponsewithtags.MethodEmptyServerResponseWithTagsResult)
+		if res.H == "true" {
+			w.WriteHeader(http.StatusNotModified)
+			return nil
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return nil
+	}
+}
+`


### PR DESCRIPTION
Fixes a case where server response encode generation fails when there are multiple empty success responses in the endpoint.