### PR TITLE
Address backslash problems on Windows

### DIFF
--- a/codegen/import.go
+++ b/codegen/import.go
@@ -1,6 +1,9 @@
 package codegen
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 type (
 	// ImportSpec defines a generated import statement.
@@ -25,7 +28,7 @@ func SimpleImport(path string) *ImportSpec {
 // Code returns the Go import statement for the ImportSpec.
 func (s *ImportSpec) Code() string {
 	if len(s.Name) > 0 {
-		return fmt.Sprintf(`%s "%s"`, s.Name, s.Path)
+		return fmt.Sprintf(`%s "%s"`, s.Name, filepath.ToSlash(s.Path))
 	}
-	return fmt.Sprintf(`"%s"`, s.Path)
+	return fmt.Sprintf(`"%s"`, filepath.ToSlash(s.Path))
 }

--- a/codegen/import_test.go
+++ b/codegen/import_test.go
@@ -1,0 +1,31 @@
+package codegen
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestImportPaths(t *testing.T) {
+	var i0 = SimpleImport("simple")
+	var i1 = NewImport("renamed", "direct")
+	var i2 = NewImport("sub", filepath.Join("base", "sub"))
+	var i3 = NewImport("remote", "example.com/something/remote")
+
+	tests := []struct {
+		i        *ImportSpec
+		expected string
+	}{
+		{i0, `"simple"`},
+		{i1, `renamed "direct"`},
+		{i2, `sub "base/sub"`},
+		{i3, `remote "example.com/something/remote"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.i.Name, func(t *testing.T) {
+			if tc.i.Code() != tc.expected {
+				t.Errorf("unexpected import code: %q != %q", tc.i.Code(), tc.expected)
+			}
+		})
+	}
+}

--- a/codegen/server/example_server.go
+++ b/codegen/server/example_server.go
@@ -30,7 +30,7 @@ func exampleSvrMain(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *c
 	if _, err := os.Stat(mainPath); !os.IsNotExist(err) {
 		return nil // file already exists, skip it.
 	}
-	idx := strings.LastIndex(genpkg, string(os.PathSeparator))
+	idx := strings.LastIndex(filepath.FromSlash(genpkg), string(os.PathSeparator))
 	rootPath := "."
 	if idx > 0 {
 		rootPath = genpkg[:idx]

--- a/codegen/service/auth_funcs.go
+++ b/codegen/service/auth_funcs.go
@@ -3,6 +3,7 @@ package service
 import (
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"goa.design/goa/codegen"
@@ -15,13 +16,13 @@ func AuthFuncsFile(genpkg string, root *expr.RootExpr) *codegen.File {
 	var (
 		apiPkg   = strings.ToLower(codegen.Goify(root.API.Name, false))
 		rootPath = "."
-		filepath = "auth.go"
+		mainPath = "auth.go"
 	)
 	{
-		if _, err := os.Stat(filepath); !os.IsNotExist(err) {
+		if _, err := os.Stat(mainPath); !os.IsNotExist(err) {
 			return nil // file already exists, skip it.
 		}
-		idx := strings.LastIndex(genpkg, string(os.PathSeparator))
+		idx := strings.LastIndex(filepath.FromSlash(genpkg), string(os.PathSeparator))
 		if idx > 0 {
 			rootPath = genpkg[:idx]
 		}
@@ -65,7 +66,7 @@ func AuthFuncsFile(genpkg string, root *expr.RootExpr) *codegen.File {
 	}
 
 	return &codegen.File{
-		Path:             filepath,
+		Path:             mainPath,
 		SectionTemplates: sections,
 		SkipExist:        true,
 	}

--- a/grpc/codegen/example_cli.go
+++ b/grpc/codegen/example_cli.go
@@ -41,7 +41,7 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 		specs []*codegen.ImportSpec
 	)
 	{
-		idx := strings.LastIndex(genpkg, string(os.PathSeparator))
+		idx := strings.LastIndex(filepath.FromSlash(genpkg), string(os.PathSeparator))
 		rootPath := "."
 		if idx > 0 {
 			rootPath = genpkg[:idx]

--- a/grpc/codegen/example_server.go
+++ b/grpc/codegen/example_server.go
@@ -40,7 +40,7 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 		specs []*codegen.ImportSpec
 	)
 	{
-		idx := strings.LastIndex(genpkg, string(os.PathSeparator))
+		idx := strings.LastIndex(filepath.FromSlash(genpkg), string(os.PathSeparator))
 		rootPath := "."
 		if idx > 0 {
 			rootPath = genpkg[:idx]

--- a/http/codegen/example_cli.go
+++ b/http/codegen/example_cli.go
@@ -30,7 +30,7 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return nil // file already exists, skip it.
 	}
-	idx := strings.LastIndex(genpkg, string(os.PathSeparator))
+	idx := strings.LastIndex(filepath.FromSlash(genpkg), string(os.PathSeparator))
 	rootPath := "."
 	if idx > 0 {
 		rootPath = genpkg[:idx]

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -30,7 +30,7 @@ func ExampleServerFiles(genpkg string, root *expr.RootExpr) []*codegen.File {
 func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codegen.File {
 	pkg := codegen.SnakeCase(codegen.Goify(svr.Name, true))
 	fpath := filepath.Join("cmd", pkg, "http.go")
-	idx := strings.LastIndex(genpkg, string(os.PathSeparator))
+	idx := strings.LastIndex(filepath.FromSlash(genpkg), string(os.PathSeparator))
 	rootPath := "."
 	if idx > 0 {
 		rootPath = genpkg[:idx]

--- a/http/codegen/openapi_test.go
+++ b/http/codegen/openapi_test.go
@@ -106,7 +106,8 @@ func TestSections(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to render template: %s", err)
 					}
-					if err := validateSwagger(buf.Bytes()); err != nil {
+					bufbytes := bytes.Replace(buf.Bytes(), []byte("\r\n"), []byte("\n"), -1)
+					if err := validateSwagger(bufbytes); err != nil {
 						t.Errorf("invalid swagger: %s", err)
 					}
 
@@ -121,8 +122,9 @@ func TestSections(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to read golden file: %s", err)
 					}
-					if !bytes.Equal(buf.Bytes(), want) {
-						t.Errorf("result do not match the golden file:\n--BEGIN--\n%s\n--END--\n", buf.Bytes())
+					want = bytes.Replace(want, []byte("\r\n"), []byte("\n"), -1)
+					if !bytes.Equal(bufbytes, want) {
+						t.Errorf("result do not match the golden file:\n--BEGIN--\n%s\n--END--\n", bufbytes)
 					}
 				})
 			}
@@ -173,7 +175,8 @@ func TestValidations(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to render template: %s", err)
 					}
-					if err := validateSwagger(buf.Bytes()); err != nil {
+					bufbytes := bytes.Replace(buf.Bytes(), []byte("\r\n"), []byte("\n"), -1)
+					if err := validateSwagger(bufbytes); err != nil {
 						t.Fatalf("invalid swagger: %s", err)
 					}
 
@@ -188,8 +191,9 @@ func TestValidations(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to read golden file: %s", err)
 					}
-					if !bytes.Equal(buf.Bytes(), want) {
-						t.Errorf("result do not match the golden file:\n--BEGIN--\n%s\n--END--\n", buf.Bytes())
+					want = bytes.Replace(want, []byte("\r\n"), []byte("\n"), -1)
+					if !bytes.Equal(bufbytes, want) {
+						t.Errorf("result do not match the golden file:\n--BEGIN--\n%s\n--END--\n", bufbytes)
 					}
 				})
 			}
@@ -238,7 +242,8 @@ func TestExtensions(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to render template: %s", err)
 					}
-					if err := validateSwagger(buf.Bytes()); err != nil {
+					bufbytes := bytes.Replace(buf.Bytes(), []byte("\r\n"), []byte("\n"), -1)
+					if err := validateSwagger(bufbytes); err != nil {
 						t.Fatalf("invalid swagger: %s", err)
 					}
 
@@ -253,8 +258,9 @@ func TestExtensions(t *testing.T) {
 					if err != nil {
 						t.Fatalf("failed to read golden file: %s", err)
 					}
-					if !bytes.Equal(buf.Bytes(), want) {
-						t.Errorf("result do not match the golden file:\n--BEGIN--\n%s\n--END--\n", buf.Bytes())
+					want = bytes.Replace(want, []byte("\r\n"), []byte("\n"), -1)
+					if !bytes.Equal(bufbytes, want) {
+						t.Errorf("result do not match the golden file:\n--BEGIN--\n%s\n--END--\n", bufbytes)
 					}
 				})
 			}


### PR DESCRIPTION
I was attempting to use goa v2 on windows, and ran into a few problems. I've worked around them locally, and wanted to share back, but I'm not entirely sure how to provoke them, as attempting to find minimal steps resulted in slightly different behavior than I encountered.

I am strongly skeptical that my changes are the "right" fix, but determining that will require more familiarity with go and goa than I have, and may result in a much more invasive set of changes. I'm willing to rework my patches, time depending, so please share any feedback. Alternately, I hope this report is enough to isolate what you need. Here are the issues I saw, and further description of what I changed in my commits. 

**Top-level import uses backslash**
go requires forward slashes in import paths. When running on Windows, the use of `filepath.Join` to build what is later used as an import path results in backslashes. I cover for this in 5ac020c with `filepath.ToSlash`, but think a more correct approach may be to use e.g. `path.Join` and avoid introducing backslashes in the first place.

**Example code miscalculates rootPath**
In an odd reversal of the above problem, many of the `*/codegen/example_*.go` files attempt to parse off the base part of a path. In my case, the code was receiving an import path (using forward slashes), but parsing with `os.PathSeparator` (a backslash on Windows). This resulted in a `rootPath` of `"."`, and example code that didn't compile. I worked around this by parsing a copy that I first passed through `filepath.FromSlash`, but I think a more correct approach may be to ensure that the incoming path is always in import form, and use an explicit `"/"` instead of `string(os.PathSeparator)`. These changes are in 72940a0.

**Reproduction steps**
Follow the instructions in the readme for https://github.com/goadesign/goa/tree/v2 through `goa gen calcsvc/design` and `goa example calcsvc/design` on Windows. (I've been testing on Windows 10 1803, but any supported Windows should match.) This results in a calc.go file containing `import ( calcsvc "calcsvc\gen\calc" )` and in a variant I haven't yet isolated how to reproduce, a cmd/calc/http.go file containing `import ( calcsvc "." )` (instead of `calcsvc "calcsvc/gen/calc"`). I had originally tested with another directory layer which reported an error during `goa gen`, and then (after the first fix) an error during `go build` of the server and cli generated by `goa example`.

**Tests**
I'm not sure how to write a test for this that will identify either problem while testing on non-Windows. I was able to add a test for the backslashes (04e0c4b), but it feels tightly coupled to my solution, and only failed on Windows. I'm less clear how to write a test for the imports generated by `goa example`. In getting there, I also tweaked the golden file comparisons (66e406d) as they didn't handle the CRLF newlines introduced by checking out on Windows with whatever gitconfig applied in my case.