### PR TITLE
Reserve "v" and "c" variable names

### DIFF
--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -614,7 +614,9 @@ func (svc *ServiceData) Endpoint(name string) *EndpointData {
 // It records the user types needed by the service definition in userTypes.
 func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 	svc := service.Services.Get(hs.ServiceExpr.Name)
-
+	scope := codegen.NewNameScope()
+	scope.Unique("c") // 'c' is reserved as the client's receiver name.
+	scope.Unique("v") // 'v' is reserved as the request builder payload argument name.
 	rd := &ServiceData{
 		Service:          svc,
 		ServerStruct:     "Server",
@@ -625,7 +627,7 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 		ClientStruct:     "Client",
 		ServerTypeNames:  make(map[string]bool),
 		ClientTypeNames:  make(map[string]bool),
-		Scope:            codegen.NewNameScope(),
+		Scope:            scope,
 	}
 
 	for _, s := range hs.FileServers {
@@ -770,7 +772,6 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 			{
 				name = fmt.Sprintf("Build%sRequest", ep.VarName)
 				s := codegen.NewNameScope()
-				s.Unique("c") // 'c' is reserved as the client's receiver name.
 				for _, ca := range routes[0].PathInit.ClientArgs {
 					if ca.FieldName != "" {
 						ca.Name = s.Unique(ca.Name)

--- a/http/codegen/testdata/multipart_code.go
+++ b/http/codegen/testdata/multipart_code.go
@@ -144,18 +144,18 @@ func NewServiceMultipartWithParamMethodMultipartWithParamDecoder(mux goahttp.Mux
 			}
 
 			var (
-				c   map[int][]string
+				c2  map[int][]string
 				err error
 			)
 			{
-				cRaw := r.URL.Query()
-				if len(cRaw) == 0 {
+				c2Raw := r.URL.Query()
+				if len(c2Raw) == 0 {
 					err = goa.MergeErrors(err, goa.MissingFieldError("c", "query string"))
 				}
-				for keyRaw, valRaw := range cRaw {
+				for keyRaw, valRaw := range c2Raw {
 					if strings.HasPrefix(keyRaw, "c[") {
-						if c == nil {
-							c = make(map[int][]string)
+						if c2 == nil {
+							c2 = make(map[int][]string)
 						}
 						var keya int
 						{
@@ -168,14 +168,14 @@ func NewServiceMultipartWithParamMethodMultipartWithParamDecoder(mux goahttp.Mux
 							}
 							keya = int(v)
 						}
-						c[keya] = valRaw
+						c2[keya] = valRaw
 					}
 				}
 			}
 			if err != nil {
 				return err
 			}
-			(*p).C = c
+			(*p).C = c2
 			return nil
 		})
 	}
@@ -199,7 +199,7 @@ func NewServiceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersD
 			}
 			var (
 				a   string
-				c   map[int][]string
+				c2  map[int][]string
 				b   *string
 				err error
 
@@ -208,14 +208,14 @@ func NewServiceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersD
 			a = params["a"]
 			err = goa.MergeErrors(err, goa.ValidatePattern("a", a, "patterna"))
 			{
-				cRaw := r.URL.Query()
-				if len(cRaw) == 0 {
+				c2Raw := r.URL.Query()
+				if len(c2Raw) == 0 {
 					err = goa.MergeErrors(err, goa.MissingFieldError("c", "query string"))
 				}
-				for keyRaw, valRaw := range cRaw {
+				for keyRaw, valRaw := range c2Raw {
 					if strings.HasPrefix(keyRaw, "c[") {
-						if c == nil {
-							c = make(map[int][]string)
+						if c2 == nil {
+							c2 = make(map[int][]string)
 						}
 						var keya int
 						{
@@ -228,7 +228,7 @@ func NewServiceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersD
 							}
 							keya = int(v)
 						}
-						c[keya] = valRaw
+						c2[keya] = valRaw
 					}
 				}
 			}
@@ -243,7 +243,7 @@ func NewServiceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersD
 				return err
 			}
 			(*p).A = a
-			(*p).C = c
+			(*p).C = c2
 			(*p).B = b
 			return nil
 		})

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -701,7 +701,7 @@ func BuildMethodQueryBoolPayload(serviceQueryBoolMethodQueryBoolQ string) (*serv
 
 var BodyQueryPathObjectBuildCode = `// BuildMethodBodyQueryPathObjectPayload builds the payload for the
 // ServiceBodyQueryPathObject MethodBodyQueryPathObject endpoint from CLI flags.
-func BuildMethodBodyQueryPathObjectPayload(serviceBodyQueryPathObjectMethodBodyQueryPathObjectBody string, serviceBodyQueryPathObjectMethodBodyQueryPathObjectC string, serviceBodyQueryPathObjectMethodBodyQueryPathObjectB string) (*servicebodyquerypathobject.MethodBodyQueryPathObjectPayload, error) {
+func BuildMethodBodyQueryPathObjectPayload(serviceBodyQueryPathObjectMethodBodyQueryPathObjectBody string, serviceBodyQueryPathObjectMethodBodyQueryPathObjectC2 string, serviceBodyQueryPathObjectMethodBodyQueryPathObjectB string) (*servicebodyquerypathobject.MethodBodyQueryPathObjectPayload, error) {
 	var err error
 	var body MethodBodyQueryPathObjectRequestBody
 	{
@@ -710,9 +710,9 @@ func BuildMethodBodyQueryPathObjectPayload(serviceBodyQueryPathObjectMethodBodyQ
 			return nil, fmt.Errorf("invalid JSON for body, example of valid JSON:\n%s", "'{\n      \"a\": \"Ullam aut.\"\n   }'")
 		}
 	}
-	var c string
+	var c2 string
 	{
-		c = serviceBodyQueryPathObjectMethodBodyQueryPathObjectC
+		c2 = serviceBodyQueryPathObjectMethodBodyQueryPathObjectC2
 	}
 	var b *string
 	{
@@ -723,7 +723,7 @@ func BuildMethodBodyQueryPathObjectPayload(serviceBodyQueryPathObjectMethodBodyQ
 	v := &servicebodyquerypathobject.MethodBodyQueryPathObjectPayload{
 		A: body.A,
 	}
-	v.C = &c
+	v.C = &c2
 	v.B = b
 	return v, nil
 }

--- a/http/codegen/testdata/payload_constructor_functions.go
+++ b/http/codegen/testdata/payload_constructor_functions.go
@@ -774,11 +774,11 @@ func NewMethodUserBodyPathValidatePayloadType(body *MethodUserBodyPathValidateRe
 
 var PayloadBodyQueryPathObjectConstructorCode = `// NewMethodBodyQueryPathObjectPayload builds a ServiceBodyQueryPathObject
 // service MethodBodyQueryPathObject endpoint payload.
-func NewMethodBodyQueryPathObjectPayload(body *MethodBodyQueryPathObjectRequestBody, c string, b *string) *servicebodyquerypathobject.MethodBodyQueryPathObjectPayload {
+func NewMethodBodyQueryPathObjectPayload(body *MethodBodyQueryPathObjectRequestBody, c2 string, b *string) *servicebodyquerypathobject.MethodBodyQueryPathObjectPayload {
 	v := &servicebodyquerypathobject.MethodBodyQueryPathObjectPayload{
 		A: body.A,
 	}
-	v.C = &c
+	v.C = &c2
 	v.B = b
 	return v
 }
@@ -787,11 +787,11 @@ func NewMethodBodyQueryPathObjectPayload(body *MethodBodyQueryPathObjectRequestB
 var PayloadBodyQueryPathObjectValidateConstructorCode = `// NewMethodBodyQueryPathObjectValidatePayload builds a
 // ServiceBodyQueryPathObjectValidate service MethodBodyQueryPathObjectValidate
 // endpoint payload.
-func NewMethodBodyQueryPathObjectValidatePayload(body *MethodBodyQueryPathObjectValidateRequestBody, c string, b string) *servicebodyquerypathobjectvalidate.MethodBodyQueryPathObjectValidatePayload {
+func NewMethodBodyQueryPathObjectValidatePayload(body *MethodBodyQueryPathObjectValidateRequestBody, c2 string, b string) *servicebodyquerypathobjectvalidate.MethodBodyQueryPathObjectValidatePayload {
 	v := &servicebodyquerypathobjectvalidate.MethodBodyQueryPathObjectValidatePayload{
 		A: *body.A,
 	}
-	v.C = c
+	v.C = c2
 	v.B = b
 	return v
 }
@@ -799,11 +799,11 @@ func NewMethodBodyQueryPathObjectValidatePayload(body *MethodBodyQueryPathObject
 
 var PayloadBodyQueryPathUserConstructorCode = `// NewMethodBodyQueryPathUserPayloadType builds a ServiceBodyQueryPathUser
 // service MethodBodyQueryPathUser endpoint payload.
-func NewMethodBodyQueryPathUserPayloadType(body *MethodBodyQueryPathUserRequestBody, c string, b *string) *servicebodyquerypathuser.PayloadType {
+func NewMethodBodyQueryPathUserPayloadType(body *MethodBodyQueryPathUserRequestBody, c2 string, b *string) *servicebodyquerypathuser.PayloadType {
 	v := &servicebodyquerypathuser.PayloadType{
 		A: body.A,
 	}
-	v.C = &c
+	v.C = &c2
 	v.B = b
 	return v
 }
@@ -812,11 +812,11 @@ func NewMethodBodyQueryPathUserPayloadType(body *MethodBodyQueryPathUserRequestB
 var PayloadBodyQueryPathUserValidateConstructorCode = `// NewMethodBodyQueryPathUserValidatePayloadType builds a
 // ServiceBodyQueryPathUserValidate service MethodBodyQueryPathUserValidate
 // endpoint payload.
-func NewMethodBodyQueryPathUserValidatePayloadType(body *MethodBodyQueryPathUserValidateRequestBody, c string, b string) *servicebodyquerypathuservalidate.PayloadType {
+func NewMethodBodyQueryPathUserValidatePayloadType(body *MethodBodyQueryPathUserValidateRequestBody, c2 string, b string) *servicebodyquerypathuservalidate.PayloadType {
 	v := &servicebodyquerypathuservalidate.PayloadType{
 		A: *body.A,
 	}
-	v.C = c
+	v.C = c2
 	v.B = b
 	return v
 }

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -4267,17 +4267,17 @@ func DecodeMethodBodyQueryPathObjectRequest(mux goahttp.Muxer, decoder func(*htt
 		}
 
 		var (
-			c string
-			b *string
+			c2 string
+			b  *string
 
 			params = mux.Vars(r)
 		)
-		c = params["c"]
+		c2 = params["c"]
 		bRaw := r.URL.Query().Get("b")
 		if bRaw != "" {
 			b = &bRaw
 		}
-		payload := NewMethodBodyQueryPathObjectPayload(&body, c, b)
+		payload := NewMethodBodyQueryPathObjectPayload(&body, c2, b)
 
 		return payload, nil
 	}
@@ -4306,13 +4306,13 @@ func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder f
 		}
 
 		var (
-			c string
-			b string
+			c2 string
+			b  string
 
 			params = mux.Vars(r)
 		)
-		c = params["c"]
-		err = goa.MergeErrors(err, goa.ValidatePattern("c", c, "patternc"))
+		c2 = params["c"]
+		err = goa.MergeErrors(err, goa.ValidatePattern("c2", c2, "patternc"))
 		b = r.URL.Query().Get("b")
 		if b == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("b", "query string"))
@@ -4321,7 +4321,7 @@ func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder f
 		if err != nil {
 			return nil, err
 		}
-		payload := NewMethodBodyQueryPathObjectValidatePayload(&body, c, b)
+		payload := NewMethodBodyQueryPathObjectValidatePayload(&body, c2, b)
 
 		return payload, nil
 	}
@@ -4345,17 +4345,17 @@ func DecodeMethodBodyQueryPathUserRequest(mux goahttp.Muxer, decoder func(*http.
 		}
 
 		var (
-			c string
-			b *string
+			c2 string
+			b  *string
 
 			params = mux.Vars(r)
 		)
-		c = params["c"]
+		c2 = params["c"]
 		bRaw := r.URL.Query().Get("b")
 		if bRaw != "" {
 			b = &bRaw
 		}
-		payload := NewMethodBodyQueryPathUserPayloadType(&body, c, b)
+		payload := NewMethodBodyQueryPathUserPayloadType(&body, c2, b)
 
 		return payload, nil
 	}
@@ -4384,13 +4384,13 @@ func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder fun
 		}
 
 		var (
-			c string
-			b string
+			c2 string
+			b  string
 
 			params = mux.Vars(r)
 		)
-		c = params["c"]
-		err = goa.MergeErrors(err, goa.ValidatePattern("c", c, "patternc"))
+		c2 = params["c"]
+		err = goa.MergeErrors(err, goa.ValidatePattern("c2", c2, "patternc"))
 		b = r.URL.Query().Get("b")
 		if b == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("b", "query string"))
@@ -4399,7 +4399,7 @@ func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder fun
 		if err != nil {
 			return nil, err
 		}
-		payload := NewMethodBodyQueryPathUserValidatePayloadType(&body, c, b)
+		payload := NewMethodBodyQueryPathUserValidatePayloadType(&body, c2, b)
 
 		return payload, nil
 	}


### PR DESCRIPTION
when computing unique variable names as these are used in the templates
used to generate the code and can thus potentially create conflicts with
names derived from user provided values.

Fix #2204 