### PR TITLE
v1: Use http.NewRequestWithContext in goagen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.11.x
+- 1.13.x
 sudo: false
 install:
 - export PATH=${PATH}:${HOME}/gopath/bin

--- a/goagen/gen_client/generator.go
+++ b/goagen/gen_client/generator.go
@@ -1037,7 +1037,7 @@ func (c * Client) {{ .Name }}(ctx context.Context, {{ if .DirName }}filename, {{
 	}
 {{ if .DirName }}	p := path.Join("{{ .RequestDir }}", filename)
 {{ end }}	u := url.URL{Host: c.Host, Scheme: scheme, Path: {{ if .DirName }}p{{ else }}"{{ .RequestPath }}"{{ end }}}
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return 0, err
 	}
@@ -1146,8 +1146,8 @@ func (c *Client) {{ $funcName }}(ctx context.Context, path string{{ if .Params }
 	{{ end }}	values.Set("{{ .Name }}", {{ .ValueName }})
 {{ if .CheckNil }}	}
 {{ end }}{{ end }}{{ end }}	u.RawQuery = values.Encode()
-{{ end }}{{ if .HasPayload }}	req, err := http.NewRequest({{ $route := index .Routes 0 }}"{{ $route.Verb }}", u.String(), &body)
-{{ else }}	req, err := http.NewRequest({{ $route := index .Routes 0 }}"{{ $route.Verb }}", u.String(), nil)
+{{ end }}{{ if .HasPayload }}	req, err := http.NewRequestWithContext(ctx, {{ $route := index .Routes 0 }}"{{ $route.Verb }}", u.String(), &body)
+{{ else }}	req, err := http.NewRequestWithContext(ctx, {{ $route := index .Routes 0 }}"{{ $route.Verb }}", u.String(), nil)
 {{ end }}	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some methods generated by `goagen` do not use `ctx` defined as arguments, *http.Request always uses context.Background(). 

To include `ctx` in *http.Request, use http.NewRequestWithContext() added in Go 1.13. 