### PR TITLE
https://github.com/goadesign/goa/issues/2013 struct:field:type implementation

### DIFF
--- a/codegen/generator/example.go
+++ b/codegen/generator/example.go
@@ -59,6 +59,13 @@ func Example(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 				files = append(files, fs...)
 			}
 		}
+		for _, f := range files {
+			if len(f.SectionTemplates) > 0 {
+				for _, s := range r.Services {
+					service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s)
+				}
+			}
+		}
 	}
 	return files, nil
 }

--- a/codegen/generator/service.go
+++ b/codegen/generator/service.go
@@ -26,6 +26,11 @@ func Service(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 				if f := service.ViewsFile(genpkg, s); f != nil {
 					files = append(files, f)
 				}
+				for _, f := range files {
+					if len(f.SectionTemplates) > 0 {
+						service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s)
+					}
+				}
 				f, err := service.ConvertFile(r, s)
 				if err != nil {
 					return nil, err

--- a/codegen/generator/transport.go
+++ b/codegen/generator/transport.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"goa.design/goa/codegen"
+	"goa.design/goa/codegen/service"
 	"goa.design/goa/eval"
 	"goa.design/goa/expr"
 	grpccodegen "goa.design/goa/grpc/codegen"
@@ -36,6 +37,14 @@ func Transport(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 		files = append(files, grpccodegen.ServerTypeFiles(genpkg, r)...)
 		files = append(files, grpccodegen.ClientTypeFiles(genpkg, r)...)
 		files = append(files, grpccodegen.ClientCLIFiles(genpkg, r)...)
+
+		for _, f := range files {
+			if len(f.SectionTemplates) > 0 {
+				for _, s := range r.Services {
+					service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s)
+				}
+			}
+		}
 	}
 	if len(files) == 0 {
 		return nil, fmt.Errorf("transport: no HTTP/gRPC design found")

--- a/codegen/header.go
+++ b/codegen/header.go
@@ -18,15 +18,18 @@ func Header(title, pack string, imports []*ImportSpec) *SectionTemplate {
 	}
 }
 
-// AddImport adds an import to a section template that was generated with
+// AddImports adds imports to a section template that was generated with
 // Header.
-func AddImport(section *SectionTemplate, imprt *ImportSpec) {
+func AddImports(section *SectionTemplate, imprts ...*ImportSpec) {
+	if len(imprts) == 0 {
+		return
+	}
 	var specs []*ImportSpec
 	if data, ok := section.Data.(map[string]interface{}); ok {
 		if imports, ok := data["Imports"]; ok {
 			specs = imports.([]*ImportSpec)
 		}
-		data["Imports"] = append(specs, imprt)
+		data["Imports"] = append(specs, imprts...)
 	}
 }
 

--- a/codegen/header.go
+++ b/codegen/header.go
@@ -18,9 +18,9 @@ func Header(title, pack string, imports []*ImportSpec) *SectionTemplate {
 	}
 }
 
-// AddImports adds imports to a section template that was generated with
+// AddImport adds imports to a section template that was generated with
 // Header.
-func AddImports(section *SectionTemplate, imprts ...*ImportSpec) {
+func AddImport(section *SectionTemplate, imprts ...*ImportSpec) {
 	if len(imprts) == 0 {
 		return
 	}

--- a/codegen/import.go
+++ b/codegen/import.go
@@ -34,10 +34,10 @@ func (s *ImportSpec) Code() string {
 	return fmt.Sprintf(`"%s"`, s.Path)
 }
 
-// GetMetaTypeInfo gets type and import info from an attributes metadata. struct:field:type can have 3 arguments,
+// getMetaTypeInfo gets type and import info from an attribute's metadata. struct:field:type can have 3 arguments,
 // first being the go type name, second being import path,
 // and third being the name of a qualified import, in case of name collisions.
-func GetMetaTypeInfo(att *expr.AttributeExpr) (typeName string, importS *ImportSpec) {
+func getMetaTypeInfo(att *expr.AttributeExpr) (typeName string, importS *ImportSpec) {
 	if att == nil {
 		return typeName, importS
 	}
@@ -61,7 +61,7 @@ func GetMetaTypeImports(att *expr.AttributeExpr) []*ImportSpec {
 		return nil
 	}
 	uniqueImports := make(map[ImportSpec]struct{})
-	_, im := GetMetaTypeInfo(att)
+	_, im := getMetaTypeInfo(att)
 	if im != nil {
 		uniqueImports[*im] = struct{}{}
 	}
@@ -73,23 +73,23 @@ func GetMetaTypeImports(att *expr.AttributeExpr) []*ImportSpec {
 			}
 		}
 	case *expr.Array:
-		_, im := GetMetaTypeInfo(t.ElemType)
+		_, im := getMetaTypeInfo(t.ElemType)
 		if im != nil {
 			uniqueImports[*im] = struct{}{}
 		}
 	case *expr.Map:
-		_, im := GetMetaTypeInfo(t.ElemType)
+		_, im := getMetaTypeInfo(t.ElemType)
 		if im != nil {
 			uniqueImports[*im] = struct{}{}
 		}
-		_, im = GetMetaTypeInfo(t.KeyType)
+		_, im = getMetaTypeInfo(t.KeyType)
 		if im != nil {
 			uniqueImports[*im] = struct{}{}
 		}
 	case *expr.Object:
 		for _, key := range *t {
 			if key != nil {
-				_, im := GetMetaTypeInfo(key.Attribute)
+				_, im := getMetaTypeInfo(key.Attribute)
 				if im != nil {
 					uniqueImports[*im] = struct{}{}
 				}
@@ -105,10 +105,11 @@ func GetMetaTypeImports(att *expr.AttributeExpr) []*ImportSpec {
 	return imports
 }
 
+// AddServiceMetaTypeImports adds meta type imports for each method of the service expr
 func AddServiceMetaTypeImports(header *SectionTemplate, svc *expr.ServiceExpr) {
 	for _, m := range svc.Methods {
-		AddImports(header, GetMetaTypeImports(m.Payload)...)
-		AddImports(header, GetMetaTypeImports(m.StreamingPayload)...)
-		AddImports(header, GetMetaTypeImports(m.Result)...)
+		AddImport(header, GetMetaTypeImports(m.Payload)...)
+		AddImport(header, GetMetaTypeImports(m.StreamingPayload)...)
+		AddImport(header, GetMetaTypeImports(m.Result)...)
 	}
 }

--- a/codegen/import.go
+++ b/codegen/import.go
@@ -97,7 +97,7 @@ func GetMetaTypeImports(att *expr.AttributeExpr) []*ImportSpec {
 		}
 	}
 	imports := make([]*ImportSpec, 0)
-	for imp, _ := range uniqueImports {
+	for imp := range uniqueImports {
 		// Copy loop variable into body so next iteration doesnt overwrite its address https://stackoverflow.com/questions/27610039/golang-appending-leaves-only-last-element
 		copy := imp
 		imports = append(imports, &copy)

--- a/codegen/scope.go
+++ b/codegen/scope.go
@@ -98,6 +98,9 @@ func (s *NameScope) Name(name string) string {
 func (s *NameScope) GoTypeDef(att *expr.AttributeExpr, ptr, useDefault bool) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
+		if t, _ := GetMetaTypeInfo(att); t != "" {
+			return t
+		}
 		return GoNativeTypeName(actual)
 	case *expr.Array:
 		d := s.GoTypeDef(actual.ElemType, ptr, useDefault)
@@ -186,6 +189,9 @@ func (s *NameScope) GoTypeName(att *expr.AttributeExpr) string {
 func (s *NameScope) GoFullTypeName(att *expr.AttributeExpr, pkg string) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
+		if t, _ := GetMetaTypeInfo(att); t != "" {
+			return t
+		}
 		return GoNativeTypeName(actual)
 	case *expr.Array:
 		return "[]" + s.GoFullTypeRef(actual.ElemType, pkg)

--- a/codegen/scope.go
+++ b/codegen/scope.go
@@ -98,7 +98,7 @@ func (s *NameScope) Name(name string) string {
 func (s *NameScope) GoTypeDef(att *expr.AttributeExpr, ptr, useDefault bool) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
-		if t, _ := GetMetaTypeInfo(att); t != "" {
+		if t, _ := getMetaTypeInfo(att); t != "" {
 			return t
 		}
 		return GoNativeTypeName(actual)
@@ -189,7 +189,7 @@ func (s *NameScope) GoTypeName(att *expr.AttributeExpr) string {
 func (s *NameScope) GoFullTypeName(att *expr.AttributeExpr, pkg string) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
-		if t, _ := GetMetaTypeInfo(att); t != "" {
+		if t, _ := getMetaTypeInfo(att); t != "" {
 			return t
 		}
 		return GoNativeTypeName(actual)

--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -66,7 +66,6 @@ func File(genpkg string, service *expr.ServiceExpr) *codegen.File {
 			}
 		}
 	}
-
 	for _, ut := range svc.userTypes {
 		if _, ok := seen[ut.Name]; !ok {
 			sections = append(sections, &codegen.SectionTemplate{
@@ -153,6 +152,23 @@ func File(genpkg string, service *expr.ServiceExpr) *codegen.File {
 	}
 
 	return &codegen.File{Path: path, SectionTemplates: sections}
+}
+
+func AddServiceDataMetaTypeImports(header *codegen.SectionTemplate, serviceE *expr.ServiceExpr) {
+	codegen.AddServiceMetaTypeImports(header, serviceE)
+	svc := Services.Get(serviceE.Name)
+	for _, ut := range svc.userTypes {
+		codegen.AddImports(header, codegen.GetMetaTypeImports(ut.Type.Attribute())...)
+	}
+	for _, et := range svc.errorTypes {
+		codegen.AddImports(header, codegen.GetMetaTypeImports(et.Type.Attribute())...)
+	}
+	for _, t := range svc.viewedResultTypes {
+		codegen.AddImports(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
+	}
+	for _, t := range svc.projectedTypes {
+		codegen.AddImports(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
+	}
 }
 
 func errorName(et *UserTypeData) string {

--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -154,20 +154,21 @@ func File(genpkg string, service *expr.ServiceExpr) *codegen.File {
 	return &codegen.File{Path: path, SectionTemplates: sections}
 }
 
+// AddServiceDataMetaTypeImports Adds all imports defined by struct:field:type from the service expr and the service data
 func AddServiceDataMetaTypeImports(header *codegen.SectionTemplate, serviceE *expr.ServiceExpr) {
 	codegen.AddServiceMetaTypeImports(header, serviceE)
 	svc := Services.Get(serviceE.Name)
 	for _, ut := range svc.userTypes {
-		codegen.AddImports(header, codegen.GetMetaTypeImports(ut.Type.Attribute())...)
+		codegen.AddImport(header, codegen.GetMetaTypeImports(ut.Type.Attribute())...)
 	}
 	for _, et := range svc.errorTypes {
-		codegen.AddImports(header, codegen.GetMetaTypeImports(et.Type.Attribute())...)
+		codegen.AddImport(header, codegen.GetMetaTypeImports(et.Type.Attribute())...)
 	}
 	for _, t := range svc.viewedResultTypes {
-		codegen.AddImports(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
+		codegen.AddImport(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
 	}
 	for _, t := range svc.projectedTypes {
-		codegen.AddImports(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
+		codegen.AddImport(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
 	}
 }
 

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -63,6 +63,21 @@ import (
 //        })
 //    })
 //
+// - "struct:field:type" overrides the Go struct field type specified in the design.
+//		Applicable to attributes only. The import path of the type should be passed in as the second parameter, if needed.
+//		If the default imported package name conflicts with another, you can override that as well with the third parameter.
+//
+//    var MyType = Type("BigOleMessage", func() {
+//        Attribute("type", String, "Type of big payload")
+//				Attribute("bigPayload", String, "Don't parse it if you don't have to",func() {
+//					Meta("struct:field:type","json.RawMessage","encoding/json")
+//				})
+//				Attribute("id", String, func() {
+//					Meta("struct:field:type","bison.ObjectId", "github.com/globalsign/mgo/bson", "bison")
+//				})
+//    })
+//
+//
 // - "struct:tag:xxx" sets a generated Go struct field tag and overrides tags
 // that goa would otherwise set. If the metadata value is a slice then the
 // strings are joined with the space character as separator. Applicable to

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -63,7 +63,8 @@ import (
 //        })
 //    })
 //
-// - "struct:field:type" overrides the Go struct field type specified in the design.
+// - "struct:field:type" overrides the Go struct field type specified in the design, with one caveat;
+//		if the type would have been a pointer (such as its not Required) the new type will also be a pointer.
 //		Applicable to attributes only. The import path of the type should be passed in as the second parameter, if needed.
 //		If the default imported package name conflicts with another, you can override that as well with the third parameter.
 //

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -64,9 +64,9 @@ import (
 //    })
 //
 // - "struct:field:type" overrides the Go struct field type specified in the design, with one caveat;
-//		if the type would have been a pointer (such as its not Required) the new type will also be a pointer.
-//		Applicable to attributes only. The import path of the type should be passed in as the second parameter, if needed.
-//		If the default imported package name conflicts with another, you can override that as well with the third parameter.
+// if the type would have been a pointer (such as its not Required) the new type will also be a pointer.
+// Applicable to attributes only. The import path of the type should be passed in as the second parameter, if needed.
+// If the default imported package name conflicts with another, you can override that as well with the third parameter.
 //
 //    var MyType = Type("BigOleMessage", func() {
 //        Attribute("type", String, "Type of big payload")


### PR DESCRIPTION
I also tried to solve a bug in Goa 1 which didn't place the user defined import inside all of the files, just user_types, which led to issues when using this meta tag with Payloads.

Since ImportSpec takes in an additional Name parameter I figured adding qualified imports would be useful as well.

I also noticed the AddImports function wasn't being used anywhere within goa, and made the signature more useful.