### PR TITLE
Fix invalid paths in generated OpenAPI definitions

### DIFF
--- a/http/codegen/openapi/openapi_v2_builder.go
+++ b/http/codegen/openapi/openapi_v2_builder.go
@@ -566,12 +566,7 @@ func buildPathFromFileServer(s *V2, root *expr.RootExpr, fs *expr.HTTPFileServer
 			Schemes:      schemes,
 		}
 
-		key := expr.HTTPWildcardRegex.ReplaceAllStringFunc(
-			path,
-			func(w string) string {
-				return fmt.Sprintf("/{%s}", w[2:])
-			},
-		)
+		key := expr.HTTPWildcardRegex.ReplaceAllString(path, "/{$1}")
 		if key == "" {
 			key = "/"
 		}

--- a/http/codegen/openapi/openapi_v2_builder_test.go
+++ b/http/codegen/openapi/openapi_v2_builder_test.go
@@ -1,0 +1,51 @@
+package openapi
+
+import (
+	"testing"
+
+	"goa.design/goa/expr"
+)
+
+func TestBuildPathFromFileServer(t *testing.T) {
+	cases := []struct {
+		path     string
+		expected string
+	}{
+		{
+			path:     "/foo",
+			expected: "/foo",
+		},
+		{
+			path:     "/foo/{bar}",
+			expected: "/foo/{bar}",
+		},
+		{
+			path:     "/foo/{*bar}",
+			expected: "/foo/{bar}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			s := &V2{
+				Paths: make(map[string]interface{}),
+			}
+			root := &expr.RootExpr{
+				API: &expr.APIExpr{},
+			}
+			fs := &expr.HTTPFileServerExpr{
+				Service: &expr.HTTPServiceExpr{
+					ServiceExpr: &expr.ServiceExpr{
+						Name: "service",
+					},
+				},
+				RequestPaths: []string{tc.path},
+			}
+			buildPathFromFileServer(s, root, fs)
+			for actual := range s.Paths {
+				if actual != tc.expected {
+					t.Errorf("got %#v, expected %#v", actual, tc.expected)
+				}
+			}
+		})
+	}
+}

--- a/http/codegen/openapi/openapi_v2_builder_test.go
+++ b/http/codegen/openapi/openapi_v2_builder_test.go
@@ -3,7 +3,7 @@ package openapi
 import (
 	"testing"
 
-	"goa.design/goa/expr"
+	"goa.design/goa/v3/expr"
 )
 
 func TestBuildPathFromFileServer(t *testing.T) {


### PR DESCRIPTION
This is backport of #2306 to v3.