### PR TITLE
Remove empty validate methods in gRPC

### DIFF
--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -148,7 +148,6 @@ func wrapAttr(att *expr.AttributeExpr, tname string) {
 					},
 				},
 			},
-			Validation: &expr.ValidationExpr{Required: []string{"field"}},
 		}
 	}
 	switch dt := att.Type.(type) {

--- a/grpc/codegen/testdata/request_decoder_code.go
+++ b/grpc/codegen/testdata/request_decoder_code.go
@@ -32,9 +32,6 @@ func DecodeMethodUnaryRPCNoResultRequest(ctx context.Context, v interface{}, md 
 		if message, ok = v.(*service_unary_rpc_no_resultpb.MethodUnaryRPCNoResultRequest); !ok {
 			return nil, goagrpc.ErrInvalidType("ServiceUnaryRPCNoResult", "MethodUnaryRPCNoResult", "*service_unary_rpc_no_resultpb.MethodUnaryRPCNoResultRequest", v)
 		}
-		if err := ValidateMethodUnaryRPCNoResultRequest(message); err != nil {
-			return nil, err
-		}
 	}
 	var payload []string
 	{
@@ -54,9 +51,6 @@ func DecodeMethodMessageMapRequest(ctx context.Context, v interface{}, md metada
 	{
 		if message, ok = v.(*service_message_mappb.MethodMessageMapRequest); !ok {
 			return nil, goagrpc.ErrInvalidType("ServiceMessageMap", "MethodMessageMap", "*service_message_mappb.MethodMessageMapRequest", v)
-		}
-		if err := ValidateMethodMessageMapRequest(message); err != nil {
-			return nil, err
 		}
 	}
 	var payload map[int]*servicemessagemap.UT

--- a/grpc/codegen/testdata/response_decoder_code.go
+++ b/grpc/codegen/testdata/response_decoder_code.go
@@ -52,9 +52,6 @@ func DecodeMethodMessageArrayResponse(ctx context.Context, v interface{}, hdr, t
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageArray", "MethodMessageArray", "*service_message_arraypb.MethodMessageArrayResponse", v)
 	}
-	if err := ValidateMethodMessageArrayResponse(message); err != nil {
-		return nil, err
-	}
 	res := NewMethodMessageArrayResult(message)
 	return res, nil
 }

--- a/grpc/codegen/testdata/server_type_code.go
+++ b/grpc/codegen/testdata/server_type_code.go
@@ -22,37 +22,6 @@ func NewMethodPayloadWithNestedTypesResponse() *service_payload_with_nested_type
 	return message
 }
 
-// ValidateMethodPayloadWithNestedTypesRequest runs the validations defined on
-// MethodPayloadWithNestedTypesRequest.
-func ValidateMethodPayloadWithNestedTypesRequest(message *service_payload_with_nested_typespb.MethodPayloadWithNestedTypesRequest) (err error) {
-	if message.AParams != nil {
-		if err2 := ValidateAParams(message.AParams); err2 != nil {
-			err = goa.MergeErrors(err, err2)
-		}
-	}
-	return
-}
-
-// ValidateAParams runs the validations defined on AParams.
-func ValidateAParams(message *service_payload_with_nested_typespb.AParams) (err error) {
-	for _, v := range message.A {
-		if v != nil {
-			if err2 := ValidateArrayOfString(v); err2 != nil {
-				err = goa.MergeErrors(err, err2)
-			}
-		}
-	}
-	return
-}
-
-// ValidateArrayOfString runs the validations defined on ArrayOfString.
-func ValidateArrayOfString(message *service_payload_with_nested_typespb.ArrayOfString) (err error) {
-	if message.Field == nil {
-		err = goa.MergeErrors(err, goa.MissingFieldError("field", "message"))
-	}
-	return
-}
-
 // protobufServicePayloadWithNestedTypespbAParamsToServicepayloadwithnestedtypesAParams
 // builds a value of type *servicepayloadwithnestedtypes.AParams from a value
 // of type *service_payload_with_nested_typespb.AParams.

--- a/grpc/codegen/testdata/server_type_code.go
+++ b/grpc/codegen/testdata/server_type_code.go
@@ -53,12 +53,6 @@ func ValidateArrayOfString(message *service_payload_with_nested_typespb.ArrayOfS
 	return
 }
 
-// ValidateBParams runs the validations defined on BParams.
-func ValidateBParams(message *service_payload_with_nested_typespb.BParams) (err error) {
-
-	return
-}
-
 // protobufServicePayloadWithNestedTypespbAParamsToServicepayloadwithnestedtypesAParams
 // builds a value of type *servicepayloadwithnestedtypes.AParams from a value
 // of type *service_payload_with_nested_typespb.AParams.

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -166,9 +166,6 @@ func (s *MethodServerStreamingArrayClientStream) Recv() ([]int, error) {
 	if err != nil {
 		return res, err
 	}
-	if err = ValidateMethodServerStreamingArrayResponse(v); err != nil {
-		return res, err
-	}
 	return NewMethodServerStreamingArrayResponse(v), nil
 }
 `
@@ -189,9 +186,6 @@ func (s *MethodServerStreamingMapClientStream) Recv() (map[string]*serviceserver
 	var res map[string]*serviceserverstreamingmap.UserType
 	v, err := s.stream.Recv()
 	if err != nil {
-		return res, err
-	}
-	if err = ValidateMethodServerStreamingMapResponse(v); err != nil {
 		return res, err
 	}
 	return NewMethodServerStreamingMapResponse(v), nil


### PR DESCRIPTION
`field` is internal to goa and should never be validated.