### PR TITLE
Use yaml.Unmarshal for swagger.yaml

### DIFF
--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -122,7 +122,7 @@ func (g *Generator) Cleanup() {
 
 func jsonToYAML(rawJSON []byte) ([]byte, error) {
 	var yamlSource interface{}
-	if err := json.Unmarshal(rawJSON, &yamlSource); err != nil {
+	if err := yaml.Unmarshal(rawJSON, &yamlSource); err != nil {
 		return nil, err
 	}
 

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -99,12 +99,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 	g.genfiles = append(g.genfiles, swaggerFile)
 
 	// YAML
-	var yamlSource interface{}
-	if err = yaml.Unmarshal(rawJSON, &yamlSource); err != nil {
-		return nil, err
-	}
-
-	rawYAML, err := yaml.Marshal(yamlSource)
+	rawYAML, err := jsonToYAML(rawJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -123,4 +118,13 @@ func (g *Generator) Cleanup() {
 		os.Remove(f)
 	}
 	g.genfiles = nil
+}
+
+func jsonToYAML(rawJSON []byte) ([]byte, error) {
+	var yamlSource interface{}
+	if err := json.Unmarshal(rawJSON, &yamlSource); err != nil {
+		return nil, err
+	}
+
+	return yaml.Marshal(yamlSource)
 }

--- a/goagen/gen_swagger/generator.go
+++ b/goagen/gen_swagger/generator.go
@@ -100,7 +100,7 @@ func (g *Generator) Generate() (_ []string, err error) {
 
 	// YAML
 	var yamlSource interface{}
-	if err = json.Unmarshal(rawJSON, &yamlSource); err != nil {
+	if err = yaml.Unmarshal(rawJSON, &yamlSource); err != nil {
 		return nil, err
 	}
 

--- a/goagen/gen_swagger/generator_export_test.go
+++ b/goagen/gen_swagger/generator_export_test.go
@@ -1,0 +1,4 @@
+package genswagger
+
+// Export internal functions for testing.
+var JSONToYAML = jsonToYAML

--- a/goagen/gen_swagger/generator_test.go
+++ b/goagen/gen_swagger/generator_test.go
@@ -36,3 +36,22 @@ var _ = Describe("NewGenerator", func() {
 		})
 	})
 })
+
+var _ = Describe("jsonToYAML", func() {
+	var rawYAML []byte
+	var err error
+
+	Context("with JSON which has a number type value", func() {
+		BeforeEach(func() {
+
+			rawYAML, _ = genswagger.JSONToYAML(
+				[]byte(`{"id":1234567}`),
+			)
+		})
+
+		It("converts JSON to YAML and keeps right number type", func() {
+			Ω(string(rawYAML)).Should(Equal("id: 1234567\n"))
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Converting JSON to YAML, we need yaml.Unmarshal to keep the right number type.

via https://github.com/ghodss/yaml/blob/f5bccc04aa10faf16af8a8c9664a452bf7d80101/yaml.go#L65-L81

An example is here.

```
apidsl.Attribute("id", design.Integer, "Unique bottle ID", func() {
  apidsl.Example(1234567)
})
```

Using json.Unmarshal, goagen swagger generates this swagger.yaml.

```json
id:
  description: Unique bottle ID
  example: 1.234567e+06
  format: int64
  type: integer
```

After using yaml.Unmarshal, goagen swagger generates this swagger.yaml.

```json
id:
  description: Unique bottle ID
  example: 1234567
  format: int64
  type: integer
```