### PR TITLE
Add failing test case for validation of array of UserTypes

### DIFF
--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -222,12 +222,12 @@ func recurseValidationCode(att *expr.AttributeExpr, attCtx *AttributeContext, re
 		ctx.Pointer = false
 		val := recurseValidationCode(a.ElemType, ctx, true, "e", context+"[*]", seen).String()
 
-		switch a.ElemType.Type.(type) {
-		case expr.UserType:
-			// For user and result types, call the Validate method
-			val = runUserValT(attCtx.Scope.Name(a.ElemType, ctx.Pkg), "e")
-		}
 		if val != "" {
+			switch a.ElemType.Type.(type) {
+			case expr.UserType:
+				// For user and result types, call the Validate method
+				val = runUserValT(attCtx.Scope.Name(a.ElemType, ctx.Pkg), "e")
+			}
 			data := map[string]interface{}{
 				"target":     target,
 				"validation": val,

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -221,12 +221,13 @@ func recurseValidationCode(att *expr.AttributeExpr, attCtx *AttributeContext, re
 		ctx := attCtx.Dup()
 		ctx.Pointer = false
 		val := recurseValidationCode(a.ElemType, ctx, true, "e", context+"[*]", seen).String()
+
+		switch a.ElemType.Type.(type) {
+		case expr.UserType:
+			// For user and result types, call the Validate method
+			val = runUserValT(attCtx.Scope.Name(a.ElemType, ctx.Pkg), "e")
+		}
 		if val != "" {
-			switch a.ElemType.Type.(type) {
-			case expr.UserType:
-				// For user and result types, call the Validate method
-				val = runUserValT(attCtx.Scope.Name(a.ElemType, ctx.Pkg), "e")
-			}
 			data := map[string]interface{}{
 				"target":     target,
 				"validation": val,

--- a/http/codegen/server_types_test.go
+++ b/http/codegen/server_types_test.go
@@ -224,103 +224,105 @@ const PayloadValidateRecurseFile = `// MethodPayloadValidateRecurseValidatePaylo
 // "ServicePayloadValidateRecurseValidatePayload" service
 // "MethodPayloadValidateRecurseValidatePayload" endpoint HTTP request body.
 type MethodPayloadValidateRecurseValidatePayloadRequestBody struct {
-    A     *int                  ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
-    Inner *UTInnerRequestBody ` + "`" + `form:"inner,omitempty" json:"inner,omitempty" xml:"inner,omitempty"` + "`" + `
+	A     *int                ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
+	Inner *UTInnerRequestBody ` + "`" + `form:"inner,omitempty" json:"inner,omitempty" xml:"inner,omitempty"` + "`" + `
 }
 
 // UTInnerRequestBody is used to define fields on request body types.
 type UTInnerRequestBody struct {
-    B *string ` + "`" + `form:"b,omitempty" json:"b,omitempty" xml:"b,omitempty"` + "`" + `
+	B *string ` + "`" + `form:"b,omitempty" json:"b,omitempty" xml:"b,omitempty"` + "`" + `
 }
 
 // NewMethodPayloadValidateRecurseValidatePayloadPayload builds a
 // ServicePayloadValidateRecurseValidatePayload service
 // MethodPayloadValidateRecurseValidatePayload endpoint payload.
 func NewMethodPayloadValidateRecurseValidatePayloadPayload(body *MethodPayloadValidateRecurseValidatePayloadRequestBody) *servicepayloadvalidaterecursevalidatepayload.MethodPayloadValidateRecurseValidatePayloadPayload {
-    v := &servicepayloadvalidaterecursevalidatepayload.MethodPayloadValidateRecurseValidatePayloadPayload{
-        A: *body.A,
-    }
-    v.Inner = unmarshalUTInnerRequestBodyToServicepayloadvalidaterecursevalidatepayloadUTInner(body.Inner)
-    return v
+	v := &servicepayloadvalidaterecursevalidatepayload.MethodPayloadValidateRecurseValidatePayloadPayload{
+		A: *body.A,
+	}
+	v.Inner = unmarshalUTInnerRequestBodyToServicepayloadvalidaterecursevalidatepayloadUTInner(body.Inner)
+	return v
 }
 
 // ValidateMethodPayloadValidateRecurseValidatePayloadRequestBody runs the
 // validations defined on MethodPayloadValidateRecurseValidatePayloadRequestBody
 func ValidateMethodPayloadValidateRecurseValidatePayloadRequestBody(body *MethodPayloadValidateRecurseValidatePayloadRequestBody) (err error) {
-    if body.A == nil {
-        err = goa.MergeErrors(err, goa.MissingFieldError("a", "body"))
-    }
-    if body.Inner == nil {
-        err = goa.MergeErrors(err, goa.MissingFieldError("inner", "body"))
-    }
-    if body.Inner != nil {
-        if err2 := ValidateUTInnerRequestBody(body.Inner); err2 != nil {
-            err = goa.MergeErrors(err, err2)
-        }
-    }
-    return
+	if body.A == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("a", "body"))
+	}
+	if body.Inner == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("inner", "body"))
+	}
+	if body.Inner != nil {
+		if err2 := ValidateUTInnerRequestBody(body.Inner); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	return
 }
 
 // ValidateUTInnerRequestBody runs the validations defined on UTInnerRequestBody
 func ValidateUTInnerRequestBody(body *UTInnerRequestBody) (err error) {
-    if body.B == nil {
-        err = goa.MergeErrors(err, goa.MissingFieldError("b", "body"))
-    }
-    return
-}`
+	if body.B == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("b", "body"))
+	}
+	return
+}
+`
 
 const PayloadValidateArrayRecurseFile = `// MethodPayloadValidateArrayRecurseValidatePayloadRequestBody is the type of
 // the "ServicePayloadValidateArrayRecurseValidatePayload" service
 // "MethodPayloadValidateArrayRecurseValidatePayload" endpoint HTTP request
 // body.
 type MethodPayloadValidateArrayRecurseValidatePayloadRequestBody struct {
-    A     *int                  ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
-    Inner []*UTInnerRequestBody ` + "`" + `form:"inner,omitempty" json:"inner,omitempty" xml:"inner,omitempty"` + "`" + `
+	A     *int                  ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
+	Inner []*UTInnerRequestBody ` + "`" + `form:"inner,omitempty" json:"inner,omitempty" xml:"inner,omitempty"` + "`" + `
 }
 
 // UTInnerRequestBody is used to define fields on request body types.
 type UTInnerRequestBody struct {
-    B *string ` + "`" + `form:"b,omitempty" json:"b,omitempty" xml:"b,omitempty"` + "`" + `
+	B *string ` + "`" + `form:"b,omitempty" json:"b,omitempty" xml:"b,omitempty"` + "`" + `
 }
 
 // NewMethodPayloadValidateArrayRecurseValidatePayloadUTOuter builds a
 // ServicePayloadValidateArrayRecurseValidatePayload service
 // MethodPayloadValidateArrayRecurseValidatePayload endpoint payload.
 func NewMethodPayloadValidateArrayRecurseValidatePayloadUTOuter(body *MethodPayloadValidateArrayRecurseValidatePayloadRequestBody) *servicepayloadvalidatearrayrecursevalidatepayload.UTOuter {
-    v := &servicepayloadvalidatearrayrecursevalidatepayload.UTOuter{
-        A: *body.A,
-    }
-    v.Inner = make([]*servicepayloadvalidatearrayrecursevalidatepayload.UTInner, len(body.Inner))
-    for i, val := range body.Inner {
-        v.Inner[i] = unmarshalUTInnerRequestBodyToServicepayloadvalidatearrayrecursevalidatepayloadUTInner(val)
-    }
-    return v
+	v := &servicepayloadvalidatearrayrecursevalidatepayload.UTOuter{
+		A: *body.A,
+	}
+	v.Inner = make([]*servicepayloadvalidatearrayrecursevalidatepayload.UTInner, len(body.Inner))
+	for i, val := range body.Inner {
+		v.Inner[i] = unmarshalUTInnerRequestBodyToServicepayloadvalidatearrayrecursevalidatepayloadUTInner(val)
+	}
+	return v
 }
 
 // ValidateMethodPayloadValidateArrayRecurseValidatePayloadRequestBody runs the
 // validations defined on
 // MethodPayloadValidateArrayRecurseValidatePayloadRequestBody
 func ValidateMethodPayloadValidateArrayRecurseValidatePayloadRequestBody(body *MethodPayloadValidateArrayRecurseValidatePayloadRequestBody) (err error) {
-    if body.A == nil {
-        err = goa.MergeErrors(err, goa.MissingFieldError("a", "body"))
-    }
-    if body.Inner == nil {
-        err = goa.MergeErrors(err, goa.MissingFieldError("inner", "body"))
-    }
-    for _, e := range body.Inner {
-        if e != nil {
-            if err2 := ValidateUTInnerRequestBody(e); err2 != nil {
-                err = goa.MergeErrors(err, err2)
-            }
-        }
-    }
-    return
+	if body.A == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("a", "body"))
+	}
+	if body.Inner == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("inner", "body"))
+	}
+	for _, e := range body.Inner {
+		if e != nil {
+			if err2 := ValidateUTInnerRequestBody(e); err2 != nil {
+				err = goa.MergeErrors(err, err2)
+			}
+		}
+	}
+	return
 }
 
 // ValidateUTInnerRequestBody runs the validations defined on UTInnerRequestBody
 func ValidateUTInnerRequestBody(body *UTInnerRequestBody) (err error) {
-    if body.B == nil {
-        err = goa.MergeErrors(err, goa.MissingFieldError("b", "body"))
-    }
-    return
-}`
+	if body.B == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("b", "body"))
+	}
+	return
+}
+`

--- a/http/codegen/server_types_test.go
+++ b/http/codegen/server_types_test.go
@@ -19,6 +19,8 @@ func TestServerTypes(t *testing.T) {
 		{"mixed-payload-attrs", testdata.MixedPayloadInBodyDSL, MixedPayloadInBodyServerTypesFile},
 		{"multiple-methods", testdata.MultipleMethodsDSL, MultipleMethodsServerTypesFile},
 		{"payload-extend-validate", testdata.PayloadExtendedValidateDSL, PayloadExtendedValidateServerTypesFile},
+		{"payload-validate-recursion", testdata.PayloadValidateRecurseDSL, PayloadValidateRecurseFile},
+		{"payload-validate-array-recursion", testdata.PayloadValidateArrayRecurseDSL, PayloadValidateArrayRecurseFile},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -217,3 +219,108 @@ func ValidateMethodQueryStringExtendedValidatePayloadRequestBody(body *MethodQue
 	return
 }
 `
+
+const PayloadValidateRecurseFile = `// MethodPayloadValidateRecurseValidatePayloadRequestBody is the type of the
+// "ServicePayloadValidateRecurseValidatePayload" service
+// "MethodPayloadValidateRecurseValidatePayload" endpoint HTTP request body.
+type MethodPayloadValidateRecurseValidatePayloadRequestBody struct {
+    A     *int                  ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
+    Inner *UTInnerRequestBody ` + "`" + `form:"inner,omitempty" json:"inner,omitempty" xml:"inner,omitempty"` + "`" + `
+}
+
+// UTInnerRequestBody is used to define fields on request body types.
+type UTInnerRequestBody struct {
+    B *string ` + "`" + `form:"b,omitempty" json:"b,omitempty" xml:"b,omitempty"` + "`" + `
+}
+
+// NewMethodPayloadValidateRecurseValidatePayloadPayload builds a
+// ServicePayloadValidateRecurseValidatePayload service
+// MethodPayloadValidateRecurseValidatePayload endpoint payload.
+func NewMethodPayloadValidateRecurseValidatePayloadPayload(body *MethodPayloadValidateRecurseValidatePayloadRequestBody) *servicepayloadvalidaterecursevalidatepayload.MethodPayloadValidateRecurseValidatePayloadPayload {
+    v := &servicepayloadvalidaterecursevalidatepayload.MethodPayloadValidateRecurseValidatePayloadPayload{
+        A: *body.A,
+    }
+    v.Inner = unmarshalUTInnerRequestBodyToServicepayloadvalidaterecursevalidatepayloadUTInner(body.Inner)
+    return v
+}
+
+// ValidateMethodPayloadValidateRecurseValidatePayloadRequestBody runs the
+// validations defined on MethodPayloadValidateRecurseValidatePayloadRequestBody
+func ValidateMethodPayloadValidateRecurseValidatePayloadRequestBody(body *MethodPayloadValidateRecurseValidatePayloadRequestBody) (err error) {
+    if body.A == nil {
+        err = goa.MergeErrors(err, goa.MissingFieldError("a", "body"))
+    }
+    if body.Inner == nil {
+        err = goa.MergeErrors(err, goa.MissingFieldError("inner", "body"))
+    }
+    if body.Inner != nil {
+        if err2 := ValidateUTInnerRequestBody(body.Inner); err2 != nil {
+            err = goa.MergeErrors(err, err2)
+        }
+    }
+    return
+}
+
+// ValidateUTInnerRequestBody runs the validations defined on UTInnerRequestBody
+func ValidateUTInnerRequestBody(body *UTInnerRequestBody) (err error) {
+    if body.B == nil {
+        err = goa.MergeErrors(err, goa.MissingFieldError("b", "body"))
+    }
+    return
+}`
+
+const PayloadValidateArrayRecurseFile = `// MethodPayloadValidateArrayRecurseValidatePayloadRequestBody is the type of
+// the "ServicePayloadValidateArrayRecurseValidatePayload" service
+// "MethodPayloadValidateArrayRecurseValidatePayload" endpoint HTTP request
+// body.
+type MethodPayloadValidateArrayRecurseValidatePayloadRequestBody struct {
+    A     *int                  ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
+    Inner []*UTInnerRequestBody ` + "`" + `form:"inner,omitempty" json:"inner,omitempty" xml:"inner,omitempty"` + "`" + `
+}
+
+// UTInnerRequestBody is used to define fields on request body types.
+type UTInnerRequestBody struct {
+    B *string ` + "`" + `form:"b,omitempty" json:"b,omitempty" xml:"b,omitempty"` + "`" + `
+}
+
+// NewMethodPayloadValidateArrayRecurseValidatePayloadUTOuter builds a
+// ServicePayloadValidateArrayRecurseValidatePayload service
+// MethodPayloadValidateArrayRecurseValidatePayload endpoint payload.
+func NewMethodPayloadValidateArrayRecurseValidatePayloadUTOuter(body *MethodPayloadValidateArrayRecurseValidatePayloadRequestBody) *servicepayloadvalidatearrayrecursevalidatepayload.UTOuter {
+    v := &servicepayloadvalidatearrayrecursevalidatepayload.UTOuter{
+        A: *body.A,
+    }
+    v.Inner = make([]*servicepayloadvalidatearrayrecursevalidatepayload.UTInner, len(body.Inner))
+    for i, val := range body.Inner {
+        v.Inner[i] = unmarshalUTInnerRequestBodyToServicepayloadvalidatearrayrecursevalidatepayloadUTInner(val)
+    }
+    return v
+}
+
+// ValidateMethodPayloadValidateArrayRecurseValidatePayloadRequestBody runs the
+// validations defined on
+// MethodPayloadValidateArrayRecurseValidatePayloadRequestBody
+func ValidateMethodPayloadValidateArrayRecurseValidatePayloadRequestBody(body *MethodPayloadValidateArrayRecurseValidatePayloadRequestBody) (err error) {
+    if body.A == nil {
+        err = goa.MergeErrors(err, goa.MissingFieldError("a", "body"))
+    }
+    if body.Inner == nil {
+        err = goa.MergeErrors(err, goa.MissingFieldError("inner", "body"))
+    }
+    for _, e := range body.Inner {
+        if e != nil {
+            if err2 := ValidateUTInnerRequestBody(e); err2 != nil {
+                err = goa.MergeErrors(err, err2)
+            }
+        }
+    }
+    return
+}
+
+// ValidateUTInnerRequestBody runs the validations defined on UTInnerRequestBody
+func ValidateUTInnerRequestBody(body *UTInnerRequestBody) (err error) {
+    if body.B == nil {
+        err = goa.MergeErrors(err, goa.MissingFieldError("b", "body"))
+    }
+    return
+}`

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -1361,6 +1361,49 @@ var PayloadExtendedValidateDSL = func() {
 	})
 }
 
+var PayloadValidateRecurseDSL = func() {
+	var UTInner = Type("UTInner", func() {
+		Attribute("b", String)
+		Required("b")
+	})
+	var UTOuter = Type("UTOuter", func() {
+		Attribute("a", Int)
+		Attribute("inner", UTInner)
+		Required("a", "inner")
+	})
+	Service("ServicePayloadValidateRecurseValidatePayload", func() {
+		Method("MethodPayloadValidateRecurseValidatePayload", func() {
+			Payload(func() {
+				Extend(UTOuter)
+				Required("q", "body")
+			})
+			HTTP(func() {
+				GET("/")
+			})
+		})
+	})
+}
+
+var PayloadValidateArrayRecurseDSL = func() {
+	var UTInner = Type("UTInner", func() {
+		Attribute("b", String)
+		Required("b")
+	})
+	var UTOuter = Type("UTOuter", func() {
+		Attribute("a", Int)
+		Attribute("inner", ArrayOf(UTInner))
+		Required("a", "inner")
+	})
+	Service("ServicePayloadValidateArrayRecurseValidatePayload", func() {
+		Method("MethodPayloadValidateArrayRecurseValidatePayload", func() {
+			Payload(UTOuter)
+			HTTP(func() {
+				GET("/")
+			})
+		})
+	})
+}
+
 var PayloadPathStringDSL = func() {
 	Service("ServicePathString", func() {
 		Method("MethodPathString", func() {


### PR DESCRIPTION
An existing issue (#2148) shows unmarshalling errors due to validation not occurring for `ArrayOf(UserType)`.

Looking at the code, it looks like this _should_ be handled in [validation.go@226](https://github.com/goadesign/goa/blob/599df23a2ff78d4353b91a814790f9ab229d43bc/codegen/validation.go#L226) but for a reason unknown to me, `val` is always empty.

This failing test case highlights the issue.