### PR TITLE
Use build.Default.GOPATH instead of env GOPATH (#1930)

### DIFF
--- a/goagen/codegen/helpers.go
+++ b/goagen/codegen/helpers.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"bytes"
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"strings"
@@ -35,7 +36,7 @@ func CommandLine() string {
 
 	if len(os.Args) > 1 {
 		args := make([]string, len(os.Args)-1)
-		gopaths := filepath.SplitList(os.Getenv("GOPATH"))
+		gopaths := filepath.SplitList(envOr("GOPATH", build.Default.GOPATH))
 		for i, a := range os.Args[1:] {
 			for _, p := range gopaths {
 				p = "=" + p

--- a/goagen/codegen/workspace.go
+++ b/goagen/codegen/workspace.go
@@ -92,7 +92,7 @@ func NewWorkspace(prefix string) (*Workspace, error) {
 	os.MkdirAll(filepath.Join(dir, "bin"), 0755)
 
 	// setup GOPATH
-	gopath := os.Getenv("GOPATH")
+	gopath := envOr("GOPATH", build.Default.GOPATH)
 	os.Setenv("GOPATH", fmt.Sprintf("%s%c%s", dir, os.PathListSeparator, gopath))
 
 	// we're done
@@ -101,7 +101,7 @@ func NewWorkspace(prefix string) (*Workspace, error) {
 
 // WorkspaceFor returns the Go workspace for the given Go source file.
 func WorkspaceFor(source string) (*Workspace, error) {
-	gopaths := os.Getenv("GOPATH")
+	gopaths := envOr("GOPATH", build.Default.GOPATH)
 	// We use absolute paths so that in particular on Windows the case gets normalized
 	sourcePath, err := filepath.Abs(source)
 	if err != nil {
@@ -371,7 +371,7 @@ func PackagePath(path string) (string, error) {
 // PackageSourcePath returns the absolute path to the given package source.
 func PackageSourcePath(pkg string) (string, error) {
 	buildCtx := build.Default
-	buildCtx.GOPATH = os.Getenv("GOPATH") // Reevaluate each time to be nice to tests
+	buildCtx.GOPATH = envOr("GOPATH", build.Default.GOPATH) // Reevaluate each time to be nice to tests
 	wd, err := os.Getwd()
 	if err != nil {
 		wd = "."

--- a/goagen/meta/generator.go
+++ b/goagen/meta/generator.go
@@ -82,9 +82,6 @@ func NewGenerator(genfunc string, imports []*codegen.ImportSpec, flags map[strin
 // Generate compiles and runs the generator and returns the generated filenames.
 func (m *Generator) Generate() ([]string, error) {
 	// Sanity checks
-	if os.Getenv("GOPATH") == "" {
-		return nil, fmt.Errorf("GOPATH not set")
-	}
 	if m.OutDir == "" {
 		return nil, fmt.Errorf("missing output directory flag")
 	}

--- a/goagen/meta/generator_test.go
+++ b/goagen/meta/generator_test.go
@@ -89,23 +89,6 @@ var _ = Describe("Run", func() {
 		genWorkspace.Delete()
 	})
 
-	Context("with no GOPATH environment variable", func() {
-		var gopath string
-
-		BeforeEach(func() {
-			gopath = os.Getenv("GOPATH")
-			os.Setenv("GOPATH", "")
-		})
-
-		AfterEach(func() {
-			os.Setenv("GOPATH", gopath)
-		})
-
-		It("fails with a useful error message", func() {
-			Ω(compileError).Should(MatchError("GOPATH not set"))
-		})
-	})
-
 	Context("with an invalid GOPATH environment variable", func() {
 		var gopath string
 		const invalidPath = "DOES NOT EXIST"


### PR DESCRIPTION
* Use build.Default.GOPATH instead of env GOPATH

* Specify package name for some packages