### PR TITLE
struct:field:type implementation (#2053)

### DIFF
--- a/codegen/generator/example.go
+++ b/codegen/generator/example.go
@@ -59,6 +59,13 @@ func Example(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 				files = append(files, fs...)
 			}
 		}
+		for _, f := range files {
+			if len(f.SectionTemplates) > 0 {
+				for _, s := range r.Services {
+					service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s)
+				}
+			}
+		}
 	}
 	return files, nil
 }

--- a/codegen/generator/service.go
+++ b/codegen/generator/service.go
@@ -26,6 +26,11 @@ func Service(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 				if f := service.ViewsFile(genpkg, s); f != nil {
 					files = append(files, f)
 				}
+				for _, f := range files {
+					if len(f.SectionTemplates) > 0 {
+						service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s)
+					}
+				}
 				f, err := service.ConvertFile(r, s)
 				if err != nil {
 					return nil, err

--- a/codegen/generator/transport.go
+++ b/codegen/generator/transport.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/codegen/service"
 	"goa.design/goa/v3/eval"
 	"goa.design/goa/v3/expr"
 	grpccodegen "goa.design/goa/v3/grpc/codegen"
@@ -36,6 +37,14 @@ func Transport(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 		files = append(files, grpccodegen.ServerTypeFiles(genpkg, r)...)
 		files = append(files, grpccodegen.ClientTypeFiles(genpkg, r)...)
 		files = append(files, grpccodegen.ClientCLIFiles(genpkg, r)...)
+
+		for _, f := range files {
+			if len(f.SectionTemplates) > 0 {
+				for _, s := range r.Services {
+					service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s)
+				}
+			}
+		}
 	}
 	if len(files) == 0 {
 		return nil, fmt.Errorf("transport: no HTTP/gRPC design found")

--- a/codegen/header.go
+++ b/codegen/header.go
@@ -18,15 +18,18 @@ func Header(title, pack string, imports []*ImportSpec) *SectionTemplate {
 	}
 }
 
-// AddImport adds an import to a section template that was generated with
+// AddImport adds imports to a section template that was generated with
 // Header.
-func AddImport(section *SectionTemplate, imprt *ImportSpec) {
+func AddImport(section *SectionTemplate, imprts ...*ImportSpec) {
+	if len(imprts) == 0 {
+		return
+	}
 	var specs []*ImportSpec
 	if data, ok := section.Data.(map[string]interface{}); ok {
 		if imports, ok := data["Imports"]; ok {
 			specs = imports.([]*ImportSpec)
 		}
-		data["Imports"] = append(specs, imprt)
+		data["Imports"] = append(specs, imprts...)
 	}
 }
 

--- a/codegen/import.go
+++ b/codegen/import.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"goa.design/goa/v3/expr"
 	"goa.design/goa/v3/pkg"
 )
 
@@ -60,4 +61,97 @@ func (s *ImportSpec) Code() string {
 		return fmt.Sprintf(`%s "%s"`, s.Name, s.Path)
 	}
 	return fmt.Sprintf(`"%s"`, s.Path)
+}
+
+// getMetaTypeInfo gets type and import info from an attribute's metadata. struct:field:type can have 3 arguments,
+// first being the go type name, second being import path,
+// and third being the name of a qualified import, in case of name collisions.
+func getMetaTypeInfo(att *expr.AttributeExpr) (typeName string, importS *ImportSpec) {
+	if att == nil {
+		return typeName, importS
+	}
+	if args, ok := att.Meta["struct:field:type"]; ok {
+		if len(args) > 0 {
+			typeName = args[0]
+		}
+		if len(args) > 1 {
+			importS = &ImportSpec{Path: args[1]}
+		}
+		if len(args) > 2 {
+			importS.Name = args[2]
+		}
+	}
+	return typeName, importS
+}
+
+// GetMetaTypeImports parses the attribute for all user defined imports
+func GetMetaTypeImports(att *expr.AttributeExpr) []*ImportSpec {
+	return safelyGetMetaTypeImports(att, nil)
+}
+
+// safelyGetMetaTypeImports parses attributes while keeping track of previous usertypes to avoid infinite recursion
+func safelyGetMetaTypeImports(att *expr.AttributeExpr, seen map[string]struct{}) []*ImportSpec {
+	if att == nil {
+		return nil
+	}
+	if seen == nil {
+		seen = make(map[string]struct{})
+	}
+	uniqueImports := make(map[ImportSpec]struct{})
+	imports := make([]*ImportSpec, 0)
+
+	switch t := att.Type.(type) {
+	case expr.UserType:
+		if _, wasSeen := seen[t.ID()]; wasSeen {
+			return imports
+		}
+		seen[t.ID()] = struct{}{}
+		for _, im := range safelyGetMetaTypeImports(t.Attribute(), seen) {
+			if im != nil {
+				uniqueImports[*im] = struct{}{}
+			}
+		}
+	case *expr.Array:
+		_, im := getMetaTypeInfo(t.ElemType)
+		if im != nil {
+			uniqueImports[*im] = struct{}{}
+		}
+	case *expr.Map:
+		_, im := getMetaTypeInfo(t.ElemType)
+		if im != nil {
+			uniqueImports[*im] = struct{}{}
+		}
+		_, im = getMetaTypeInfo(t.KeyType)
+		if im != nil {
+			uniqueImports[*im] = struct{}{}
+		}
+	case *expr.Object:
+		for _, key := range *t {
+			if key != nil {
+				_, im := getMetaTypeInfo(key.Attribute)
+				if im != nil {
+					uniqueImports[*im] = struct{}{}
+				}
+			}
+		}
+	}
+	_, im := getMetaTypeInfo(att)
+	if im != nil {
+		uniqueImports[*im] = struct{}{}
+	}
+	for imp := range uniqueImports {
+		// Copy loop variable into body so next iteration doesnt overwrite its address https://stackoverflow.com/questions/27610039/golang-appending-leaves-only-last-element
+		copy := imp
+		imports = append(imports, &copy)
+	}
+	return imports
+}
+
+// AddServiceMetaTypeImports adds meta type imports for each method of the service expr
+func AddServiceMetaTypeImports(header *SectionTemplate, svc *expr.ServiceExpr) {
+	for _, m := range svc.Methods {
+		AddImport(header, GetMetaTypeImports(m.Payload)...)
+		AddImport(header, GetMetaTypeImports(m.StreamingPayload)...)
+		AddImport(header, GetMetaTypeImports(m.Result)...)
+	}
 }

--- a/codegen/scope.go
+++ b/codegen/scope.go
@@ -98,6 +98,9 @@ func (s *NameScope) Name(name string) string {
 func (s *NameScope) GoTypeDef(att *expr.AttributeExpr, ptr, useDefault bool) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
+		if t, _ := getMetaTypeInfo(att); t != "" {
+			return t
+		}
 		return GoNativeTypeName(actual)
 	case *expr.Array:
 		d := s.GoTypeDef(actual.ElemType, ptr, useDefault)
@@ -186,6 +189,9 @@ func (s *NameScope) GoTypeName(att *expr.AttributeExpr) string {
 func (s *NameScope) GoFullTypeName(att *expr.AttributeExpr, pkg string) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
+		if t, _ := getMetaTypeInfo(att); t != "" {
+			return t
+		}
 		return GoNativeTypeName(actual)
 	case *expr.Array:
 		return "[]" + s.GoFullTypeRef(actual.ElemType, pkg)

--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -66,7 +66,6 @@ func File(genpkg string, service *expr.ServiceExpr) *codegen.File {
 			}
 		}
 	}
-
 	for _, ut := range svc.userTypes {
 		if _, ok := seen[ut.Name]; !ok {
 			sections = append(sections, &codegen.SectionTemplate{
@@ -150,6 +149,24 @@ func File(genpkg string, service *expr.ServiceExpr) *codegen.File {
 	}
 
 	return &codegen.File{Path: path, SectionTemplates: sections}
+}
+
+// AddServiceDataMetaTypeImports Adds all imports defined by struct:field:type from the service expr and the service data
+func AddServiceDataMetaTypeImports(header *codegen.SectionTemplate, serviceE *expr.ServiceExpr) {
+	codegen.AddServiceMetaTypeImports(header, serviceE)
+	svc := Services.Get(serviceE.Name)
+	for _, ut := range svc.userTypes {
+		codegen.AddImport(header, codegen.GetMetaTypeImports(ut.Type.Attribute())...)
+	}
+	for _, et := range svc.errorTypes {
+		codegen.AddImport(header, codegen.GetMetaTypeImports(et.Type.Attribute())...)
+	}
+	for _, t := range svc.viewedResultTypes {
+		codegen.AddImport(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
+	}
+	for _, t := range svc.projectedTypes {
+		codegen.AddImport(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
+	}
 }
 
 func errorName(et *UserTypeData) string {

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -63,6 +63,22 @@ import (
 //        })
 //    })
 //
+// - "struct:field:type" overrides the Go struct field type specified in the design, with one caveat;
+// if the type would have been a pointer (such as its not Required) the new type will also be a pointer.
+// Applicable to attributes only. The import path of the type should be passed in as the second parameter, if needed.
+// If the default imported package name conflicts with another, you can override that as well with the third parameter.
+//
+//    var MyType = Type("BigOleMessage", func() {
+//        Attribute("type", String, "Type of big payload")
+//				Attribute("bigPayload", String, "Don't parse it if you don't have to",func() {
+//					Meta("struct:field:type","json.RawMessage","encoding/json")
+//				})
+//				Attribute("id", String, func() {
+//					Meta("struct:field:type","bison.ObjectId", "github.com/globalsign/mgo/bson", "bison")
+//				})
+//    })
+//
+//
 // - "struct:tag:xxx" sets a generated Go struct field tag and overrides tags
 // that goa would otherwise set. If the metadata value is a slice then the
 // strings are joined with the space character as separator. Applicable to


### PR DESCRIPTION
* Added support for struct:field:type, added new functions for adding imports to codegen.File and added a new parameter to struct:field:type that allows qualified imports. Meta imports are available for method payloads to use as well

* added comments, maintained backward compat with AddImport, unexported GetMetaType

* appeased linter, added tests to to types_test.go, clarified pointer caveat with struct:field:type

* aligned comments

* fix infinite recursion