### PR TITLE
Add support for Params and Headers DSL

### DIFF
--- a/dsl/http.go
+++ b/dsl/http.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"reflect"
-
 	"goa.design/goa/eval"
 	"goa.design/goa/expr"
 )
@@ -386,8 +384,7 @@ func Header(name string, args ...interface{}) {
 // method HTTP expression to define the HTTP endpoint path and query string
 // parameters.
 //
-// Params accepts one argument: Either a function listing the parameters or a
-// user type which must be an object and whose attributes define the parameters.
+// Params accepts one argument which is a function listing the parameters.
 //
 // Example:
 //
@@ -408,20 +405,12 @@ func Params(args interface{}) {
 		eval.IncompatibleDSL()
 		return
 	}
-	if fn, ok := args.(func()); ok {
-		eval.Execute(fn, p)
-		return
-	}
-	t, ok := args.(expr.UserType)
+	fn, ok := args.(func())
 	if !ok {
-		eval.InvalidArgError("function or type", args)
+		eval.InvalidArgError("function", args)
 		return
 	}
-	o := expr.AsObject(t)
-	if o == nil {
-		eval.ReportError("type must be an object but got %s", reflect.TypeOf(args).Name())
-	}
-	p.Merge(expr.NewMappedAttributeExpr(&expr.AttributeExpr{Type: o}))
+	eval.Execute(fn, p)
 }
 
 // Param describes a single HTTP request path or query string parameter.
@@ -817,6 +806,7 @@ func headers(exp eval.Expression) *expr.MappedAttributeExpr {
 		}
 		return e.Headers
 	case *expr.MappedAttributeExpr:
+		fmt.Println(fmt.Sprintf("%#v", e.EvalName()))
 		return e
 	default:
 		return nil

--- a/dsl/http.go
+++ b/dsl/http.go
@@ -816,6 +816,8 @@ func headers(exp eval.Expression) *expr.MappedAttributeExpr {
 			e.Headers = expr.NewEmptyMappedAttributeExpr()
 		}
 		return e.Headers
+	case *expr.MappedAttributeExpr:
+		return e
 	default:
 		return nil
 	}
@@ -841,6 +843,8 @@ func params(exp eval.Expression) *expr.MappedAttributeExpr {
 			e.Params = expr.NewEmptyMappedAttributeExpr()
 		}
 		return e.Params
+	case *expr.MappedAttributeExpr:
+		return e
 	default:
 		return nil
 	}

--- a/dsl/validation.go
+++ b/dsl/validation.go
@@ -360,6 +360,8 @@ func Required(names ...string) {
 		at = def
 	case *expr.ResultTypeExpr:
 		at = def.AttributeExpr
+	case *expr.MappedAttributeExpr:
+		at = def.AttributeExpr
 	default:
 		eval.IncompatibleDSL()
 		return

--- a/expr/http_response.go
+++ b/expr/http_response.go
@@ -240,6 +240,7 @@ func (r *HTTPResponseExpr) Finalize(a *HTTPEndpointExpr, svcAtt *AttributeExpr) 
 			r.ContentType = rt.ContentType
 		}
 	}
+	initAttr(r.Headers, svcAtt)
 }
 
 // Dup creates a copy of the response expression.

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -166,10 +166,10 @@ func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.Buil
 			tn = arg.TypeName
 		}
 		fdata = append(fdata, &cli.FieldData{
-			Name:     arg.Name,
-			VarName:  arg.Name,
-			TypeName: tn,
-			Init:     code,
+			Name:    arg.Name,
+			VarName: arg.Name,
+			TypeRef: tn,
+			Init:    code,
 		})
 	}
 	if e.Method.PayloadRef == "" {

--- a/http/codegen/client_cli.go
+++ b/http/codegen/client_cli.go
@@ -198,8 +198,10 @@ func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.Buil
 	)
 	for i, arg := range args {
 		pInitArgs[i] = &cli.PayloadInitArgData{
-			Name:      arg.Name,
-			FieldName: arg.FieldName,
+			Name:         arg.Name,
+			Pointer:      arg.Pointer,
+			FieldName:    arg.FieldName,
+			FieldPointer: arg.FieldPointer,
 		}
 
 		f := cli.NewFlagData(e.ServiceName, e.Method.Name, arg.Name, arg.TypeName, arg.Description, arg.Required, arg.Example)
@@ -218,11 +220,10 @@ func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.Buil
 			tn = arg.TypeName
 		}
 		fdata = append(fdata, &cli.FieldData{
-			Name:     arg.Name,
-			VarName:  arg.Name,
-			TypeName: tn,
-			Init:     code,
-			Pointer:  arg.Pointer,
+			Name:    arg.Name,
+			VarName: arg.Name,
+			TypeRef: tn,
+			Init:    code,
 		})
 	}
 

--- a/http/codegen/client_cli_test.go
+++ b/http/codegen/client_cli_test.go
@@ -38,6 +38,7 @@ func TestClientCLIFiles(t *testing.T) {
 		{"map-query", testdata.PayloadMapQueryPrimitiveArrayDSL, testdata.MapQueryParseCode, 0, 3},
 		{"map-query-object", testdata.PayloadMapQueryObjectDSL, testdata.MapQueryObjectBuildCode, 1, 1},
 		{"empty-body-build", testdata.PayloadBodyPrimitiveFieldEmptyDSL, testdata.EmptyBodyBuildCode, 1, 1},
+		{"with-params-and-headers-dsl", testdata.WithParamsAndHeadersBlockDSL, testdata.WithParamsAndHeadersBlockBuildCode, 1, 1},
 	}
 
 	for _, c := range cases {

--- a/http/codegen/client_decode_test.go
+++ b/http/codegen/client_decode_test.go
@@ -21,6 +21,12 @@ func TestClientDecode(t *testing.T) {
 		{"explicit-body-result-collection", testdata.ExplicitBodyResultCollectionDSL, testdata.ExplicitBodyResultCollectionDecodeCode},
 		{"tag-result-multiple-views", testdata.ResultMultipleViewsTagDSL, testdata.ResultMultipleViewsTagDecodeCode},
 		{"empty-server-response-with-tags", testdata.EmptyServerResponseWithTagsDSL, testdata.EmptyServerResponseWithTagsDecodeCode},
+		{"header-string-array", testdata.ResultHeaderStringArrayDSL, testdata.ResultHeaderStringArrayResponseDecodeCode},
+		{"header-string-array-validate", testdata.ResultHeaderStringArrayValidateDSL, testdata.ResultHeaderStringArrayValidateResponseDecodeCode},
+		{"header-array", testdata.ResultHeaderArrayDSL, testdata.ResultHeaderArrayResponseDecodeCode},
+		{"header-array-validate", testdata.ResultHeaderArrayValidateDSL, testdata.ResultHeaderArrayValidateResponseDecodeCode},
+		{"with-headers-dsl", testdata.WithHeadersBlockDSL, testdata.WithHeadersBlockResponseDecodeCode},
+		{"with-headers-dsl-viewed-result", testdata.WithHeadersBlockViewedResultDSL, testdata.WithHeadersBlockViewedResultResponseDecodeCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -224,7 +224,7 @@ func {{ .Name }}({{- range .ClientArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) 
 		{{- if .ReturnIsStruct }}
 			{{- range .ClientArgs }}
 				{{- if .FieldName }}
-			{{ if $.ReturnTypeAttribute }}res{{ else }}v{{ end }}.{{ .FieldName }} = {{ if .Pointer }}&{{ end }}{{ .Name }}
+			{{ if $.ReturnTypeAttribute }}res{{ else }}v{{ end }}.{{ .FieldName }} = {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }}
 				{{- end }}
 			{{- end }}
 		{{- end }}
@@ -234,7 +234,7 @@ func {{ .Name }}({{- range .ClientArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) 
 			return &{{ .ReturnTypeName }}{
 			{{- range .ClientArgs }}
 				{{- if .FieldName }}
-				{{ .FieldName }}: {{ if .Pointer }}&{{ end }}{{ .Name }},
+				{{ .FieldName }}: {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }},
 				{{- end }}
 			{{- end }}
 			}

--- a/http/codegen/server_decode_test.go
+++ b/http/codegen/server_decode_test.go
@@ -170,6 +170,7 @@ func TestDecode(t *testing.T) {
 		{"multipart-body-user-type", testdata.PayloadMultipartUserTypeDSL, testdata.PayloadMultipartUserTypeDecodeCode},
 		{"multipart-body-array-type", testdata.PayloadMultipartArrayTypeDSL, testdata.PayloadMultipartArrayTypeDecodeCode},
 		{"multipart-body-map-type", testdata.PayloadMultipartMapTypeDSL, testdata.PayloadMultipartMapTypeDecodeCode},
+		{"with-params-and-headers-dsl", testdata.WithParamsAndHeadersBlockDSL, testdata.WithParamsAndHeadersBlockDecodeCode},
 	}
 	golden := makeGolden(t, "testdata/payload_decode_functions.go")
 	if golden != nil {

--- a/http/codegen/server_types.go
+++ b/http/codegen/server_types.go
@@ -219,7 +219,7 @@ func {{ .Name }}({{- range .ServerArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) 
 		{{- if .ReturnIsStruct }}
 			{{- range .ServerArgs }}
 				{{- if .FieldName }}
-			{{ if $.ReturnTypeAttribute }}res{{ else }}v{{ end }}.{{ .FieldName }} = {{ if .Pointer }}&{{ end }}{{ .Name }}
+			{{ if $.ReturnTypeAttribute }}res{{ else }}v{{ end }}.{{ .FieldName }} = {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }}
 				{{- end }}
 			{{- end }}
 		{{- end }}
@@ -229,7 +229,7 @@ func {{ .Name }}({{- range .ServerArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) 
 			return &{{ .ReturnTypeName }}{
 			{{- range .ServerArgs }}
 				{{- if .FieldName }}
-				{{ .FieldName }}: {{ if .Pointer }}&{{ end }}{{ .Name }},
+				{{ .FieldName }}: {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }},
 				{{- end }}
 			{{- end }}
 			}

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1107,30 +1107,40 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			for _, sc := range r.Schemes {
 				if sc.Type == "Basic" {
 					uatt := e.MethodExpr.Payload.Find(sc.UsernameAttr)
+					uref := svc.Scope.GoTypeRef(uatt)
+					if sc.UsernamePointer {
+						uref = "*" + uref
+					}
 					uarg := &InitArgData{
-						Name:        sc.UsernameAttr,
-						FieldName:   sc.UsernameField,
-						Description: uatt.Description,
-						Ref:         sc.UsernameAttr,
-						Required:    sc.UsernameRequired,
-						TypeName:    svc.Scope.GoTypeName(uatt),
-						TypeRef:     svc.Scope.GoTypeRef(uatt),
-						Pointer:     sc.UsernamePointer,
-						Validate:    codegen.RecursiveValidationCode(uatt, httpsvrctx, sc.UsernameRequired, sc.UsernameAttr),
-						Example:     uatt.Example(expr.Root.API.Random()),
+						Name:         sc.UsernameAttr,
+						FieldName:    sc.UsernameField,
+						FieldPointer: sc.UsernamePointer,
+						Description:  uatt.Description,
+						Ref:          sc.UsernameAttr,
+						Required:     sc.UsernameRequired,
+						TypeName:     svc.Scope.GoTypeName(uatt),
+						TypeRef:      uref,
+						Pointer:      sc.UsernamePointer,
+						Validate:     codegen.RecursiveValidationCode(uatt, httpsvrctx, sc.UsernameRequired, sc.UsernameAttr),
+						Example:      uatt.Example(expr.Root.API.Random()),
 					}
 					patt := e.MethodExpr.Payload.Find(sc.PasswordAttr)
+					pref := svc.Scope.GoTypeRef(patt)
+					if sc.PasswordPointer {
+						pref = "*" + pref
+					}
 					parg := &InitArgData{
-						Name:        sc.PasswordAttr,
-						FieldName:   sc.PasswordField,
-						Description: patt.Description,
-						Ref:         sc.PasswordAttr,
-						Required:    sc.PasswordRequired,
-						TypeName:    svc.Scope.GoTypeName(patt),
-						TypeRef:     svc.Scope.GoTypeRef(patt),
-						Pointer:     sc.PasswordPointer,
-						Validate:    codegen.RecursiveValidationCode(patt, httpsvrctx, sc.PasswordRequired, sc.PasswordAttr),
-						Example:     patt.Example(expr.Root.API.Random()),
+						Name:         sc.PasswordAttr,
+						FieldName:    sc.PasswordField,
+						FieldPointer: sc.PasswordPointer,
+						Description:  patt.Description,
+						Ref:          sc.PasswordAttr,
+						Required:     sc.PasswordRequired,
+						TypeName:     svc.Scope.GoTypeName(patt),
+						TypeRef:      pref,
+						Pointer:      sc.PasswordPointer,
+						Validate:     codegen.RecursiveValidationCode(patt, httpsvrctx, sc.PasswordRequired, sc.PasswordAttr),
+						Example:      patt.Example(expr.Root.API.Random()),
 					}
 					cliArgs = []*InitArgData{uarg, parg}
 					done = true

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -2168,16 +2168,12 @@ func extractPathParams(a *expr.MappedAttributeExpr, service *expr.AttributeExpr,
 		if !expr.IsObject(service.Type) {
 			fieldName = ""
 		}
-		fieldPtr := false
-		if expr.IsObject(service.Type) && service.IsPrimitivePointer(name, true) {
-			fieldPtr = true
-		}
 		params = append(params, &ParamData{
 			Name:           elem,
 			AttributeName:  name,
 			Description:    c.Description,
 			FieldName:      fieldName,
-			FieldPointer:   fieldPtr,
+			FieldPointer:   expr.IsObject(service.Type) && service.IsPrimitivePointer(name, true),
 			VarName:        varn,
 			Required:       true,
 			Type:           c.Type,
@@ -2217,16 +2213,12 @@ func extractQueryParams(a *expr.MappedAttributeExpr, service *expr.AttributeExpr
 		if !expr.IsObject(service.Type) {
 			fieldName = ""
 		}
-		fieldPtr := false
-		if expr.IsObject(service.Type) && service.IsPrimitivePointer(name, true) {
-			fieldPtr = true
-		}
 		params = append(params, &ParamData{
 			Name:          elem,
 			AttributeName: name,
 			Description:   c.Description,
 			FieldName:     fieldName,
-			FieldPointer:  fieldPtr,
+			FieldPointer:  expr.IsObject(service.Type) && service.IsPrimitivePointer(name, true),
 			VarName:       varn,
 			Required:      required,
 			Type:          c.Type,
@@ -2267,14 +2259,12 @@ func extractHeaders(a *expr.MappedAttributeExpr, svcAtt *expr.AttributeExpr, svc
 			typeRef = scope.GoTypeRef(hattr)
 
 			fieldName string
-			fieldPtr  bool
 			pointer   bool
 		)
 		{
 			pointer = a.IsPrimitivePointer(name, true)
 			if expr.IsObject(svcAtt.Type) {
 				fieldName = codegen.Goify(name, true)
-				fieldPtr = svcCtx.IsPrimitivePointer(name, svcAtt)
 			}
 			if pointer {
 				typeRef = "*" + typeRef
@@ -2286,7 +2276,7 @@ func extractHeaders(a *expr.MappedAttributeExpr, svcAtt *expr.AttributeExpr, svc
 			Description:   hattr.Description,
 			CanonicalName: http.CanonicalHeaderKey(elem),
 			FieldName:     fieldName,
-			FieldPointer:  fieldPtr,
+			FieldPointer:  expr.IsObject(svcAtt.Type) && svcCtx.IsPrimitivePointer(name, svcAtt),
 			VarName:       varn,
 			TypeName:      scope.GoTypeName(hattr),
 			TypeRef:       typeRef,

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -710,11 +710,9 @@ func BuildMethodBodyQueryPathObjectPayload(serviceBodyQueryPathObjectMethodBodyQ
 			return nil, fmt.Errorf("invalid JSON for body, example of valid JSON:\n%s", "'{\n      \"a\": \"Ullam aut.\"\n   }'")
 		}
 	}
-	var c *string
+	var c string
 	{
-		if serviceBodyQueryPathObjectMethodBodyQueryPathObjectC != "" {
-			c = &serviceBodyQueryPathObjectMethodBodyQueryPathObjectC
-		}
+		c = serviceBodyQueryPathObjectMethodBodyQueryPathObjectC
 	}
 	var b *string
 	{
@@ -725,7 +723,7 @@ func BuildMethodBodyQueryPathObjectPayload(serviceBodyQueryPathObjectMethodBodyQ
 	v := &servicebodyquerypathobject.MethodBodyQueryPathObjectPayload{
 		A: body.A,
 	}
-	v.C = c
+	v.C = &c
 	v.B = b
 	return v, nil
 }
@@ -1225,5 +1223,71 @@ func BuildMethodBodyPrimitiveArrayUserPayload(serviceBodyPrimitiveArrayUserMetho
 		A: a,
 	}
 	return payload, nil
+}
+`
+
+var WithParamsAndHeadersBlockBuildCode = `// BuildMethodAPayload builds the payload for the
+// ServiceWithParamsAndHeadersBlock MethodA endpoint from CLI flags.
+func BuildMethodAPayload(serviceWithParamsAndHeadersBlockMethodABody string, serviceWithParamsAndHeadersBlockMethodAPath string, serviceWithParamsAndHeadersBlockMethodAOptional string, serviceWithParamsAndHeadersBlockMethodAOptionalButRequiredParam string, serviceWithParamsAndHeadersBlockMethodARequired string, serviceWithParamsAndHeadersBlockMethodAOptionalButRequiredHeader string) (*servicewithparamsandheadersblock.MethodAPayload, error) {
+	var err error
+	var body MethodARequestBody
+	{
+		err = json.Unmarshal([]byte(serviceWithParamsAndHeadersBlockMethodABody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, example of valid JSON:\n%s", "'{\n      \"body\": \"Inventore optio quia ullam aut iste iste.\"\n   }'")
+		}
+	}
+	var path uint
+	{
+		var v uint64
+		v, err = strconv.ParseUint(serviceWithParamsAndHeadersBlockMethodAPath, 10, 64)
+		path = uint(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for path, must be UINT")
+		}
+	}
+	var optional *int
+	{
+		if serviceWithParamsAndHeadersBlockMethodAOptional != "" {
+			var v int64
+			v, err = strconv.ParseInt(serviceWithParamsAndHeadersBlockMethodAOptional, 10, 64)
+			val := int(v)
+			optional = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for optional, must be INT")
+			}
+		}
+	}
+	var optionalButRequiredParam float32
+	{
+		var v float64
+		v, err = strconv.ParseFloat(serviceWithParamsAndHeadersBlockMethodAOptionalButRequiredParam, 32)
+		optionalButRequiredParam = float32(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for optionalButRequiredParam, must be FLOAT32")
+		}
+	}
+	var required string
+	{
+		required = serviceWithParamsAndHeadersBlockMethodARequired
+	}
+	var optionalButRequiredHeader float32
+	{
+		var v float64
+		v, err = strconv.ParseFloat(serviceWithParamsAndHeadersBlockMethodAOptionalButRequiredHeader, 32)
+		optionalButRequiredHeader = float32(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for optionalButRequiredHeader, must be FLOAT32")
+		}
+	}
+	v := &servicewithparamsandheadersblock.MethodAPayload{
+		Body: body.Body,
+	}
+	v.Path = &path
+	v.Optional = optional
+	v.OptionalButRequiredParam = &optionalButRequiredParam
+	v.Required = required
+	v.OptionalButRequiredHeader = &optionalButRequiredHeader
+	return v, nil
 }
 `

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -2601,3 +2601,32 @@ var MixedPayloadInBodyDSL = func() {
 		})
 	})
 }
+
+var WithParamsAndHeadersBlockDSL = func() {
+	Service("ServiceWithParamsAndHeadersBlock", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("required", String)
+				Attribute("optional", Int)
+				Attribute("optional_but_required_param", Float32)
+				Attribute("optional_but_required_header", Float32)
+				Attribute("path", UInt)
+				Attribute("body", String)
+				Required("required")
+			})
+			HTTP(func() {
+				POST("/{path}")
+				Params(func() {
+					Param("optional", Int)
+					Param("optional_but_required_param", Float32)
+					Required("optional_but_required_param")
+				})
+				Headers(func() {
+					Header("required", String)
+					Header("optional_but_required_header", Float32)
+					Required("optional_but_required_header")
+				})
+			})
+		})
+	})
+}

--- a/http/codegen/testdata/result_decode_functions.go
+++ b/http/codegen/testdata/result_decode_functions.go
@@ -245,7 +245,7 @@ func DecodeMethodTagMultipleViewsResponse(decoder func(*http.Response) goahttp.D
 			var (
 				c *string
 			)
-			cRaw := resp.Header.Get("c")
+			cRaw := resp.Header.Get("C")
 			if cRaw != "" {
 				c = &cRaw
 			}
@@ -313,6 +313,331 @@ func DecodeMethodEmptyServerResponseWithTagsResponse(decoder func(*http.Response
 		default:
 			body, _ := ioutil.ReadAll(resp.Body)
 			return nil, goahttp.ErrInvalidResponse("ServiceEmptyServerResponseWithTags", "MethodEmptyServerResponseWithTags", resp.StatusCode, string(body))
+		}
+	}
+}
+`
+
+var ResultHeaderStringArrayResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
+// ServiceHeaderStringArrayResponse MethodA endpoint. restoreBody controls
+// whether the response body should be restored after having been read.
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
+	return func(resp *http.Response) (interface{}, error) {
+		if restoreBody {
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				array []string
+			)
+			array = resp.Header["Array"]
+
+			res := NewMethodAResultOK(array)
+			return res, nil
+		default:
+			body, _ := ioutil.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("ServiceHeaderStringArrayResponse", "MethodA", resp.StatusCode, string(body))
+		}
+	}
+}
+`
+
+var ResultHeaderStringArrayValidateResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
+// ServiceHeaderStringArrayValidateResponse MethodA endpoint. restoreBody
+// controls whether the response body should be restored after having been read.
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
+	return func(resp *http.Response) (interface{}, error) {
+		if restoreBody {
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				array []string
+				err   error
+			)
+			array = resp.Header["Array"]
+
+			if len(array) < 5 {
+				err = goa.MergeErrors(err, goa.InvalidLengthError("array", array, len(array), 5, true))
+			}
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ServiceHeaderStringArrayValidateResponse", "MethodA", err)
+			}
+			res := NewMethodAResultOK(array)
+			return res, nil
+		default:
+			body, _ := ioutil.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("ServiceHeaderStringArrayValidateResponse", "MethodA", resp.StatusCode, string(body))
+		}
+	}
+}
+`
+
+var ResultHeaderArrayResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
+// ServiceHeaderArrayResponse MethodA endpoint. restoreBody controls whether
+// the response body should be restored after having been read.
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
+	return func(resp *http.Response) (interface{}, error) {
+		if restoreBody {
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				array []uint
+				err   error
+			)
+			{
+				arrayRaw := resp.Header["Array"]
+
+				if arrayRaw != nil {
+					array = make([]uint, len(arrayRaw))
+					for i, rv := range arrayRaw {
+						v, err2 := strconv.ParseUint(rv, 10, strconv.IntSize)
+						if err2 != nil {
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("array", arrayRaw, "array of unsigned integers"))
+						}
+						array[i] = uint(v)
+					}
+				}
+			}
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ServiceHeaderArrayResponse", "MethodA", err)
+			}
+			res := NewMethodAResultOK(array)
+			return res, nil
+		default:
+			body, _ := ioutil.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("ServiceHeaderArrayResponse", "MethodA", resp.StatusCode, string(body))
+		}
+	}
+}
+`
+
+var ResultHeaderArrayValidateResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
+// ServiceHeaderArrayValidateResponse MethodA endpoint. restoreBody controls
+// whether the response body should be restored after having been read.
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
+	return func(resp *http.Response) (interface{}, error) {
+		if restoreBody {
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				array []int
+				err   error
+			)
+			{
+				arrayRaw := resp.Header["Array"]
+
+				if arrayRaw != nil {
+					array = make([]int, len(arrayRaw))
+					for i, rv := range arrayRaw {
+						v, err2 := strconv.ParseInt(rv, 10, strconv.IntSize)
+						if err2 != nil {
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("array", arrayRaw, "array of integers"))
+						}
+						array[i] = int(v)
+					}
+				}
+			}
+			for _, e := range array {
+				if e < 5 {
+					err = goa.MergeErrors(err, goa.InvalidRangeError("array[*]", e, 5, true))
+				}
+			}
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ServiceHeaderArrayValidateResponse", "MethodA", err)
+			}
+			res := NewMethodAResultOK(array)
+			return res, nil
+		default:
+			body, _ := ioutil.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("ServiceHeaderArrayValidateResponse", "MethodA", resp.StatusCode, string(body))
+		}
+	}
+}
+`
+
+var WithHeadersBlockResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
+// ServiceWithHeadersBlock MethodA endpoint. restoreBody controls whether the
+// response body should be restored after having been read.
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
+	return func(resp *http.Response) (interface{}, error) {
+		if restoreBody {
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				required            int
+				optional            *float32
+				optionalButRequired uint
+				err                 error
+			)
+			{
+				requiredRaw := resp.Header.Get("X-Request-Id")
+				if requiredRaw == "" {
+					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlock", "MethodA", goa.MissingFieldError("X-Request-ID", "header"))
+				}
+				v, err2 := strconv.ParseInt(requiredRaw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("required", requiredRaw, "integer"))
+				}
+				required = int(v)
+			}
+			{
+				optionalRaw := resp.Header.Get("Authorization")
+				if optionalRaw != "" {
+					v, err2 := strconv.ParseFloat(optionalRaw, 32)
+					if err2 != nil {
+						err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optional", optionalRaw, "float"))
+					}
+					pv := float32(v)
+					optional = &pv
+				}
+			}
+			{
+				optionalButRequiredRaw := resp.Header.Get("Location")
+				if optionalButRequiredRaw == "" {
+					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlock", "MethodA", goa.MissingFieldError("Location", "header"))
+				}
+				v, err2 := strconv.ParseUint(optionalButRequiredRaw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optionalButRequired", optionalButRequiredRaw, "unsigned integer"))
+				}
+				optionalButRequired = uint(v)
+			}
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ServiceWithHeadersBlock", "MethodA", err)
+			}
+			res := NewMethodAResultOK(required, optional, optionalButRequired)
+			return res, nil
+		default:
+			body, _ := ioutil.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("ServiceWithHeadersBlock", "MethodA", resp.StatusCode, string(body))
+		}
+	}
+}
+`
+
+var WithHeadersBlockViewedResultResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
+// ServiceWithHeadersBlockViewedResult MethodA endpoint. restoreBody controls
+// whether the response body should be restored after having been read.
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
+	return func(resp *http.Response) (interface{}, error) {
+		if restoreBody {
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return nil, err
+			}
+			resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			defer func() {
+				resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			}()
+		} else {
+			defer resp.Body.Close()
+		}
+		switch resp.StatusCode {
+		case http.StatusOK:
+			var (
+				required            int
+				optional            *float32
+				optionalButRequired uint
+				err                 error
+			)
+			{
+				requiredRaw := resp.Header.Get("X-Request-Id")
+				if requiredRaw == "" {
+					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlockViewedResult", "MethodA", goa.MissingFieldError("X-Request-ID", "header"))
+				}
+				v, err2 := strconv.ParseInt(requiredRaw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("required", requiredRaw, "integer"))
+				}
+				required = int(v)
+			}
+			{
+				optionalRaw := resp.Header.Get("Authorization")
+				if optionalRaw != "" {
+					v, err2 := strconv.ParseFloat(optionalRaw, 32)
+					if err2 != nil {
+						err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optional", optionalRaw, "float"))
+					}
+					pv := float32(v)
+					optional = &pv
+				}
+			}
+			{
+				optionalButRequiredRaw := resp.Header.Get("Location")
+				if optionalButRequiredRaw == "" {
+					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlockViewedResult", "MethodA", goa.MissingFieldError("Location", "header"))
+				}
+				v, err2 := strconv.ParseUint(optionalButRequiredRaw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optionalButRequired", optionalButRequiredRaw, "unsigned integer"))
+				}
+				optionalButRequired = uint(v)
+			}
+			if err != nil {
+				return nil, goahttp.ErrValidationError("ServiceWithHeadersBlockViewedResult", "MethodA", err)
+			}
+			p := NewMethodAAResultOK(required, optional, optionalButRequired)
+			view := resp.Header.Get("goa-view")
+			vres := &servicewithheadersblockviewedresultviews.AResult{p, view}
+			res := servicewithheadersblockviewedresult.NewAResult(vres)
+			return res, nil
+		default:
+			body, _ := ioutil.ReadAll(resp.Body)
+			return nil, goahttp.ErrInvalidResponse("ServiceWithHeadersBlockViewedResult", "MethodA", resp.StatusCode, string(body))
 		}
 	}
 }

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -1070,3 +1070,130 @@ var EmptyServerResponseWithTagsDSL = func() {
 		})
 	})
 }
+
+var ResultHeaderStringArrayDSL = func() {
+	Service("ServiceHeaderStringArrayResponse", func() {
+		Method("MethodA", func() {
+			Result(func() {
+				Attribute("array", ArrayOf(String))
+			})
+			HTTP(func() {
+				GET("/")
+				Response(StatusOK, func() {
+					Header("array")
+				})
+			})
+		})
+	})
+}
+
+var ResultHeaderStringArrayValidateDSL = func() {
+	Service("ServiceHeaderStringArrayValidateResponse", func() {
+		Method("MethodA", func() {
+			Result(func() {
+				Attribute("array", ArrayOf(String), func() {
+					MinLength(5)
+				})
+			})
+			HTTP(func() {
+				GET("/")
+				Response(StatusOK, func() {
+					Header("array")
+				})
+			})
+		})
+	})
+}
+
+var ResultHeaderArrayDSL = func() {
+	Service("ServiceHeaderArrayResponse", func() {
+		Method("MethodA", func() {
+			Result(func() {
+				Attribute("array", ArrayOf(UInt))
+			})
+			HTTP(func() {
+				GET("/")
+				Response(StatusOK, func() {
+					Header("array")
+				})
+			})
+		})
+	})
+}
+
+var ResultHeaderArrayValidateDSL = func() {
+	Service("ServiceHeaderArrayValidateResponse", func() {
+		Method("MethodA", func() {
+			Result(func() {
+				Attribute("array", ArrayOf(Int), func() {
+					Elem(func() {
+						Minimum(5)
+					})
+				})
+			})
+			HTTP(func() {
+				GET("/")
+				Response(StatusOK, func() {
+					Header("array")
+				})
+			})
+		})
+	})
+}
+
+var WithHeadersBlockDSL = func() {
+	Service("ServiceWithHeadersBlock", func() {
+		Method("MethodA", func() {
+			Result(func() {
+				Attribute("required", Int)
+				Attribute("optional", Float32)
+				Attribute("optional_but_required", UInt)
+				Required("required")
+			})
+			HTTP(func() {
+				GET("/")
+				Response(StatusOK, func() {
+					Headers(func() {
+						Header("required:X-Request-ID")
+						Header("optional:Authorization")
+						Header("optional_but_required:Location")
+						Required("optional_but_required")
+					})
+				})
+			})
+		})
+	})
+}
+
+var WithHeadersBlockViewedResultDSL = func() {
+	var AResult = ResultType("application/vnd.goa.aresult", func() {
+		TypeName("AResult")
+		Attributes(func() {
+			Attribute("required", Int)
+			Attribute("optional", Float32)
+			Attribute("optional_but_required", UInt)
+			Required("required")
+		})
+		View("tiny", func() {
+			Attribute("required")
+			Attribute("optional")
+			Attribute("optional_but_required")
+		})
+	})
+	Service("ServiceWithHeadersBlockViewedResult", func() {
+		Method("MethodA", func() {
+			Result(AResult)
+			HTTP(func() {
+				GET("/")
+				Response(StatusOK, func() {
+					Headers(func() {
+						Header("required:X-Request-ID")
+						Header("optional:Authorization")
+						Header("optional_but_required:Location")
+						Required("optional_but_required")
+					})
+				})
+			})
+		})
+	})
+}

--- a/http/codegen/testdata/result_encode_functions.go
+++ b/http/codegen/testdata/result_encode_functions.go
@@ -8,7 +8,7 @@ func EncodeMethodHeaderBoolResponse(encoder func(context.Context, http.ResponseW
 		if res.H != nil {
 			val := res.H
 			hs := strconv.FormatBool(*val)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -24,7 +24,7 @@ func EncodeMethodHeaderIntResponse(encoder func(context.Context, http.ResponseWr
 		if res.H != nil {
 			val := res.H
 			hs := strconv.Itoa(*val)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -40,7 +40,7 @@ func EncodeMethodHeaderInt32Response(encoder func(context.Context, http.Response
 		if res.H != nil {
 			val := res.H
 			hs := strconv.FormatInt(int64(*val), 10)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -56,7 +56,7 @@ func EncodeMethodHeaderInt64Response(encoder func(context.Context, http.Response
 		if res.H != nil {
 			val := res.H
 			hs := strconv.FormatInt(*val, 10)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -72,7 +72,7 @@ func EncodeMethodHeaderUIntResponse(encoder func(context.Context, http.ResponseW
 		if res.H != nil {
 			val := res.H
 			hs := strconv.FormatUint(uint64(*val), 10)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -88,7 +88,7 @@ func EncodeMethodHeaderUInt32Response(encoder func(context.Context, http.Respons
 		if res.H != nil {
 			val := res.H
 			hs := strconv.FormatUint(uint64(*val), 10)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -104,7 +104,7 @@ func EncodeMethodHeaderUInt64Response(encoder func(context.Context, http.Respons
 		if res.H != nil {
 			val := res.H
 			hs := strconv.FormatUint(*val, 10)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -120,7 +120,7 @@ func EncodeMethodHeaderFloat32Response(encoder func(context.Context, http.Respon
 		if res.H != nil {
 			val := res.H
 			hs := strconv.FormatFloat(float64(*val), 'f', -1, 32)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -136,7 +136,7 @@ func EncodeMethodHeaderFloat64Response(encoder func(context.Context, http.Respon
 		if res.H != nil {
 			val := res.H
 			hs := strconv.FormatFloat(*val, 'f', -1, 64)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -150,7 +150,7 @@ func EncodeMethodHeaderStringResponse(encoder func(context.Context, http.Respons
 	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
 		res := v.(*serviceheaderstring.MethodHeaderStringResult)
 		if res.H != nil {
-			w.Header().Set("h", *res.H)
+			w.Header().Set("H", *res.H)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -166,7 +166,7 @@ func EncodeMethodHeaderBytesResponse(encoder func(context.Context, http.Response
 		if res.H != nil {
 			val := res.H
 			hs := string(val)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -182,7 +182,7 @@ func EncodeMethodHeaderAnyResponse(encoder func(context.Context, http.ResponseWr
 		if res.H != nil {
 			val := res.H
 			hs := fmt.Sprintf("%v", val)
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -203,7 +203,7 @@ func EncodeMethodHeaderArrayBoolResponse(encoder func(context.Context, http.Resp
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -224,7 +224,7 @@ func EncodeMethodHeaderArrayIntResponse(encoder func(context.Context, http.Respo
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -245,7 +245,7 @@ func EncodeMethodHeaderArrayInt32Response(encoder func(context.Context, http.Res
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -266,7 +266,7 @@ func EncodeMethodHeaderArrayInt64Response(encoder func(context.Context, http.Res
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -287,7 +287,7 @@ func EncodeMethodHeaderArrayUIntResponse(encoder func(context.Context, http.Resp
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -308,7 +308,7 @@ func EncodeMethodHeaderArrayUInt32Response(encoder func(context.Context, http.Re
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -329,7 +329,7 @@ func EncodeMethodHeaderArrayUInt64Response(encoder func(context.Context, http.Re
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -350,7 +350,7 @@ func EncodeMethodHeaderArrayFloat32Response(encoder func(context.Context, http.R
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -371,7 +371,7 @@ func EncodeMethodHeaderArrayFloat64Response(encoder func(context.Context, http.R
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -387,7 +387,7 @@ func EncodeMethodHeaderArrayStringResponse(encoder func(context.Context, http.Re
 		if res.H != nil {
 			val := res.H
 			hs := strings.Join(val, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -408,7 +408,7 @@ func EncodeMethodHeaderArrayBytesResponse(encoder func(context.Context, http.Res
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -429,7 +429,7 @@ func EncodeMethodHeaderArrayAnyResponse(encoder func(context.Context, http.Respo
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -444,7 +444,7 @@ func EncodeMethodHeaderBoolDefaultResponse(encoder func(context.Context, http.Re
 		res := v.(*serviceheaderbooldefault.MethodHeaderBoolDefaultResult)
 		val := res.H
 		hs := strconv.FormatBool(val)
-		w.Header().Set("h", hs)
+		w.Header().Set("H", hs)
 		w.WriteHeader(http.StatusOK)
 		return nil
 	}
@@ -459,7 +459,7 @@ func EncodeMethodHeaderBoolRequiredDefaultResponse(encoder func(context.Context,
 		res := v.(*serviceheaderboolrequireddefault.MethodHeaderBoolRequiredDefaultResult)
 		val := res.H
 		hs := strconv.FormatBool(val)
-		w.Header().Set("h", hs)
+		w.Header().Set("H", hs)
 		w.WriteHeader(http.StatusOK)
 		return nil
 	}
@@ -472,7 +472,7 @@ var ResultHeaderStringDefaultEncodeCode = `// EncodeMethodHeaderStringDefaultRes
 func EncodeMethodHeaderStringDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
 	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
 		res := v.(*serviceheaderstringdefault.MethodHeaderStringDefaultResult)
-		w.Header().Set("h", res.H)
+		w.Header().Set("H", res.H)
 		w.WriteHeader(http.StatusOK)
 		return nil
 	}
@@ -485,7 +485,7 @@ var ResultHeaderStringRequiredDefaultEncodeCode = `// EncodeMethodHeaderStringRe
 func EncodeMethodHeaderStringRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
 	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
 		res := v.(*serviceheaderstringrequireddefault.MethodHeaderStringRequiredDefaultResult)
-		w.Header().Set("h", res.H)
+		w.Header().Set("H", res.H)
 		w.WriteHeader(http.StatusOK)
 		return nil
 	}
@@ -506,9 +506,9 @@ func EncodeMethodHeaderArrayBoolDefaultResponse(encoder func(context.Context, ht
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		} else {
-			w.Header().Set("h", "true, false")
+			w.Header().Set("H", "true, false")
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -530,9 +530,9 @@ func EncodeMethodHeaderArrayBoolRequiredDefaultResponse(encoder func(context.Con
 				hsSlice[i] = es
 			}
 			hs := strings.Join(hsSlice, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		} else {
-			w.Header().Set("h", "true, false")
+			w.Header().Set("H", "true, false")
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -549,9 +549,9 @@ func EncodeMethodHeaderArrayStringDefaultResponse(encoder func(context.Context, 
 		if res.H != nil {
 			val := res.H
 			hs := strings.Join(val, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		} else {
-			w.Header().Set("h", "foo, bar")
+			w.Header().Set("H", "foo, bar")
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -568,9 +568,9 @@ func EncodeMethodHeaderArrayStringRequiredDefaultResponse(encoder func(context.C
 		if res.H != nil {
 			val := res.H
 			hs := strings.Join(val, ", ")
-			w.Header().Set("h", hs)
+			w.Header().Set("H", hs)
 		} else {
-			w.Header().Set("h", "foo, bar")
+			w.Header().Set("H", "foo, bar")
 		}
 		w.WriteHeader(http.StatusOK)
 		return nil
@@ -874,7 +874,7 @@ func EncodeMethodBodyHeaderObjectResponse(encoder func(context.Context, http.Res
 		enc := encoder(ctx, w)
 		body := NewMethodBodyHeaderObjectResponseBody(res)
 		if res.B != nil {
-			w.Header().Set("b", *res.B)
+			w.Header().Set("B", *res.B)
 		}
 		w.WriteHeader(http.StatusOK)
 		return enc.Encode(body)
@@ -890,7 +890,7 @@ func EncodeMethodBodyHeaderUserResponse(encoder func(context.Context, http.Respo
 		enc := encoder(ctx, w)
 		body := NewMethodBodyHeaderUserResponseBody(res)
 		if res.B != nil {
-			w.Header().Set("b", *res.B)
+			w.Header().Set("B", *res.B)
 		}
 		w.WriteHeader(http.StatusOK)
 		return enc.Encode(body)
@@ -904,7 +904,7 @@ func EncodeMethodTagStringResponse(encoder func(context.Context, http.ResponseWr
 	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
 		res := v.(*servicetagstring.MethodTagStringResult)
 		if res.H != nil && *res.H == "value" {
-			w.Header().Set("h", *res.H)
+			w.Header().Set("H", *res.H)
 			w.WriteHeader(http.StatusAccepted)
 			return nil
 		}
@@ -922,7 +922,7 @@ func EncodeMethodTagStringRequiredResponse(encoder func(context.Context, http.Re
 	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
 		res := v.(*servicetagstringrequired.MethodTagStringRequiredResult)
 		if res.H == "value" {
-			w.Header().Set("h", res.H)
+			w.Header().Set("H", res.H)
 			w.WriteHeader(http.StatusAccepted)
 			return nil
 		}
@@ -949,7 +949,7 @@ func EncodeMethodTagMultipleViewsResponse(encoder func(context.Context, http.Res
 			case "tiny":
 				body = NewMethodTagMultipleViewsAcceptedResponseBodyTiny(res.Projected)
 			}
-			w.Header().Set("c", *res.Projected.C)
+			w.Header().Set("C", *res.Projected.C)
 			w.WriteHeader(http.StatusAccepted)
 			return enc.Encode(body)
 		}


### PR DESCRIPTION
* Fixes bug where adding `Params` or `Headers` DSL inside HTTP endpoint had no effect
* All headers are encoded/decoded in the [canonical header key format](https://godoc.org/net/http#CanonicalHeaderKey).
* Fixed DSL documentation for `Headers` and `Params` to take only function type as argument. It doesn't make sense to use a UserType here to define params and headers since we map the params and headers to the service payload and result types.
* Path parameters are now always required flags in the HTTP CLI