### PR TITLE
fix Decode{{Name}}Request method

### DIFF
--- a/grpc/codegen/server.go
+++ b/grpc/codegen/server.go
@@ -329,12 +329,12 @@ func Decode{{ .Method.VarName }}Request(ctx context.Context, v interface{}, md m
 				if vals := md.Get({{ printf "%q" .Name }}); len(vals) == 0 {
 					err = goa.MergeErrors(err, goa.MissingFieldError({{ printf "%q" .Name }}, "metadata"))
 				} else {
-					{{ .VarName }}Raw = vals[0]
+					{{ .VarName }}Raw := vals[0]
 					{{ template "type_conversion" . }}
 				}
 			{{- else }}
 				if vals := md.Get({{ printf "%q" .Name }}); len(vals) > 0 {
-					{{ .VarName }}Raw = vals[0]
+					{{ .VarName }}Raw := vals[0]
 					{{ template "type_conversion" . }}
 				}
 			{{- end }}

--- a/grpc/codegen/testdata/request_decoder_code.go
+++ b/grpc/codegen/testdata/request_decoder_code.go
@@ -99,7 +99,7 @@ func DecodeMethodClientStreamingRPCWithPayloadRequest(ctx context.Context, v int
 		if vals := md.Get("goa_payload"); len(vals) == 0 {
 			err = goa.MergeErrors(err, goa.MissingFieldError("goa_payload", "metadata"))
 		} else {
-			goaPayloadRaw = vals[0]
+			goaPayloadRaw := vals[0]
 
 			v, err2 := strconv.ParseInt(goaPayloadRaw, 10, strconv.IntSize)
 			if err2 != nil {
@@ -130,7 +130,7 @@ func DecodeMethodBidirectionalStreamingRPCWithPayloadRequest(ctx context.Context
 	)
 	{
 		if vals := md.Get("a"); len(vals) > 0 {
-			aRaw = vals[0]
+			aRaw := vals[0]
 
 			v, err2 := strconv.ParseInt(aRaw, 10, strconv.IntSize)
 			if err2 != nil {

--- a/grpc/codegen/testdata/request_decoder_code.go
+++ b/grpc/codegen/testdata/request_decoder_code.go
@@ -163,7 +163,7 @@ func DecodeMethodMessageWithMetadataRequest(ctx context.Context, v interface{}, 
 	)
 	{
 		if vals := md.Get("Authorization"); len(vals) > 0 {
-			inMetadataRaw = vals[0]
+			inMetadataRaw := vals[0]
 
 			v, err2 := strconv.ParseInt(inMetadataRaw, 10, strconv.IntSize)
 			if err2 != nil {
@@ -202,7 +202,7 @@ func DecodeMethodMessageWithValidateRequest(ctx context.Context, v interface{}, 
 	)
 	{
 		if vals := md.Get("Authorization"); len(vals) > 0 {
-			inMetadataRaw = vals[0]
+			inMetadataRaw := vals[0]
 
 			v, err2 := strconv.ParseInt(inMetadataRaw, 10, strconv.IntSize)
 			if err2 != nil {


### PR DESCRIPTION
For client streaming with payload, Goa uses metadata to also send a unary payload.
This change fixes code generation for non-string payload fields.