### PR TITLE
Fix cli flag handling

### DIFF
--- a/examples/basic/gen/grpc/cli/calc/cli.go
+++ b/examples/basic/gen/grpc/cli/calc/cli.go
@@ -52,7 +52,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -61,7 +61,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "calc":
 			svcf = calcFlags
@@ -69,7 +69,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -78,7 +78,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "calc":
 			switch epn {
@@ -94,8 +94,8 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/basic/gen/http/cli/calc/cli.go
+++ b/examples/basic/gen/http/cli/calc/cli.go
@@ -57,7 +57,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -66,7 +66,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "calc":
 			svcf = calcFlags
@@ -74,7 +74,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -83,7 +83,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "calc":
 			switch epn {
@@ -99,8 +99,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/cellar/gen/grpc/cli/cellar/cli.go
+++ b/examples/cellar/gen/grpc/cli/cellar/cli.go
@@ -92,7 +92,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -101,7 +101,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "sommelier":
 			svcf = sommelierFlags
@@ -111,7 +111,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -120,7 +120,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "sommelier":
 			switch epn {
@@ -161,8 +161,8 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/cellar/gen/http/cli/cellar/cli.go
+++ b/examples/cellar/gen/http/cli/cellar/cli.go
@@ -103,7 +103,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -112,7 +112,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "sommelier":
 			svcf = sommelierFlags
@@ -122,7 +122,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -131,7 +131,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "sommelier":
 			switch epn {
@@ -172,8 +172,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/error/gen/grpc/cli/divider/cli.go
+++ b/examples/error/gen/grpc/cli/divider/cli.go
@@ -56,7 +56,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -65,7 +65,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "divider":
 			svcf = dividerFlags
@@ -73,7 +73,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -82,7 +82,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "divider":
 			switch epn {
@@ -101,8 +101,8 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/error/gen/http/cli/divider/cli.go
+++ b/examples/error/gen/http/cli/divider/cli.go
@@ -62,7 +62,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -71,7 +71,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "divider":
 			svcf = dividerFlags
@@ -79,7 +79,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -88,7 +88,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "divider":
 			switch epn {
@@ -107,8 +107,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/multipart/gen/http/cli/resume/cli.go
+++ b/examples/multipart/gen/http/cli/resume/cli.go
@@ -60,7 +60,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -69,7 +69,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "resume":
 			svcf = resumeFlags
@@ -77,7 +77,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -86,7 +86,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "resume":
 			switch epn {
@@ -105,8 +105,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/security/gen/grpc/cli/multi_auth/cli.go
+++ b/examples/security/gen/grpc/cli/multi_auth/cli.go
@@ -66,7 +66,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -75,7 +75,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "secured-service":
 			svcf = securedServiceFlags
@@ -83,7 +83,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -92,7 +92,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "secured-service":
 			switch epn {
@@ -117,8 +117,8 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/security/gen/http/cli/multi_auth/cli.go
+++ b/examples/security/gen/http/cli/multi_auth/cli.go
@@ -75,7 +75,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -84,7 +84,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "secured-service":
 			svcf = securedServiceFlags
@@ -92,7 +92,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -101,7 +101,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "secured-service":
 			switch epn {
@@ -126,8 +126,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/streaming/gen/grpc/cli/chatter/cli.go
+++ b/examples/streaming/gen/grpc/cli/chatter/cli.go
@@ -67,7 +67,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -76,7 +76,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "chatter":
 			svcf = chatterFlags
@@ -84,7 +84,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -93,7 +93,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "chatter":
 			switch epn {
@@ -121,8 +121,8 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/examples/streaming/gen/http/cli/chatter/cli.go
+++ b/examples/streaming/gen/http/cli/chatter/cli.go
@@ -76,7 +76,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -85,7 +85,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "chatter":
 			svcf = chatterFlags
@@ -93,7 +93,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -102,7 +102,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "chatter":
 			switch epn {
@@ -130,8 +130,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -659,7 +659,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -668,7 +668,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 	{{- range . }}
 		case "{{ .Name }}":
@@ -678,7 +678,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -687,7 +687,7 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 	{{- range . }}
 		case "{{ .Name }}":
@@ -705,8 +705,8 @@ func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, 
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/http/codegen/client_cli.go
+++ b/http/codegen/client_cli.go
@@ -711,7 +711,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -720,7 +720,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 	{{- range . }}
 		case "{{ .Name }}":
@@ -730,7 +730,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -739,7 +739,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 	{{- range . }}
 		case "{{ .Name }}":
@@ -757,8 +757,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -34,7 +34,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -43,7 +43,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "service-multi-no-payload1":
 			svcf = serviceMultiNoPayload1Flags
@@ -53,7 +53,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -62,7 +62,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "service-multi-no-payload1":
 			switch epn {
@@ -91,8 +91,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -170,7 +170,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -179,7 +179,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "service-multi-simple1":
 			svcf = serviceMultiSimple1Flags
@@ -189,7 +189,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -198,7 +198,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "service-multi-simple1":
 			switch epn {
@@ -227,8 +227,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -303,7 +303,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -312,7 +312,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "service-multi-required1":
 			svcf = serviceMultiRequired1Flags
@@ -322,7 +322,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -331,7 +331,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "service-multi-required1":
 			switch epn {
@@ -357,8 +357,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -424,7 +424,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -433,7 +433,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "service-multi":
 			svcf = serviceMultiFlags
@@ -441,7 +441,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -450,7 +450,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "service-multi":
 			switch epn {
@@ -469,8 +469,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -644,7 +644,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -653,7 +653,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "service-body-primitive-bool-validate":
 			svcf = serviceBodyPrimitiveBoolValidateFlags
@@ -661,7 +661,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -670,7 +670,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "service-body-primitive-bool-validate":
 			switch epn {
@@ -686,8 +686,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -742,7 +742,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -751,7 +751,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "service-body-primitive-array-string-validate":
 			svcf = serviceBodyPrimitiveArrayStringValidateFlags
@@ -759,7 +759,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -768,7 +768,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "service-body-primitive-array-string-validate":
 			switch epn {
@@ -784,8 +784,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -897,7 +897,7 @@ func ParseEndpoint(
 		return nil, nil, err
 	}
 
-	if len(os.Args) < flag.NFlag()+3 {
+	if flag.NArg() < 2 { // two non flag args are required: SERVICE and ENDPOINT (aka COMMAND)
 		return nil, nil, fmt.Errorf("not enough arguments")
 	}
 
@@ -906,7 +906,7 @@ func ParseEndpoint(
 		svcf *flag.FlagSet
 	)
 	{
-		svcn = os.Args[1+flag.NFlag()]
+		svcn = flag.Arg(0)
 		switch svcn {
 		case "service-map-query-primitive-array":
 			svcf = serviceMapQueryPrimitiveArrayFlags
@@ -914,7 +914,7 @@ func ParseEndpoint(
 			return nil, nil, fmt.Errorf("unknown service %q", svcn)
 		}
 	}
-	if err := svcf.Parse(os.Args[2+flag.NFlag():]); err != nil {
+	if err := svcf.Parse(flag.Args()[1:]); err != nil {
 		return nil, nil, err
 	}
 
@@ -923,7 +923,7 @@ func ParseEndpoint(
 		epf *flag.FlagSet
 	)
 	{
-		epn = os.Args[2+flag.NFlag()+svcf.NFlag()]
+		epn = svcf.Arg(0)
 		switch svcn {
 		case "service-map-query-primitive-array":
 			switch epn {
@@ -939,8 +939,8 @@ func ParseEndpoint(
 	}
 
 	// Parse endpoint flags if any
-	if len(os.Args) > 2+flag.NFlag()+svcf.NFlag() {
-		if err := epf.Parse(os.Args[3+flag.NFlag()+svcf.NFlag():]); err != nil {
+	if svcf.NArg() > 1 {
+		if err := epf.Parse(svcf.Args()[1:]); err != nil {
 			return nil, nil, err
 		}
 	}


### PR DESCRIPTION
This fixes the generated cli code to properly handle non-boolean flags.  Currently in v2 specifying a url causes the request to fail:
```
$  go run examples/basic/cmd/calc-cli/* -url http://localhost:8080 calc add -a 1 -b 2
unknown service "http://localhost:8080"
run '/var/folders/yc/0j7srrz91g35b3l3w6g06q380000gn/T/go-build461741860/command-line-arguments/_obj/exe/grpc --help' for detailed usage.
exit status 1
```