### PR TITLE
Add OpenAPI test

### DIFF
--- a/dsl/security.go
+++ b/dsl/security.go
@@ -386,7 +386,7 @@ func PasswordField(tag interface{}, name string, args ...interface{}) {
 
 // APIKey defines the attribute used to provide the API key to an endpoint
 // secured with API keys. The parameters and usage of APIKey are the same as the
-// goa DSL Attribute function except that it accepts an extra first argument
+// Attribute function except that it accepts an extra first argument
 // corresponding to the name of the API key security scheme.
 //
 // The generated code produced by goa uses the value of the corresponding

--- a/http/codegen/openapi.go
+++ b/http/codegen/openapi.go
@@ -14,9 +14,11 @@ import (
 
 // OpenAPIFiles returns the files for the OpenAPIFile spec of the given HTTP API.
 func OpenAPIFiles(root *expr.RootExpr) ([]*codegen.File, error) {
+	// Only create a OpenAPI specification if there are HTTP services.
 	if len(root.API.HTTP.Services) == 0 {
 		return nil, nil
 	}
+
 	jsonPath := filepath.Join(codegen.Gendir, "http", "openapi.json")
 	yamlPath := filepath.Join(codegen.Gendir, "http", "openapi.yaml")
 	var (

--- a/http/codegen/testdata/openapi_v2_dsls.go
+++ b/http/codegen/testdata/openapi_v2_dsls.go
@@ -144,6 +144,21 @@ var ExplicitViewDSL = func() {
 	})
 }
 
+var InvalidDSL = func() {
+	var _ = API("test", func() {
+		Server("test", func() {
+			Host("localhost", func() {
+				URI("http://[::1]:namedport") // invalid URL
+			})
+		})
+	})
+	Service("httpService", func() {
+		Method("httpEndpoint", func() {
+			HTTP(func() { GET("/") })
+		})
+	})
+}
+
 var EmptyDSL = func() {
 	var _ = API("test", func() {
 		Server("test", func() {


### PR DESCRIPTION
Add back OpenAPI test that got removed when the logic to skip OpenAPI generation for designs that
do not include HTTP services was introduced.