### PR TITLE
[BREAKING] Refactor validation logic

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -502,7 +502,8 @@ func (d ServicesData) analyze(service *expr.ServiceExpr) *Data {
 					m.ViewedResult = vrt
 				} else {
 					projected := seenProj[rt.ID()]
-					vrt := buildViewedResultType(e.Result, projected.Type, scope, viewspkg)
+					projAtt := &expr.AttributeExpr{Type: projected.Type}
+					vrt := buildViewedResultType(e.Result, projAtt, scope, viewspkg)
 					viewedRTs = append(viewedRTs, vrt)
 					seenViewed[vrt.Name] = vrt
 					m.ViewedResult = vrt
@@ -944,7 +945,7 @@ func buildProjectedType(projected, att *expr.AttributeExpr, scope *codegen.NameS
 
 // buildViewedResultType builds a viewed result type from the given result type
 // and projected type.
-func buildViewedResultType(att *expr.AttributeExpr, projected expr.UserType, scope *codegen.NameScope, viewspkg string) *ViewedResultTypeData {
+func buildViewedResultType(att, projected *expr.AttributeExpr, scope *codegen.NameScope, viewspkg string) *ViewedResultTypeData {
 	rt := att.Type.(*expr.ResultTypeExpr)
 	var (
 		views    []*ViewData
@@ -975,15 +976,16 @@ func buildViewedResultType(att *expr.AttributeExpr, projected expr.UserType, sco
 
 	// build validation data
 	data = map[string]interface{}{
-		"ArgVar":   "result",
-		"Source":   "result",
-		"Views":    views,
-		"IsViewed": true,
+		"Projected": scope.GoTypeName(projected),
+		"ArgVar":    "result",
+		"Source":    "result",
+		"Views":     views,
+		"IsViewed":  true,
 	}
 	if err := validateTypeCodeTmpl.Execute(&buf, data); err != nil {
 		panic(err) // bug
 	}
-	name := "Validate"
+	name := "Validate" + resvar
 	validate = &ValidateData{
 		Name:        name,
 		Description: fmt.Sprintf("%s runs the validations defined on the viewed result type %s.", name, resvar),
@@ -1001,7 +1003,7 @@ func buildViewedResultType(att *expr.AttributeExpr, projected expr.UserType, sco
 		"ReturnTypeRef": vresref,
 		"IsCollection":  isarr,
 		"TargetType":    scope.GoFullTypeName(att, viewspkg),
-		"InitName":      "new" + scope.GoTypeName(&expr.AttributeExpr{Type: projected}),
+		"InitName":      "new" + scope.GoTypeName(projected),
 	}
 	if err := initTypeCodeTmpl.Execute(&buf, data); err != nil {
 		panic(err) // bug
@@ -1041,15 +1043,15 @@ func buildViewedResultType(att *expr.AttributeExpr, projected expr.UserType, sco
 	}
 	buf.Reset()
 
-	projected = wrapProjected(projected)
+	projT := wrapProjected(projected.Type.(expr.UserType))
 	return &ViewedResultTypeData{
 		UserTypeData: &UserTypeData{
 			Name:        resvar,
 			Description: fmt.Sprintf("%s is the viewed result type that is projected based on a view.", resvar),
 			VarName:     resvar,
-			Def:         scope.GoTypeDef(projected.Attribute(), true),
+			Def:         scope.GoTypeDef(projT.Attribute(), true),
 			Ref:         resref,
-			Type:        projected,
+			Type:        projT,
 		},
 		FullName:     scope.GoFullTypeName(att, viewspkg),
 		FullRef:      vresref,
@@ -1224,25 +1226,28 @@ func buildValidations(projected *expr.AttributeExpr, scope *codegen.NameScope) [
 	if rt, isrt := projected.Type.(*expr.ResultTypeExpr); isrt {
 		// for result types we create a validation function containing view
 		// specific validation logic for each view
-		isarr := expr.IsArray(projected.Type)
+		arr := expr.AsArray(projected.Type)
 		for _, view := range rt.Views {
 			var (
 				data map[string]interface{}
 				buf  bytes.Buffer
 			)
 			data = map[string]interface{}{
+				"Projected":    tname,
 				"ArgVar":       "result",
 				"Source":       "result",
-				"IsCollection": isarr,
+				"IsCollection": arr != nil,
 			}
-			name := "Validate"
+			name := "Validate" + tname
+			var vn string
 			if view.Name != "default" {
-				name += codegen.Goify(view.Name, true)
+				vn = codegen.Goify(view.Name, true)
+				name += vn
 			}
-			if isarr {
+			if arr != nil {
 				// dealing with an array type
 				data["Source"] = "item"
-				data["ValidateVar"] = name
+				data["ValidateVar"] = "Validate" + scope.GoTypeName(arr.ElemType) + vn
 			} else {
 				o := &expr.Object{}
 				sobj := expr.AsObject(projected.Type)
@@ -1259,7 +1264,7 @@ func buildValidations(projected *expr.AttributeExpr, scope *codegen.NameScope) [
 							}
 							fields = append(fields, map[string]interface{}{
 								"Name":        n.Name,
-								"ValidateVar": "Validate" + codegen.Goify(vw, true),
+								"ValidateVar": "Validate" + scope.GoTypeName(attr) + codegen.Goify(vw, true),
 								"IsRequired":  rt2.Attribute().IsRequired(n.Name),
 							})
 						} else {
@@ -1283,7 +1288,7 @@ func buildValidations(projected *expr.AttributeExpr, scope *codegen.NameScope) [
 	} else {
 		// for a user type or a result type with single view, we generate only one validation
 		// function containing the validation logic
-		name := "Validate"
+		name := "Validate" + tname
 		validations = append(validations, &ValidateData{
 			Name:        name,
 			Description: fmt.Sprintf("%s runs the validations defined on %s.", name, tname),
@@ -1419,7 +1424,7 @@ return {{ .ReturnVar }}`
 switch {{ .ArgVar }}.View {
 	{{- range .Views }}
 case {{ printf "%q" .Name }}{{ if eq .Name "default" }}, ""{{ end }}:
-	err = {{ $.ArgVar }}.Projected.Validate{{ if ne .Name "default" }}{{ goify .Name true }}{{ end }}()
+	err = Validate{{ $.Projected }}{{ if ne .Name "default" }}{{ goify .Name true }}{{ end }}({{ $.ArgVar }}.Projected)
 	{{- end }}
 default:
 	err = goa.InvalidEnumValueError("view", {{ .Source }}.View, []interface{}{ {{ range .Views }}{{ printf "%q" .Name }}, {{ end }} })
@@ -1427,7 +1432,7 @@ default:
 {{- else -}}
 	{{- if .IsCollection -}}
 for _, {{ $.Source }} := range {{ $.ArgVar }} {
-	if err2 := {{ $.Source }}.{{ .ValidateVar }}(); err2 != nil {
+	if err2 := {{ .ValidateVar }}({{ $.Source }}); err2 != nil {
 		err = goa.MergeErrors(err, err2)
 	}
 }
@@ -1440,7 +1445,7 @@ if {{ $.Source }}.{{ goify .Name true }} == nil {
 }
 			{{- end }}
 if {{ $.Source }}.{{ goify .Name true }} != nil {
-	if err2 := {{ $.Source }}.{{ goify .Name true }}.{{ .ValidateVar }}(); err2 != nil {
+	if err2 := {{ .ValidateVar }}({{ $.Source }}.{{ goify .Name true }}); err2 != nil {
 		err = goa.MergeErrors(err, err2)
 	}
 }

--- a/codegen/service/testdata/views_code.go
+++ b/codegen/service/testdata/views_code.go
@@ -14,22 +14,23 @@ type ResultTypeView struct {
 	B *string
 }
 
-// Validate runs the validations defined on the viewed result type ResultType.
-func (result *ResultType) Validate() (err error) {
+// ValidateResultType runs the validations defined on the viewed result type
+// ResultType.
+func ValidateResultType(result *ResultType) (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateResultTypeView(result.Projected)
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateResultTypeViewTiny(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
 	}
 	return
 }
 
-// Validate runs the validations defined on ResultTypeView using the "default"
-// view.
-func (result *ResultTypeView) Validate() (err error) {
+// ValidateResultTypeView runs the validations defined on ResultTypeView using
+// the "default" view.
+func ValidateResultTypeView(result *ResultTypeView) (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
@@ -39,9 +40,9 @@ func (result *ResultTypeView) Validate() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on ResultTypeView using the "tiny"
-// view.
-func (result *ResultTypeView) ValidateTiny() (err error) {
+// ValidateResultTypeViewTiny runs the validations defined on ResultTypeView
+// using the "tiny" view.
+func ValidateResultTypeViewTiny(result *ResultTypeView) (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
@@ -67,45 +68,45 @@ type ResultTypeView struct {
 	B *string
 }
 
-// Validate runs the validations defined on the viewed result type
-// ResultTypeCollection.
-func (result ResultTypeCollection) Validate() (err error) {
+// ValidateResultTypeCollection runs the validations defined on the viewed
+// result type ResultTypeCollection.
+func ValidateResultTypeCollection(result ResultTypeCollection) (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateResultTypeCollectionView(result.Projected)
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateResultTypeCollectionViewTiny(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
 	}
 	return
 }
 
-// Validate runs the validations defined on ResultTypeCollectionView using the
-// "default" view.
-func (result ResultTypeCollectionView) Validate() (err error) {
+// ValidateResultTypeCollectionView runs the validations defined on
+// ResultTypeCollectionView using the "default" view.
+func ValidateResultTypeCollectionView(result ResultTypeCollectionView) (err error) {
 	for _, item := range result {
-		if err2 := item.Validate(); err2 != nil {
+		if err2 := ValidateResultTypeView(item); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on ResultTypeCollectionView using
-// the "tiny" view.
-func (result ResultTypeCollectionView) ValidateTiny() (err error) {
+// ValidateResultTypeCollectionViewTiny runs the validations defined on
+// ResultTypeCollectionView using the "tiny" view.
+func ValidateResultTypeCollectionViewTiny(result ResultTypeCollectionView) (err error) {
 	for _, item := range result {
-		if err2 := item.ValidateTiny(); err2 != nil {
+		if err2 := ValidateResultTypeViewTiny(item); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// Validate runs the validations defined on ResultTypeView using the "default"
-// view.
-func (result *ResultTypeView) Validate() (err error) {
+// ValidateResultTypeView runs the validations defined on ResultTypeView using
+// the "default" view.
+func ValidateResultTypeView(result *ResultTypeView) (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
@@ -115,9 +116,9 @@ func (result *ResultTypeView) Validate() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on ResultTypeView using the "tiny"
-// view.
-func (result *ResultTypeView) ValidateTiny() (err error) {
+// ValidateResultTypeViewTiny runs the validations defined on ResultTypeView
+// using the "tiny" view.
+func ValidateResultTypeViewTiny(result *ResultTypeView) (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
@@ -144,39 +145,40 @@ type UserTypeView struct {
 	A *string
 }
 
-// Validate runs the validations defined on the viewed result type ResultType.
-func (result *ResultType) Validate() (err error) {
+// ValidateResultType runs the validations defined on the viewed result type
+// ResultType.
+func ValidateResultType(result *ResultType) (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateResultTypeView(result.Projected)
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateResultTypeViewTiny(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
 	}
 	return
 }
 
-// Validate runs the validations defined on ResultTypeView using the "default"
-// view.
-func (result *ResultTypeView) Validate() (err error) {
+// ValidateResultTypeView runs the validations defined on ResultTypeView using
+// the "default" view.
+func ValidateResultTypeView(result *ResultTypeView) (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on ResultTypeView using the "tiny"
-// view.
-func (result *ResultTypeView) ValidateTiny() (err error) {
+// ValidateResultTypeViewTiny runs the validations defined on ResultTypeView
+// using the "tiny" view.
+func ValidateResultTypeViewTiny(result *ResultTypeView) (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
 	return
 }
 
-// Validate runs the validations defined on UserTypeView.
-func (result *UserTypeView) Validate() (err error) {
+// ValidateUserTypeView runs the validations defined on UserTypeView.
+func ValidateUserTypeView(result *UserTypeView) (err error) {
 
 	return
 }
@@ -216,53 +218,56 @@ type RT3View struct {
 	Z *string
 }
 
-// Validate runs the validations defined on the viewed result type RT.
-func (result *RT) Validate() (err error) {
+// ValidateRT runs the validations defined on the viewed result type RT.
+func ValidateRT(result *RT) (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateRTView(result.Projected)
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateRTViewTiny(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
 	}
 	return
 }
 
-// Validate runs the validations defined on RTView using the "default" view.
-func (result *RTView) Validate() (err error) {
+// ValidateRTView runs the validations defined on RTView using the "default"
+// view.
+func ValidateRTView(result *RTView) (err error) {
 
 	if result.B != nil {
-		if err2 := result.B.ValidateExtended(); err2 != nil {
+		if err2 := ValidateRT2ViewExtended(result.B); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	if result.C != nil {
-		if err2 := result.C.Validate(); err2 != nil {
+		if err2 := ValidateRT3View(result.C); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on RTView using the "tiny" view.
-func (result *RTView) ValidateTiny() (err error) {
+// ValidateRTViewTiny runs the validations defined on RTView using the "tiny"
+// view.
+func ValidateRTViewTiny(result *RTView) (err error) {
 
 	if result.B != nil {
-		if err2 := result.B.ValidateTiny(); err2 != nil {
+		if err2 := ValidateRT2ViewTiny(result.B); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	if result.C != nil {
-		if err2 := result.C.Validate(); err2 != nil {
+		if err2 := ValidateRT3View(result.C); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// Validate runs the validations defined on RT2View using the "default" view.
-func (result *RT2View) Validate() (err error) {
+// ValidateRT2View runs the validations defined on RT2View using the "default"
+// view.
+func ValidateRT2View(result *RT2View) (err error) {
 	if result.C == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("c", "result"))
 	}
@@ -272,9 +277,9 @@ func (result *RT2View) Validate() (err error) {
 	return
 }
 
-// ValidateExtended runs the validations defined on RT2View using the
+// ValidateRT2ViewExtended runs the validations defined on RT2View using the
 // "extended" view.
-func (result *RT2View) ValidateExtended() (err error) {
+func ValidateRT2ViewExtended(result *RT2View) (err error) {
 	if result.C == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("c", "result"))
 	}
@@ -284,22 +289,24 @@ func (result *RT2View) ValidateExtended() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on RT2View using the "tiny" view.
-func (result *RT2View) ValidateTiny() (err error) {
+// ValidateRT2ViewTiny runs the validations defined on RT2View using the "tiny"
+// view.
+func ValidateRT2ViewTiny(result *RT2View) (err error) {
 	if result.D == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("d", "result"))
 	}
 	return
 }
 
-// Validate runs the validations defined on UserTypeView.
-func (result *UserTypeView) Validate() (err error) {
+// ValidateUserTypeView runs the validations defined on UserTypeView.
+func ValidateUserTypeView(result *UserTypeView) (err error) {
 
 	return
 }
 
-// Validate runs the validations defined on RT3View using the "default" view.
-func (result *RT3View) Validate() (err error) {
+// ValidateRT3View runs the validations defined on RT3View using the "default"
+// view.
+func ValidateRT3View(result *RT3View) (err error) {
 	if result.X == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("x", "result"))
 	}
@@ -309,8 +316,9 @@ func (result *RT3View) Validate() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on RT3View using the "tiny" view.
-func (result *RT3View) ValidateTiny() (err error) {
+// ValidateRT3ViewTiny runs the validations defined on RT3View using the "tiny"
+// view.
+func ValidateRT3ViewTiny(result *RT3View) (err error) {
 	if result.X == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("x", "result"))
 	}
@@ -331,39 +339,41 @@ type RTView struct {
 	A *RTView
 }
 
-// Validate runs the validations defined on the viewed result type RT.
-func (result *RT) Validate() (err error) {
+// ValidateRT runs the validations defined on the viewed result type RT.
+func ValidateRT(result *RT) (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateRTView(result.Projected)
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateRTViewTiny(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
 	}
 	return
 }
 
-// Validate runs the validations defined on RTView using the "default" view.
-func (result *RTView) Validate() (err error) {
+// ValidateRTView runs the validations defined on RTView using the "default"
+// view.
+func ValidateRTView(result *RTView) (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
 	if result.A != nil {
-		if err2 := result.A.ValidateTiny(); err2 != nil {
+		if err2 := ValidateRTViewTiny(result.A); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on RTView using the "tiny" view.
-func (result *RTView) ValidateTiny() (err error) {
+// ValidateRTViewTiny runs the validations defined on RTView using the "tiny"
+// view.
+func ValidateRTViewTiny(result *RTView) (err error) {
 	if result.A == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("a", "result"))
 	}
 	if result.A != nil {
-		if err2 := result.A.Validate(); err2 != nil {
+		if err2 := ValidateRTView(result.A); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}

--- a/codegen/service/views.go
+++ b/codegen/service/views.go
@@ -66,7 +66,7 @@ func ViewsFile(genpkg string, service *expr.ServiceExpr) *codegen.File {
 
 // input: ValidateData
 const validateT = `{{ comment .Description }}
-func (result {{ .Ref }}) {{ .Name }}() (err error) {
+func {{ .Name }}(result {{ .Ref }}) (err error) {
 	{{ .Validate }}
   return
 }

--- a/codegen/testdata/validation_code.go
+++ b/codegen/testdata/validation_code.go
@@ -1,0 +1,315 @@
+package testdata
+
+const (
+	IntegerRequiredValidationCode = `func Validate() (err error) {
+	if target.RequiredInteger < 1 {
+		err = goa.MergeErrors(err, goa.InvalidRangeError("target.required_integer", target.RequiredInteger, 1, true))
+	}
+	if target.DefaultInteger != nil {
+		if !(*target.DefaultInteger == 1 || *target.DefaultInteger == 5 || *target.DefaultInteger == 10 || *target.DefaultInteger == 100) {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []interface{}{1, 5, 10, 100}))
+		}
+	}
+	if target.Integer != nil {
+		if *target.Integer > 100 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.integer", *target.Integer, 100, false))
+		}
+	}
+}
+`
+
+	IntegerPointerValidationCode = `func Validate() (err error) {
+	if target.RequiredInteger != nil {
+		if *target.RequiredInteger < 1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.required_integer", *target.RequiredInteger, 1, true))
+		}
+	}
+	if target.DefaultInteger != nil {
+		if !(*target.DefaultInteger == 1 || *target.DefaultInteger == 5 || *target.DefaultInteger == 10 || *target.DefaultInteger == 100) {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []interface{}{1, 5, 10, 100}))
+		}
+	}
+	if target.Integer != nil {
+		if *target.Integer > 100 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.integer", *target.Integer, 100, false))
+		}
+	}
+}
+`
+
+	IntegerUseDefaultValidationCode = `func Validate() (err error) {
+	if target.RequiredInteger < 1 {
+		err = goa.MergeErrors(err, goa.InvalidRangeError("target.required_integer", target.RequiredInteger, 1, true))
+	}
+	if !(target.DefaultInteger == 1 || target.DefaultInteger == 5 || target.DefaultInteger == 10 || target.DefaultInteger == 100) {
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", target.DefaultInteger, []interface{}{1, 5, 10, 100}))
+	}
+	if target.Integer != nil {
+		if *target.Integer > 100 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.integer", *target.Integer, 100, false))
+		}
+	}
+}
+`
+
+	FloatRequiredValidationCode = `func Validate() (err error) {
+	if target.RequiredFloat < 1 {
+		err = goa.MergeErrors(err, goa.InvalidRangeError("target.required_float", target.RequiredFloat, 1, true))
+	}
+	if target.DefaultInteger != nil {
+		if !(*target.DefaultInteger == 1.2 || *target.DefaultInteger == 5 || *target.DefaultInteger == 10 || *target.DefaultInteger == 100.8) {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []interface{}{1.2, 5, 10, 100.8}))
+		}
+	}
+	if target.Float64 != nil {
+		if *target.Float64 > 100.1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.float64", *target.Float64, 100.1, false))
+		}
+	}
+}
+`
+
+	FloatPointerValidationCode = `func Validate() (err error) {
+	if target.RequiredFloat != nil {
+		if *target.RequiredFloat < 1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.required_float", *target.RequiredFloat, 1, true))
+		}
+	}
+	if target.DefaultInteger != nil {
+		if !(*target.DefaultInteger == 1.2 || *target.DefaultInteger == 5 || *target.DefaultInteger == 10 || *target.DefaultInteger == 100.8) {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []interface{}{1.2, 5, 10, 100.8}))
+		}
+	}
+	if target.Float64 != nil {
+		if *target.Float64 > 100.1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.float64", *target.Float64, 100.1, false))
+		}
+	}
+}
+`
+
+	FloatUseDefaultValidationCode = `func Validate() (err error) {
+	if target.RequiredFloat < 1 {
+		err = goa.MergeErrors(err, goa.InvalidRangeError("target.required_float", target.RequiredFloat, 1, true))
+	}
+	if !(target.DefaultInteger == 1.2 || target.DefaultInteger == 5 || target.DefaultInteger == 10 || target.DefaultInteger == 100.8) {
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", target.DefaultInteger, []interface{}{1.2, 5, 10, 100.8}))
+	}
+	if target.Float64 != nil {
+		if *target.Float64 > 100.1 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.float64", *target.Float64, 100.1, false))
+		}
+	}
+}
+`
+
+	StringRequiredValidationCode = `func Validate() (err error) {
+	err = goa.MergeErrors(err, goa.ValidatePattern("target.required_string", target.RequiredString, "^[A-z].*[a-z]$"))
+	if utf8.RuneCountInString(target.RequiredString) < 1 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_string", target.RequiredString, utf8.RuneCountInString(target.RequiredString), 1, true))
+	}
+	if utf8.RuneCountInString(target.RequiredString) > 10 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_string", target.RequiredString, utf8.RuneCountInString(target.RequiredString), 10, false))
+	}
+	if target.DefaultString != nil {
+		if !(*target.DefaultString == "foo" || *target.DefaultString == "bar") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", *target.DefaultString, []interface{}{"foo", "bar"}))
+		}
+	}
+	if target.String != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("target.string", *target.String, goa.FormatDateTime))
+	}
+}
+`
+
+	StringPointerValidationCode = `func Validate() (err error) {
+	if target.RequiredString != nil {
+		err = goa.MergeErrors(err, goa.ValidatePattern("target.required_string", *target.RequiredString, "^[A-z].*[a-z]$"))
+	}
+	if target.RequiredString != nil {
+		if utf8.RuneCountInString(*target.RequiredString) < 1 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_string", *target.RequiredString, utf8.RuneCountInString(*target.RequiredString), 1, true))
+		}
+	}
+	if target.RequiredString != nil {
+		if utf8.RuneCountInString(*target.RequiredString) > 10 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_string", *target.RequiredString, utf8.RuneCountInString(*target.RequiredString), 10, false))
+		}
+	}
+	if target.DefaultString != nil {
+		if !(*target.DefaultString == "foo" || *target.DefaultString == "bar") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", *target.DefaultString, []interface{}{"foo", "bar"}))
+		}
+	}
+	if target.String != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("target.string", *target.String, goa.FormatDateTime))
+	}
+}
+`
+
+	StringUseDefaultValidationCode = `func Validate() (err error) {
+	err = goa.MergeErrors(err, goa.ValidatePattern("target.required_string", target.RequiredString, "^[A-z].*[a-z]$"))
+	if utf8.RuneCountInString(target.RequiredString) < 1 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_string", target.RequiredString, utf8.RuneCountInString(target.RequiredString), 1, true))
+	}
+	if utf8.RuneCountInString(target.RequiredString) > 10 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_string", target.RequiredString, utf8.RuneCountInString(target.RequiredString), 10, false))
+	}
+	if !(target.DefaultString == "foo" || target.DefaultString == "bar") {
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", target.DefaultString, []interface{}{"foo", "bar"}))
+	}
+	if target.String != nil {
+		err = goa.MergeErrors(err, goa.ValidateFormat("target.string", *target.String, goa.FormatDateTime))
+	}
+}
+`
+
+	UserTypeRequiredValidationCode = `func Validate() (err error) {
+	if target.RequiredInteger != nil {
+		if err2 := ValidateInteger(target.RequiredInteger); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	if target.DefaultString != nil {
+		if err2 := ValidateString(target.DefaultString); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	if target.Float != nil {
+		if err2 := ValidateFloat(target.Float); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+}
+`
+
+	UserTypePointerValidationCode = `func Validate() (err error) {
+	if target.RequiredInteger != nil {
+		if err2 := ValidateInteger(target.RequiredInteger); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	if target.DefaultString != nil {
+		if err2 := ValidateString(target.DefaultString); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	if target.Float != nil {
+		if err2 := ValidateFloat(target.Float); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+}
+`
+	UserTypeUseDefaultValidationCode = `func Validate() (err error) {
+	if target.RequiredInteger != nil {
+		if err2 := ValidateInteger(target.RequiredInteger); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	if target.DefaultString != nil {
+		if err2 := ValidateString(target.DefaultString); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	if target.Float != nil {
+		if err2 := ValidateFloat(target.Float); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+}
+`
+
+	ArrayRequiredValidationCode = `func Validate() (err error) {
+	if len(target.RequiredArray) < 5 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_array", target.RequiredArray, len(target.RequiredArray), 5, true))
+	}
+	if len(target.DefaultArray) > 3 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.default_array", target.DefaultArray, len(target.DefaultArray), 3, false))
+	}
+	for _, e := range target.Array {
+		if !(e == 0 || e == 1 || e == 1 || e == 2 || e == 3 || e == 5) {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []interface{}{0, 1, 1, 2, 3, 5}))
+		}
+	}
+}
+`
+
+	ArrayPointerValidationCode = `func Validate() (err error) {
+	if len(target.RequiredArray) < 5 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_array", target.RequiredArray, len(target.RequiredArray), 5, true))
+	}
+	if len(target.DefaultArray) > 3 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.default_array", target.DefaultArray, len(target.DefaultArray), 3, false))
+	}
+	for _, e := range target.Array {
+		if !(e == 0 || e == 1 || e == 1 || e == 2 || e == 3 || e == 5) {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []interface{}{0, 1, 1, 2, 3, 5}))
+		}
+	}
+}
+`
+
+	ArrayUseDefaultValidationCode = `func Validate() (err error) {
+	if len(target.RequiredArray) < 5 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_array", target.RequiredArray, len(target.RequiredArray), 5, true))
+	}
+	if len(target.DefaultArray) > 3 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.default_array", target.DefaultArray, len(target.DefaultArray), 3, false))
+	}
+	for _, e := range target.Array {
+		if !(e == 0 || e == 1 || e == 1 || e == 2 || e == 3 || e == 5) {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []interface{}{0, 1, 1, 2, 3, 5}))
+		}
+	}
+}
+`
+
+	MapRequiredValidationCode = `func Validate() (err error) {
+	if len(target.RequiredMap) < 5 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_map", target.RequiredMap, len(target.RequiredMap), 5, true))
+	}
+	if len(target.DefaultMap) > 3 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.default_map", target.DefaultMap, len(target.DefaultMap), 3, false))
+	}
+	for k, v := range target.Map {
+		err = goa.MergeErrors(err, goa.ValidatePattern("target.map.key", k, "^[A-Z]"))
+		if v > 5 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.map[key]", v, 5, false))
+		}
+	}
+}
+`
+
+	MapPointerValidationCode = `func Validate() (err error) {
+	if len(target.RequiredMap) < 5 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_map", target.RequiredMap, len(target.RequiredMap), 5, true))
+	}
+	if len(target.DefaultMap) > 3 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.default_map", target.DefaultMap, len(target.DefaultMap), 3, false))
+	}
+	for k, v := range target.Map {
+		err = goa.MergeErrors(err, goa.ValidatePattern("target.map.key", k, "^[A-Z]"))
+		if v > 5 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.map[key]", v, 5, false))
+		}
+	}
+}
+`
+
+	MapUseDefaultValidationCode = `func Validate() (err error) {
+	if len(target.RequiredMap) < 5 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_map", target.RequiredMap, len(target.RequiredMap), 5, true))
+	}
+	if len(target.DefaultMap) > 3 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.default_map", target.DefaultMap, len(target.DefaultMap), 3, false))
+	}
+	for k, v := range target.Map {
+		err = goa.MergeErrors(err, goa.ValidatePattern("target.map.key", k, "^[A-Z]"))
+		if v > 5 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.map[key]", v, 5, false))
+		}
+	}
+}
+`
+)

--- a/codegen/testdata/validation_types_dsl.go
+++ b/codegen/testdata/validation_types_dsl.go
@@ -1,0 +1,95 @@
+package testdata
+
+import . "goa.design/goa/dsl"
+
+var ValidationTypesDSL = func() {
+	var (
+		IntegerT = Type("Integer", func() {
+			Attribute("required_integer", Int, func() {
+				Minimum(1)
+			})
+			Attribute("default_integer", Int32, func() {
+				Enum(1, 5, 10, 100)
+				Default(5)
+			})
+			Attribute("integer", Int64, func() {
+				Maximum(100)
+			})
+			Required("required_integer")
+		})
+
+		FloatT = Type("Float", func() {
+			Attribute("required_float", Float32, func() {
+				Minimum(1.0)
+			})
+			Attribute("default_integer", Float32, func() {
+				Enum(1.2, 5, 10, 100.8)
+				Default(5.0)
+			})
+			Attribute("float64", Float64, func() {
+				Maximum(100.1)
+			})
+			Required("required_float")
+		})
+
+		StringT = Type("String", func() {
+			Attribute("required_string", String, func() {
+				MinLength(1)
+				MaxLength(10)
+				Pattern("^[A-z].*[a-z]$")
+			})
+			Attribute("default_string", String, func() {
+				Enum("foo", "bar")
+				Default("foo")
+			})
+			Attribute("string", String, func() {
+				Format(FormatDateTime)
+			})
+			Required("required_string")
+		})
+
+		_ = Type("UserType", func() {
+			Attribute("required_integer", IntegerT)
+			Attribute("default_string", StringT, func() {
+				Default(struct{ RequiredString, DefaultString, String string }{RequiredString: "Atoz", DefaultString: "bar", String: "2018-12-18T13:22:53.108Z"})
+			})
+			Attribute("float", FloatT)
+			Required("required_integer")
+		})
+
+		_ = Type("Array", func() {
+			Attribute("required_array", ArrayOf(Int), func() {
+				MinLength(5)
+			})
+			Attribute("default_array", ArrayOf(String), func() {
+				MaxLength(3)
+				Default([]string{"foo", "bar"})
+			})
+			Attribute("array", ArrayOf(UInt64), func() {
+				Elem(func() {
+					Enum(0, 1, 1, 2, 3, 5)
+				})
+			})
+			Required("required_array")
+		})
+
+		_ = Type("Map", func() {
+			Attribute("required_map", MapOf(Int, String), func() {
+				MinLength(5)
+			})
+			Attribute("default_map", MapOf(String, String), func() {
+				MaxLength(3)
+				Default(map[string]string{"foo": "bar"})
+			})
+			Attribute("map", MapOf(String, UInt64), func() {
+				Key(func() {
+					Pattern("^[A-Z]")
+				})
+				Elem(func() {
+					Maximum(5)
+				})
+			})
+			Required("required_map")
+		})
+	)
+}

--- a/codegen/validation_test.go
+++ b/codegen/validation_test.go
@@ -1,0 +1,60 @@
+package codegen
+
+import (
+	"testing"
+
+	"goa.design/goa/codegen/testdata"
+	"goa.design/goa/expr"
+)
+
+func TestRecursiveValidationCode(t *testing.T) {
+	root := RunDSL(t, testdata.ValidationTypesDSL)
+	var (
+		integerT = root.UserType("Integer")
+		stringT  = root.UserType("String")
+		floatT   = root.UserType("Float")
+		userT    = root.UserType("UserType")
+		arrayT   = root.UserType("Array")
+		mapT     = root.UserType("Map")
+
+		pointerP  = &expr.AttributeProperties{Pointer: true}
+		requiredP = &expr.AttributeProperties{Required: true}
+		defaultP  = &expr.AttributeProperties{UseDefault: true}
+	)
+	cases := []struct {
+		Name       string
+		Type       expr.UserType
+		Properties *expr.AttributeProperties
+		Code       string
+	}{
+		{"integer-required", integerT, requiredP, testdata.IntegerRequiredValidationCode},
+		{"integer-pointer", integerT, pointerP, testdata.IntegerPointerValidationCode},
+		{"integer-use-default", integerT, defaultP, testdata.IntegerUseDefaultValidationCode},
+		{"float-required", floatT, requiredP, testdata.FloatRequiredValidationCode},
+		{"float-pointer", floatT, pointerP, testdata.FloatPointerValidationCode},
+		{"float-use-default", floatT, defaultP, testdata.FloatUseDefaultValidationCode},
+		{"string-required", stringT, requiredP, testdata.StringRequiredValidationCode},
+		{"string-pointer", stringT, pointerP, testdata.StringPointerValidationCode},
+		{"string-use-default", stringT, defaultP, testdata.StringUseDefaultValidationCode},
+		{"user-type-required", userT, requiredP, testdata.UserTypeRequiredValidationCode},
+		{"user-type-pointer", userT, pointerP, testdata.UserTypePointerValidationCode},
+		{"user-type-default", userT, defaultP, testdata.UserTypeUseDefaultValidationCode},
+		{"array-required", arrayT, requiredP, testdata.ArrayRequiredValidationCode},
+		{"array-pointer", arrayT, pointerP, testdata.ArrayPointerValidationCode},
+		{"array-use-default", arrayT, defaultP, testdata.ArrayUseDefaultValidationCode},
+		{"map-required", mapT, requiredP, testdata.MapRequiredValidationCode},
+		{"map-pointer", mapT, pointerP, testdata.MapPointerValidationCode},
+		{"map-use-default", mapT, defaultP, testdata.MapUseDefaultValidationCode},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			att := &expr.AttributeExpr{Type: c.Type}
+			an := expr.NewAttributeAnalyzer(att, c.Properties)
+			code := RecursiveValidationCode(an, "target")
+			code = FormatTestCode(t, "package foo\nfunc Validate() (err error){\n"+code+"}")
+			if code != c.Code {
+				t.Errorf("invalid code, got:\n%s\ngot vs. expected:\n%s", code, Diff(t, code, c.Code))
+			}
+		})
+	}
+}

--- a/dsl/convert.go
+++ b/dsl/convert.go
@@ -1,8 +1,8 @@
 package dsl
 
 import (
-	"goa.design/goa/expr"
 	"goa.design/goa/eval"
+	"goa.design/goa/expr"
 )
 
 // ConvertTo specifies an external type that instances of the generated struct
@@ -112,7 +112,7 @@ func ConvertTo(obj interface{}) {
 //    * struct fields must use pointers
 //    * pointers on slices or on maps are not supported
 //
-// CreateFrom must appear in Type or ResutType.
+// CreateFrom must appear in Type or ResultType.
 //
 // CreateFrom accepts one arguments: an instance of the external type.
 //

--- a/dsl/user_type.go
+++ b/dsl/user_type.go
@@ -225,6 +225,15 @@ func MapOf(k, v interface{}, fn ...func()) *expr.Map {
 }
 
 // Key makes it possible to specify validations for map keys.
+//
+// Example:
+//
+//    Attribute("map", MapOf(String, Int), func() {
+//        Key(func() {
+//            Format(FormatDateTime) // map keys are timestamps
+//        })
+//    })
+//
 func Key(fn func()) {
 	at, ok := eval.Current().(*expr.AttributeExpr)
 	if !ok {
@@ -239,6 +248,22 @@ func Key(fn func()) {
 }
 
 // Elem makes it possible to specify validations for array and map values.
+//
+// Example:
+//
+//    Attribute("array", ArrayOf(Int), func() {
+//        Elem(func() {
+//            Enum(1, 2, 3, 4, 5) // list possible values for array elements
+//        })
+//    })
+//
+//    Attribute("map", MapOf(String, Int), func() {
+//        Elem(func() {
+//            Minimum(1)
+//            Maximum(100)
+//        })
+//    })
+//
 func Elem(fn func()) {
 	at, ok := eval.Current().(*expr.AttributeExpr)
 	if !ok {

--- a/dsl/validation.go
+++ b/dsl/validation.go
@@ -55,6 +55,19 @@ const (
 
 // Enum adds a "enum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor76.
+//
+// Example:
+//
+//    Attribute("string", String, func() {
+//        Enum("this", "that", "and this")
+//    })
+//
+//    Attribute("array", ArrayOf(Int), func() {
+//		    Elem(func() {
+//		        Enum(1, 2, 3, 4, 5)  // Sets possible values for array elements
+//		    })
+//    })
+//
 func Enum(vals ...interface{}) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		for i, v := range vals {
@@ -129,6 +142,11 @@ func Enum(vals ...interface{}) {
 //
 // FormatRFC1123: RFC1123 date time
 //
+// Example:
+//
+//    Attribute("created_at", String, func() {
+//        Format(FormatDateTime)
+//    })
 func Format(f expr.ValidationFormat) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if !a.IsSupportedValidationFormat(f) {
@@ -147,6 +165,13 @@ func Format(f expr.ValidationFormat) {
 
 // Pattern adds a "pattern" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor33.
+//
+// Example:
+//
+//    Attribute("pattern", String, func() {
+//        Pattern("^[A-Z].*[0-9]$")
+//    })
+//
 func Pattern(p string) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil && a.Type.Kind() != expr.StringKind {
@@ -167,6 +192,13 @@ func Pattern(p string) {
 
 // Minimum adds a "minimum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor21.
+//
+// Example:
+//
+//    Attribute("integer", Int, func() {
+//        Minimum(100)
+//    })
+//
 func Minimum(val interface{}) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil &&
@@ -202,6 +234,13 @@ func Minimum(val interface{}) {
 
 // Maximum adds a "maximum" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor17.
+//
+// Example:
+//
+//    Attribute("integer", Int, func() {
+//        Maximum(100)
+//    })
+//
 func Maximum(val interface{}) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil &&
@@ -237,6 +276,19 @@ func Maximum(val interface{}) {
 
 // MinLength adds a "minItems" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor45.
+//
+// Example:
+//
+//    Attribute("map", MapOf(String, String), func() {
+//        MinLength(10)      // min key-values in map
+//        Key(func() {
+//            MinLength(1)   // min length of map key
+//        })
+//        Elem(func() {
+//            MinLength(5)   // min length of map elements
+//        })
+//    })
+//
 func MinLength(val int) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil {
@@ -259,6 +311,16 @@ func MinLength(val int) {
 
 // MaxLength adds a "maxItems" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor42.
+//
+// Example:
+//
+//    Attribute("array", ArrayOf(String), func() {
+//        MaxLength(200)    // max array length
+//        Elem(func() {
+//            MaxLength(5)  // max length of each array element
+//        })
+//    })
+//
 func MaxLength(val int) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil {
@@ -281,6 +343,15 @@ func MaxLength(val int) {
 
 // Required adds a "required" validation to the attribute.
 // See http://json-schema.org/latest/json-schema-validation.html#anchor61.
+//
+// Example:
+//
+//    var _ = Type("MyType", func() {
+//        Attribute("string", String)
+//        Attribute("int", Integer)
+//        Required("string", "int")
+//    })
+//
 func Required(names ...string) {
 	var at *expr.AttributeExpr
 

--- a/examples/cellar/gen/http/sommelier/client/encode_decode.go
+++ b/examples/cellar/gen/http/sommelier/client/encode_decode.go
@@ -85,7 +85,7 @@ func DecodePickResponse(decoder func(*http.Response) goahttp.Decoder, restoreBod
 			p := NewPickStoredBottleCollectionOK(body)
 			view := "default"
 			vres := sommelierviews.StoredBottleCollection{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = sommelierviews.ValidateStoredBottleCollection(vres); err != nil {
 				return nil, goahttp.ErrValidationError("sommelier", "pick", err)
 			}
 			res := sommelier.NewStoredBottleCollection(vres)

--- a/examples/cellar/gen/http/sommelier/client/types.go
+++ b/examples/cellar/gen/http/sommelier/client/types.go
@@ -131,8 +131,9 @@ func NewPickNoMatch(body PickNoMatchResponseBody) sommelier.NoMatch {
 	return v
 }
 
-// Validate runs the validations defined on StoredBottleResponse.
-func (body *StoredBottleResponse) Validate() (err error) {
+// ValidateStoredBottleResponse runs the validations defined on
+// StoredBottleResponse
+func ValidateStoredBottleResponse(body *StoredBottleResponse) (err error) {
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}
@@ -151,7 +152,7 @@ func (body *StoredBottleResponse) Validate() (err error) {
 		}
 	}
 	if body.Winery != nil {
-		if err2 := body.Winery.Validate(); err2 != nil {
+		if err2 := ValidateWineryResponse(body.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -167,7 +168,7 @@ func (body *StoredBottleResponse) Validate() (err error) {
 	}
 	for _, e := range body.Composition {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateComponentResponse(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}
@@ -190,8 +191,8 @@ func (body *StoredBottleResponse) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on WineryResponse.
-func (body *WineryResponse) Validate() (err error) {
+// ValidateWineryResponse runs the validations defined on WineryResponse
+func ValidateWineryResponse(body *WineryResponse) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -213,8 +214,8 @@ func (body *WineryResponse) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on ComponentResponse.
-func (body *ComponentResponse) Validate() (err error) {
+// ValidateComponentResponse runs the validations defined on ComponentResponse
+func ValidateComponentResponse(body *ComponentResponse) (err error) {
 	if body.Varietal == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("varietal", "body"))
 	}

--- a/examples/cellar/gen/http/sommelier/server/types.go
+++ b/examples/cellar/gen/http/sommelier/server/types.go
@@ -128,8 +128,9 @@ func NewPickCriteria(body *PickRequestBody) *sommelier.Criteria {
 	return v
 }
 
-// Validate runs the validations defined on StoredBottleResponse.
-func (body *StoredBottleResponse) Validate() (err error) {
+// ValidateStoredBottleResponse runs the validations defined on
+// StoredBottleResponse
+func ValidateStoredBottleResponse(body *StoredBottleResponse) (err error) {
 	if body.Winery == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("winery", "body"))
 	}
@@ -144,7 +145,7 @@ func (body *StoredBottleResponse) Validate() (err error) {
 	}
 	for _, e := range body.Composition {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateComponentResponse(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}
@@ -167,8 +168,8 @@ func (body *StoredBottleResponse) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on ComponentResponse.
-func (body *ComponentResponse) Validate() (err error) {
+// ValidateComponentResponse runs the validations defined on ComponentResponse
+func ValidateComponentResponse(body *ComponentResponse) (err error) {
 	err = goa.MergeErrors(err, goa.ValidatePattern("body.varietal", body.Varietal, "[A-Za-z' ]+"))
 	if utf8.RuneCountInString(body.Varietal) > 100 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.varietal", body.Varietal, utf8.RuneCountInString(body.Varietal), 100, false))

--- a/examples/cellar/gen/http/storage/client/cli.go
+++ b/examples/cellar/gen/http/storage/client/cli.go
@@ -54,7 +54,7 @@ func BuildAddPayload(storageAddBody string) (*storage.Bottle, error) {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body.name", body.Name, utf8.RuneCountInString(body.Name), 100, false))
 		}
 		if body.Winery != nil {
-			if err2 := body.Winery.Validate(); err2 != nil {
+			if err2 := ValidateWineryRequestBody(body.Winery); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}
@@ -66,7 +66,7 @@ func BuildAddPayload(storageAddBody string) (*storage.Bottle, error) {
 		}
 		for _, e := range body.Composition {
 			if e != nil {
-				if err2 := e.Validate(); err2 != nil {
+				if err2 := ValidateComponentRequestBody(e); err2 != nil {
 					err = goa.MergeErrors(err, err2)
 				}
 			}
@@ -180,7 +180,7 @@ func BuildMultiUpdatePayload(storageMultiUpdateBody string, storageMultiUpdateId
 		}
 		for _, e := range body.Bottles {
 			if e != nil {
-				if err2 := e.Validate(); err2 != nil {
+				if err2 := ValidateBottleRequestBody(e); err2 != nil {
 					err = goa.MergeErrors(err, err2)
 				}
 			}

--- a/examples/cellar/gen/http/storage/client/encode_decode.go
+++ b/examples/cellar/gen/http/storage/client/encode_decode.go
@@ -67,7 +67,7 @@ func DecodeListResponse(decoder func(*http.Response) goahttp.Decoder, restoreBod
 			p := NewListStoredBottleCollectionOK(body)
 			view := "tiny"
 			vres := storageviews.StoredBottleCollection{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = storageviews.ValidateStoredBottleCollection(vres); err != nil {
 				return nil, goahttp.ErrValidationError("storage", "list", err)
 			}
 			res := storage.NewStoredBottleCollection(vres)
@@ -154,7 +154,7 @@ func DecodeShowResponse(decoder func(*http.Response) goahttp.Decoder, restoreBod
 			p := NewShowStoredBottleOK(&body)
 			view := resp.Header.Get("goa-view")
 			vres := &storageviews.StoredBottle{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = storageviews.ValidateStoredBottle(vres); err != nil {
 				return nil, goahttp.ErrValidationError("storage", "show", err)
 			}
 			res := storage.NewStoredBottle(vres)
@@ -168,7 +168,7 @@ func DecodeShowResponse(decoder func(*http.Response) goahttp.Decoder, restoreBod
 			if err != nil {
 				return nil, goahttp.ErrDecodingError("storage", "show", err)
 			}
-			err = body.Validate()
+			err = ValidateShowNotFoundResponseBody(&body)
 			if err != nil {
 				return nil, goahttp.ErrValidationError("storage", "show", err)
 			}

--- a/examples/cellar/gen/http/storage/client/types.go
+++ b/examples/cellar/gen/http/storage/client/types.go
@@ -305,8 +305,9 @@ func NewShowNotFound(body *ShowNotFoundResponseBody) *storage.NotFound {
 	return v
 }
 
-// Validate runs the validations defined on ShowNotFoundResponseBody.
-func (body *ShowNotFoundResponseBody) Validate() (err error) {
+// ValidateShowNotFoundResponseBody runs the validations defined on
+// show_not_found_response_body
+func ValidateShowNotFoundResponseBody(body *ShowNotFoundResponseBody) (err error) {
 	if body.Message == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
 	}
@@ -316,8 +317,9 @@ func (body *ShowNotFoundResponseBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on StoredBottleResponse.
-func (body *StoredBottleResponse) Validate() (err error) {
+// ValidateStoredBottleResponse runs the validations defined on
+// StoredBottleResponse
+func ValidateStoredBottleResponse(body *StoredBottleResponse) (err error) {
 	if body.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "body"))
 	}
@@ -336,7 +338,7 @@ func (body *StoredBottleResponse) Validate() (err error) {
 		}
 	}
 	if body.Winery != nil {
-		if err2 := body.Winery.Validate(); err2 != nil {
+		if err2 := ValidateWineryResponse(body.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -352,7 +354,7 @@ func (body *StoredBottleResponse) Validate() (err error) {
 	}
 	for _, e := range body.Composition {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateComponentResponse(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}
@@ -375,8 +377,8 @@ func (body *StoredBottleResponse) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on WineryResponse.
-func (body *WineryResponse) Validate() (err error) {
+// ValidateWineryResponse runs the validations defined on WineryResponse
+func ValidateWineryResponse(body *WineryResponse) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -398,8 +400,8 @@ func (body *WineryResponse) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on ComponentResponse.
-func (body *ComponentResponse) Validate() (err error) {
+// ValidateComponentResponse runs the validations defined on ComponentResponse
+func ValidateComponentResponse(body *ComponentResponse) (err error) {
 	if body.Varietal == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("varietal", "body"))
 	}
@@ -424,8 +426,8 @@ func (body *ComponentResponse) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on WineryResponseBody.
-func (body *WineryResponseBody) Validate() (err error) {
+// ValidateWineryResponseBody runs the validations defined on WineryResponseBody
+func ValidateWineryResponseBody(body *WineryResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -447,8 +449,9 @@ func (body *WineryResponseBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on ComponentResponseBody.
-func (body *ComponentResponseBody) Validate() (err error) {
+// ValidateComponentResponseBody runs the validations defined on
+// ComponentResponseBody
+func ValidateComponentResponseBody(body *ComponentResponseBody) (err error) {
 	if body.Varietal == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("varietal", "body"))
 	}
@@ -473,8 +476,8 @@ func (body *ComponentResponseBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on WineryRequestBody.
-func (body *WineryRequestBody) Validate() (err error) {
+// ValidateWineryRequestBody runs the validations defined on WineryRequestBody
+func ValidateWineryRequestBody(body *WineryRequestBody) (err error) {
 	err = goa.MergeErrors(err, goa.ValidatePattern("body.region", body.Region, "(?i)[a-z '\\.]+"))
 	err = goa.MergeErrors(err, goa.ValidatePattern("body.country", body.Country, "(?i)[a-z '\\.]+"))
 	if body.URL != nil {
@@ -483,8 +486,9 @@ func (body *WineryRequestBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on ComponentRequestBody.
-func (body *ComponentRequestBody) Validate() (err error) {
+// ValidateComponentRequestBody runs the validations defined on
+// ComponentRequestBody
+func ValidateComponentRequestBody(body *ComponentRequestBody) (err error) {
 	err = goa.MergeErrors(err, goa.ValidatePattern("body.varietal", body.Varietal, "[A-Za-z' ]+"))
 	if utf8.RuneCountInString(body.Varietal) > 100 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.varietal", body.Varietal, utf8.RuneCountInString(body.Varietal), 100, false))
@@ -502,8 +506,8 @@ func (body *ComponentRequestBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on BottleRequestBody.
-func (body *BottleRequestBody) Validate() (err error) {
+// ValidateBottleRequestBody runs the validations defined on BottleRequestBody
+func ValidateBottleRequestBody(body *BottleRequestBody) (err error) {
 	if body.Winery == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("winery", "body"))
 	}
@@ -511,7 +515,7 @@ func (body *BottleRequestBody) Validate() (err error) {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.name", body.Name, utf8.RuneCountInString(body.Name), 100, false))
 	}
 	if body.Winery != nil {
-		if err2 := body.Winery.Validate(); err2 != nil {
+		if err2 := ValidateWineryRequestBody(body.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -523,7 +527,7 @@ func (body *BottleRequestBody) Validate() (err error) {
 	}
 	for _, e := range body.Composition {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateComponentRequestBody(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}

--- a/examples/cellar/gen/http/storage/server/encode_decode.go
+++ b/examples/cellar/gen/http/storage/server/encode_decode.go
@@ -131,7 +131,7 @@ func DecodeAddRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Dec
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateAddRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}

--- a/examples/cellar/gen/http/storage/server/types.go
+++ b/examples/cellar/gen/http/storage/server/types.go
@@ -299,8 +299,8 @@ func NewMultiUpdatePayload(body *MultiUpdateRequestBody, ids []string) *storage.
 	return v
 }
 
-// Validate runs the validations defined on AddRequestBody.
-func (body *AddRequestBody) Validate() (err error) {
+// ValidateAddRequestBody runs the validations defined on AddRequestBody
+func ValidateAddRequestBody(body *AddRequestBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -316,7 +316,7 @@ func (body *AddRequestBody) Validate() (err error) {
 		}
 	}
 	if body.Winery != nil {
-		if err2 := body.Winery.Validate(); err2 != nil {
+		if err2 := ValidateWineryRequestBody(body.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -332,7 +332,7 @@ func (body *AddRequestBody) Validate() (err error) {
 	}
 	for _, e := range body.Composition {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateComponentRequestBody(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}
@@ -355,14 +355,15 @@ func (body *AddRequestBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on MultiUpdateRequestBody.
-func (body *MultiUpdateRequestBody) Validate() (err error) {
+// ValidateMultiUpdateRequestBody runs the validations defined on
+// multi_update_request_body
+func ValidateMultiUpdateRequestBody(body *MultiUpdateRequestBody) (err error) {
 	if body.Bottles == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("bottles", "body"))
 	}
 	for _, e := range body.Bottles {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateBottleRequestBody(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}
@@ -370,8 +371,9 @@ func (body *MultiUpdateRequestBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on StoredBottleResponseTiny.
-func (body *StoredBottleResponseTiny) Validate() (err error) {
+// ValidateStoredBottleResponseTiny runs the validations defined on
+// StoredBottleResponseTiny
+func ValidateStoredBottleResponseTiny(body *StoredBottleResponseTiny) (err error) {
 	if body.Winery == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("winery", "body"))
 	}
@@ -381,8 +383,9 @@ func (body *StoredBottleResponseTiny) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on ComponentResponseBody.
-func (body *ComponentResponseBody) Validate() (err error) {
+// ValidateComponentResponseBody runs the validations defined on
+// ComponentResponseBody
+func ValidateComponentResponseBody(body *ComponentResponseBody) (err error) {
 	err = goa.MergeErrors(err, goa.ValidatePattern("body.varietal", body.Varietal, "[A-Za-z' ]+"))
 	if utf8.RuneCountInString(body.Varietal) > 100 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("body.varietal", body.Varietal, utf8.RuneCountInString(body.Varietal), 100, false))
@@ -400,8 +403,8 @@ func (body *ComponentResponseBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on WineryRequestBody.
-func (body *WineryRequestBody) Validate() (err error) {
+// ValidateWineryRequestBody runs the validations defined on WineryRequestBody
+func ValidateWineryRequestBody(body *WineryRequestBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -423,8 +426,9 @@ func (body *WineryRequestBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on ComponentRequestBody.
-func (body *ComponentRequestBody) Validate() (err error) {
+// ValidateComponentRequestBody runs the validations defined on
+// ComponentRequestBody
+func ValidateComponentRequestBody(body *ComponentRequestBody) (err error) {
 	if body.Varietal == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("varietal", "body"))
 	}
@@ -449,8 +453,8 @@ func (body *ComponentRequestBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on BottleRequestBody.
-func (body *BottleRequestBody) Validate() (err error) {
+// ValidateBottleRequestBody runs the validations defined on BottleRequestBody
+func ValidateBottleRequestBody(body *BottleRequestBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -466,7 +470,7 @@ func (body *BottleRequestBody) Validate() (err error) {
 		}
 	}
 	if body.Winery != nil {
-		if err2 := body.Winery.Validate(); err2 != nil {
+		if err2 := ValidateWineryRequestBody(body.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
@@ -482,7 +486,7 @@ func (body *BottleRequestBody) Validate() (err error) {
 	}
 	for _, e := range body.Composition {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateComponentRequestBody(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}

--- a/examples/cellar/gen/sommelier/views/view.go
+++ b/examples/cellar/gen/sommelier/views/view.go
@@ -65,45 +65,45 @@ type ComponentView struct {
 	Percentage *uint32
 }
 
-// Validate runs the validations defined on the viewed result type
-// StoredBottleCollection.
-func (result StoredBottleCollection) Validate() (err error) {
+// ValidateStoredBottleCollection runs the validations defined on the viewed
+// result type StoredBottleCollection.
+func ValidateStoredBottleCollection(result StoredBottleCollection) (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateStoredBottleCollectionView(result.Projected)
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateStoredBottleCollectionViewTiny(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
 	}
 	return
 }
 
-// Validate runs the validations defined on StoredBottleCollectionView using
-// the "default" view.
-func (result StoredBottleCollectionView) Validate() (err error) {
+// ValidateStoredBottleCollectionView runs the validations defined on
+// StoredBottleCollectionView using the "default" view.
+func ValidateStoredBottleCollectionView(result StoredBottleCollectionView) (err error) {
 	for _, item := range result {
-		if err2 := item.Validate(); err2 != nil {
+		if err2 := ValidateStoredBottleView(item); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on StoredBottleCollectionView
-// using the "tiny" view.
-func (result StoredBottleCollectionView) ValidateTiny() (err error) {
+// ValidateStoredBottleCollectionViewTiny runs the validations defined on
+// StoredBottleCollectionView using the "tiny" view.
+func ValidateStoredBottleCollectionViewTiny(result StoredBottleCollectionView) (err error) {
 	for _, item := range result {
-		if err2 := item.ValidateTiny(); err2 != nil {
+		if err2 := ValidateStoredBottleViewTiny(item); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// Validate runs the validations defined on StoredBottleView using the
-// "default" view.
-func (result *StoredBottleView) Validate() (err error) {
+// ValidateStoredBottleView runs the validations defined on StoredBottleView
+// using the "default" view.
+func ValidateStoredBottleView(result *StoredBottleView) (err error) {
 	if result.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
 	}
@@ -130,7 +130,7 @@ func (result *StoredBottleView) Validate() (err error) {
 	}
 	for _, e := range result.Composition {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateComponentView(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}
@@ -151,16 +151,16 @@ func (result *StoredBottleView) Validate() (err error) {
 		}
 	}
 	if result.Winery != nil {
-		if err2 := result.Winery.ValidateTiny(); err2 != nil {
+		if err2 := ValidateWineryViewTiny(result.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on StoredBottleView using the
-// "tiny" view.
-func (result *StoredBottleView) ValidateTiny() (err error) {
+// ValidateStoredBottleViewTiny runs the validations defined on
+// StoredBottleView using the "tiny" view.
+func ValidateStoredBottleViewTiny(result *StoredBottleView) (err error) {
 	if result.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
 	}
@@ -173,15 +173,16 @@ func (result *StoredBottleView) ValidateTiny() (err error) {
 		}
 	}
 	if result.Winery != nil {
-		if err2 := result.Winery.ValidateTiny(); err2 != nil {
+		if err2 := ValidateWineryViewTiny(result.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// Validate runs the validations defined on WineryView using the "default" view.
-func (result *WineryView) Validate() (err error) {
+// ValidateWineryView runs the validations defined on WineryView using the
+// "default" view.
+func ValidateWineryView(result *WineryView) (err error) {
 	if result.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "result"))
 	}
@@ -203,17 +204,17 @@ func (result *WineryView) Validate() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on WineryView using the "tiny"
-// view.
-func (result *WineryView) ValidateTiny() (err error) {
+// ValidateWineryViewTiny runs the validations defined on WineryView using the
+// "tiny" view.
+func ValidateWineryViewTiny(result *WineryView) (err error) {
 	if result.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "result"))
 	}
 	return
 }
 
-// Validate runs the validations defined on ComponentView.
-func (result *ComponentView) Validate() (err error) {
+// ValidateComponentView runs the validations defined on ComponentView.
+func ValidateComponentView(result *ComponentView) (err error) {
 	if result.Varietal != nil {
 		err = goa.MergeErrors(err, goa.ValidatePattern("result.varietal", *result.Varietal, "[A-Za-z' ]+"))
 	}

--- a/examples/cellar/gen/storage/views/view.go
+++ b/examples/cellar/gen/storage/views/view.go
@@ -73,58 +73,59 @@ type ComponentView struct {
 	Percentage *uint32
 }
 
-// Validate runs the validations defined on the viewed result type
-// StoredBottleCollection.
-func (result StoredBottleCollection) Validate() (err error) {
+// ValidateStoredBottleCollection runs the validations defined on the viewed
+// result type StoredBottleCollection.
+func ValidateStoredBottleCollection(result StoredBottleCollection) (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateStoredBottleCollectionView(result.Projected)
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateStoredBottleCollectionViewTiny(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
 	}
 	return
 }
 
-// Validate runs the validations defined on the viewed result type StoredBottle.
-func (result *StoredBottle) Validate() (err error) {
+// ValidateStoredBottle runs the validations defined on the viewed result type
+// StoredBottle.
+func ValidateStoredBottle(result *StoredBottle) (err error) {
 	switch result.View {
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateStoredBottleView(result.Projected)
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateStoredBottleViewTiny(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
 	}
 	return
 }
 
-// Validate runs the validations defined on StoredBottleCollectionView using
-// the "default" view.
-func (result StoredBottleCollectionView) Validate() (err error) {
+// ValidateStoredBottleCollectionView runs the validations defined on
+// StoredBottleCollectionView using the "default" view.
+func ValidateStoredBottleCollectionView(result StoredBottleCollectionView) (err error) {
 	for _, item := range result {
-		if err2 := item.Validate(); err2 != nil {
+		if err2 := ValidateStoredBottleView(item); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on StoredBottleCollectionView
-// using the "tiny" view.
-func (result StoredBottleCollectionView) ValidateTiny() (err error) {
+// ValidateStoredBottleCollectionViewTiny runs the validations defined on
+// StoredBottleCollectionView using the "tiny" view.
+func ValidateStoredBottleCollectionViewTiny(result StoredBottleCollectionView) (err error) {
 	for _, item := range result {
-		if err2 := item.ValidateTiny(); err2 != nil {
+		if err2 := ValidateStoredBottleViewTiny(item); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// Validate runs the validations defined on StoredBottleView using the
-// "default" view.
-func (result *StoredBottleView) Validate() (err error) {
+// ValidateStoredBottleView runs the validations defined on StoredBottleView
+// using the "default" view.
+func ValidateStoredBottleView(result *StoredBottleView) (err error) {
 	if result.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
 	}
@@ -151,7 +152,7 @@ func (result *StoredBottleView) Validate() (err error) {
 	}
 	for _, e := range result.Composition {
 		if e != nil {
-			if err2 := e.Validate(); err2 != nil {
+			if err2 := ValidateComponentView(e); err2 != nil {
 				err = goa.MergeErrors(err, err2)
 			}
 		}
@@ -172,16 +173,16 @@ func (result *StoredBottleView) Validate() (err error) {
 		}
 	}
 	if result.Winery != nil {
-		if err2 := result.Winery.ValidateTiny(); err2 != nil {
+		if err2 := ValidateWineryViewTiny(result.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on StoredBottleView using the
-// "tiny" view.
-func (result *StoredBottleView) ValidateTiny() (err error) {
+// ValidateStoredBottleViewTiny runs the validations defined on
+// StoredBottleView using the "tiny" view.
+func ValidateStoredBottleViewTiny(result *StoredBottleView) (err error) {
 	if result.ID == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("id", "result"))
 	}
@@ -194,15 +195,16 @@ func (result *StoredBottleView) ValidateTiny() (err error) {
 		}
 	}
 	if result.Winery != nil {
-		if err2 := result.Winery.ValidateTiny(); err2 != nil {
+		if err2 := ValidateWineryViewTiny(result.Winery); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// Validate runs the validations defined on WineryView using the "default" view.
-func (result *WineryView) Validate() (err error) {
+// ValidateWineryView runs the validations defined on WineryView using the
+// "default" view.
+func ValidateWineryView(result *WineryView) (err error) {
 	if result.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "result"))
 	}
@@ -224,17 +226,17 @@ func (result *WineryView) Validate() (err error) {
 	return
 }
 
-// ValidateTiny runs the validations defined on WineryView using the "tiny"
-// view.
-func (result *WineryView) ValidateTiny() (err error) {
+// ValidateWineryViewTiny runs the validations defined on WineryView using the
+// "tiny" view.
+func ValidateWineryViewTiny(result *WineryView) (err error) {
 	if result.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "result"))
 	}
 	return
 }
 
-// Validate runs the validations defined on ComponentView.
-func (result *ComponentView) Validate() (err error) {
+// ValidateComponentView runs the validations defined on ComponentView.
+func ValidateComponentView(result *ComponentView) (err error) {
 	if result.Varietal != nil {
 		err = goa.MergeErrors(err, goa.ValidatePattern("result.varietal", *result.Varietal, "[A-Za-z' ]+"))
 	}

--- a/examples/chatter/gen/chatter/views/view.go
+++ b/examples/chatter/gen/chatter/views/view.go
@@ -43,67 +43,68 @@ type ChatSummaryView struct {
 	SentAt *string
 }
 
-// Validate runs the validations defined on the viewed result type
-// ChatSummaryCollection.
-func (result ChatSummaryCollection) Validate() (err error) {
+// ValidateChatSummaryCollection runs the validations defined on the viewed
+// result type ChatSummaryCollection.
+func ValidateChatSummaryCollection(result ChatSummaryCollection) (err error) {
 	switch result.View {
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateChatSummaryCollectionViewTiny(result.Projected)
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateChatSummaryCollectionView(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"tiny", "default"})
 	}
 	return
 }
 
-// Validate runs the validations defined on the viewed result type ChatSummary.
-func (result *ChatSummary) Validate() (err error) {
+// ValidateChatSummary runs the validations defined on the viewed result type
+// ChatSummary.
+func ValidateChatSummary(result *ChatSummary) (err error) {
 	switch result.View {
 	case "tiny":
-		err = result.Projected.ValidateTiny()
+		err = ValidateChatSummaryViewTiny(result.Projected)
 	case "default", "":
-		err = result.Projected.Validate()
+		err = ValidateChatSummaryView(result.Projected)
 	default:
 		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"tiny", "default"})
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on ChatSummaryCollectionView using
-// the "tiny" view.
-func (result ChatSummaryCollectionView) ValidateTiny() (err error) {
+// ValidateChatSummaryCollectionViewTiny runs the validations defined on
+// ChatSummaryCollectionView using the "tiny" view.
+func ValidateChatSummaryCollectionViewTiny(result ChatSummaryCollectionView) (err error) {
 	for _, item := range result {
-		if err2 := item.ValidateTiny(); err2 != nil {
+		if err2 := ValidateChatSummaryViewTiny(item); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// Validate runs the validations defined on ChatSummaryCollectionView using the
-// "default" view.
-func (result ChatSummaryCollectionView) Validate() (err error) {
+// ValidateChatSummaryCollectionView runs the validations defined on
+// ChatSummaryCollectionView using the "default" view.
+func ValidateChatSummaryCollectionView(result ChatSummaryCollectionView) (err error) {
 	for _, item := range result {
-		if err2 := item.Validate(); err2 != nil {
+		if err2 := ValidateChatSummaryView(item); err2 != nil {
 			err = goa.MergeErrors(err, err2)
 		}
 	}
 	return
 }
 
-// ValidateTiny runs the validations defined on ChatSummaryView using the
-// "tiny" view.
-func (result *ChatSummaryView) ValidateTiny() (err error) {
+// ValidateChatSummaryViewTiny runs the validations defined on ChatSummaryView
+// using the "tiny" view.
+func ValidateChatSummaryViewTiny(result *ChatSummaryView) (err error) {
 	if result.Message == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("message", "result"))
 	}
 	return
 }
 
-// Validate runs the validations defined on ChatSummaryView using the "default"
-// view.
-func (result *ChatSummaryView) Validate() (err error) {
+// ValidateChatSummaryView runs the validations defined on ChatSummaryView
+// using the "default" view.
+func ValidateChatSummaryView(result *ChatSummaryView) (err error) {
 	if result.Message == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("message", "result"))
 	}

--- a/examples/chatter/gen/http/chatter/client/client.go
+++ b/examples/chatter/gen/http/chatter/client/client.go
@@ -301,7 +301,7 @@ func (s *summaryClientStream) CloseAndRecv() (chattersvc.ChatSummaryCollection, 
 	}
 	res := NewSummaryChatSummaryCollectionOK(body)
 	vres := chattersvcviews.ChatSummaryCollection{res, "default"}
-	if err := vres.Validate(); err != nil {
+	if err := chattersvcviews.ValidateChatSummaryCollection(vres); err != nil {
 		return rv, goahttp.ErrValidationError("chatter", "summary", err)
 	}
 	return chattersvc.NewChatSummaryCollection(vres), nil
@@ -364,7 +364,7 @@ func (s *historyClientStream) Recv() (*chattersvc.ChatSummary, error) {
 	}
 	res := NewHistoryChatSummaryOK(&body)
 	vres := &chattersvcviews.ChatSummary{res, s.view}
-	if err := vres.Validate(); err != nil {
+	if err := chattersvcviews.ValidateChatSummary(vres); err != nil {
 		return rv, goahttp.ErrValidationError("chatter", "history", err)
 	}
 	return chattersvc.NewChatSummary(vres), nil

--- a/examples/chatter/gen/http/chatter/client/encode_decode.go
+++ b/examples/chatter/gen/http/chatter/client/encode_decode.go
@@ -358,7 +358,7 @@ func DecodeSummaryResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			p := NewSummaryChatSummaryCollectionOK(body)
 			view := "default"
 			vres := chattersvcviews.ChatSummaryCollection{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = chattersvcviews.ValidateChatSummaryCollection(vres); err != nil {
 				return nil, goahttp.ErrValidationError("chatter", "summary", err)
 			}
 			res := chattersvc.NewChatSummaryCollection(vres)
@@ -468,7 +468,7 @@ func DecodeHistoryResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			p := NewHistoryChatSummaryOK(&body)
 			view := resp.Header.Get("goa-view")
 			vres := &chattersvcviews.ChatSummary{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = chattersvcviews.ValidateChatSummary(vres); err != nil {
 				return nil, goahttp.ErrValidationError("chatter", "history", err)
 			}
 			res := chattersvc.NewChatSummary(vres)

--- a/examples/chatter/gen/http/chatter/client/types.go
+++ b/examples/chatter/gen/http/chatter/client/types.go
@@ -163,8 +163,9 @@ func NewHistoryUnauthorized(body HistoryUnauthorizedResponseBody) chattersvc.Una
 	return v
 }
 
-// Validate runs the validations defined on ChatSummaryResponse.
-func (body *ChatSummaryResponse) Validate() (err error) {
+// ValidateChatSummaryResponse runs the validations defined on
+// ChatSummaryResponse
+func ValidateChatSummaryResponse(body *ChatSummaryResponse) (err error) {
 	if body.Message == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("message", "body"))
 	}

--- a/examples/chatter/gen/http/chatter/server/types.go
+++ b/examples/chatter/gen/http/chatter/server/types.go
@@ -213,8 +213,9 @@ func NewHistoryPayload(view *string, token string) *chattersvc.HistoryPayload {
 	}
 }
 
-// Validate runs the validations defined on ChatSummaryResponse.
-func (body *ChatSummaryResponse) Validate() (err error) {
+// ValidateChatSummaryResponse runs the validations defined on
+// ChatSummaryResponse
+func ValidateChatSummaryResponse(body *ChatSummaryResponse) (err error) {
 	if body.SentAt != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("body.sent_at", *body.SentAt, goa.FormatDateTime))
 	}

--- a/examples/error/gen/http/divider/client/encode_decode.go
+++ b/examples/error/gen/http/divider/client/encode_decode.go
@@ -88,7 +88,7 @@ func DecodeIntegerDivideResponse(decoder func(*http.Response) goahttp.Decoder, r
 			if err != nil {
 				return nil, goahttp.ErrDecodingError("divider", "integer_divide", err)
 			}
-			err = body.Validate()
+			err = ValidateIntegerDivideHasRemainderResponseBody(&body)
 			if err != nil {
 				return nil, goahttp.ErrValidationError("divider", "integer_divide", err)
 			}
@@ -102,7 +102,7 @@ func DecodeIntegerDivideResponse(decoder func(*http.Response) goahttp.Decoder, r
 			if err != nil {
 				return nil, goahttp.ErrDecodingError("divider", "integer_divide", err)
 			}
-			err = body.Validate()
+			err = ValidateIntegerDivideDivByZeroResponseBody(&body)
 			if err != nil {
 				return nil, goahttp.ErrValidationError("divider", "integer_divide", err)
 			}
@@ -116,7 +116,7 @@ func DecodeIntegerDivideResponse(decoder func(*http.Response) goahttp.Decoder, r
 			if err != nil {
 				return nil, goahttp.ErrDecodingError("divider", "integer_divide", err)
 			}
-			err = body.Validate()
+			err = ValidateIntegerDivideTimeoutResponseBody(&body)
 			if err != nil {
 				return nil, goahttp.ErrValidationError("divider", "integer_divide", err)
 			}
@@ -196,7 +196,7 @@ func DecodeDivideResponse(decoder func(*http.Response) goahttp.Decoder, restoreB
 			if err != nil {
 				return nil, goahttp.ErrDecodingError("divider", "divide", err)
 			}
-			err = body.Validate()
+			err = ValidateDivideDivByZeroResponseBody(&body)
 			if err != nil {
 				return nil, goahttp.ErrValidationError("divider", "divide", err)
 			}
@@ -210,7 +210,7 @@ func DecodeDivideResponse(decoder func(*http.Response) goahttp.Decoder, restoreB
 			if err != nil {
 				return nil, goahttp.ErrDecodingError("divider", "divide", err)
 			}
-			err = body.Validate()
+			err = ValidateDivideTimeoutResponseBody(&body)
 			if err != nil {
 				return nil, goahttp.ErrValidationError("divider", "divide", err)
 			}

--- a/examples/error/gen/http/divider/client/types.go
+++ b/examples/error/gen/http/divider/client/types.go
@@ -171,9 +171,9 @@ func NewDivideTimeout(body *DivideTimeoutResponseBody) *goa.ServiceError {
 	return v
 }
 
-// Validate runs the validations defined on
-// IntegerDivideHasRemainderResponseBody.
-func (body *IntegerDivideHasRemainderResponseBody) Validate() (err error) {
+// ValidateIntegerDivideHasRemainderResponseBody runs the validations defined
+// on integer_divide_has_remainder_response_body
+func ValidateIntegerDivideHasRemainderResponseBody(body *IntegerDivideHasRemainderResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -195,8 +195,9 @@ func (body *IntegerDivideHasRemainderResponseBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on IntegerDivideDivByZeroResponseBody.
-func (body *IntegerDivideDivByZeroResponseBody) Validate() (err error) {
+// ValidateIntegerDivideDivByZeroResponseBody runs the validations defined on
+// integer_divide_div_by_zero_response_body
+func ValidateIntegerDivideDivByZeroResponseBody(body *IntegerDivideDivByZeroResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -218,8 +219,9 @@ func (body *IntegerDivideDivByZeroResponseBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on IntegerDivideTimeoutResponseBody.
-func (body *IntegerDivideTimeoutResponseBody) Validate() (err error) {
+// ValidateIntegerDivideTimeoutResponseBody runs the validations defined on
+// integer_divide_timeout_response_body
+func ValidateIntegerDivideTimeoutResponseBody(body *IntegerDivideTimeoutResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -241,8 +243,9 @@ func (body *IntegerDivideTimeoutResponseBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on DivideDivByZeroResponseBody.
-func (body *DivideDivByZeroResponseBody) Validate() (err error) {
+// ValidateDivideDivByZeroResponseBody runs the validations defined on
+// divide_div_by_zero_response_body
+func ValidateDivideDivByZeroResponseBody(body *DivideDivByZeroResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}
@@ -264,8 +267,9 @@ func (body *DivideDivByZeroResponseBody) Validate() (err error) {
 	return
 }
 
-// Validate runs the validations defined on DivideTimeoutResponseBody.
-func (body *DivideTimeoutResponseBody) Validate() (err error) {
+// ValidateDivideTimeoutResponseBody runs the validations defined on
+// divide_timeout_response_body
+func ValidateDivideTimeoutResponseBody(body *DivideTimeoutResponseBody) (err error) {
 	if body.Name == nil {
 		err = goa.MergeErrors(err, goa.MissingFieldError("name", "body"))
 	}

--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -1,18 +1,20 @@
 package codegen
 
 import (
-	"goa.design/goa/codegen"
 	"goa.design/goa/expr"
 )
 
 type (
-	protobufAttribute struct{}
+	protobufAnalyzer struct {
+		*expr.Analyzer
+	}
 )
 
-// newProtoBufAttributeHelper returns an AttributeHelper for protocol buffer
-// types.
-func newProtoBufAttributeHelper() codegen.AttributeHelper {
-	return &protobufAttribute{}
+// newProtoBufAnalyzer returns an attribute analyzer for protocol buffer types.
+func newProtoBufAnalyzer(att *expr.AttributeExpr, p *expr.AttributeProperties) expr.AttributeAnalyzer {
+	return &protobufAnalyzer{
+		Analyzer: &expr.Analyzer{AttributeExpr: att, AttributeProperties: p},
+	}
 }
 
 // IsPointer returns true if the given attribute expression is a pointer type.
@@ -20,6 +22,6 @@ func newProtoBufAttributeHelper() codegen.AttributeHelper {
 // In proto3 syntax, primitive fields are always non-pointers even when
 // optional or has default values.
 //
-func (p *protobufAttribute) IsPointer(att *expr.AttributeExpr, required, pointer, useDefault bool) bool {
+func (p *protobufAnalyzer) IsPointer() bool {
 	return false
 }

--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -1,0 +1,25 @@
+package codegen
+
+import (
+	"goa.design/goa/codegen"
+	"goa.design/goa/expr"
+)
+
+type (
+	protobufAttribute struct{}
+)
+
+// newProtoBufAttributeHelper returns an AttributeHelper for protocol buffer
+// types.
+func newProtoBufAttributeHelper() codegen.AttributeHelper {
+	return &protobufAttribute{}
+}
+
+// IsPointer returns true if the given attribute expression is a pointer type.
+//
+// In proto3 syntax, primitive fields are always non-pointers even when
+// optional or has default values.
+//
+func (p *protobufAttribute) IsPointer(att *expr.AttributeExpr, required, pointer, useDefault bool) bool {
+	return false
+}

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -516,7 +516,7 @@ func {{ .ResponseDecoder }}(decoder func(*http.Response) goahttp.Decoder, restor
 				{{- end }}
 			vres := {{ if not $.Method.ViewedResult.IsCollection }}&{{ end }}{{ $.Method.ViewedResult.ViewsPkg}}.{{ $.Method.ViewedResult.VarName }}{p, view}
 			{{- if .ClientBody }}
-				if err = vres.Validate(); err != nil {
+				if err = {{ $.Method.ViewedResult.ViewsPkg}}.Validate{{ $.Method.Result }}(vres); err != nil {
 					return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", err)
 				}
 			{{- end }}
@@ -736,7 +736,7 @@ func (c *{{ .ClientStream.VarName }}) Recv() ({{ .Result.Ref }}, error) {
 		return nil, err
 	}
 	{{- if .Method.ViewedResult }}
-	if err := &vres.Validate(); err != nil {
+	if err := {{ .Method.ViewedResult.ViewsPkg }}.Validate{{ .Result.Name }}(vres); err != nil {
 		return nil, goahttp.ErrValidationError("{{ $.ServiceName }}", "{{ $.Method.Name }}", err)
 	}
 	return {{ $.ServicePkgName }}.{{ .Method.ViewedResult.ResultInit.Name }}(vres), nil

--- a/http/codegen/server_types.go
+++ b/http/codegen/server_types.go
@@ -247,8 +247,8 @@ func {{ .Name }}({{ range .ServerArgs }}{{ .Name }} {{.TypeRef }}, {{ end }}) {{
 `
 
 // input: TypeData
-const validateT = `{{ printf "Validate runs the validations defined on %s." .VarName | comment }}
-func (body {{ .Ref }}) Validate() (err error) {
+const validateT = `{{ printf "Validate%s runs the validations defined on %s" .VarName .Name | comment }}
+func Validate{{ .VarName }}(body {{ .Ref }}) (err error) {
 	{{ .ValidateDef }}
 	return
 }

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1845,7 +1845,7 @@ func buildRequestBodyType(sd *ServiceData, e *expr.HTTPEndpointExpr, body, att *
 				// generate validation code for unmarshaled type (server-side).
 				validateDef = codegen.RecursiveValidationCode(body, true, svr, !svr, "body")
 				if validateDef != "" {
-					validateRef = "err = body.Validate()"
+					validateRef = fmt.Sprintf("err = Validate%s(&body)", varname)
 				}
 			}
 		} else {
@@ -1978,7 +1978,7 @@ func buildResponseBodyType(sd *ServiceData, e *expr.HTTPEndpointExpr, body, att 
 				// generate validation code for unmarshaled type (client-side).
 				validateDef = codegen.RecursiveValidationCode(body, true, !svr, svr, "body")
 				if validateDef != "" {
-					validateRef = "err = body.Validate()"
+					validateRef = fmt.Sprintf("err = Validate%s(&body)", varname)
 				}
 			}
 		} else if !expr.IsPrimitive(body.Type) && mustInit {
@@ -2277,7 +2277,7 @@ func attributeTypeData(ut expr.UserType, req, ptr, server bool, scope *codegen.N
 		def = goTypeDef(scope, ut.Attribute(), ptr, useDefault)
 		validate = codegen.RecursiveValidationCode(ut.Attribute(), true, ptr, useDefault, "body")
 		if validate != "" {
-			validateRef = "err = v.Validate()"
+			validateRef = fmt.Sprintf("err = Validate%s(v)", name)
 		}
 	}
 	return &TypeData{
@@ -2596,7 +2596,7 @@ func (s *{{ .VarName }}) {{ .RecvName }}() ({{ .RecvTypeRef }}, error) {
 		res := {{ .Response.ResultInit.Name }}({{ range .Response.ResultInit.ClientArgs }}{{ .Ref }},{{ end }})
 		{{- if .Endpoint.Method.ViewedResult }}{{ with .Endpoint.Method.ViewedResult }}
 			vres := {{ if not .IsCollection }}&{{ end }}{{ .ViewsPkg }}.{{ .VarName }}{res, {{ if .ViewName }}{{ printf "%q" .ViewName }}{{ else }}s.view{{ end }} }
-			if err := vres.Validate(); err != nil {
+			if err := {{ .ViewsPkg }}.Validate{{ $.Endpoint.Method.Result }}(vres); err != nil {
 				return rv, goahttp.ErrValidationError("{{ $.Endpoint.ServiceName }}", "{{ $.Endpoint.Method.Name }}", err)
 			}
 			return {{ $.PkgName }}.{{ .ResultInit.Name }}(vres){{ end }}, nil

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -23,6 +23,12 @@ var (
 	pathInitTmpl = template.Must(template.New("path-init").Funcs(template.FuncMap{"goify": codegen.Goify}).Parse(pathInitT))
 	// requestInitTmpl is the template used to render request constructors.
 	requestInitTmpl = template.Must(template.New("request-init").Parse(requestInitT))
+	// requiredProperty is the set of attribute properties to analyze attributes
+	// where required attributes are non-pointers.
+	requiredProperty = &expr.AttributeProperties{Required: true}
+	// useDefaultProperty is the set of attribute properties to analyze
+	// attributes where attributes with default values are non-pointers.
+	useDefaultProperty = &expr.AttributeProperties{Required: true, UseDefault: true}
 )
 
 type (
@@ -663,7 +669,8 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 						pointer := a.Params.IsPrimitivePointer(arg, false)
 						var vcode string
 						if att.Validation != nil {
-							vcode = codegen.RecursiveValidationCode(att, true, false, false, name)
+							an := expr.NewAttributeAnalyzer(att, requiredProperty)
+							vcode = codegen.RecursiveValidationCode(an, name)
 						}
 						initArgs[j] = &InitArgData{
 							Name:        name,
@@ -929,6 +936,8 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 					fieldName = codegen.Goify(name, true)
 				}
 				varn := codegen.Goify(name, false)
+				an := expr.NewAttributeAnalyzer(payload, &expr.AttributeProperties{Required: required})
+				validate := codegen.RecursiveValidationCode(an, varn)
 				mapQueryParam = &ParamData{
 					Name:           name,
 					VarName:        varn,
@@ -938,7 +947,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 					TypeName:       svc.Scope.GoTypeName(pAtt),
 					TypeRef:        svc.Scope.GoTypeRef(pAtt),
 					Map:            expr.AsMap(payload.Type) != nil,
-					Validate:       codegen.RecursiveValidationCode(payload, required, false, false, varn),
+					Validate:       validate,
 					DefaultValue:   pAtt.DefaultValue,
 					Example:        pAtt.Example(expr.Root.API.Random()),
 					MapQueryParams: e.MapQueryParams,
@@ -1016,8 +1025,8 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			)
 			if ut, ok := body.(expr.UserType); ok {
 				if val := ut.Attribute().Validation; val != nil {
-					svcode = codegen.RecursiveValidationCode(ut.Attribute(), true, false, false, "body")
-					cvcode = codegen.RecursiveValidationCode(ut.Attribute(), true, false, true, "body")
+					svcode = codegen.RecursiveValidationCode(expr.NewAttributeAnalyzer(ut.Attribute(), requiredProperty), "body")
+					cvcode = codegen.RecursiveValidationCode(expr.NewAttributeAnalyzer(ut.Attribute(), useDefaultProperty), "body")
 				}
 			}
 			serverArgs = []*InitArgData{{
@@ -1103,7 +1112,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 						TypeName:    svc.Scope.GoTypeName(uatt),
 						TypeRef:     svc.Scope.GoTypeRef(uatt),
 						Pointer:     sc.UsernamePointer,
-						Validate:    codegen.RecursiveValidationCode(uatt, true, false, false, sc.UsernameAttr),
+						Validate:    codegen.RecursiveValidationCode(expr.NewAttributeAnalyzer(uatt, requiredProperty), sc.UsernameAttr),
 						Example:     uatt.Example(expr.Root.API.Random()),
 					}
 					patt := e.MethodExpr.Payload.Find(sc.PasswordAttr)
@@ -1116,7 +1125,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 						TypeName:    svc.Scope.GoTypeName(patt),
 						TypeRef:     svc.Scope.GoTypeRef(patt),
 						Pointer:     sc.PasswordPointer,
-						Validate:    codegen.RecursiveValidationCode(uatt, true, false, false, sc.PasswordAttr),
+						Validate:    codegen.RecursiveValidationCode(expr.NewAttributeAnalyzer(patt, requiredProperty), sc.PasswordAttr),
 						Example:     patt.Example(expr.Root.API.Random()),
 					}
 					cliArgs = []*InitArgData{uarg, parg}
@@ -1393,7 +1402,8 @@ func buildResponses(e *expr.HTTPEndpointExpr, result *expr.AttributeExpr, viewed
 							var vcode string
 							if ut, ok := resp.Body.Type.(expr.UserType); ok {
 								if val := ut.Attribute().Validation; val != nil {
-									vcode = codegen.RecursiveValidationCode(ut.Attribute(), true, false, false, "body")
+									an := expr.NewAttributeAnalyzer(ut.Attribute(), requiredProperty)
+									vcode = codegen.RecursiveValidationCode(an, "body")
 								}
 							}
 							clientArgs = []*InitArgData{{
@@ -1723,7 +1733,8 @@ func buildStreamData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData
 							}
 							if ut, ok := body.(expr.UserType); ok {
 								if val := ut.Attribute().Validation; val != nil {
-									svcode = codegen.RecursiveValidationCode(ut.Attribute(), true, false, false, "body")
+									an := expr.NewAttributeAnalyzer(ut.Attribute(), requiredProperty)
+									svcode = codegen.RecursiveValidationCode(an, "body")
 								}
 							}
 						}
@@ -1843,14 +1854,26 @@ func buildRequestBodyType(sd *ServiceData, e *expr.HTTPEndpointExpr, body, att *
 				varname, svc.Name, e.Name())
 			if svr {
 				// generate validation code for unmarshaled type (server-side).
-				validateDef = codegen.RecursiveValidationCode(body, true, svr, !svr, "body")
+				an := expr.NewAttributeAnalyzer(body,
+					&expr.AttributeProperties{
+						Required:   true,
+						Pointer:    svr,
+						UseDefault: !svr,
+					})
+				validateDef = codegen.RecursiveValidationCode(an, "body")
 				if validateDef != "" {
 					validateRef = fmt.Sprintf("err = Validate%s(&body)", varname)
 				}
 			}
 		} else {
 			varname = svc.Scope.GoTypeRef(&expr.AttributeExpr{Type: body.Type})
-			validateRef = codegen.RecursiveValidationCode(body, true, svr, !svr, "body")
+			an := expr.NewAttributeAnalyzer(body,
+				&expr.AttributeProperties{
+					Required:   true,
+					Pointer:    svr,
+					UseDefault: !svr,
+				})
+			validateRef = codegen.RecursiveValidationCode(an, "body")
 			desc = body.Description
 		}
 	}
@@ -1968,6 +1991,12 @@ func buildResponseBodyType(sd *ServiceData, e *expr.HTTPEndpointExpr, body, att 
 		ref = svc.Scope.GoTypeRef(body)
 		mustInit = att.Type != expr.Empty && needInit(body.Type)
 
+		an := expr.NewAttributeAnalyzer(body,
+			&expr.AttributeProperties{
+				Required:   true,
+				Pointer:    !svr,
+				UseDefault: svr,
+			})
 		if ut, ok := body.Type.(expr.UserType); ok {
 			// response body is a user type.
 			varname = codegen.Goify(ut.Name(), true)
@@ -1976,7 +2005,7 @@ func buildResponseBodyType(sd *ServiceData, e *expr.HTTPEndpointExpr, body, att 
 				varname, svc.Name, e.Name())
 			if !svr && view == nil {
 				// generate validation code for unmarshaled type (client-side).
-				validateDef = codegen.RecursiveValidationCode(body, true, !svr, svr, "body")
+				validateDef = codegen.RecursiveValidationCode(an, "body")
 				if validateDef != "" {
 					validateRef = fmt.Sprintf("err = Validate%s(&body)", varname)
 				}
@@ -1988,11 +2017,11 @@ func buildResponseBodyType(sd *ServiceData, e *expr.HTTPEndpointExpr, body, att 
 			desc = fmt.Sprintf("%s is the type of the %q service %q endpoint HTTP response body.",
 				varname, svc.Name, e.Name())
 			def = goTypeDef(svc.Scope, body, !svr, svr)
-			validateRef = codegen.RecursiveValidationCode(body, true, !svr, svr, "body")
+			validateRef = codegen.RecursiveValidationCode(an, "body")
 		} else {
 			// response body is a primitive type.
 			varname = svc.Scope.GoTypeRef(body)
-			validateRef = codegen.RecursiveValidationCode(body, true, !svr, svr, "body")
+			validateRef = codegen.RecursiveValidationCode(an, "body")
 			desc = body.Description
 		}
 	}
@@ -2106,7 +2135,7 @@ func extractPathParams(a *expr.MappedAttributeExpr, serviceType *expr.AttributeE
 			StringSlice:    arr != nil && arr.ElemType.Type.Kind() == expr.StringKind,
 			Map:            false,
 			MapStringSlice: false,
-			Validate:       codegen.RecursiveValidationCode(c, true, false, false, varn),
+			Validate:       codegen.RecursiveValidationCode(expr.NewAttributeAnalyzer(c, requiredProperty), varn),
 			DefaultValue:   c.DefaultValue,
 			Example:        c.Example(expr.Root.API.Random()),
 		})
@@ -2132,6 +2161,11 @@ func extractQueryParams(a *expr.MappedAttributeExpr, serviceType *expr.Attribute
 		if !expr.IsObject(serviceType.Type) {
 			fieldName = ""
 		}
+		an := expr.NewAttributeAnalyzer(c, &expr.AttributeProperties{
+			Required:   required,
+			UseDefault: c.DefaultValue != nil,
+		})
+		validate := codegen.RecursiveValidationCode(an, varn)
 		params = append(params, &ParamData{
 			Name:          elem,
 			AttributeName: name,
@@ -2150,7 +2184,7 @@ func extractQueryParams(a *expr.MappedAttributeExpr, serviceType *expr.Attribute
 				mp.KeyType.Type.Kind() == expr.StringKind &&
 				mp.ElemType.Type.Kind() == expr.ArrayKind &&
 				expr.AsArray(mp.ElemType.Type).ElemType.Type.Kind() == expr.StringKind,
-			Validate:     codegen.RecursiveValidationCode(c, required, false, c.DefaultValue != nil, varn),
+			Validate:     validate,
 			DefaultValue: c.DefaultValue,
 			Example:      c.Example(expr.Root.API.Random()),
 		})
@@ -2186,6 +2220,12 @@ func extractHeaders(a *expr.MappedAttributeExpr, serviceType *expr.AttributeExpr
 		if pointer {
 			typeRef = "*" + typeRef
 		}
+		an := expr.NewAttributeAnalyzer(hattr,
+			&expr.AttributeProperties{
+				Required:   required,
+				UseDefault: hattr.DefaultValue != nil,
+			})
+		validate := codegen.RecursiveValidationCode(an, varn)
 		headers = append(headers, &HeaderData{
 			Name:          elem,
 			AttributeName: name,
@@ -2200,7 +2240,7 @@ func extractHeaders(a *expr.MappedAttributeExpr, serviceType *expr.AttributeExpr
 			Slice:         arr != nil,
 			StringSlice:   arr != nil && arr.ElemType.Type.Kind() == expr.StringKind,
 			Type:          hattr.Type,
-			Validate:      codegen.RecursiveValidationCode(hattr, required, false, hattr.DefaultValue != nil, varn),
+			Validate:      validate,
 			DefaultValue:  hattr.DefaultValue,
 			Example:       hattr.Example(expr.Root.API.Random()),
 		})
@@ -2275,7 +2315,13 @@ func attributeTypeData(ut expr.UserType, req, ptr, server bool, scope *codegen.N
 		useDefault := !req && server || req && !server
 
 		def = goTypeDef(scope, ut.Attribute(), ptr, useDefault)
-		validate = codegen.RecursiveValidationCode(ut.Attribute(), true, ptr, useDefault, "body")
+		an := expr.NewAttributeAnalyzer(ut.Attribute(),
+			&expr.AttributeProperties{
+				Required:   true,
+				Pointer:    ptr,
+				UseDefault: useDefault,
+			})
+		validate = codegen.RecursiveValidationCode(an, "body")
 		if validate != "" {
 			validateRef = fmt.Sprintf("err = Validate%s(v)", name)
 		}

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -3114,7 +3114,7 @@ func DecodeMethodBodyStringValidateRequest(mux goahttp.Muxer, decoder func(*http
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyStringValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3162,7 +3162,7 @@ func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyUserRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3219,7 +3219,7 @@ func DecodeMethodBodyUserValidateRequest(mux goahttp.Muxer, decoder func(*http.R
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyUserValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3268,7 +3268,7 @@ func DecodeMethodBodyArrayStringValidateRequest(mux goahttp.Muxer, decoder func(
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyArrayStringValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3294,7 +3294,7 @@ func DecodeMethodBodyArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Requ
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyArrayUserRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3320,7 +3320,7 @@ func DecodeMethodBodyArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyArrayUserValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3368,7 +3368,7 @@ func DecodeMethodBodyMapStringValidateRequest(mux goahttp.Muxer, decoder func(*h
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyMapStringValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3394,7 +3394,7 @@ func DecodeMethodBodyMapUserRequest(mux goahttp.Muxer, decoder func(*http.Reques
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyMapUserRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3420,7 +3420,7 @@ func DecodeMethodBodyMapUserValidateRequest(mux goahttp.Muxer, decoder func(*htt
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyMapUserValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3582,7 +3582,7 @@ func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decode
 		}
 		for _, e := range body {
 			if e != nil {
-				if err2 := e.Validate(); err2 != nil {
+				if err2 := ValidatePayloadTypeRequestBody(e); err2 != nil {
 					err = goa.MergeErrors(err, err2)
 				}
 			}
@@ -3698,7 +3698,7 @@ func DecodeMethodBodyQueryObjectValidateRequest(mux goahttp.Muxer, decoder func(
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyQueryObjectValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3766,7 +3766,7 @@ func DecodeMethodBodyQueryUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyQueryUserValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3834,7 +3834,7 @@ func DecodeMethodBodyPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyPathObjectValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3900,7 +3900,7 @@ func DecodeMethodUserBodyPathValidateRequest(mux goahttp.Muxer, decoder func(*ht
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodUserBodyPathValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -3972,7 +3972,7 @@ func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder f
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyQueryPathObjectValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -4050,7 +4050,7 @@ func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder fun
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodBodyQueryPathUserValidateRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}
@@ -4158,7 +4158,7 @@ func DecodeMethodMapQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Req
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		err = body.Validate()
+		err = ValidateMethodMapQueryObjectRequestBody(&body)
 		if err != nil {
 			return nil, err
 		}

--- a/http/codegen/testdata/result_decode_functions.go
+++ b/http/codegen/testdata/result_decode_functions.go
@@ -68,7 +68,7 @@ func DecodeMethodBodyMultipleViewResponse(decoder func(*http.Response) goahttp.D
 			p := NewMethodBodyMultipleViewResulttypemultipleviewsOK(&body, c)
 			view := resp.Header.Get("goa-view")
 			vres := &servicebodymultipleviewviews.Resulttypemultipleviews{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = servicebodymultipleviewviews.ValidateResulttypemultipleviews(vres); err != nil {
 				return nil, goahttp.ErrValidationError("ServiceBodyMultipleView", "MethodBodyMultipleView", err)
 			}
 			res := servicebodymultipleview.NewResulttypemultipleviews(vres)
@@ -159,7 +159,7 @@ func DecodeMethodExplicitBodyUserResultMultipleViewResponse(decoder func(*http.R
 			p := NewMethodExplicitBodyUserResultMultipleViewResulttypemultipleviewsOK(&body, c)
 			view := resp.Header.Get("goa-view")
 			vres := &serviceexplicitbodyuserresultmultipleviewviews.Resulttypemultipleviews{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = serviceexplicitbodyuserresultmultipleviewviews.ValidateResulttypemultipleviews(vres); err != nil {
 				return nil, goahttp.ErrValidationError("ServiceExplicitBodyUserResultMultipleView", "MethodExplicitBodyUserResultMultipleView", err)
 			}
 			res := serviceexplicitbodyuserresultmultipleview.NewResulttypemultipleviews(vres)
@@ -210,7 +210,7 @@ func DecodeMethodTagMultipleViewsResponse(decoder func(*http.Response) goahttp.D
 			p := NewMethodTagMultipleViewsResulttypemultipleviewsAccepted(&body, c)
 			view := resp.Header.Get("goa-view")
 			vres := &servicetagmultipleviewsviews.Resulttypemultipleviews{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = servicetagmultipleviewsviews.ValidateResulttypemultipleviews(vres); err != nil {
 				return nil, goahttp.ErrValidationError("ServiceTagMultipleViews", "MethodTagMultipleViews", err)
 			}
 			res := servicetagmultipleviews.NewResulttypemultipleviews(vres)
@@ -229,7 +229,7 @@ func DecodeMethodTagMultipleViewsResponse(decoder func(*http.Response) goahttp.D
 			p := NewMethodTagMultipleViewsResulttypemultipleviewsOK(&body)
 			view := resp.Header.Get("goa-view")
 			vres := &servicetagmultipleviewsviews.Resulttypemultipleviews{p, view}
-			if err = vres.Validate(); err != nil {
+			if err = servicetagmultipleviewsviews.ValidateResulttypemultipleviews(vres); err != nil {
 				return nil, goahttp.ErrValidationError("ServiceTagMultipleViews", "MethodTagMultipleViews", err)
 			}
 			res := servicetagmultipleviews.NewResulttypemultipleviews(vres)

--- a/http/codegen/testdata/streaming_code.go
+++ b/http/codegen/testdata/streaming_code.go
@@ -338,7 +338,7 @@ func (s *StreamingResultWithViewsMethodClientStream) Recv() (*streamingresultwit
 	}
 	res := NewStreamingResultWithViewsMethodUsertypeOK(&body)
 	vres := &streamingresultwithviewsserviceviews.Usertype{res, s.view}
-	if err := vres.Validate(); err != nil {
+	if err := streamingresultwithviewsserviceviews.ValidateUsertype(vres); err != nil {
 		return rv, goahttp.ErrValidationError("StreamingResultWithViewsService", "StreamingResultWithViewsMethod", err)
 	}
 	return streamingresultwithviewsservice.NewUsertype(vres), nil
@@ -404,7 +404,7 @@ func (s *StreamingResultWithExplicitViewMethodClientStream) Recv() (*streamingre
 	}
 	res := NewStreamingResultWithExplicitViewMethodUsertypeOK(&body)
 	vres := &streamingresultwithexplicitviewserviceviews.Usertype{res, "extended"}
-	if err := vres.Validate(); err != nil {
+	if err := streamingresultwithexplicitviewserviceviews.ValidateUsertype(vres); err != nil {
 		return rv, goahttp.ErrValidationError("StreamingResultWithExplicitViewService", "StreamingResultWithExplicitViewMethod", err)
 	}
 	return streamingresultwithexplicitviewservice.NewUsertype(vres), nil
@@ -504,7 +504,7 @@ func (s *StreamingResultCollectionWithViewsMethodClientStream) Recv() (streaming
 	}
 	res := NewStreamingResultCollectionWithViewsMethodUsertypeCollectionOK(body)
 	vres := streamingresultcollectionwithviewsserviceviews.UsertypeCollection{res, s.view}
-	if err := vres.Validate(); err != nil {
+	if err := streamingresultcollectionwithviewsserviceviews.ValidateUsertypeCollection(vres); err != nil {
 		return rv, goahttp.ErrValidationError("StreamingResultCollectionWithViewsService", "StreamingResultCollectionWithViewsMethod", err)
 	}
 	return streamingresultcollectionwithviewsservice.NewUsertypeCollection(vres), nil
@@ -600,7 +600,7 @@ func (s *StreamingResultCollectionWithExplicitViewMethodClientStream) Recv() (st
 	}
 	res := NewStreamingResultCollectionWithExplicitViewMethodUsertypeCollectionOK(body)
 	vres := streamingresultcollectionwithexplicitviewserviceviews.UsertypeCollection{res, "tiny"}
-	if err := vres.Validate(); err != nil {
+	if err := streamingresultcollectionwithexplicitviewserviceviews.ValidateUsertypeCollection(vres); err != nil {
 		return rv, goahttp.ErrValidationError("StreamingResultCollectionWithExplicitViewService", "StreamingResultCollectionWithExplicitViewMethod", err)
 	}
 	return streamingresultcollectionwithexplicitviewservice.NewUsertypeCollection(vres), nil
@@ -1328,7 +1328,7 @@ func (s *StreamingPayloadResultWithViewsMethodClientStream) CloseAndRecv() (*str
 	}
 	res := NewStreamingPayloadResultWithViewsMethodUsertypeOK(&body)
 	vres := &streamingpayloadresultwithviewsserviceviews.Usertype{res, s.view}
-	if err := vres.Validate(); err != nil {
+	if err := streamingpayloadresultwithviewsserviceviews.ValidateUsertype(vres); err != nil {
 		return rv, goahttp.ErrValidationError("StreamingPayloadResultWithViewsService", "StreamingPayloadResultWithViewsMethod", err)
 	}
 	return streamingpayloadresultwithviewsservice.NewUsertype(vres), nil
@@ -1422,7 +1422,7 @@ func (s *StreamingPayloadResultWithExplicitViewMethodClientStream) CloseAndRecv(
 	}
 	res := NewStreamingPayloadResultWithExplicitViewMethodUsertypeOK(&body)
 	vres := &streamingpayloadresultwithexplicitviewserviceviews.Usertype{res, "extended"}
-	if err := vres.Validate(); err != nil {
+	if err := streamingpayloadresultwithexplicitviewserviceviews.ValidateUsertype(vres); err != nil {
 		return rv, goahttp.ErrValidationError("StreamingPayloadResultWithExplicitViewService", "StreamingPayloadResultWithExplicitViewMethod", err)
 	}
 	return streamingpayloadresultwithexplicitviewservice.NewUsertype(vres), nil
@@ -1529,7 +1529,7 @@ func (s *StreamingPayloadResultCollectionWithViewsMethodClientStream) CloseAndRe
 	}
 	res := NewStreamingPayloadResultCollectionWithViewsMethodUsertypeCollectionOK(body)
 	vres := streamingpayloadresultcollectionwithviewsserviceviews.UsertypeCollection{res, s.view}
-	if err := vres.Validate(); err != nil {
+	if err := streamingpayloadresultcollectionwithviewsserviceviews.ValidateUsertypeCollection(vres); err != nil {
 		return rv, goahttp.ErrValidationError("StreamingPayloadResultCollectionWithViewsService", "StreamingPayloadResultCollectionWithViewsMethod", err)
 	}
 	return streamingpayloadresultcollectionwithviewsservice.NewUsertypeCollection(vres), nil
@@ -1627,7 +1627,7 @@ func (s *StreamingPayloadResultCollectionWithExplicitViewMethodClientStream) Clo
 	}
 	res := NewStreamingPayloadResultCollectionWithExplicitViewMethodUsertypeCollectionOK(body)
 	vres := streamingpayloadresultcollectionwithexplicitviewserviceviews.UsertypeCollection{res, "tiny"}
-	if err := vres.Validate(); err != nil {
+	if err := streamingpayloadresultcollectionwithexplicitviewserviceviews.ValidateUsertypeCollection(vres); err != nil {
 		return rv, goahttp.ErrValidationError("StreamingPayloadResultCollectionWithExplicitViewService", "StreamingPayloadResultCollectionWithExplicitViewMethod", err)
 	}
 	return streamingpayloadresultcollectionwithexplicitviewservice.NewUsertypeCollection(vres), nil
@@ -2545,7 +2545,7 @@ func (s *BidirectionalStreamingResultWithViewsMethodClientStream) Recv() (*bidir
 	}
 	res := NewBidirectionalStreamingResultWithViewsMethodUsertypeOK(&body)
 	vres := &bidirectionalstreamingresultwithviewsserviceviews.Usertype{res, s.view}
-	if err := vres.Validate(); err != nil {
+	if err := bidirectionalstreamingresultwithviewsserviceviews.ValidateUsertype(vres); err != nil {
 		return rv, goahttp.ErrValidationError("BidirectionalStreamingResultWithViewsService", "BidirectionalStreamingResultWithViewsMethod", err)
 	}
 	return bidirectionalstreamingresultwithviewsservice.NewUsertype(vres), nil
@@ -2665,7 +2665,7 @@ func (s *BidirectionalStreamingResultWithExplicitViewMethodClientStream) Recv() 
 	}
 	res := NewBidirectionalStreamingResultWithExplicitViewMethodUsertypeOK(&body)
 	vres := &bidirectionalstreamingresultwithexplicitviewserviceviews.Usertype{res, "extended"}
-	if err := vres.Validate(); err != nil {
+	if err := bidirectionalstreamingresultwithexplicitviewserviceviews.ValidateUsertype(vres); err != nil {
 		return rv, goahttp.ErrValidationError("BidirectionalStreamingResultWithExplicitViewService", "BidirectionalStreamingResultWithExplicitViewMethod", err)
 	}
 	return bidirectionalstreamingresultwithexplicitviewservice.NewUsertype(vres), nil
@@ -2785,7 +2785,7 @@ func (s *BidirectionalStreamingResultCollectionWithViewsMethodClientStream) Recv
 	}
 	res := NewBidirectionalStreamingResultCollectionWithViewsMethodUsertypeCollectionOK(body)
 	vres := bidirectionalstreamingresultcollectionwithviewsserviceviews.UsertypeCollection{res, s.view}
-	if err := vres.Validate(); err != nil {
+	if err := bidirectionalstreamingresultcollectionwithviewsserviceviews.ValidateUsertypeCollection(vres); err != nil {
 		return rv, goahttp.ErrValidationError("BidirectionalStreamingResultCollectionWithViewsService", "BidirectionalStreamingResultCollectionWithViewsMethod", err)
 	}
 	return bidirectionalstreamingresultcollectionwithviewsservice.NewUsertypeCollection(vres), nil
@@ -2893,7 +2893,7 @@ func (s *BidirectionalStreamingResultCollectionWithExplicitViewMethodClientStrea
 	}
 	res := NewBidirectionalStreamingResultCollectionWithExplicitViewMethodUsertypeCollectionOK(body)
 	vres := bidirectionalstreamingresultcollectionwithexplicitviewserviceviews.UsertypeCollection{res, "tiny"}
-	if err := vres.Validate(); err != nil {
+	if err := bidirectionalstreamingresultcollectionwithexplicitviewserviceviews.ValidateUsertypeCollection(vres); err != nil {
 		return rv, goahttp.ErrValidationError("BidirectionalStreamingResultCollectionWithExplicitViewService", "BidirectionalStreamingResultCollectionWithExplicitViewMethod", err)
 	}
 	return bidirectionalstreamingresultcollectionwithexplicitviewservice.NewUsertypeCollection(vres), nil


### PR DESCRIPTION
# Summary of changes
* Add a helper interface in validation logic to determine if an attribute is a pointer. In gRPC, the primitive attribute types are always non-pointers when protobuf code is generated.
* Remove `Validate()` function defined on a user type. Instead have a `Validate<user-type-name>` function. Once we have gRPC support, this change would be useful to define validation on a gRPC protobuf type in an external package.

# Actions users must take
If you don't use the `.Validate()` functions outside of the generated code, then no changes necessary. If you use them outside of the generated code, change them to `Validate<user-type-name>(<arg>)`.