### PR TITLE
Fix handling of dashes in example flags

### DIFF
--- a/codegen/funcs.go
+++ b/codegen/funcs.go
@@ -148,10 +148,18 @@ func CamelCase(name string, firstUpper bool, acronym bool) string {
 }
 
 // SnakeCase produces the snake_case version of the given CamelCase string.
+// News    => news
+// OldNews => old_news
+// CNNNews => cnn_news
 func SnakeCase(name string) string {
+	// Special handling for single "words" starting with multiple upper case letters
 	for u, l := range toLower {
 		name = strings.Replace(name, u, l, -1)
 	}
+
+	// Special handling for dashes to convert them into underscores
+	name = strings.Replace(name, "-", "_", -1)
+
 	var b bytes.Buffer
 	ln := len(name)
 	if ln == 0 {

--- a/codegen/funcs_test.go
+++ b/codegen/funcs_test.go
@@ -18,6 +18,8 @@ func TestSnakeCase(t *testing.T) {
 		"sequential uppers 2":   {"aaAAAa", "aa_aa_aa"},
 		"end sequential uppers": {"aaAA", "aa_aa"},
 		"multiple_uppers":       {"aaAaaAaa", "aa_aaa_aaa"},
+		"dashes":                {"aa-Aaa-Aaa", "aa_aaa_aaa"},
+		"dashes 2":              {"aa-AAaaAA-Aaa", "aa_a_aaa_aa_aaa"},
 		"underscores":           {"aa_Aaa_Aaa", "aa_aaa_aaa"},
 		"underscores 2":         {"aa_AAaaAA_Aaa", "aa_a_aaa_aa_aaa"},
 		"numbers":               {"aa1", "aa1"},
@@ -54,6 +56,36 @@ func TestCamelCase(t *testing.T) {
 	for k, tc := range cases {
 		t.Run(k, func(t *testing.T) {
 			actual := CamelCase(tc.str, tc.firstUpper, tc.useAcronyum)
+			if actual != tc.expected {
+				t.Errorf("got %q, expected %q", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestKebabCase(t *testing.T) {
+	cases := map[string]struct {
+		str      string
+		expected string
+	}{
+		"all lower":             {"aaa", "aaa"},
+		"start upper":           {"Aaa", "aaa"},
+		"start upper 2":         {"AAAaa", "aa-aaa"},
+		"mid upper":             {"aAa", "a-aa"},
+		"end upper":             {"aaA", "aa-a"},
+		"sequential uppers":     {"aaAAaa", "aa-a-aaa"},
+		"sequential uppers 2":   {"aaAAAa", "aa-aa-aa"},
+		"end sequential uppers": {"aaAA", "aa-aa"},
+		"multiple_uppers":       {"aaAaaAaa", "aa-aaa-aaa"},
+		"underscores":           {"aa_Aaa_Aaa", "aa-aaa-aaa"},
+		"underscores 2":         {"aa_AAaaAA_Aaa", "aa-a-aaa-aa-aaa"},
+		"dashes":                {"aa-Aaa-Aaa", "aa-aaa-aaa"},
+		"dashes 2":              {"aa-AAaaAA-Aaa", "aa-a-aaa-aa-aaa"},
+		"numbers":               {"aa1", "aa1"},
+	}
+	for k, tc := range cases {
+		t.Run(k, func(t *testing.T) {
+			actual := KebabCase(tc.str)
 			if actual != tc.expected {
 				t.Errorf("got %q, expected %q", actual, tc.expected)
 			}


### PR DESCRIPTION
The flags make use of KebabCase to render the flag names.
Kebab case would produce double dashes for strings with underscores in them.