### PR TITLE
V3: Remove v3 dependencies from imports

### DIFF
--- a/codegen/service/example_svc_test.go
+++ b/codegen/service/example_svc_test.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"goa.design/goa/v3/codegen"
-	"goa.design/goa/v3/codegen/service/testdata"
-	"goa.design/goa/v3/expr"
+	"goa.design/goa/codegen"
+	"goa.design/goa/codegen/service/testdata"
+	"goa.design/goa/expr"
 )
 
 func TestExampleServiceFiles(t *testing.T) {

--- a/codegen/service/testdata/example_svc_dsls.go
+++ b/codegen/service/testdata/example_svc_dsls.go
@@ -1,7 +1,7 @@
 package testdata
 
 import (
-	. "goa.design/goa/v3/dsl"
+	. "goa.design/goa/dsl"
 )
 
 var ConflictWithAPINameAndServiceNameDSL = func() {


### PR DESCRIPTION
I made a mistake to describe the v3 dependency in #2172 .