### PR TITLE
Use err when decoding error response type

### DIFF
--- a/http/codegen/client_decode_test.go
+++ b/http/codegen/client_decode_test.go
@@ -27,6 +27,7 @@ func TestClientDecode(t *testing.T) {
 		{"header-array-validate", testdata.ResultHeaderArrayValidateDSL, testdata.ResultHeaderArrayValidateResponseDecodeCode},
 		{"with-headers-dsl", testdata.WithHeadersBlockDSL, testdata.WithHeadersBlockResponseDecodeCode},
 		{"with-headers-dsl-viewed-result", testdata.WithHeadersBlockViewedResultDSL, testdata.WithHeadersBlockViewedResultResponseDecodeCode},
+		{"validate-error-response-type", testdata.ValidateErrorResponseTypeDSL, testdata.ValidateErrorResponseTypeDecodeCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1664,13 +1664,23 @@ func buildErrorsData(e *expr.HTTPEndpointExpr, sd *ServiceData) []*ErrorGroupDat
 			}
 
 			headers := extractHeaders(v.Response.Headers, v.ErrorExpr.AttributeExpr, svcctx, sd.Scope)
+			var mustValidate bool
+			{
+				for _, h := range headers {
+					if h.Validate != "" || h.Required || needConversion(h.Type) {
+						mustValidate = true
+						break
+					}
+				}
+			}
 			responseData = &ResponseData{
-				StatusCode:  statusCodeToHTTPConst(v.Response.StatusCode),
-				Headers:     headers,
-				ErrorHeader: v.Name,
-				ServerBody:  serverBodyData,
-				ClientBody:  clientBodyData,
-				ResultInit:  init,
+				StatusCode:   statusCodeToHTTPConst(v.Response.StatusCode),
+				Headers:      headers,
+				ErrorHeader:  v.Name,
+				ServerBody:   serverBodyData,
+				ClientBody:   clientBodyData,
+				ResultInit:   init,
+				MustValidate: mustValidate,
 			}
 		}
 

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -1197,3 +1197,38 @@ var WithHeadersBlockViewedResultDSL = func() {
 		})
 	})
 }
+
+var ValidateErrorResponseTypeDSL = func() {
+	var AResult = ResultType("application/vnd.goa.aresult", func() {
+		TypeName("AResult")
+		Attributes(func() {
+			Attribute("required", Int)
+			Required("required")
+		})
+	})
+	var AError = Type("AError", func() {
+		Attribute("error", String)
+		Attribute("num_occur", Int, func() {
+			Minimum(1)
+		})
+		Required("error")
+	})
+	Service("ValidateErrorResponseType", func() {
+		Method("MethodA", func() {
+			Result(AResult)
+			Error("some_error", AError)
+			HTTP(func() {
+				GET("/")
+				Response(StatusOK, func() {
+					Headers(func() {
+						Header("required:X-Request-ID")
+					})
+				})
+				Response("some_error", StatusBadRequest, func() {
+					Header("error:X-Application-Error")
+					Header("num_occur:X-Occur")
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
Fixes a bug where `err` variable is not used after initialization when decoding error response types.