### PR TITLE
Return complete list of transform helpers

### DIFF
--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -443,7 +443,7 @@ func collectHelpers(source, target *expr.AttributeExpr, req bool, ta *TransformA
 		var err error
 		{
 			walkMatches(source, target, func(srcMatt, _ *expr.MappedAttributeExpr, srcc, tgtc *expr.AttributeExpr, n string) {
-				name := transformHelperName(source, target, ta)
+				name := transformHelperName(srcc, tgtc, ta)
 				if _, ok := seen[name]; ok {
 					return
 				}

--- a/codegen/go_transform_helpers_test.go
+++ b/codegen/go_transform_helpers_test.go
@@ -1,0 +1,58 @@
+package codegen
+
+import (
+	"testing"
+
+	"goa.design/goa/codegen/testdata"
+	"goa.design/goa/expr"
+)
+
+func TestGoTransformHelpers(t *testing.T) {
+	root := RunDSL(t, testdata.TestTypesDSL)
+	var (
+		scope = NewNameScope()
+		// types to test
+		simple    = root.UserType("Simple")
+		recursive = root.UserType("Recursive")
+		composite = root.UserType("Composite")
+		deep      = root.UserType("Deep")
+		// attribute contexts used in test cases
+		defaultCtx = NewAttributeContext(false, false, true, "", scope)
+	)
+	tc := []struct {
+		Name        string
+		Type        expr.DataType
+		HelperNames []string
+	}{
+		{"simple", simple, []string{}},
+		{"recursive", recursive, []string{"transformRecursiveToRecursive"}},
+		{"composite", composite, []string{"transformSimpleToSimple"}},
+		{"deep", deep, []string{"transformCompositeToComposite", "transformSimpleToSimple"}},
+	}
+	for _, c := range tc {
+		t.Run(c.Name, func(t *testing.T) {
+			if c.Type == nil {
+				t.Fatal("source type not found in testdata")
+			}
+			_, funcs, err := GoTransform(&expr.AttributeExpr{Type: c.Type}, &expr.AttributeExpr{Type: c.Type}, "source", "target", defaultCtx, defaultCtx, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(funcs) != len(c.HelperNames) {
+				t.Errorf("invalid helpers count, got: %d, expected %d", len(funcs), len(c.HelperNames))
+			} else {
+				var diffs []string
+				actual := make([]string, len(funcs))
+				for i, f := range funcs {
+					actual[i] = f.Name
+					if c.HelperNames[i] != f.Name {
+						diffs = append(diffs, f.Name)
+					}
+				}
+				if len(diffs) > 0 {
+					t.Errorf("invalid helper names, got: %v, expected: %v", actual, c.HelperNames)
+				}
+			}
+		})
+	}
+}

--- a/codegen/go_transform_test.go
+++ b/codegen/go_transform_test.go
@@ -90,8 +90,8 @@ func TestGoTransform(t *testing.T) {
 
 			// others
 			{"recursive-to-recursive", recursive, recursive, defaultCtx, defaultCtx, srcTgtUseDefaultRecursiveToRecursiveCode},
-			{"recursiveArray-to-recursiveArray", recursiveArray, recursiveArray, defaultCtx, defaultCtx, srcTgtUseDefaultRecursiveArrayToRecursiveArrayCode},
-			{"recursiveMap-to-recursiveMap", recursiveMap, recursiveMap, defaultCtx, defaultCtx, srcTgtUseDefaultRecursiveMapToRecursiveMapCode},
+			{"recursive-array-to-recursive-array", recursiveArray, recursiveArray, defaultCtx, defaultCtx, srcTgtUseDefaultRecursiveArrayToRecursiveArrayCode},
+			{"recursive-map-to-recursive-map", recursiveMap, recursiveMap, defaultCtx, defaultCtx, srcTgtUseDefaultRecursiveMapToRecursiveMapCode},
 			{"composite-to-custom-field", composite, customField, defaultCtx, defaultCtx, srcTgtUseDefaultCompositeToCustomFieldCode},
 			{"custom-field-to-composite", customField, composite, defaultCtx, defaultCtx, srcTgtUseDefaultCustomFieldToCompositeCode},
 			{"composite-to-custom-field-pkg", composite, customField, defaultCtx, defaultCtxPkg, srcTgtUseDefaultCompositeToCustomFieldPkgCode},

--- a/codegen/testdata/types_dsl.go
+++ b/codegen/testdata/types_dsl.go
@@ -90,12 +90,17 @@ var TestTypesDSL = func() {
 			Attribute("map_array", ArrayOf(MapOf(Int, String)))
 		})
 
-		_ = Type("Composite", func() {
+		Composite = Type("Composite", func() {
 			Attribute("required_string", String)
 			Attribute("default_int", Int)
 			Attribute("type", Simple)
 			Attribute("map", MapOf(Int, String))
 			Attribute("array", ArrayOf(String))
+		})
+
+		_ = Type("Deep", func() {
+			Attribute("string", String)
+			Attribute("inner", Composite)
 		})
 
 		_ = Type("CompositeWithCustomField", func() {


### PR DESCRIPTION
when dealing with user types that have attributes defined with
user types recursively.

Fix #2126