### PR TITLE
Fixed ArrayOf(UInt32) conversion to use the right cast

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1023,7 +1023,7 @@ const typeConversionT = `{{- define "slice_conversion" }}
 			if err2 != nil {
 				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of unsigned integers"))
 			}
-			{{ .VarName }}[i] = int32(v)
+			{{ .VarName }}[i] = uint32(v)
 		{{- else if eq .Type.ElemType.Type.Name "uint64" }}
 			v, err2 := strconv.ParseUint(rv, 10, 64)
 			if err2 != nil {

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -1117,7 +1117,7 @@ func DecodeMethodQueryArrayUInt32ValidateRequest(mux goahttp.Muxer, decoder func
 				if err2 != nil {
 					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("q", qRaw, "array of unsigned integers"))
 				}
-				q[i] = int32(v)
+				q[i] = uint32(v)
 			}
 		}
 		if len(q) < 1 {

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -1083,7 +1083,7 @@ func DecodeMethodQueryArrayUInt32Request(mux goahttp.Muxer, decoder func(*http.R
 					if err2 != nil {
 						err = goa.MergeErrors(err, goa.InvalidFieldTypeError("q", qRaw, "array of unsigned integers"))
 					}
-					q[i] = int32(v)
+					q[i] = uint32(v)
 				}
 			}
 		}


### PR DESCRIPTION
The generated DecodeXyz function for uint32 arrays was using an int32() cast instead of uint32.