### PR TITLE
Properly inherit params and payload attributes to child services

### DIFF
--- a/dsl/http.go
+++ b/dsl/http.go
@@ -699,6 +699,10 @@ func Body(args ...interface{}) {
 // Parent sets the name of the parent service. The parent service canonical
 // method path is used as prefix for all the service HTTP endpoint paths.
 //
+// Attributes of the parent method payload that map to parent path parameters
+// are automatically merged into the child method payload type if not already
+// defined.
+//
 // Parent must appear in a Service expression.
 //
 // Parent accepts one argument: the name of the parent service.

--- a/expr/http_endpoint_test.go
+++ b/expr/http_endpoint_test.go
@@ -60,6 +60,9 @@ func TestHTTPEndpointValidation(t *testing.T) {
 		"endpoint-missing-token-extend": {
 			DSL: testdata.EndpointExtendToken,
 		},
+		"endpoint-has-parent": {
+			DSL: testdata.EndpointHasParent,
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/expr/testdata/endpoint_dsls.go
+++ b/expr/testdata/endpoint_dsls.go
@@ -150,6 +150,39 @@ var EndpointExtendToken = func() {
 	})
 }
 
+var EndpointHasParent = func() {
+	Service("Parent", func() {
+		HTTP(func() {
+			Path("/parents")
+			CanonicalMethod("Method")
+		})
+		Method("Method", func() {
+			Payload(func() {
+				Attribute("parent_id", Int)
+				Attribute("query_1", String)
+			})
+			HTTP(func() {
+				GET("/{parent_id}")
+				Param("query_1")
+			})
+		})
+	})
+	Service("Child", func() {
+		HTTP(func() {
+			Path("/children")
+			Parent("Parent")
+		})
+		Method("Method", func() {
+			Payload(func() {
+				Attribute("child_id", Int)
+			})
+			HTTP(func() {
+				GET("/{child_id}")
+			})
+		})
+	})
+}
+
 var FinalizeEndpointBodyAsExtendedTypeDSL = func() {
 	var EntityData = Type("EntityData", func() {
 		Attribute("name", String)


### PR DESCRIPTION
This is backport of #2283 to v3.