### PR TITLE
Fixed #2180 in v3 by only deleting subdirs within the target gen dir

### DIFF
--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -272,8 +272,8 @@ func (g *Generator) runGoCmd(args ...string) error {
 	return nil
 }
 
-// cleanupDirs returns the names of the directories to delete before generating
-// code.
+// cleanupDirs returns the paths of the subdirectories under gendir to delete
+// before generating code.
 func cleanupDirs(cmd, output string) []string {
 	if cmd == "gen" {
 		gendirPath := filepath.Join(output, codegen.Gendir)

--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -276,7 +276,23 @@ func (g *Generator) runGoCmd(args ...string) error {
 // code.
 func cleanupDirs(cmd, output string) []string {
 	if cmd == "gen" {
-		return []string{filepath.Join(output, codegen.Gendir)}
+		gendirPath := filepath.Join(output, codegen.Gendir)
+		gendir, err := os.Open(gendirPath)
+		if err != nil {
+			return nil
+		}
+		defer gendir.Close()
+		finfos, err := gendir.Readdir(-1)
+		if err != nil {
+			return []string{gendirPath}
+		}
+		dirs := []string{}
+		for _, fi := range finfos {
+			if fi.IsDir() {
+				dirs = append(dirs, filepath.Join(gendirPath, fi.Name()))
+			}
+		}
+		return dirs
 	}
 	return nil
 }


### PR DESCRIPTION
cleanupDirs() now returns the subdirs in output/gen whenever it can. This leaves all top-level files as-is in the gen dir to allow for documentation or scripts to live here in source control. Go source is never generated into this top-level dir, so no worries there.

https://github.com/goadesign/goa/issues/2180