### PR TITLE
IND-1925 X-Ray tracing record in-progress requests

### DIFF
--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -46,6 +46,15 @@ const (
 //     }
 //     return
 //
+// An X-Ray trace is limited to 500 KB of segment data (JSON) being submitted
+// for it. See: https://aws.amazon.com/xray/pricing/
+//
+// Traces running for multiple minutes may encounter additional dynamic limits,
+// resulting in the trace being limited to less than 500 KB. The workaround is
+// to send less data -- fewer segments, subsegments, annotations, or metadata.
+// And perhaps split up a single large trace into several different traces.
+//
+// Besides those varying size limitations, a trace may be open for up to 7 days.
 func New(service, daemon string) (goa.Middleware, error) {
 	connection, err := periodicallyRedialingConn(context.Background(), time.Minute, func() (net.Conn, error) {
 		return net.Dial("udp", daemon)

--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -124,10 +124,10 @@ func newSegment(ctx context.Context, traceID, name string, req *http.Request, c 
 
 	s := NewSegment(name, traceID, spanID, c)
 	s.RecordRequest(req, "")
-
 	if parentID != "" {
 		s.ParentID = parentID
 	}
+	s.SubmitInProgressSegment()
 
 	return s
 }

--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -127,7 +127,7 @@ func newSegment(ctx context.Context, traceID, name string, req *http.Request, c 
 	if parentID != "" {
 		s.ParentID = parentID
 	}
-	s.SubmitInProgressSegment()
+	s.SubmitInProgress()
 
 	return s
 }

--- a/middleware/xray/middleware.go
+++ b/middleware/xray/middleware.go
@@ -54,6 +54,13 @@ const (
 // to send less data -- fewer segments, subsegments, annotations, or metadata.
 // And perhaps split up a single large trace into several different traces.
 //
+// Here are some observations of the relationship between trace duration and
+// the number of bytes that could be sent successfully:
+//   - 49 seconds: 543 KB
+//   - 2.4 minutes: 51 KB
+//   - 6.8 minutes: 14 KB
+//   - 1.4 hours:   14 KB
+//
 // Besides those varying size limitations, a trace may be open for up to 7 days.
 func New(service, daemon string) (goa.Middleware, error) {
 	connection, err := periodicallyRedialingConn(context.Background(), time.Minute, func() (net.Conn, error) {

--- a/middleware/xray/segment.go
+++ b/middleware/xray/segment.go
@@ -151,7 +151,7 @@ type (
 // NewSegment creates a new segment that gets written to the given connection
 // on close.
 func NewSegment(name, traceID, spanID string, conn net.Conn) *Segment {
-	return &Segment{
+	s := &Segment{
 		Mutex:      &sync.Mutex{},
 		Name:       name,
 		TraceID:    traceID,
@@ -160,6 +160,8 @@ func NewSegment(name, traceID, spanID string, conn net.Conn) *Segment {
 		InProgress: true,
 		conn:       conn,
 	}
+	s.flush() // notify X-Ray about the in-progress segment
+	return s
 }
 
 // RecordRequest traces a request.
@@ -264,6 +266,7 @@ func (s *Segment) NewSubsegment(name string) *Segment {
 		Parent:     s,
 		conn:       s.conn,
 	}
+	sub.flush() // notify X-Ray about the in-progress segment
 	s.Subsegments = append(s.Subsegments, sub)
 	s.counter++
 	return sub

--- a/middleware/xray/segment.go
+++ b/middleware/xray/segment.go
@@ -349,8 +349,10 @@ func (s *Segment) Close() {
 // SubmitInProgressSegment sends this in-progress segment to the AWS X-Ray daemon.
 // This way, the segment will be immediately visible in the UI, with status "Pending".
 // When this segment is closed, the final version will overwrite any in-progress version.
-// https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
 // This method should be called no more than once for this segment. Subsequent calls will have no effect.
+//
+// See the `in_progress` docs:
+//     https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields
 func (s *Segment) SubmitInProgressSegment() {
 	s.Lock()
 	defer s.Unlock()

--- a/middleware/xray/segment.go
+++ b/middleware/xray/segment.go
@@ -275,7 +275,7 @@ func (s *Segment) NewSubsegment(name string) *Segment {
 //
 func (s *Segment) Capture(name string, fn func()) {
 	sub := s.NewSubsegment(name)
-	sub.SubmitInProgressSegment()
+	sub.SubmitInProgress()
 	defer sub.Close()
 	fn()
 }
@@ -346,14 +346,14 @@ func (s *Segment) Close() {
 	s.flush()
 }
 
-// SubmitInProgressSegment sends this in-progress segment to the AWS X-Ray daemon.
+// SubmitInProgress sends this in-progress segment to the AWS X-Ray daemon.
 // This way, the segment will be immediately visible in the UI, with status "Pending".
 // When this segment is closed, the final version will overwrite any in-progress version.
 // This method should be called no more than once for this segment. Subsequent calls will have no effect.
 //
 // See the `in_progress` docs:
 //     https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields
-func (s *Segment) SubmitInProgressSegment() {
+func (s *Segment) SubmitInProgress() {
 	s.Lock()
 	defer s.Unlock()
 

--- a/middleware/xray/segment.go
+++ b/middleware/xray/segment.go
@@ -34,11 +34,11 @@ type (
 		// remote service. It is only initialized for the root segment.
 		ParentID string `json:"parent_id,omitempty"`
 		// StartTime is the segment start time.
-		StartTime float64 `json:"start_time,omitempty"`
+		StartTime float64 `json:"start_time"`
 		// EndTime is the segment end time.
 		EndTime float64 `json:"end_time,omitempty"`
 		// InProgress is true if the segment hasn't completed yet.
-		InProgress bool `json:"in_progress"`
+		InProgress bool `json:"in_progress,omitempty""`
 		// HTTP contains the HTTP request and response information and is
 		// only initialized for the root segment.
 		HTTP *HTTP `json:"http,omitempty"`
@@ -48,15 +48,15 @@ type (
 		// Error is true when a request causes an internal error. It is
 		// automatically set by Close when the response status code is
 		// 500 or more.
-		Error bool `json:"error"`
+		Error bool `json:"error,omitempty""`
 		// Fault is true when a request results in an error that is due
 		// to the user. Typically it should be set when the response
 		// status code is between 400 and 500 (but not 429).
-		Fault bool `json:"fault"`
+		Fault bool `json:"fault,omitempty""`
 		// Throttle is true when a request is throttled. It is set to
 		// true when the segment closes and the response status code is
 		// 429. Client code may set it to true manually as well.
-		Throttle bool `json:"throttle"`
+		Throttle bool `json:"throttle,omitempty""`
 		// Annotations contains the segment annotations.
 		Annotations map[string]interface{} `json:"annotations,omitempty"`
 		// Metadata contains the segment metadata.

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -179,7 +179,7 @@ func TestRecordRequest(t *testing.T) {
 	}
 }
 
-func TestNewSubsegment(t *testing.T) {
+func TestSegment_NewSubsegment(t *testing.T) {
 	conn, err := net.Dial("udp", udplisten)
 	if err != nil {
 		t.Fatalf("failed to connect to daemon - %s", err)
@@ -190,6 +190,9 @@ func TestNewSubsegment(t *testing.T) {
 		before = now()
 		ss     = s.NewSubsegment(name)
 	)
+	if ss.submittedInProgressSegment {
+		t.Errorf("subsegment submittedInProgressSegment should initially be false")
+	}
 	if ss.ID == "" {
 		t.Errorf("subsegment ID not initialized")
 	}
@@ -208,6 +211,71 @@ func TestNewSubsegment(t *testing.T) {
 	if ss.Parent != s {
 		t.Errorf("invalid subsegment parent, expected %v, got %v", s, ss.Parent)
 	}
+}
+
+func TestSegment_SubmitInProgressSegment(t *testing.T) {
+	t.Run("call twice then close -- second call is ignored", func(t *testing.T) {
+		conn, err := net.Dial("udp", udplisten)
+		if err != nil {
+			t.Fatalf("failed to connect to daemon - %s", err)
+		}
+
+		segment := NewSegment("hello", NewTraceID(), NewID(), conn)
+
+		// call SubmitInProgressSegment() twice, then Close it
+		messages := readUDP(t, 2, func() {
+			segment.Namespace = "1"
+			segment.SubmitInProgressSegment()
+			segment.Namespace = "2"
+			segment.SubmitInProgressSegment() // should have no effect
+			segment.Namespace = "3"
+			segment.Close()
+		})
+
+		// verify the In-Progress segment
+		s := extractSegment(t, messages[0])
+		if !s.InProgress {
+			t.Errorf("expected segment to be InProgress, but it's not")
+		}
+		if s.Namespace != "1" {
+			t.Errorf("unexpected segment namespace, expected %q got %q", "1", s.Namespace)
+		}
+
+		// verify the final segment (the second In-Progress segment would not have been sent)
+		s = extractSegment(t, messages[1])
+		if s.InProgress {
+			t.Errorf("expected segment to not be InProgress, but it is")
+		}
+		if s.Namespace != "3" {
+			t.Errorf("unexpected segment namespace, expected %q got %q", "3", s.Namespace)
+		}
+	})
+
+	t.Run("calling after already Closed -- no effect", func(t *testing.T) {
+		conn, err := net.Dial("udp", udplisten)
+		if err != nil {
+			t.Fatalf("failed to connect to daemon - %s", err)
+		}
+
+		segment := NewSegment("hello", NewTraceID(), NewID(), conn)
+
+		// Close(), then call SubmitInProgressSegment(), only expect 1 segment written
+		messages := readUDP(t, 1, func() {
+			segment.Namespace = "1"
+			segment.Close()
+			segment.Namespace = "2"
+			segment.SubmitInProgressSegment() // should have no effect
+		})
+
+		// verify the In-Progress segment
+		s := extractSegment(t, messages[0])
+		if s.InProgress {
+			t.Errorf("expected segment to be closed, but it is still InProgress")
+		}
+		if s.Namespace != "1" {
+			t.Errorf("unexpected segment namespace, expected %q got %q", "1", s.Namespace)
+		}
+	})
 }
 
 // TestRace starts two goroutines and races them to call Segment's public function. In this way, when tests are run
@@ -232,6 +300,7 @@ func TestRace(t *testing.T) {
 		s.RecordResponse(resp)
 		s.RecordContextResponse(ctx)
 		s.RecordError(rErr)
+		s.SubmitInProgressSegment()
 
 		sub := s.NewSubsegment("sub")
 		s.Capture("sub2", func() {})

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -180,9 +180,13 @@ func TestRecordRequest(t *testing.T) {
 }
 
 func TestNewSubsegment(t *testing.T) {
+	conn, err := net.Dial("udp", udplisten)
+	if err != nil {
+		t.Fatalf("failed to connect to daemon - %s", err)
+	}
 	var (
 		name   = "sub"
-		s      = &Segment{Mutex: &sync.Mutex{}}
+		s      = &Segment{Mutex: &sync.Mutex{}, conn: conn}
 		before = now()
 		ss     = s.NewSubsegment(name)
 	)

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -213,7 +213,7 @@ func TestSegment_NewSubsegment(t *testing.T) {
 	}
 }
 
-func TestSegment_SubmitInProgressSegment(t *testing.T) {
+func TestSegment_SubmitInProgress(t *testing.T) {
 	t.Run("call twice then close -- second call is ignored", func(t *testing.T) {
 		conn, err := net.Dial("udp", udplisten)
 		if err != nil {

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -190,15 +190,6 @@ func TestNewSubsegment(t *testing.T) {
 		before = now()
 		ss     = s.NewSubsegment(name)
 	)
-	if s.counter != 1 {
-		t.Errorf("counter not incremented after call to Subsegment")
-	}
-	if len(s.Subsegments) != 1 {
-		t.Fatalf("invalid count of subsegments, expected 1 got %d", len(s.Subsegments))
-	}
-	if s.Subsegments[0] != ss {
-		t.Errorf("invalid subsegments element, expected %v - got %v", name, s.Subsegments[0])
-	}
 	if ss.ID == "" {
 		t.Errorf("subsegment ID not initialized")
 	}

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -222,12 +222,12 @@ func TestSegment_SubmitInProgressSegment(t *testing.T) {
 
 		segment := NewSegment("hello", NewTraceID(), NewID(), conn)
 
-		// call SubmitInProgressSegment() twice, then Close it
+		// call SubmitInProgress() twice, then Close it
 		messages := readUDP(t, 2, func() {
 			segment.Namespace = "1"
-			segment.SubmitInProgressSegment()
+			segment.SubmitInProgress()
 			segment.Namespace = "2"
-			segment.SubmitInProgressSegment() // should have no effect
+			segment.SubmitInProgress() // should have no effect
 			segment.Namespace = "3"
 			segment.Close()
 		})
@@ -259,12 +259,12 @@ func TestSegment_SubmitInProgressSegment(t *testing.T) {
 
 		segment := NewSegment("hello", NewTraceID(), NewID(), conn)
 
-		// Close(), then call SubmitInProgressSegment(), only expect 1 segment written
+		// Close(), then call SubmitInProgress(), only expect 1 segment written
 		messages := readUDP(t, 1, func() {
 			segment.Namespace = "1"
 			segment.Close()
 			segment.Namespace = "2"
-			segment.SubmitInProgressSegment() // should have no effect
+			segment.SubmitInProgress() // should have no effect
 		})
 
 		// verify the In-Progress segment
@@ -300,7 +300,7 @@ func TestRace(t *testing.T) {
 		s.RecordResponse(resp)
 		s.RecordContextResponse(ctx)
 		s.RecordError(rErr)
-		s.SubmitInProgressSegment()
+		s.SubmitInProgress()
 
 		sub := s.NewSubsegment("sub")
 		s.Capture("sub2", func() {})

--- a/middleware/xray/transport.go
+++ b/middleware/xray/transport.go
@@ -31,7 +31,7 @@ func (t *xrayTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	sub := s.NewSubsegment(req.URL.Host)
 	sub.RecordRequest(req, "remote")
-	sub.SubmitInProgressSegment()
+	sub.SubmitInProgress()
 	defer sub.Close()
 
 	resp, err := t.wrapped.RoundTrip(req)

--- a/middleware/xray/transport.go
+++ b/middleware/xray/transport.go
@@ -30,9 +30,9 @@ func (t *xrayTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	sub := s.NewSubsegment(req.URL.Host)
-	defer sub.Close()
-
 	sub.RecordRequest(req, "remote")
+	sub.SubmitInProgressSegment()
+	defer sub.Close()
 
 	resp, err := t.wrapped.RoundTrip(req)
 

--- a/middleware/xray/transport_test.go
+++ b/middleware/xray/transport_test.go
@@ -1,7 +1,6 @@
 package xray
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -68,23 +67,16 @@ func TestTransportExample(t *testing.T) {
 			t.Errorf("HTTP Response Status is invalid, expected %d got %d", http.StatusOK, resp.StatusCode)
 		}
 	})
-	// skip the first message, having `"in_progress":true`
-	js := messages[1]
+
+	// expect the first message is InProgress
+	s := extractSegment(t, messages[0])
+	if !s.InProgress {
+		t.Fatalf("expected first segment to be InProgress but it was not")
+	}
 
 	//
 	// Verify
-	var s *Segment
-	elems := strings.Split(js, "\n")
-	if len(elems) != 2 {
-		t.Fatalf("invalid number of lines, expected 2 got %d: %v", len(elems), elems)
-	}
-	if elems[0] != udpHeader[:len(udpHeader)-1] {
-		t.Errorf("invalid header, got %s", elems[0])
-	}
-	err = json.Unmarshal([]byte(elems[1]), &s)
-	if err != nil {
-		t.Fatal(err)
-	}
+	s = extractSegment(t, messages[1])
 	url, _ := url.Parse(server.URL)
 	if s.Name != url.Host {
 		t.Errorf("unexpected segment name, expected %q - got %q", url.Host, s.Name)
@@ -236,22 +228,14 @@ func TestTransport(t *testing.T) {
 				t.Errorf("%s: Response Status is invalid, expected %d got %d", k, c.Response.Status, resp.StatusCode)
 			}
 		})
-		// skip the first message, having `"in_progress":true`
-		js := messages[1]
-
-		var s *Segment
-		elems := strings.Split(js, "\n")
-		if len(elems) != 2 {
-			t.Fatalf("%s: invalid number of lines, expected 2 got %d: %v", k, len(elems), elems)
-		}
-		if elems[0] != udpHeader[:len(udpHeader)-1] {
-			t.Errorf("%s: invalid header, got %s", k, elems[0])
-		}
-		err = json.Unmarshal([]byte(elems[1]), &s)
-		if err != nil {
-			t.Fatal(err)
+		// expect the first message is InProgress
+		s := extractSegment(t, messages[0])
+		if !s.InProgress {
+			t.Errorf("%s: expected first segment to be InProgress but it was not", k)
 		}
 
+		// second message
+		s = extractSegment(t, messages[1])
 		if s.Name != host {
 			t.Errorf("%s: unexpected segment name, expected %q - got %q", k, host, s.Name)
 		}

--- a/middleware/xray/transport_test.go
+++ b/middleware/xray/transport_test.go
@@ -59,7 +59,7 @@ func TestTransportExample(t *testing.T) {
 	// Setting context on request
 	req = req.WithContext(ctx)
 
-	js := readUDP(t, func() {
+	messages := readUDP(t, 1, func() {
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			t.Fatalf("failed to make request - %s", err)
@@ -68,6 +68,7 @@ func TestTransportExample(t *testing.T) {
 			t.Errorf("HTTP Response Status is invalid, expected %d got %d", http.StatusOK, resp.StatusCode)
 		}
 	})
+	js := messages[0]
 
 	//
 	// Verify
@@ -225,7 +226,7 @@ func TestTransport(t *testing.T) {
 			req.Host = c.Request.Host
 		}
 
-		js := readUDP(t, func() {
+		messages := readUDP(t, 1, func() {
 			resp, err := WrapTransport(rt).RoundTrip(req)
 			if c.Segment.Exception == "" && err != nil {
 				t.Errorf("%s: Expected no error got %s", k, err)
@@ -234,6 +235,7 @@ func TestTransport(t *testing.T) {
 				t.Errorf("%s: Response Status is invalid, expected %d got %d", k, c.Response.Status, resp.StatusCode)
 			}
 		})
+		js := messages[0]
 
 		var s *Segment
 		elems := strings.Split(js, "\n")

--- a/middleware/xray/transport_test.go
+++ b/middleware/xray/transport_test.go
@@ -59,7 +59,7 @@ func TestTransportExample(t *testing.T) {
 	// Setting context on request
 	req = req.WithContext(ctx)
 
-	messages := readUDP(t, 1, func() {
+	messages := readUDP(t, 2, func() {
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			t.Fatalf("failed to make request - %s", err)
@@ -68,7 +68,8 @@ func TestTransportExample(t *testing.T) {
 			t.Errorf("HTTP Response Status is invalid, expected %d got %d", http.StatusOK, resp.StatusCode)
 		}
 	})
-	js := messages[0]
+	// skip the first message, having `"in_progress":true`
+	js := messages[1]
 
 	//
 	// Verify
@@ -226,7 +227,7 @@ func TestTransport(t *testing.T) {
 			req.Host = c.Request.Host
 		}
 
-		messages := readUDP(t, 1, func() {
+		messages := readUDP(t, 2, func() {
 			resp, err := WrapTransport(rt).RoundTrip(req)
 			if c.Segment.Exception == "" && err != nil {
 				t.Errorf("%s: Expected no error got %s", k, err)
@@ -235,7 +236,8 @@ func TestTransport(t *testing.T) {
 				t.Errorf("%s: Response Status is invalid, expected %d got %d", k, c.Response.Status, resp.StatusCode)
 			}
 		})
-		js := messages[0]
+		// skip the first message, having `"in_progress":true`
+		js := messages[1]
 
 		var s *Segment
 		elems := strings.Split(js, "\n")

--- a/middleware/xray/wrap_doer.go
+++ b/middleware/xray/wrap_doer.go
@@ -29,13 +29,13 @@ func (r *wrapDoer) Do(ctx context.Context, req *http.Request) (*http.Response, e
 	}
 
 	sub := s.NewSubsegment(req.URL.Host)
+	sub.RecordRequest(req, "remote")
+	sub.SubmitInProgressSegment()
 	defer sub.Close()
 
 	// update the context with the latest segment
 	ctx = middleware.WithTrace(ctx, sub.TraceID, sub.ID, sub.ParentID)
 	ctx = WithSegment(ctx, sub)
-
-	sub.RecordRequest(req, "remote")
 
 	resp, err := r.wrapped.Do(ctx, req)
 

--- a/middleware/xray/wrap_doer.go
+++ b/middleware/xray/wrap_doer.go
@@ -30,7 +30,7 @@ func (r *wrapDoer) Do(ctx context.Context, req *http.Request) (*http.Response, e
 
 	sub := s.NewSubsegment(req.URL.Host)
 	sub.RecordRequest(req, "remote")
-	sub.SubmitInProgressSegment()
+	sub.SubmitInProgress()
 	defer sub.Close()
 
 	// update the context with the latest segment

--- a/middleware/xray/wrap_doer_test.go
+++ b/middleware/xray/wrap_doer_test.go
@@ -64,7 +64,7 @@ func TestWrapDoer(t *testing.T) {
 
 			var s Segment
 			Expect(json.Unmarshal([]byte(lines[1]), &s)).To(Succeed())
-			Expect(s).To(MatchFields(IgnoreMissing|IgnoreExtras, Fields{
+			Expect(s).To(MatchFields(IgnoreExtras, Fields{
 				"Name":       Equal("somehost:80"),
 				"Type":       Equal("subsegment"),
 				"ID":         SatisfyAll(Not(BeEmpty()), Not(Equal(segment.ID))), // randomly generated
@@ -84,7 +84,7 @@ func TestWrapDoer(t *testing.T) {
 			var s Segment
 			err := json.Unmarshal([]byte(lines[1]), &s)
 			Expect(err).To(Succeed())
-			Expect(s).To(MatchFields(IgnoreMissing|IgnoreExtras, Fields{
+			Expect(s).To(MatchFields(IgnoreExtras, Fields{
 				"Name":      Equal("somehost:80"),
 				"Namespace": Equal("remote"),
 				"Type":      Equal("subsegment"),
@@ -131,7 +131,7 @@ func TestWrapDoer(t *testing.T) {
 
 			var s Segment
 			Expect(json.Unmarshal([]byte(lines[1]), &s)).To(Succeed())
-			Expect(s).To(MatchFields(IgnoreMissing|IgnoreExtras, Fields{
+			Expect(s).To(MatchFields(IgnoreExtras, Fields{
 				"Name":       Equal("somehost:80"),
 				"Type":       Equal("subsegment"),
 				"ID":         SatisfyAll(Not(BeEmpty()), Not(Equal(segment.ID))), // randomly generated
@@ -151,7 +151,7 @@ func TestWrapDoer(t *testing.T) {
 			var s Segment
 			err := json.Unmarshal([]byte(lines[1]), &s)
 			Expect(err).To(Succeed())
-			Expect(s).To(MatchFields(IgnoreMissing|IgnoreExtras, Fields{
+			Expect(s).To(MatchFields(IgnoreExtras, Fields{
 				"Name":      Equal("somehost:80"),
 				"Namespace": Equal("remote"),
 				"Type":      Equal("subsegment"),

--- a/middleware/xray/wrap_doer_test.go
+++ b/middleware/xray/wrap_doer_test.go
@@ -47,10 +47,6 @@ func TestWrapDoer(t *testing.T) {
 
 		// add an xray segment to the context
 		xrayConn := NewTestNetConn()
-		xrayConn.Expect("Write", func(b []byte) (int, error) {
-			Expect(b).To(ContainSubstring(`"in_progress":true`))
-			return len(b), nil
-		})
 		segment := NewSegment(segmentName, traceID, spanID, xrayConn)
 		ctx = WithSegment(ctx, segment)
 
@@ -116,10 +112,6 @@ func TestWrapDoer(t *testing.T) {
 
 		// add an xray segment to the context
 		xrayConn := NewTestNetConn()
-		xrayConn.Expect("Write", func(b []byte) (int, error) {
-			Expect(b).To(ContainSubstring(`"in_progress":true`))
-			return len(b), nil
-		})
 		segment := NewSegment(segmentName, traceID, spanID, xrayConn)
 		ctx = WithSegment(ctx, segment)
 


### PR DESCRIPTION
Modernize the the goa X-Ray segments to support writing "In Progress" segments to the xray-daemon.

This way, in the X-Ray UI we can see a live view of what is happening in the system, with "Pending" segments and their hierarchy visible.

The current behavior is that X-Ray is only notified about a segment when it is fully completed, which could take several minutes. Meanwhile, the trace in the UI is confusing, missing the key top-level hierarchy while subsystems have already started reporting their completed segments.

This PR makes the following changes:
- Add the `SubmitInProgress` method to `xray.Segment`. Whoever creates the segment can call this method shortly afterwards to ensure the X-Ray UI will immediately show the segment, as "Pending".
- `xray` middleware, `xray.WrapDoer`, and `xray.WrapTransport` will automatically submit their newly created in-progress segments, with useful information populated regarding the request.
- Each (sub)segment now writes just itself to the xray-daemon, rather than having the parent submit a large document (potentially exceeding the 64KB limit) containing all of its subsegment descendants.
See: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments
- Save segment space by omitting empty fields: `in_progress`, `error`, `fault`, `throttle`.
This matches the AWS SDK: https://github.com/aws/aws-xray-sdk-go/blob/852dc097d2b83915ece2ab4953e4de711d953626/xray/segment_model.go#L40-L45