### PR TITLE
Better error message if services could not be found.

### DIFF
--- a/http/codegen/client_cli.go
+++ b/http/codegen/client_cli.go
@@ -97,6 +97,10 @@ func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, da
 	}
 	for _, sv := range svr.Services {
 		svc := root.Service(sv)
+		if svc == nil {
+			panic("No HTTP service found for: " + sv)
+		}
+
 		sd := HTTPServices.Get(svc.Name)
 		if sd == nil {
 			continue


### PR DESCRIPTION
`goa gen` panics with `invalid memory adress`, if a service name was misspelled.
This PR shows a more distinct error message to help the developer to find his mistake.

e.g. 
```
	Server("front_service", func() {
		Services("ui") // <- misspelled
	})
```
```
var _ = Service("UI", func() {
    ...
}
```
doing a `goa gen` leads to:

```
exit status 2
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x90922f]

goroutine 1 [running]:
goa.design/goa/http/codegen.endpointParser(0xc000214253, 0x3d, 0xfd4cc0, 0xc000204280, 0xc000172e40, 0x1, 0x1, 0x1)
        /mnt/c/work/go/src/goa.design/goa/http/codegen/client_cli.go:105 +0x51f
goa.design/goa/http/codegen.ClientCLIFiles(0xc000214253, 0x3d, 0xfd4cc0, 0x2, 0xc000316090, 0x2)
        /mnt/c/work/go/src/goa.design/goa/http/codegen/client_cli.go:61 +0x661
goa.design/goa/codegen/generator.Transport(0xc000214253, 0x3d, 0xc000280600, 0x3, 0x4, 0x3, 0x4, 0x3, 0x0, 0x0)
        /mnt/c/work/go/src/goa.design/goa/codegen/generator/transport.go:30 +0x546
goa.design/goa/codegen/generator.Generate(0x7ffff237477e, 0x1, 0xa7a163, 0x3, 0x4, 0xc0001743c0, 0xa, 0xc00016f060, 0x30)
        /mnt/c/work/go/src/goa.design/goa/codegen/generator/generate.go:62 +0x398
main.main()

```
