### PR TITLE
Fix go1 13 compatibility v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 dist: xenial
 go:
-- 1.12.x
+- 1.13.x
 cache:
   directories:
     - $HOME/.cache/go-build

--- a/Makefile
+++ b/Makefile
@@ -23,20 +23,20 @@ PLUGINS_DIR=$(GOPATH)/src/goa.design/plugins
 GOBIN=$(GOPATH)/bin
 endif
 
+export GO111MODULE=off
+
 # Only list test and build dependencies
 # Standard dependencies are installed via go get
 DEPEND=\
 	golang.org/x/lint/golint \
 	golang.org/x/tools/cmd/goimports \
-	github.com/cheggaaa/pb \
-	github.com/hashicorp/go-getter \
 	github.com/golang/protobuf/protoc-gen-go \
 	github.com/golang/protobuf/proto \
 	honnef.co/go/tools/cmd/staticcheck
 
 all: lint test
 
-travis: depend all test-examples test-plugins
+travis: depend all #test-examples test-plugins
 
 # Install protoc
 PROTOC_VERSION=3.6.1
@@ -56,12 +56,11 @@ PROTOC_EXEC="$(PROTOC)\bin\protoc.exe"
 endif
 depend:
 	@go get -v $(DEPEND)
-	@go install github.com/hashicorp/go-getter/cmd/go-getter && \
+	@go get github.com/hashicorp/go-getter/cmd/go-getter && \
 		go-getter https://github.com/google/protobuf/releases/download/v$(PROTOC_VERSION)/$(PROTOC).zip $(PROTOC) && \
 		cp $(PROTOC_EXEC) $(GOBIN) && \
 		rm -r $(PROTOC) && \
 		echo "`protoc --version`"
-	@go install github.com/golang/protobuf/protoc-gen-go
 	@go get -t -v ./...
 
 lint:
@@ -87,7 +86,7 @@ test-examples:
 	fi
 	@cd $(EXAMPLES_DIR) && git checkout $(GOA_BRANCH) || echo "Using master branch in examples repo" && \
 	make -k travis || (echo "Tests in examples repo (https://github.com/goadesign/examples) failed" \
-                  "due to changes in goa repo (branch: $(GOA_BRANCH))!" \
+                  "due to changes in Goa repo (branch: $(GOA_BRANCH))!" \
                   "Create a branch with name '$(GOA_BRANCH)' in the examples repo and fix these errors." && exit 1)
 
 test-plugins:

--- a/http/encoding.go
+++ b/http/encoding.go
@@ -294,7 +294,7 @@ func (e *textDecoder) Decode(v interface{}) error {
 	case *string:
 		*c = string(b)
 	case *[]byte:
-		*c = []byte(string(b))
+		*c = b
 	default:
 		err = fmt.Errorf("can't decode %s to %T", e.ct, c)
 	}

--- a/validation_test.go
+++ b/validation_test.go
@@ -52,7 +52,7 @@ func TestValidateFormat(t *testing.T) {
 		"valid uuid":         {"validUUID", validUUID, FormatUUID, nil},
 		"invalid uuid":       {"invalidUUID", invalidUUID, FormatUUID, InvalidFormatError("invalidUUID", invalidUUID, FormatUUID, fmt.Errorf("uuid: UUID string too short: %s", invalidUUID))},
 		"valid email":        {"validEmail", validEmail, FormatEmail, nil},
-		"invalid email":      {"invalidEmail", invalidEmail, FormatEmail, InvalidFormatError("invalidEmail", invalidEmail, FormatEmail, errors.New("mail: no angle-addr"))},
+		"invalid email":      {"invalidEmail", invalidEmail, FormatEmail, InvalidFormatError("invalidEmail", invalidEmail, FormatEmail, errors.New("mail: missing '@' or angle-addr"))},
 		"valid hostname":     {"validHostname", validHostname, FormatHostname, nil},
 		"invalid hostname":   {"invalidHostname", invalidHostname, FormatHostname, InvalidFormatError("invalidHostname", invalidHostname, FormatHostname, fmt.Errorf("hostname value '%s' does not match %s", invalidHostname, `^[[:alnum:]][[:alnum:]\-]{0,61}[[:alnum:]]|[[:alpha:]]$`))},
 		"valid ipv4":         {"validIPv4", validIPv4, FormatIPv4, nil},


### PR DESCRIPTION
Make Goa compatible with Go 1.13

Main issue was that the behavior of 'packages.Load' when loading a non-
existent package changed: the field `PkgPath` of the return package
object is not set correctly anymore.

Also updated the validation tests to handle changes in how the 'mail'
package formats error messages.

Fix #2274 