### PR TITLE
Messages called from rpc match message names when reserved name

### DIFF
--- a/grpc/codegen/proto_test.go
+++ b/grpc/codegen/proto_test.go
@@ -3,9 +3,9 @@ package codegen
 import (
 	"testing"
 
+	"github.com/allofthesepeople/goa/grpc/codegen/testdata"
 	"goa.design/goa/codegen"
 	"goa.design/goa/expr"
-	"goa.design/goa/grpc/codegen/testdata"
 )
 
 func TestProtoFiles(t *testing.T) {
@@ -21,6 +21,7 @@ func TestProtoFiles(t *testing.T) {
 		{"client-streaming-rpc", testdata.ClientStreamingRPCDSL, testdata.ClientStreamingRPCProtoCode},
 		{"bidirectional-streaming-rpc", testdata.BidirectionalStreamingRPCDSL, testdata.BidirectionalStreamingRPCProtoCode},
 		{"same-service-and-message-name", testdata.MessageWithServiceNameDSL, testdata.MessageWithServiceNameProtoCode},
+		{"method-with-reserved-proto-name", testdata.MethodWithReservedNameDSL, testdata.MethodWithReservedNameProtoCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/grpc/codegen/proto_test.go
+++ b/grpc/codegen/proto_test.go
@@ -3,9 +3,9 @@ package codegen
 import (
 	"testing"
 
-	"github.com/allofthesepeople/goa/grpc/codegen/testdata"
 	"goa.design/goa/codegen"
 	"goa.design/goa/expr"
+	"goa.design/goa/grpc/codegen/testdata"
 )
 
 func TestProtoFiles(t *testing.T) {

--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -419,14 +419,12 @@ func (d ServicesData) analyze(gs *expr.GRPCServiceExpr) *ServiceData {
 		seen = make(map[string]struct{})
 	}
 	for _, e := range gs.GRPCEndpoints {
-		en := protoBufify(e.Name(), true)
-
 		// convert request and response types to protocol buffer message types
-		e.Request = makeProtoBufMessage(e.Request, en+"Request", sd.Scope)
+		e.Request = makeProtoBufMessage(e.Request, protoBufify(e.Name()+"Request", true), sd.Scope)
 		if e.MethodExpr.StreamingPayload.Type != expr.Empty {
-			e.StreamingRequest = makeProtoBufMessage(e.StreamingRequest, en+"StreamingRequest", sd.Scope)
+			e.StreamingRequest = makeProtoBufMessage(e.StreamingRequest, protoBufify(e.Name()+"StreamingRequest", true), sd.Scope)
 		}
-		e.Response.Message = makeProtoBufMessage(e.Response.Message, en+"Response", sd.Scope)
+		e.Response.Message = makeProtoBufMessage(e.Response.Message, protoBufify(e.Name()+"Response", true), sd.Scope)
 
 		// collect all the nested messages and return the top-level message
 		collect := func(att *expr.AttributeExpr) *service.UserTypeData {

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -567,3 +567,11 @@ var MessageWithServiceNameDSL = func() {
 		})
 	})
 }
+
+var MethodWithReservedNameDSL = func() {
+	Service("MethodWithReservedName", func() {
+		Method("string", func() {
+			GRPC(func() {})
+		})
+	})
+}

--- a/grpc/codegen/testdata/proto_code.go
+++ b/grpc/codegen/testdata/proto_code.go
@@ -292,3 +292,16 @@ message MethodMessageWithSecurityRequest {
 message MethodMessageWithSecurityResponse {
 }
 `
+
+const MethodWithReservedNameProtoCode = `// Service is the MethodWithReservedName service interface.
+service MethodWithReservedName {
+	// String implements string.
+	rpc String (StringRequest) returns (StringResponse);
+}
+
+message StringRequest {
+}
+
+message StringResponse {
+}
+`


### PR DESCRIPTION
`protoBufify` is applied inconsistently when the method is a reserved name. Resulting in different signatures to the protobuf message types and method signature.

## Example design

```go
package design

import . "goa.design/goa/dsl"

var _ = Service("My Great Cat Service", func() {
	Method("rpc", func() {
		Result(Empty)
		GRPC(func() {
			Response(CodeOK)
		})
	})
})
```

```shell
➜ goa gen github.com/allofthesepeople/goatest/design
exit status 1
failed to run protoc: exit status 1: my_great_cat_service.proto:17:18: "Rpc_Request" is not defined.
my_great_cat_service.proto:17:40: "Rpc_Response" is not defined.
```

resulting in a protofile where the service definition signatures do not match the Message types:

```proto
…
service MyGreatCatService {
	// RPC implements rpc.
	rpc RPC (Rpc_Request) returns (Rpc_Response);
}

message RPCRequest {
}

message RPCResponse {
}
```

Change applies `protoBufify` to the whole message name rather than just the method part.
