### PR TITLE
v3: Fix grpc bidirectional streaming client close

### DIFF
--- a/grpc/codegen/client.go
+++ b/grpc/codegen/client.go
@@ -90,7 +90,7 @@ func client(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 						Data:   e.ClientStream,
 					})
 				}
-				if e.ServerStream.MustClose {
+				if e.ClientStream.MustClose {
 					sections = append(sections, &codegen.SectionTemplate{
 						Name:   "client-stream-close",
 						Source: streamCloseT,
@@ -287,7 +287,7 @@ func Decode{{ .Method.VarName }}Response(ctx context.Context, v interface{}, hdr
     }
   }
 {{- end }}
-{{- if .ServerStream }}
+{{- if .ClientStream }}
 	return &{{ .ClientStream.VarName }}{
 		stream: v.({{ .ClientStream.Interface }}),
 	{{- if .ViewedResultRef }}

--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -1334,8 +1334,13 @@ func (s *{{ .VarName }}) {{ .RecvName }}() ({{ .RecvRef }}, error) {
 // input: StreamData
 const streamCloseT = `
 func (s *{{ .VarName }}) Close() error {
+{{- if eq .Type "client" }}
+	{{ comment "Close the send direction of the stream" }}
+	return s.stream.CloseSend()
+{{- else }}
 	{{ comment "nothing to do here" }}
 	return nil
+{{- end }}
 }
 `
 

--- a/grpc/codegen/streaming_test.go
+++ b/grpc/codegen/streaming_test.go
@@ -40,7 +40,6 @@ func TestStreaming(t *testing.T) {
 			{"server-stream-set-view", nil},
 			{"client-stream-struct-type", &testdata.ServerStreamingClientStructCode},
 			{"client-stream-recv", &testdata.ServerStreamingClientRecvCode},
-			{"client-stream-close", &testdata.ServerStreamingClientCloseCode},
 		}},
 		{"server-streaming-result-with-views", testdata.ServerStreamingResultWithViewsDSL, []*sectionExpectation{
 			{"server-stream-struct-type", &testdata.ServerStreamingResultWithViewsServerStructCode},

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -44,12 +44,6 @@ func (s *MethodServerStreamingUserTypeRPCClientStream) Recv() (*serviceserverstr
 }
 `
 
-var ServerStreamingClientCloseCode = `func (s *MethodServerStreamingUserTypeRPCClientStream) Close() error {
-	// nothing to do here
-	return nil
-}
-`
-
 var ServerStreamingResultWithViewsServerStructCode = `// MethodServerStreamingUserTypeRPCServerStream implements the
 // serviceserverstreamingusertyperpc.MethodServerStreamingUserTypeRPCServerStream
 // interface.
@@ -328,7 +322,7 @@ func (s *MethodBidirectionalStreamingRPCClientStream) Recv() (*servicebidirectio
 `
 
 var BidirectionalStreamingClientCloseCode = `func (s *MethodBidirectionalStreamingRPCClientStream) Close() error {
-	// nothing to do here
-	return nil
+	// Close the send direction of the stream
+	return s.stream.CloseSend()
 }
 `


### PR DESCRIPTION
- Make client.Close() call CloseSend() on the internal client stream
- Don't implement Close() in the server streaming client because Close() isn't in the corresponding interface

Fixes #2216