### PR TITLE
Add tests for design.LicenseExpr.EvalName()

### DIFF
--- a/expr/api_test.go
+++ b/expr/api_test.go
@@ -129,3 +129,19 @@ func TestApiExpr_Hash(t *testing.T) {
 		}
 	}
 }
+
+func TestLicenseExprEvalName(t *testing.T) {
+	cases := map[string]struct {
+		name     string
+		expected string
+	}{
+		"foo": {name: "foo", expected: "License foo"},
+	}
+
+	for k, tc := range cases {
+		license := LicenseExpr{Name: tc.name}
+		if actual := license.EvalName(); actual != tc.expected {
+			t.Errorf("%s: got %#v, expected %#v", k, actual, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1706