### PR TITLE
Re-enable building examples during CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DEPEND=\
 
 all: lint test
 
-travis: depend all #test-examples test-plugins
+travis: depend all test-examples test-plugins
 
 # Install protoc
 PROTOC_VERSION=3.6.1


### PR DESCRIPTION
Now that the 'goa' tool on the v3 branch supports Go 1.13