### PR TITLE
Fix dsl.Description doc comment

### DIFF
--- a/dsl/description.go
+++ b/dsl/description.go
@@ -8,7 +8,7 @@ import (
 // Description sets the expression description.
 //
 // Description may appear in API, Docs, Type or Attribute.
-// Description may also appear in Response and FileServer.
+// Description may also appear in Response and Files.
 //
 // Description accepts one arguments: the description string.
 //


### PR DESCRIPTION
[Description](https://godoc.org/goa.design/goa/dsl#Description) refers to `FileServer` as one of the places where it can be used.
It should read `Files` instead.