### PR TITLE
trace_discards_v2

### DIFF
--- a/grpc/middleware/trace.go
+++ b/grpc/middleware/trace.go
@@ -113,7 +113,7 @@ func SampleSize(s int) middleware.TraceOption {
 	return middleware.SampleSize(s)
 }
 
-// DiscardFromTrace adds a regular expression for matching a request path to be discarded from X-Ray tracing.
+// DiscardFromTrace adds a regular expression for matching a request path to be discarded from tracing.
 // see middleware.DiscardFromTrace() for more details.
 func DiscardFromTrace(discard *regexp.Regexp) middleware.TraceOption {
 	return middleware.DiscardFromTrace(discard)

--- a/http/middleware/trace.go
+++ b/http/middleware/trace.go
@@ -93,7 +93,7 @@ func SampleSize(s int) middleware.TraceOption {
 	return middleware.SampleSize(s)
 }
 
-// DiscardFromTrace adds a regular expression for matching a request path to be discarded from X-Ray tracing.
+// DiscardFromTrace adds a regular expression for matching a request path to be discarded from tracing.
 // see middleware.DiscardFromTrace() for more details.
 func DiscardFromTrace(discard *regexp.Regexp) middleware.TraceOption {
 	return middleware.DiscardFromTrace(discard)

--- a/http/middleware/trace.go
+++ b/http/middleware/trace.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"regexp"
 
 	"goa.design/goa/middleware"
 )
@@ -38,9 +39,21 @@ func Trace(opts ...middleware.TraceOption) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// insert a new trace ID only if not already being traced.
 			traceID := r.Header.Get(TraceIDHeader)
-			if traceID == "" && sampler.Sample() {
-				// insert tracing only within sample.
-				traceID = o.TraceID()
+			if traceID == "" {
+				// check for discards only if we do not already have a trace ID and before sampling.
+				var discarded bool
+				if r.URL != nil { // docs imply but do not actually state that URL cannot be nil
+					for _, discard := range o.Discards() {
+						if discard.MatchString(r.URL.Path) {
+							discarded = true
+							break
+						}
+					}
+				}
+				if !discarded && sampler.Sample() {
+					// insert tracing only within sample.
+					traceID = o.TraceID()
+				}
 			}
 			if traceID == "" {
 				h.ServeHTTP(w, r)
@@ -78,6 +91,12 @@ func MaxSamplingRate(r int) middleware.TraceOption {
 // SampleSize is a wrapper for the top-level SampleSize.
 func SampleSize(s int) middleware.TraceOption {
 	return middleware.SampleSize(s)
+}
+
+// DiscardFromTrace adds a regular expression for matching a request path to be discarded from X-Ray tracing.
+// see middleware.DiscardFromTrace() for more details.
+func DiscardFromTrace(discard *regexp.Regexp) middleware.TraceOption {
+	return middleware.DiscardFromTrace(discard)
 }
 
 // WrapDoer wraps a goa client Doer and sets the trace headers so that the

--- a/http/middleware/trace_test.go
+++ b/http/middleware/trace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	httpm "goa.design/goa/http/middleware"
@@ -26,26 +27,40 @@ func TestMiddleware(t *testing.T) {
 		spanID     = "testSpanID"
 		newTraceID = func() string { return traceID }
 		newID      = func() string { return spanID }
+		discard    = regexp.MustCompile("^/$")
 	)
 
 	cases := map[string]struct {
 		Rate                  int
 		TraceID, ParentSpanID string
+		Discard               *regexp.Regexp
 		// output
 		CtxTraceID, CtxSpanID, CtxParentID string
 	}{
-		"no-trace": {100, "", "", traceID, spanID, ""},
-		"trace":    {100, "trace", "", "trace", spanID, ""},
-		"parent":   {100, "trace", "parent", "trace", spanID, "parent"},
+		"no-trace":             {100, "", "", nil, traceID, spanID, ""},
+		"no-trace-discarded":   {100, "", "", discard, "", "", ""},
+		"trace":                {100, "trace", "", nil, "trace", spanID, ""},
+		"trace-not-discarded":  {100, "trace", "", discard, "trace", spanID, ""},
+		"parent":               {100, "trace", "parent", nil, "trace", spanID, "parent"},
+		"parent-not-discarded": {100, "trace", "parent", discard, "trace", spanID, "parent"},
 
-		"zero-rate-no-trace": {0, "", "", "", "", ""},
-		"zero-rate-trace":    {0, "trace", "", "trace", spanID, ""},
-		"zero-rate-parent":   {0, "trace", "parent", "trace", spanID, "parent"},
+		"zero-rate-no-trace":             {0, "", "", nil, "", "", ""},
+		"zero-rate-trace":                {0, "trace", "", nil, "trace", spanID, ""},
+		"zero-rate-trace-not-discarded":  {0, "trace", "", discard, "trace", spanID, ""},
+		"zero-rate-parent-not-discarded": {0, "trace", "parent", discard, "trace", spanID, "parent"},
 	}
 
 	for k, c := range cases {
+		traceOptions := []middleware.TraceOption{
+			httpm.SamplingPercent(c.Rate),
+			httpm.SpanIDFunc(newID),
+			httpm.TraceIDFunc(newTraceID),
+		}
+		if c.Discard != nil {
+			traceOptions = append(traceOptions, httpm.DiscardFromTrace(c.Discard))
+		}
 		var (
-			m       = httpm.Trace(httpm.SamplingPercent(c.Rate), httpm.SpanIDFunc(newID), httpm.TraceIDFunc(newTraceID))
+			m       = httpm.Trace(traceOptions...)
 			h       = new(testHandler)
 			headers = make(http.Header)
 		)

--- a/middleware/trace.go
+++ b/middleware/trace.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"regexp"
 )
 
 type (
@@ -20,6 +21,7 @@ type (
 		samplingPercent int
 		maxSamplingRate int
 		sampleSize      int
+		discards        []*regexp.Regexp
 	}
 
 	// tracedLogger is a logger which logs the trace ID with every log entry
@@ -65,6 +67,12 @@ func (o *TraceOptions) TraceID() string {
 // generates span IDs.
 func (o *TraceOptions) SpanID() string {
 	return o.spanIDFunc()
+}
+
+// Discards returns the list of regular expressions used to match paths to be
+// discarded from tracing.
+func (o *TraceOptions) Discards() []*regexp.Regexp {
+	return o.discards
 }
 
 // TraceIDFunc configures the function used to compute trace IDs. Use this
@@ -124,6 +132,22 @@ func SampleSize(s int) TraceOption {
 	}
 	return func(o *TraceOptions) *TraceOptions {
 		o.sampleSize = s
+		return o
+	}
+}
+
+// DiscardFromTrace adds a regular expression for matching a request path to be discarded from X-Ray tracing.
+// this is useful for frequent API calls that are not important to trace, such as health checks.
+// the pattern can be a full or partial match and could even support both HTTP and gRPC paths with an
+// OR expression, etc.
+//
+// note that discards can be overridden if the incoming request already has a trace ID.
+func DiscardFromTrace(discard *regexp.Regexp) TraceOption {
+	if discard == nil {
+		panic("discard cannot be nil")
+	}
+	return func(o *TraceOptions) *TraceOptions {
+		o.discards = append(o.discards, discard)
 		return o
 	}
 }

--- a/middleware/trace.go
+++ b/middleware/trace.go
@@ -136,7 +136,7 @@ func SampleSize(s int) TraceOption {
 	}
 }
 
-// DiscardFromTrace adds a regular expression for matching a request path to be discarded from X-Ray tracing.
+// DiscardFromTrace adds a regular expression for matching a request path to be discarded from tracing.
 // this is useful for frequent API calls that are not important to trace, such as health checks.
 // the pattern can be a full or partial match and could even support both HTTP and gRPC paths with an
 // OR expression, etc.

--- a/middleware/trace_test.go
+++ b/middleware/trace_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"math"
+	"regexp"
 	"testing"
 )
 
@@ -89,6 +90,24 @@ func TestNewTraceOptions(t *testing.T) {
 					}
 				}()
 				NewTraceOptions(SampleSize(c.SampleSize))
+			}()
+		}
+	}
+
+	// invalid discard
+	{
+		cases := map[string]struct{ Discard *regexp.Regexp }{
+			"nil": {nil},
+		}
+		for k, c := range cases {
+			func() {
+				defer func() {
+					r := recover()
+					if r != "discard cannot be nil" {
+						t.Errorf("DiscardFromTrace(%s): NewTraceOptions did *not* panic as expected: %v", k, r)
+					}
+				}()
+				NewTraceOptions(DiscardFromTrace(c.Discard))
 			}()
 		}
 	}


### PR DESCRIPTION
added DiscardFromTrace() option for tracing in HTTP and gRPC.
useful to omit API calls such as health-checks, which happen frequently but are not interesting to trace.
