### PR TITLE
Issue 2157 - Add support for text plain content type

### DIFF
--- a/expr/http_response.go
+++ b/expr/http_response.go
@@ -141,12 +141,12 @@ func (r *HTTPResponseExpr) Validate(e *HTTPEndpointExpr) *eval.ValidationErrors 
 	}
 
 	// text/html can only encode strings so make sure there isn't an explicit conflict with the content-type and response.
-	if r.ContentType == "text/html" {
+	if r.ContentType == "text/html" || r.ContentType == "text/plain" {
 		if e.MethodExpr.Result.Type != nil && e.MethodExpr.Result.Type != String && e.MethodExpr.Result.Type != Bytes && r.Body == nil {
-			verr.Add(r, "Result type must be String or Bytes when ContentType is 'text/html'")
+			verr.Add(r, fmt.Sprintf("Result type must be String or Bytes when ContentType is '%s'", r.ContentType))
 		}
 		if r.Body != nil && r.Body.Type != String && r.Body.Type != Bytes {
-			verr.Add(r, "Result type must be String or Bytes when ContentType is 'text/html'")
+			verr.Add(r, fmt.Sprintf("Result type must be String or Bytes when ContentType is '%s'", r.ContentType))
 		}
 	}
 

--- a/expr/http_response_test.go
+++ b/expr/http_response_test.go
@@ -17,10 +17,12 @@ func TestHTTPResponseValidation(t *testing.T) {
 		{"non empty result", nonEmptyResultEmptyResponseDSL, ""},
 		{"non empty response", emptyResultNonEmptyResponseDSL, ""},
 		{"string result", stringResultResponseWithHeadersDSL, ""},
+		{"string result", stringResultResponseWithTextContentTypeDSL, ""},
 		{"object result", objectResultResponseWithHeadersDSL, ""},
 		{"array result", arrayResultResponseWithHeadersDSL, ""},
 		{"map result", mapResultResponseWithHeadersDSL, ""},
 		{"invalid", emptyResultResponseWithHeadersDSL, `HTTP response of service "EmptyResultResponseWithHeaders" HTTP endpoint "Method": response defines headers but result is empty`},
+		{"not string or []byte", intResultResponseWithTextContentTypeDSL, `HTTP response of service "StringResultResponseWithHeaders" HTTP endpoint "Method": Result type must be String or Bytes when ContentType is 'text/plain'`},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -82,6 +84,20 @@ var stringResultResponseWithHeadersDSL = func() {
 	})
 }
 
+var stringResultResponseWithTextContentTypeDSL = func() {
+	Service("StringResultResponseWithHeaders", func() {
+		Method("Method", func() {
+			Result(String)
+			HTTP(func() {
+				POST("/")
+				Response(func() {
+					ContentType("text/plain")
+				})
+			})
+		})
+	})
+}
+
 var objectResultResponseWithHeadersDSL = func() {
 	Service("ObjectResultResponseWithHeaders", func() {
 		Method("Method", func() {
@@ -137,6 +153,20 @@ var emptyResultResponseWithHeadersDSL = func() {
 				POST("/")
 				Response(func() {
 					Header("foo:Location")
+				})
+			})
+		})
+	})
+}
+
+var intResultResponseWithTextContentTypeDSL = func() {
+	Service("StringResultResponseWithHeaders", func() {
+		Method("Method", func() {
+			Result(Int)
+			HTTP(func() {
+				POST("/")
+				Response(func() {
+					ContentType("text/plain")
 				})
 			})
 		})

--- a/http/encoding.go
+++ b/http/encoding.go
@@ -103,10 +103,8 @@ func ResponseEncoder(ctx context.Context, w http.ResponseWriter) Encoder {
 			return xml.NewEncoder(w), "application/xml"
 		case "application/gob":
 			return gob.NewEncoder(w), "application/gob"
-		case "text/html":
-			return newTextHTMLEncoder(w), "text/html"
-		case "text/plain":
-			return newTextPlainEncoder(w), "text/plain"
+		case "text/html", "text/plain":
+			return newTextEncoder(w, a), a
 		}
 		return nil, ""
 	}
@@ -139,10 +137,9 @@ func ResponseEncoder(ctx context.Context, w http.ResponseWriter) Encoder {
 					enc = xml.NewEncoder(w)
 				case ct == "application/gob" || strings.HasSuffix(ct, "+gob"):
 					enc = gob.NewEncoder(w)
-				case ct == "text/html" || strings.HasSuffix(ct, "+html"):
-					enc = newTextHTMLEncoder(w)
-				case ct == "text/plain" || strings.HasSuffix(ct, "+txt"):
-					enc = newTextPlainEncoder(w)
+				case ct == "text/html" || ct == "text/plain" ||
+					strings.HasSuffix(ct, "+html") || strings.HasSuffix(ct, "+txt"):
+					enc = newTextEncoder(w, ct)
 				default:
 					enc = json.NewEncoder(w)
 				}
@@ -197,10 +194,9 @@ func ResponseDecoder(resp *http.Response) Decoder {
 		return xml.NewDecoder(resp.Body)
 	case ct == "application/gob" || strings.HasSuffix(ct, "+gob"):
 		return gob.NewDecoder(resp.Body)
-	case ct == "text/html" || strings.HasSuffix(ct, "+html"):
-		return newTextHTMLDecoder(resp.Body)
-	case ct == "text/plain" || strings.HasSuffix(ct, "+txt"):
-		return newTextPlainDecoder(resp.Body)
+	case ct == "text/html" || ct == "text/plain" ||
+		strings.HasSuffix(ct, "+html") || strings.HasSuffix(ct, "+txt"):
+		return newTextDecoder(resp.Body, ct)
 	default:
 		return json.NewDecoder(resp.Body)
 	}
@@ -253,15 +249,16 @@ func SetContentType(w http.ResponseWriter, ct string) {
 	w.Header().Set("Content-Type", h+suffix)
 }
 
-func newTextHTMLEncoder(w io.Writer) Encoder {
-	return &textHTMLEncoder{w}
+func newTextEncoder(w io.Writer, ct string) Encoder {
+	return &textEncoder{w, ct}
 }
 
-type textHTMLEncoder struct {
-	w io.Writer
+type textEncoder struct {
+	w  io.Writer
+	ct string
 }
 
-func (e *textHTMLEncoder) Encode(v interface{}) error {
+func (e *textEncoder) Encode(v interface{}) error {
 	var err error
 
 	switch c := v.(type) {
@@ -272,21 +269,22 @@ func (e *textHTMLEncoder) Encode(v interface{}) error {
 	case []byte:
 		_, err = e.w.Write(c)
 	default:
-		err = fmt.Errorf("can't encode %T as text/html", c)
+		err = fmt.Errorf("can't encode %T as %s", c, e.ct)
 	}
 
 	return err
 }
 
-func newTextHTMLDecoder(r io.Reader) Decoder {
-	return &textHTMLDecoder{r}
+func newTextDecoder(r io.Reader, ct string) Decoder {
+	return &textDecoder{r, ct}
 }
 
-type textHTMLDecoder struct {
-	r io.Reader
+type textDecoder struct {
+	r  io.Reader
+	ct string
 }
 
-func (e *textHTMLDecoder) Decode(v interface{}) error {
+func (e *textDecoder) Decode(v interface{}) error {
 	b, err := ioutil.ReadAll(e.r)
 	if err != nil {
 		return err
@@ -298,58 +296,7 @@ func (e *textHTMLDecoder) Decode(v interface{}) error {
 	case *[]byte:
 		*c = []byte(string(b))
 	default:
-		err = fmt.Errorf("can't decode text/html to %T", c)
-	}
-
-	return err
-}
-
-func newTextPlainEncoder(w io.Writer) Encoder {
-	return &textPlainEncoder{w}
-}
-
-type textPlainEncoder struct {
-	w io.Writer
-}
-
-func (e *textPlainEncoder) Encode(v interface{}) error {
-	var err error
-
-	switch c := v.(type) {
-	case string:
-		_, err = e.w.Write([]byte(c))
-	case *string: // v may be a string pointer when the Response Body is set to the field of a custom response type.
-		_, err = e.w.Write([]byte(*c))
-	case []byte:
-		_, err = e.w.Write(c)
-	default:
-		err = fmt.Errorf("can't encode %T as text/plain", c)
-	}
-
-	return err
-}
-
-func newTextPlainDecoder(r io.Reader) Decoder {
-	return &textPlainDecoder{r}
-}
-
-type textPlainDecoder struct {
-	r io.Reader
-}
-
-func (e *textPlainDecoder) Decode(v interface{}) error {
-	b, err := ioutil.ReadAll(e.r)
-	if err != nil {
-		return err
-	}
-
-	switch c := v.(type) {
-	case *string:
-		*c = string(b)
-	case *[]byte:
-		*c = []byte(string(b))
-	default:
-		err = fmt.Errorf("can't decode text/plain to %T", c)
+		err = fmt.Errorf("can't decode %s to %T", e.ct, c)
 	}
 
 	return err

--- a/http/encoding_test.go
+++ b/http/encoding_test.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+var (
+	testString = "test string"
+)
+
+func TestTextPlainEncoder_Encode(t *testing.T) {
+	cases := []struct {
+		name  string
+		value interface{}
+		error error
+	}{
+		{"string", testString, nil},
+		{"*string", &testString, nil},
+		{"[]byte", []byte(testString), nil},
+		{"other", 123, fmt.Errorf("can't encode int as text/plain")},
+	}
+
+	buffer := bytes.Buffer{}
+	encoder := textPlainEncoder{w: &buffer}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buffer.Reset()
+			err := encoder.Encode(c.value)
+			if c.error != nil {
+				if err == nil || c.error.Error() != err.Error() {
+					t.Errorf("got error %q, expected %q", err, c.error)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("got error %q, expected <nil>", err)
+				}
+				if buffer.String() != testString {
+					t.Errorf("got string %s, expected %s", buffer.String(), testString)
+				}
+			}
+		})
+	}
+}
+
+func TestTextPlainDecoder_Decode_String(t *testing.T) {
+	buffer := bytes.Buffer{}
+	buffer.WriteString(testString)
+	encoder := textPlainDecoder{r: &buffer}
+
+	var value string
+	err := encoder.Decode(&value)
+	if err != nil {
+		t.Errorf("got error %q, expected <nil>", err)
+	}
+	if testString != value {
+		t.Errorf("got string %s, expected %s", value, testString)
+	}
+}
+
+func TestTextPlainDecoder_Decode_Bytes(t *testing.T) {
+	buffer := bytes.Buffer{}
+	buffer.WriteString(testString)
+	encoder := textPlainDecoder{r: &buffer}
+
+	var value []byte
+	err := encoder.Decode(&value)
+	if err != nil {
+		t.Errorf("got error %q, expected <nil>", err)
+	}
+	if testString != string(value) {
+		t.Errorf("got string %s, expected %s", value, testString)
+	}
+}
+
+func TestTextPlainDecoder_Decode_Other(t *testing.T) {
+	buffer := bytes.Buffer{}
+	buffer.WriteString(testString)
+	encoder := textPlainDecoder{r: &buffer}
+
+	expected := fmt.Errorf("can't decode text/plain to *int")
+
+	var value int
+	err := encoder.Decode(&value)
+	if err == nil || err.Error() != expected.Error() {
+		t.Errorf("got error %q, expected %q", err, expected)
+	}
+}

--- a/http/encoding_test.go
+++ b/http/encoding_test.go
@@ -3,12 +3,45 @@ package http
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"testing"
 )
 
 var (
 	testString = "test string"
 )
+
+func TestResponseDecoder(t *testing.T) {
+	cases := []struct {
+		contentType string
+		decoderType string
+	}{
+		{"application/json", "*json.Decoder"},
+		{"+json", "*json.Decoder"},
+		{"application/xml", "*xml.Decoder"},
+		{"+xml", "*xml.Decoder"},
+		{"application/gob", "*gob.Decoder"},
+		{"+gob", "*gob.Decoder"},
+		{"text/html", "*http.textDecoder"},
+		{"+html", "*http.textDecoder"},
+		{"text/plain", "*http.textDecoder"},
+		{"+txt", "*http.textDecoder"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.contentType, func(t *testing.T) {
+			r := &http.Response{
+				Header: map[string][]string{
+					"Content-Type": {c.contentType},
+				},
+			}
+			decoder := ResponseDecoder(r)
+			if c.decoderType != fmt.Sprintf("%T", decoder) {
+				t.Errorf("got decoder type %s, expected %s", fmt.Sprintf("%T", decoder), c.decoderType)
+			}
+		})
+	}
+}
 
 func TestTextEncoder_Encode(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
Since the implementations of `Encode` and `Decode` for `http.textHtml*` and `http.textPlain*` would have been the very same, I opted for introducing a single `http.textEncoder` and `http.textDecoder`.

It should be easy enough to split them in the future, if needed.

I also took the chance of adding some tests around the code I modified.