### PR TITLE
Correctly handle attributes of type array

### DIFF
--- a/codegen/testdata/validation_code.go
+++ b/codegen/testdata/validation_code.go
@@ -220,6 +220,17 @@ const (
 }
 `
 
+	UserTypeArrayValidationCode = `func Validate() (err error) {
+	for _, e := range target.Array {
+		if e != nil {
+			if err2 := ValidateFloat(e); err2 != nil {
+				err = goa.MergeErrors(err, err2)
+			}
+		}
+	}
+}
+`
+
 	ArrayRequiredValidationCode = `func Validate() (err error) {
 	if len(target.RequiredArray) < 5 {
 		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_array", target.RequiredArray, len(target.RequiredArray), 5, true))

--- a/codegen/testdata/validation_types_dsl.go
+++ b/codegen/testdata/validation_types_dsl.go
@@ -57,6 +57,10 @@ var ValidationTypesDSL = func() {
 			Required("required_integer")
 		})
 
+		_ = Type("ArrayUserType", func() {
+			Attribute("array", ArrayOf(FloatT))
+		})
+
 		_ = Type("Array", func() {
 			Attribute("required_array", ArrayOf(Int), func() {
 				MinLength(5)

--- a/codegen/validation_test.go
+++ b/codegen/validation_test.go
@@ -16,6 +16,7 @@ func TestRecursiveValidationCode(t *testing.T) {
 		stringT  = root.UserType("String")
 		floatT   = root.UserType("Float")
 		userT    = root.UserType("UserType")
+		arrayUT  = root.UserType("ArrayUserType")
 		arrayT   = root.UserType("Array")
 		mapT     = root.UserType("Map")
 	)
@@ -39,6 +40,7 @@ func TestRecursiveValidationCode(t *testing.T) {
 		{"user-type-required", userT, true, false, false, testdata.UserTypeRequiredValidationCode},
 		{"user-type-pointer", userT, false, true, false, testdata.UserTypePointerValidationCode},
 		{"user-type-default", userT, false, false, true, testdata.UserTypeUseDefaultValidationCode},
+		{"user-type-array-required", arrayUT, true, true, false, testdata.UserTypeArrayValidationCode},
 		{"array-required", arrayT, true, false, false, testdata.ArrayRequiredValidationCode},
 		{"array-pointer", arrayT, false, true, false, testdata.ArrayPointerValidationCode},
 		{"array-use-default", arrayT, false, false, true, testdata.ArrayUseDefaultValidationCode},

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -2376,7 +2376,8 @@ func attributeTypeData(ut expr.UserType, req, ptr, server bool, rd *ServiceData)
 	}
 }
 
-// httpContext returns an attribute context for HTTP attributes.
+// httpContext returns a context for attributes of types used to marshal and
+// unmarshal HTTP requests and responses.
 //
 // pkg is the package name where the body type exists
 //


### PR DESCRIPTION
When the array elements type is a user type that contains required
attributes.

Fix #2164