### PR TITLE
Remove security validations in HTTPEndpointExpr since MethodExpr already validates them

### DIFF
--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -322,29 +322,6 @@ func (e *HTTPEndpointExpr) Validate() error {
 		verr.Merge(er.Validate())
 	}
 
-	// Validate security definitions
-	for _, req := range e.MethodExpr.Requirements {
-		for _, sch := range req.Schemes {
-			var name, msg string
-			switch sch.Kind {
-			case APIKeyKind:
-				name = "security:apikey:" + sch.SchemeName
-				msg = "API key attribute (use APIKey)"
-			case JWTKind:
-				name = "security:token"
-				msg = "JWT token attribute (use Token)"
-			case OAuth2Kind:
-				name = "security:accesstoken"
-				msg = "access token attribute (use AccessToken)"
-			}
-			if name != "" {
-				if f := TaggedAttribute(e.MethodExpr.Payload, name); f == "" {
-					verr.Add(e, "Payload must define %s required by security scheme %q.", msg, sch.SchemeName)
-				}
-			}
-		}
-	}
-
 	// Validate definitions of params, headers and bodies against definition of payload
 	if isEmpty(e.MethodExpr.Payload) {
 		if e.MapQueryParams != nil {

--- a/expr/http_endpoint_test.go
+++ b/expr/http_endpoint_test.go
@@ -80,11 +80,11 @@ func TestHTTPEndpointValidation(t *testing.T) {
 				}
 
 				if len(c.Errors) != len(errors) {
-					t.Errorf("%s: got %d, expected the number of error values to match %d", name, len(errors), len(c.Errors))
+					t.Errorf("got %d, expected the number of error values to match %d\nerrors:\n%s", len(errors), len(c.Errors), err.Error())
 				} else {
 					for i, err := range errors {
 						if err.Error() != c.Errors[i] {
-							t.Errorf("%s:\ngot \t\t%q,\nexpected\t%q at index %d", name, err.Error(), c.Errors[i], i)
+							t.Errorf("got \t\t%q,\nexpected\t%q at index %d", err.Error(), c.Errors[i], i)
 						}
 					}
 				}


### PR DESCRIPTION
* No need to validate security requirements in HTTPEndpointExpr as [MethodExpr already does that](https://github.com/goadesign/goa/blob/v3/expr/method.go#L104-L135)
* Fixes a bug where validation fails if security attribute is extended inside a UserType ([this test case](https://github.com/goadesign/goa/blob/v3/expr/http_endpoint_test.go#L61) reproduces the bug but was returning false positive) 