### PR TITLE
V3: Fix to use the version of goa specified in go.mod file, when 'goa gen'/'goa example'

### DIFF
--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -142,14 +142,14 @@ func (g *Generator) Write(debug bool) error {
 	return err
 }
 
-const GOMODENVKEY = "GOMOD"
+const goModEnvKey = "GOMOD"
 
 func findGoMod() (string, error) {
-	env := os.Getenv(GOMODENVKEY)
+	env := os.Getenv(goModEnvKey)
 	if _, err := exec.LookPath("go"); err != nil {
 		return env, nil
 	}
-	mod, err := exec.Command("go", "env", GOMODENVKEY).Output()
+	mod, err := exec.Command("go", "env", goModEnvKey).Output()
 	if err != nil {
 		return env, nil
 	}

--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -175,7 +175,7 @@ func (g *Generator) goaPackage() (string, error) {
 	return parseGoModGoaPackage(goaPkg, fp)
 }
 
-var reMod = regexp.MustCompile(`(goa\.design/goa/v\d+?)\s+(\S+?)\s*$`)
+var reMod = regexp.MustCompile(`^\s*(?:require )?\s*(goa\.design/goa/v\d+?)\s+([^\/]\S+?)\s*(?:\/\/.+)?$`)
 
 func parseGoModGoaPackage(pkg string, r io.Reader) (string, error) {
 	s := bufio.NewScanner(r)

--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -197,7 +197,7 @@ func (g *Generator) Compile() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("go get %s", goaPkg)
+	fmt.Println("go get ", goaPkg)
 	if err := g.runGoCmd("get", goaPkg); err != nil {
 		return err
 	}

--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -144,16 +144,16 @@ func (g *Generator) Write(debug bool) error {
 
 const goModEnvKey = "GOMOD"
 
-func findGoMod() (string, error) {
+func findGoMod() string {
 	env := os.Getenv(goModEnvKey)
 	if _, err := exec.LookPath("go"); err != nil {
-		return env, nil
+		return env
 	}
 	mod, err := exec.Command("go", "env", goModEnvKey).Output()
 	if err != nil {
-		return env, nil
+		return env
 	}
-	return strings.TrimSpace(string(mod)), nil
+	return strings.TrimSpace(string(mod))
 }
 
 func (g *Generator) goaPackage() (string, error) {
@@ -162,10 +162,7 @@ func (g *Generator) goaPackage() (string, error) {
 		return goaPkg, nil
 	}
 	goaPkg = fmt.Sprintf("goa.design/goa/v%d", g.DesignVersion)
-	gomod, err := findGoMod()
-	if err != nil {
-		return "", fmt.Errorf("find go.mod error, %v", err)
-	}
+	gomod := findGoMod()
 	if _, err := os.Stat(gomod); err != nil {
 		return goaPkg, nil
 	}

--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -197,7 +197,6 @@ func (g *Generator) Compile() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("go get ", goaPkg)
 	if err := g.runGoCmd("get", goaPkg); err != nil {
 		return err
 	}

--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -197,6 +197,7 @@ func (g *Generator) Compile() error {
 	if err != nil {
 		return err
 	}
+	fmt.Println("go get %s", goaPkg)
 	if err := g.runGoCmd("get", goaPkg); err != nil {
 		return err
 	}

--- a/cmd/goa/gen_test.go
+++ b/cmd/goa/gen_test.go
@@ -35,11 +35,10 @@ func TestGenerator_goaPackage(t *testing.T) {
 		})
 	}
 }
+
 func TestParseGoModGoaPackage(t *testing.T) {
 	input := `module calc
-
 go 1.12
-
 require (
         github.com/smartystreets/assertions v1.0.0 // indirect
         goa.design/goa/v3 v3.0.3-0.20190704022140-85024ebc66dc

--- a/cmd/goa/gen_test.go
+++ b/cmd/goa/gen_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -37,20 +38,67 @@ func TestGenerator_goaPackage(t *testing.T) {
 }
 
 func TestParseGoModGoaPackage(t *testing.T) {
-	input := `module calc
+	cases := []struct {
+		Name     string
+		Mod      string
+		Package  string
+		Expected string
+	}{
+		{
+			Name:     "simple require",
+			Mod:      "require    goa.design/goa/v3   v3.0.3-0.20190704022140-85024ebc66dc",
+			Package:  "goa.design/goa/v3",
+			Expected: "goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc",
+		},
+		{
+			Name: "in require block",
+			Mod: `module calc
 go 1.12
 require (
-        github.com/smartystreets/assertions v1.0.0 // indirect
+        github.com/ikawaha/kagome v1.0.0 // indirect
         goa.design/goa/v3 v3.0.3-0.20190704022140-85024ebc66dc
         goa.design/plugins/v3 v3.0.1
 )
-`
-	expected := `goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc`
-	pkg, err := parseGoModGoaPackage("goa.design/goa/v3", []byte(input))
-	if err != nil {
-		t.Fatalf("unexpected error, %v", err)
+`,
+			Package:  "goa.design/goa/v3",
+			Expected: `goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc`,
+		},
+		{
+			Name: "not found",
+			Mod: `module calc
+go 1.12
+require (
+        github.com/ikawaha/kagome v1.0.0 // indirect
+        goa.design/plugins/v3 v3.0.1
+)
+`,
+			Package:  "goa.design/goa/v3",
+			Expected: "goa.design/goa/v3",
+		},
+		{
+			Name: "with replace",
+			Mod: `module calc
+go 1.12
+replace goa.design/goa/v3 => ../../../goa.design/goa
+require (
+        github.com/ikawaha/kagome v1.0.0 // indirect
+        goa.design/goa/v3 v3.0.3-0.20190704022140-85024ebc66dc
+        goa.design/plugins/v3 v3.0.1
+)
+`,
+			Package:  "goa.design/goa/v3",
+			Expected: `goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc`,
+		},
 	}
-	if pkg != expected {
-		t.Errorf("expected %v, got %v", expected, pkg)
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			pkg, err := parseGoModGoaPackage("goa.design/goa/v3", strings.NewReader(c.Mod))
+			if err != nil {
+				t.Fatalf("unexpected error, %v", err)
+			}
+			if pkg != c.Expected {
+				t.Errorf("expected %v, got %v", c.Expected, pkg)
+			}
+		})
 	}
 }

--- a/cmd/goa/gen_test.go
+++ b/cmd/goa/gen_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -146,5 +147,64 @@ require (
 				t.Errorf("expected %v, got %v", c.Expected, pkg)
 			}
 		})
+	}
+}
+
+func TestModPatternRegexp(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Input    string
+		Expected []string
+	}{
+		{
+			Name:     "goa v3 release version",
+			Input:    "goa.design/goa/v3 v3.0.2",
+			Expected: []string{"goa.design/goa/v3 v3.0.2", "goa.design/goa/v3", "v3.0.2"},
+		},
+		{
+			Name:     "goa v3 commit number",
+			Input:    "goa.design/goa/v3 02c84c9b39d845611bfe6e8a96465d698ea374b1",
+			Expected: []string{"goa.design/goa/v3 02c84c9b39d845611bfe6e8a96465d698ea374b1", "goa.design/goa/v3", "02c84c9b39d845611bfe6e8a96465d698ea374b1"},
+		},
+		{
+			Name:     "goa v3 with comment",
+			Input:    "goa.design/goa/v3   v3.0.2 //comment1 //comment2 //comment3",
+			Expected: []string{"goa.design/goa/v3   v3.0.2 //comment1 //comment2 //comment3", "goa.design/goa/v3", "v3.0.2"},
+		},
+		{
+			Name:     "goa v3 with require and comment",
+			Input:    "require goa.design/goa/v3 v3.0.2 //comment",
+			Expected: []string{"require goa.design/goa/v3 v3.0.2 //comment", "goa.design/goa/v3", "v3.0.2"},
+		},
+		{
+			Name:     "goa v2",
+			Input:    "goa.design/goa/v2 v2.0.0",
+			Expected: []string{"goa.design/goa/v2 v2.0.0", "goa.design/goa/v2", "v2.0.0"},
+		},
+		{
+			Name:     "goa v123",
+			Input:    "   goa.design/goa/v123    v123.4.5   ",
+			Expected: []string{"   goa.design/goa/v123    v123.4.5   ", "goa.design/goa/v123", "v123.4.5"},
+		},
+		{
+			Name:     "without version",
+			Input:    "goa.design/goa/v3",
+			Expected: nil,
+		},
+		{
+			Name:     "comment out",
+			Input:    "// goa.design/goa/v3 v3.0.0",
+			Expected: nil,
+		},
+		{
+			Name:     "irrelevant package",
+			Input:    "github.com/ikawaha/kagome v1.10.0",
+			Expected: nil,
+		},
+	}
+	for _, c := range cases {
+		if got := reMod.FindStringSubmatch(c.Input); !reflect.DeepEqual(c.Expected, got) {
+			t.Errorf("expected %+v, got %+v", c.Expected, got)
+		}
 	}
 }

--- a/cmd/goa/gen_test.go
+++ b/cmd/goa/gen_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGenerator_goaPackage(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Version  int
+		Expected string
+	}{
+		{
+			Name:     "specify v2",
+			Version:  2,
+			Expected: "goa.design/goa",
+		},
+		{
+			Name:     "specify v3, but go.mod file does not exist",
+			Version:  3,
+			Expected: "goa.design/goa/v3",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			pkg, err := (&Generator{
+				DesignVersion: c.Version,
+			}).goaPackage()
+			if err != nil {
+				t.Fatalf("unexpected error, %v", err)
+			}
+			if pkg != c.Expected {
+				t.Errorf("expected %v, got %v", c.Expected, pkg)
+			}
+		})
+	}
+}
+func TestParseGoModGoaPackage(t *testing.T) {
+	input := `module calc
+
+go 1.12
+
+require (
+        github.com/smartystreets/assertions v1.0.0 // indirect
+        goa.design/goa/v3 v3.0.3-0.20190704022140-85024ebc66dc
+        goa.design/plugins/v3 v3.0.1
+)
+`
+	expected := `goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc`
+	pkg, err := parseGoModGoaPackage("goa.design/goa/v3", []byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error, %v", err)
+	}
+	if pkg != expected {
+		t.Errorf("expected %v, got %v", expected, pkg)
+	}
+}

--- a/cmd/goa/gen_test.go
+++ b/cmd/goa/gen_test.go
@@ -61,7 +61,7 @@ require (
 )
 `,
 			Package:  "goa.design/goa/v3",
-			Expected: `goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc`,
+			Expected: "goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc",
 		},
 		{
 			Name: "not found",
@@ -87,7 +87,53 @@ require (
 )
 `,
 			Package:  "goa.design/goa/v3",
-			Expected: `goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc`,
+			Expected: "goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc",
+		},
+		{
+			Name: "with comment",
+			Mod: `module calc
+go 1.12
+replace goa.design/goa/v3 => ../../../goa.design/goa
+require (
+        github.com/ikawaha/kagome v1.0.0 // indirect
+        goa.design/goa/v3 v3.0.3-0.20190704022140-85024ebc66dc // indirect // comment
+        goa.design/plugins/v3 v3.0.1
+)
+`,
+			Package:  "goa.design/goa/v3",
+			Expected: "goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc",
+		},
+		{
+			Name:     "require with comment",
+			Mod:      " require goa.design/goa/v3 v3.0.3-0.20190704022140-85024ebc66dc// indirect // comment",
+			Package:  "goa.design/goa/v3",
+			Expected: "goa.design/goa/v3@v3.0.3-0.20190704022140-85024ebc66dc",
+		},
+		{
+			Name: "comment out",
+			Mod: `module calc
+go 1.12
+replace goa.design/goa/v3 => ../../../goa.design/goa
+require (
+        github.com/ikawaha/kagome v1.0.0 // indirect
+        // goa.design/goa/v3 v3.0.3-0.20190704022140-85024ebc66dc
+        goa.design/plugins/v3 v3.0.1
+)
+`,
+			Package:  "goa.design/goa/v3",
+			Expected: "goa.design/goa/v3",
+		},
+		{
+			Name:     "without version",
+			Mod:      "     goa.design/goa/v3//v3.0.3-0.20190704022140-85024ebc66dc",
+			Package:  "goa.design/goa/v3",
+			Expected: "goa.design/goa/v3",
+		},
+		{
+			Name:     "different version",
+			Mod:      "goa.design/goa/v2 v2.0.3-0.20190704022140-85024ebc66dc // comment",
+			Package:  "goa.design/goa/v3",
+			Expected: "goa.design/goa/v3",
 		},
 	}
 	for _, c := range cases {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v1.0.0
+	github.com/sirkon/goproxy v1.4.0
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
 	golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v1.0.0
-	github.com/sirkon/goproxy v1.4.0
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
 	golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c


### PR DESCRIPTION
Fix issue #2181