### PR TITLE
Handle nil requests in GRPC client method builder

### DIFF
--- a/grpc/codegen/client.go
+++ b/grpc/codegen/client.go
@@ -240,7 +240,10 @@ func Build{{ .Method.VarName }}Func(grpccli {{ .PkgName }}.{{ .ClientInterface }
 		for _, opt := range cliopts {
 			opts = append(opts, opt)
 		}
-		return grpccli.{{ .Method.VarName }}(ctx{{ if not .Method.StreamingPayload }}, reqpb.({{ .Request.ClientConvert.TgtRef }}){{ end }}, opts...)
+		if reqpb != nil {
+			return grpccli.{{ .Method.VarName }}(ctx{{ if not .Method.StreamingPayload }}, reqpb.({{ .Request.ClientConvert.TgtRef }}){{ end }}, opts...)
+		}
+		return grpccli.{{ .Method.VarName }}(ctx{{ if not .Method.StreamingPayload }}, &{{ .Request.ClientConvert.TgtName }}{}{{ end }}, opts...)
 	}
 }
 `


### PR DESCRIPTION
## What's up

The GRPC client remote method builder function casts the request interface into a pointer to the proto request struct. However, if the endpoint's input is an empty message then the client will be passing in a nil request interface. This causes a panic at the site of the interface cast.

## What this does

Checks if the proto request obj is nil before casting. If it's nil, then we return a pointer to the empty proto request struct instead of casting the request interface to it.

### Before
```go
// BuildDoStuffFunc builds the remote method to invoke for "dummy" service
// "doStuff" endpoint.
func BuildDoStuffFunc(grpccli dummypb.DummyClient, cliopts ...grpc.CallOption) goagrpc.RemoteFunc {
	return func(ctx context.Context, reqpb interface{}, opts ...grpc.CallOption) (interface{}, error) {
		for _, opt := range cliopts {
			opts = append(opts, opt)
		}
		return grpccli.DoStuff(ctx, reqpb.(*dummypb.DoStuffRequest), opts...)
	}
}
```

### After
```go
// BuildDoStuffFunc builds the remote method to invoke for "dummy" service
// "doStuff" endpoint.
func BuildDoStuffFunc(grpccli dummypb.DummyClient, cliopts ...grpc.CallOption) goagrpc.RemoteFunc {
	return func(ctx context.Context, reqpb interface{}, opts ...grpc.CallOption) (interface{}, error) {
		for _, opt := range cliopts {
			opts = append(opts, opt)
		}
		if reqpb != nil {
			return grpccli.DoStuff(ctx, reqpb.(*dummypb.DoStuffRequest), opts...)
		}
		return grpccli.DoStuff(ctx, &dummypb.DoStuffRequest{}, opts...)
	}
}
```
Fixes #2185