### PR TITLE
Use build.Default.GOPATH instead of env GOPATH

### DIFF
--- a/design/random.go
+++ b/design/random.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/manveru/faker"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // RandomGenerator generates consistent random values of different types given a seed.

--- a/design/types.go
+++ b/design/types.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/goadesign/goa/dslengine"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // DefaultView is the name of the default view.

--- a/goagen/codegen/helpers.go
+++ b/goagen/codegen/helpers.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"bytes"
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +36,7 @@ func CommandLine() string {
 
 	if len(os.Args) > 1 {
 		args := make([]string, len(os.Args)-1)
-		gopaths := filepath.SplitList(os.Getenv("GOPATH"))
+		gopaths := filepath.SplitList(envOr("GOPATH", build.Default.GOPATH))
 		for i, a := range os.Args[1:] {
 			for _, p := range gopaths {
 				p = "=" + p
@@ -57,6 +58,15 @@ func CommandLine() string {
 
 	cmd := fmt.Sprintf("$ %s %s", rawcmd, param)
 	return strings.Replace(cmd, " --", "\n\t--", -1)
+}
+
+// Copied from go/build/build.go
+func envOr(name, def string) string {
+	s := os.Getenv(name)
+	if s == "" {
+		return def
+	}
+	return s
 }
 
 // Comment produces line comments by concatenating the given strings and producing 80 characters

--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -89,7 +89,7 @@ func NewWorkspace(prefix string) (*Workspace, error) {
 	os.MkdirAll(filepath.Join(dir, "bin"), 0755)
 
 	// setup GOPATH
-	gopath := os.Getenv("GOPATH")
+	gopath := envOr("GOPATH", build.Default.GOPATH)
 	os.Setenv("GOPATH", fmt.Sprintf("%s%c%s", dir, os.PathListSeparator, gopath))
 
 	// we're done
@@ -98,7 +98,7 @@ func NewWorkspace(prefix string) (*Workspace, error) {
 
 // WorkspaceFor returns the Go workspace for the given Go source file.
 func WorkspaceFor(source string) (*Workspace, error) {
-	gopaths := os.Getenv("GOPATH")
+	gopaths := envOr("GOPATH", build.Default.GOPATH)
 	// We use absolute paths so that in particular on Windows the case gets normalized
 	sourcePath, err := filepath.Abs(source)
 	if err != nil {
@@ -316,7 +316,7 @@ func PackagePath(path string) (string, error) {
 	if err != nil {
 		absPath = path
 	}
-	gopaths := filepath.SplitList(os.Getenv("GOPATH"))
+	gopaths := filepath.SplitList(envOr("GOPATH", build.Default.GOPATH))
 	for _, gopath := range gopaths {
 		if gp, err := filepath.Abs(gopath); err == nil {
 			gopath = gp
@@ -333,7 +333,7 @@ func PackagePath(path string) (string, error) {
 // PackageSourcePath returns the absolute path to the given package source.
 func PackageSourcePath(pkg string) (string, error) {
 	buildCtx := build.Default
-	buildCtx.GOPATH = os.Getenv("GOPATH") // Reevaluate each time to be nice to tests
+	buildCtx.GOPATH = envOr("GOPATH", build.Default.GOPATH) // Reevaluate each time to be nice to tests
 	wd, err := os.Getwd()
 	if err != nil {
 		wd = "."

--- a/goagen/gen_app/encoding_test.go
+++ b/goagen/gen_app/encoding_test.go
@@ -2,7 +2,7 @@ package genapp_test
 
 import (
 	"github.com/goadesign/goa/design"
-	"github.com/goadesign/goa/goagen/gen_app"
+	genapp "github.com/goadesign/goa/goagen/gen_app"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/goagen/gen_app/generator_test.go
+++ b/goagen/gen_app/generator_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_app"
+	genapp "github.com/goadesign/goa/goagen/gen_app"
 	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/goagen/gen_app/test_generator_test.go
+++ b/goagen/gen_app/test_generator_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_app"
+	genapp "github.com/goadesign/goa/goagen/gen_app"
 	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/goagen/gen_app/writers_test.go
+++ b/goagen/gen_app/writers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/goadesign/goa/design/apidsl"
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_app"
+	genapp "github.com/goadesign/goa/goagen/gen_app"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/goagen/gen_client/cli_generator_test.go
+++ b/goagen/gen_client/cli_generator_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_client"
+	genclient "github.com/goadesign/goa/goagen/gen_client"
 	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -13,7 +13,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_app"
+	genapp "github.com/goadesign/goa/goagen/gen_app"
 	"github.com/goadesign/goa/goagen/utils"
 )
 

--- a/goagen/gen_client/generator_test.go
+++ b/goagen/gen_client/generator_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_client"
+	genclient "github.com/goadesign/goa/goagen/gen_client"
 	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/goagen/gen_controller/generator.go
+++ b/goagen/gen_controller/generator.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_main"
+	genmain "github.com/goadesign/goa/goagen/gen_main"
 	"github.com/goadesign/goa/goagen/utils"
 )
 

--- a/goagen/gen_controller/generator_test.go
+++ b/goagen/gen_controller/generator_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_controller"
+	gencontroller "github.com/goadesign/goa/goagen/gen_controller"
 	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/goagen/gen_js/generator_test.go
+++ b/goagen/gen_js/generator_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/goadesign/goa/design"
-	"github.com/goadesign/goa/goagen/gen_js"
+	genjs "github.com/goadesign/goa/goagen/gen_js"
 	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/goagen/gen_main/generator_test.go
+++ b/goagen/gen_main/generator_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/goadesign/goa/design"
-	"github.com/goadesign/goa/goagen/gen_main"
+	genmain "github.com/goadesign/goa/goagen/gen_main"
 	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/goagen/gen_schema/generator_test.go
+++ b/goagen/gen_schema/generator_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/goadesign/goa/design/apidsl"
 	"github.com/goadesign/goa/dslengine"
 	"github.com/goadesign/goa/goagen/codegen"
-	"github.com/goadesign/goa/goagen/gen_schema"
+	genschema "github.com/goadesign/goa/goagen/gen_schema"
 	"github.com/goadesign/goa/version"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/goagen/gen_schema/json_schema_test.go
+++ b/goagen/gen_schema/json_schema_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/goadesign/goa/design"
 	. "github.com/goadesign/goa/design/apidsl"
 	"github.com/goadesign/goa/dslengine"
-	"github.com/goadesign/goa/goagen/gen_schema"
+	genschema "github.com/goadesign/goa/goagen/gen_schema"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/goagen/codegen"

--- a/goagen/gen_swagger/generator_test.go
+++ b/goagen/gen_swagger/generator_test.go
@@ -2,7 +2,7 @@ package genswagger_test
 
 import (
 	"github.com/goadesign/goa/design"
-	"github.com/goadesign/goa/goagen/gen_swagger"
+	genswagger "github.com/goadesign/goa/goagen/gen_swagger"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/goagen/gen_swagger/swagger.go
+++ b/goagen/gen_swagger/swagger.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/dslengine"
-	"github.com/goadesign/goa/goagen/gen_schema"
+	genschema "github.com/goadesign/goa/goagen/gen_schema"
 )
 
 type (

--- a/goagen/gen_swagger/swagger_test.go
+++ b/goagen/gen_swagger/swagger_test.go
@@ -9,8 +9,8 @@ import (
 	. "github.com/goadesign/goa/design"
 	. "github.com/goadesign/goa/design/apidsl"
 	"github.com/goadesign/goa/dslengine"
-	"github.com/goadesign/goa/goagen/gen_schema"
-	"github.com/goadesign/goa/goagen/gen_swagger"
+	genschema "github.com/goadesign/goa/goagen/gen_schema"
+	genswagger "github.com/goadesign/goa/goagen/gen_swagger"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -82,9 +82,6 @@ func NewGenerator(genfunc string, imports []*codegen.ImportSpec, flags map[strin
 // Generate compiles and runs the generator and returns the generated filenames.
 func (m *Generator) Generate() ([]string, error) {
 	// Sanity checks
-	if os.Getenv("GOPATH") == "" {
-		return nil, fmt.Errorf("GOPATH not set")
-	}
 	if m.OutDir == "" {
 		return nil, fmt.Errorf("missing output directory flag")
 	}

--- a/goagen/meta/generator_test.go
+++ b/goagen/meta/generator_test.go
@@ -89,23 +89,6 @@ var _ = Describe("Run", func() {
 		genWorkspace.Delete()
 	})
 
-	Context("with no GOPATH environment variable", func() {
-		var gopath string
-
-		BeforeEach(func() {
-			gopath = os.Getenv("GOPATH")
-			os.Setenv("GOPATH", "")
-		})
-
-		AfterEach(func() {
-			os.Setenv("GOPATH", gopath)
-		})
-
-		It("fails with a useful error message", func() {
-			Ω(compileError).Should(MatchError("GOPATH not set"))
-		})
-	})
-
 	Context("with an invalid GOPATH environment variable", func() {
 		var gopath string
 		const invalidPath = "DOES NOT EXIST"

--- a/logging/kit/adapter_test.go
+++ b/logging/kit/adapter_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/goadesign/goa"
-	"github.com/goadesign/goa/logging/kit"
+	goakit "github.com/goadesign/goa/logging/kit"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/logging/log15/adapter_test.go
+++ b/logging/log15/adapter_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/goadesign/goa"
-	"github.com/goadesign/goa/logging/log15"
+	goalog15 "github.com/goadesign/goa/logging/log15"
 	"github.com/inconshreveable/log15"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/logging/logrus/adapter_test.go
+++ b/logging/logrus/adapter_test.go
@@ -6,7 +6,7 @@ import (
 	"context"
 
 	"github.com/goadesign/goa"
-	"github.com/goadesign/goa/logging/logrus"
+	goalogrus "github.com/goadesign/goa/logging/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"

--- a/metrics.go
+++ b/metrics.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 )
 
 const (

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/armon/go-metrics"
+	metrics "github.com/armon/go-metrics"
 )
 
 var _ = Describe("Metrics", func() {

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -9,7 +9,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // FromString Wrapper around the real FromString


### PR DESCRIPTION
Go v1.8+ set a default GOPATH if the GOPATH env variable is not set. This patch makes it possible to use `goagen` with a default GOPATH.

I found this issue during trying to improve goa to support Go modules (for #1914). I'm plannning to open another pull request for that.