### PR TITLE
(v2) Move xray test helpers into separate package (#2190)

### DIFF
--- a/grpc/middleware/xray/middleware_test.go
+++ b/grpc/middleware/xray/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	grpcm "goa.design/goa/grpc/middleware"
 	"goa.design/goa/middleware"
 	"goa.design/goa/middleware/xray"
+	"goa.design/goa/middleware/xray/xraytest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -174,7 +175,7 @@ func TestUnaryServerMiddleware(t *testing.T) {
 				ctx = peer.NewContext(ctx, &peer.Peer{Addr: &mockAddr{c.Request.RemoteAddr}})
 			}
 
-			messages := xray.ReadUDP(t, udplisten, expMsgs, func() {
+			messages := xraytest.ReadUDP(t, udplisten, expMsgs, func() {
 				m(ctx, &wrappers.StringValue{Value: "request"}, unary, handler)
 			})
 			if expMsgs == 0 {
@@ -182,13 +183,13 @@ func TestUnaryServerMiddleware(t *testing.T) {
 			}
 
 			// expect the first message is InProgress
-			s := xray.ExtractSegment(t, messages[0])
+			s := xraytest.ExtractSegment(t, messages[0])
 			if !s.InProgress {
 				t.Fatal("expected first segment to be InProgress but it was not")
 			}
 
 			// second message
-			s = xray.ExtractSegment(t, messages[1])
+			s = xraytest.ExtractSegment(t, messages[1])
 			if s.Name != "service" {
 				t.Errorf("unexpected segment name, expected \"service\" - got %q", s.Name)
 			}
@@ -320,7 +321,7 @@ func TestStreamServerMiddleware(t *testing.T) {
 			}
 			wss := grpcm.NewWrappedServerStream(ctx, &testServerStream{})
 
-			messages := xray.ReadUDP(t, udplisten, expMsgs, func() {
+			messages := xraytest.ReadUDP(t, udplisten, expMsgs, func() {
 				m(nil, wss, streamInfo, handler)
 			})
 			if expMsgs == 0 {
@@ -328,13 +329,13 @@ func TestStreamServerMiddleware(t *testing.T) {
 			}
 
 			// expect the first message is InProgress
-			s := xray.ExtractSegment(t, messages[0])
+			s := xraytest.ExtractSegment(t, messages[0])
 			if !s.InProgress {
 				t.Fatal("expected first segment to be InProgress but it was not")
 			}
 
 			// second message
-			s = xray.ExtractSegment(t, messages[1])
+			s = xraytest.ExtractSegment(t, messages[1])
 			if s.Name != "service" {
 				t.Errorf("unexpected segment name, expected \"service\" - got %q", s.Name)
 			}
@@ -437,7 +438,7 @@ func TestUnaryClient(t *testing.T) {
 				ctx = context.WithValue(ctx, xray.SegKey, segment)
 			}
 
-			messages := xray.ReadUDP(t, udplisten, expMsgs, func() {
+			messages := xraytest.ReadUDP(t, udplisten, expMsgs, func() {
 				UnaryClient(host)(ctx, "Test.Test", req, resp, nil, invoker)
 			})
 			if expMsgs == 0 {
@@ -445,13 +446,13 @@ func TestUnaryClient(t *testing.T) {
 			}
 
 			// expect the first message is InProgress
-			s := xray.ExtractSegment(t, messages[0])
+			s := xraytest.ExtractSegment(t, messages[0])
 			if !s.InProgress {
 				t.Fatal("expected first segment to be InProgress but it was not")
 			}
 
 			// second message
-			s = xray.ExtractSegment(t, messages[1])
+			s = xraytest.ExtractSegment(t, messages[1])
 			if s.Name != host {
 				t.Errorf("unexpected segment name: expected %q, got %q", host, s.Name)
 			}
@@ -548,7 +549,7 @@ func TestStreamClient(t *testing.T) {
 				ctx = context.WithValue(ctx, xray.SegKey, segment)
 			}
 
-			messages := xray.ReadUDP(t, udplisten, expMsgs, func() {
+			messages := xraytest.ReadUDP(t, udplisten, expMsgs, func() {
 				cs, err := StreamClient(host)(ctx, nil, nil, "Test.Test", streamer)
 				errored := err != nil
 				if tc.RequestError != errored {
@@ -568,13 +569,13 @@ func TestStreamClient(t *testing.T) {
 			}
 
 			// expect the first message is InProgress
-			s := xray.ExtractSegment(t, messages[0])
+			s := xraytest.ExtractSegment(t, messages[0])
 			if !s.InProgress {
 				t.Fatal("expected first segment to be InProgress but it was not")
 			}
 
 			// second message
-			s = xray.ExtractSegment(t, messages[1])
+			s = xraytest.ExtractSegment(t, messages[1])
 			if s.Name != host {
 				t.Errorf("unexpected segment name: expected %q, got %q", host, s.Name)
 			}

--- a/http/middleware/xray/middleware_test.go
+++ b/http/middleware/xray/middleware_test.go
@@ -10,6 +10,7 @@ import (
 
 	"goa.design/goa/middleware"
 	"goa.design/goa/middleware/xray"
+	"goa.design/goa/middleware/xray/xraytest"
 )
 
 const (
@@ -157,18 +158,18 @@ func TestMiddleware(t *testing.T) {
 				req.Host = c.Request.Host
 			}
 			req = req.WithContext(ctx)
-			messages := xray.ReadUDP(t, udplisten, 2, func() {
+			messages := xraytest.ReadUDP(t, udplisten, 2, func() {
 				m(h).ServeHTTP(rw, req)
 			})
 
 			// expect the first message is InProgress
-			s := xray.ExtractSegment(t, messages[0])
+			s := xraytest.ExtractSegment(t, messages[0])
 			if !s.InProgress {
 				t.Fatal("expected first segment to be InProgress but it was not")
 			}
 
 			// second message
-			s = xray.ExtractSegment(t, messages[1])
+			s = xraytest.ExtractSegment(t, messages[1])
 			if s.Name != "service" {
 				t.Errorf("unexpected segment name, expected service - got %s", s.Name)
 			}

--- a/http/middleware/xray/wrap_doer_test.go
+++ b/http/middleware/xray/wrap_doer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"goa.design/goa/middleware/xray"
+	"goa.design/goa/middleware/xray/xraytest"
 )
 
 // testDoer simply tests if the request context is set with X-Ray segment
@@ -60,7 +61,7 @@ func TestWrapDoer(t *testing.T) {
 			}
 
 			doer := newTestDoer(t, tc.Segment, tc.StatusCode)
-			messages := xray.ReadUDP(t, udplisten, expMsgs, func() {
+			messages := xraytest.ReadUDP(t, udplisten, expMsgs, func() {
 				WrapDoer(doer).Do(req)
 			})
 			if expMsgs == 0 {
@@ -68,13 +69,13 @@ func TestWrapDoer(t *testing.T) {
 			}
 
 			// expect the first message is InProgress
-			s := xray.ExtractSegment(t, messages[0])
+			s := xraytest.ExtractSegment(t, messages[0])
 			if !s.InProgress {
 				t.Fatal("expected first segment to be InProgress but it was not")
 			}
 
 			// second message
-			s = xray.ExtractSegment(t, messages[1])
+			s = xraytest.ExtractSegment(t, messages[1])
 			if s.Name != host {
 				t.Fatalf("unexpected segment name: expected %q, got %q", host, s.Name)
 			}

--- a/http/middleware/xray/wrap_transport_test.go
+++ b/http/middleware/xray/wrap_transport_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"goa.design/goa/middleware/xray"
+	"goa.design/goa/middleware/xray/xraytest"
 )
 
 type mockRoundTripper struct {
@@ -56,7 +57,7 @@ func TestTransportExample(t *testing.T) {
 	// Setting context on request
 	req = req.WithContext(ctx)
 
-	messages := xray.ReadUDP(t, udplisten, 2, func() {
+	messages := xraytest.ReadUDP(t, udplisten, 2, func() {
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			t.Fatalf("failed to make request - %s", err)
@@ -67,13 +68,13 @@ func TestTransportExample(t *testing.T) {
 	})
 
 	// expect the first message is InProgress
-	s := xray.ExtractSegment(t, messages[0])
+	s := xraytest.ExtractSegment(t, messages[0])
 	if !s.InProgress {
 		t.Fatal("expected first segment to be InProgress but it was not")
 	}
 
 	// second message
-	s = xray.ExtractSegment(t, messages[1])
+	s = xraytest.ExtractSegment(t, messages[1])
 	url, _ := url.Parse(server.URL)
 	if s.Name != url.Host {
 		t.Errorf("unexpected segment name, expected %q - got %q", url.Host, s.Name)
@@ -215,7 +216,7 @@ func TestTransport(t *testing.T) {
 				req.Host = c.Request.Host
 			}
 
-			messages := xray.ReadUDP(t, udplisten, 2, func() {
+			messages := xraytest.ReadUDP(t, udplisten, 2, func() {
 				resp, err := WrapTransport(rt).RoundTrip(req)
 				if c.Segment.Exception == "" && err != nil {
 					t.Errorf("expected no error got %s", err)
@@ -226,13 +227,13 @@ func TestTransport(t *testing.T) {
 			})
 
 			// expect the first message is InProgress
-			s := xray.ExtractSegment(t, messages[0])
+			s := xraytest.ExtractSegment(t, messages[0])
 			if !s.InProgress {
 				t.Fatal("expected first segment to be InProgress but it was not")
 			}
 
 			// second message
-			s = xray.ExtractSegment(t, messages[1])
+			s = xraytest.ExtractSegment(t, messages[1])
 			if s.Name != host {
 				t.Errorf("unexpected segment name, expected %q - got %q", host, s.Name)
 			}

--- a/middleware/xray/segment_test.go
+++ b/middleware/xray/segment_test.go
@@ -1,10 +1,12 @@
-package xray
+package xray_test
 
 import (
 	"net"
 	"regexp"
-	"sync"
 	"testing"
+
+	"goa.design/goa/middleware/xray"
+	"goa.design/goa/middleware/xray/xraytest"
 )
 
 const (
@@ -19,8 +21,8 @@ func TestSegment_NewSubsegment(t *testing.T) {
 	}
 	var (
 		name   = "sub"
-		s      = &Segment{Mutex: &sync.Mutex{}, conn: conn}
-		before = now()
+		s      = xray.NewSegment("", "", "", conn)
+		before = s.StartTime
 		ss     = s.NewSubsegment(name)
 	)
 	if ss.ID == "" {
@@ -50,10 +52,10 @@ func TestSegment_SubmitInProgress(t *testing.T) {
 			t.Fatalf("failed to connect to daemon - %s", err)
 		}
 
-		segment := NewSegment("hello", NewTraceID(), NewID(), conn)
+		segment := xray.NewSegment("hello", xray.NewTraceID(), xray.NewID(), conn)
 
 		// call SubmitInProgress() twice, then Close it
-		messages := ReadUDP(t, udplisten, 2, func() {
+		messages := xraytest.ReadUDP(t, udplisten, 2, func() {
 			segment.Namespace = "1"
 			segment.SubmitInProgress()
 			segment.Namespace = "2"
@@ -63,7 +65,7 @@ func TestSegment_SubmitInProgress(t *testing.T) {
 		})
 
 		// verify the In-Progress segment
-		s := ExtractSegment(t, messages[0])
+		s := xraytest.ExtractSegment(t, messages[0])
 		if !s.InProgress {
 			t.Errorf("expected segment to be InProgress, but it's not")
 		}
@@ -72,7 +74,7 @@ func TestSegment_SubmitInProgress(t *testing.T) {
 		}
 
 		// verify the final segment (the second In-Progress segment would not have been sent)
-		s = ExtractSegment(t, messages[1])
+		s = xraytest.ExtractSegment(t, messages[1])
 		if s.InProgress {
 			t.Errorf("expected segment to not be InProgress, but it is")
 		}
@@ -87,10 +89,10 @@ func TestSegment_SubmitInProgress(t *testing.T) {
 			t.Fatalf("failed to connect to daemon - %s", err)
 		}
 
-		segment := NewSegment("hello", NewTraceID(), NewID(), conn)
+		segment := xray.NewSegment("hello", xray.NewTraceID(), xray.NewID(), conn)
 
 		// Close(), then call SubmitInProgress(), only expect 1 segment written
-		messages := ReadUDP(t, udplisten, 1, func() {
+		messages := xraytest.ReadUDP(t, udplisten, 1, func() {
 			segment.Namespace = "1"
 			segment.Close()
 			segment.Namespace = "2"
@@ -98,7 +100,7 @@ func TestSegment_SubmitInProgress(t *testing.T) {
 		})
 
 		// verify the In-Progress segment
-		s := ExtractSegment(t, messages[0])
+		s := xraytest.ExtractSegment(t, messages[0])
 		if s.InProgress {
 			t.Errorf("expected segment to be closed, but it is still InProgress")
 		}

--- a/middleware/xray/xraytest/testing.go
+++ b/middleware/xray/xraytest/testing.go
@@ -1,4 +1,6 @@
-package xray
+// Package xraytest contains test helpers for package xray that are used by
+// transport-specific X-Ray middleware tests.
+package xraytest
 
 import (
 	"encoding/json"
@@ -6,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"goa.design/goa/middleware/xray"
 )
 
 // ReadUDP verifies that exactly the expected number of messages are received.
@@ -56,15 +60,15 @@ func ReadUDP(t *testing.T, udplisten string, expectedMessages int, sender func()
 }
 
 // ExtractSegment returns the unmarshalled segment JSON from a ReadUDP response.
-func ExtractSegment(t *testing.T, js string) *Segment {
+func ExtractSegment(t *testing.T, js string) *xray.Segment {
 	t.Helper()
 
-	var s *Segment
+	var s *xray.Segment
 	elems := strings.Split(js, "\n")
 	if len(elems) != 2 {
 		t.Fatalf("invalid number of lines, expected 2 got %d: %v", len(elems), elems)
 	}
-	if elems[0] != UDPHeader[:len(UDPHeader)-1] {
+	if elems[0] != xray.UDPHeader[:len(xray.UDPHeader)-1] {
 		t.Errorf("invalid header, got %s", elems[0])
 	}
 	err := json.Unmarshal([]byte(elems[1]), &s)


### PR DESCRIPTION
* Rename testing.go to testing_test.go so that
"testing" is not imported in release code

* Move testing.go into its own xraytest pkg

* Change tests to refer to separate xraytest pkg

* Added package comment for staticcheck

(cherry picked from commit eeb68ca3a4fa4d7d821f932fe209ce764545bcbe)