### PR TITLE
Fixed #2193 in v3 for incorrect generated cast for Bytes payloads for client CLI

### DIFF
--- a/codegen/cli/cli.go
+++ b/codegen/cli/cli.go
@@ -493,7 +493,7 @@ func conversionCode(from, to, typeName string, pointer bool) (string, bool) {
 	case stringN:
 		parse = fmt.Sprintf("%s %s= %s", target, decl, from)
 	case bytesN:
-		parse = fmt.Sprintf("%s %s= string(%s)", target, decl, from)
+		parse = fmt.Sprintf("%s %s= []byte(%s)", target, decl, from)
 	default:
 		parse = fmt.Sprintf("err = json.Unmarshal([]byte(%s), &%s)", from, target)
 		checkErr = true


### PR DESCRIPTION
Updated the cast for CLI args for []byte payload from string() to []byte()

https://github.com/goadesign/goa/issues/2193