### PR TITLE
Add WWW-Authenticate header to 401 response if using Basic auth

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1106,11 +1106,15 @@ func {{ .ErrorEncoder }}(encoder func(context.Context, http.ResponseWriter) goah
 			return encodeError(ctx, w, v)
 		}
 		switch en.ErrorName() {
+	{{- $basicScheme := .BasicScheme }}{{- $realm := .Method.Name }}
 	{{- range $gerr := .Errors }}
 	{{- range $err := .Errors }}
 		case {{ printf "%q" .Name }}:
 			res := v.({{ $err.Ref }})
 			{{- with .Response}}
+				{{- if and $basicScheme (eq .StatusCode "http.StatusUnauthorized") }}
+				w.Header().Set("WWW-Authenticate", "Basic realm=\"{{ $realm }}\"")
+				{{- end }}
 				{{- template "response" . }}
 				{{- if .ServerBody }}
 				return enc.Encode(body)


### PR DESCRIPTION
If Basic authentication is in effect, and a StatusUnauthorized response is about to be returned, add
`WWW-Authenticate: Basic realm="$Method.Name"`
header to cause the browser to prompt for username and password.
This applies whenever an error that is mapped to StatusUnauthorized will be returned, due to
1. the authorization logic returning an error that is mapped to StatusUnauthorized, or
2. the username or password field of the payload is marked required and was not supplied, and "missing_field" is mapped to StatusUnauthorized in the design.

If you think this is a reasonable change, let me know and I can add a test to http/codegen/testdata