### PR TITLE
Fix package name of generated dummy multipart file

### DIFF
--- a/codegen/example/testdata/dsls.go
+++ b/codegen/example/testdata/dsls.go
@@ -207,3 +207,40 @@ var SingleServerMultipleHostsWithVariablesDSL = func() {
 		})
 	})
 }
+
+var ConflictWithAPINameAndServiceNamesIncludingMultipartDSL = func() {
+	var _ = API("aloha", func() {
+		Title("conflict with API name and service names including multipart")
+	})
+	var _ = Service("aloha", func() { // same as API name
+		Method("create", func() {
+			Payload(func() {
+				Attribute("price", Int)
+			})
+			HTTP(func() {
+				POST("/aloha")
+				MultipartRequest()
+			})
+		})
+	})
+	var _ = Service("alohaapi", func() { // API name + 'api' suffix
+		Method("create", func() {
+			Payload(func() {
+				Attribute("price", Int)
+			})
+			HTTP(func() {
+				POST("/aloha")
+			})
+		})
+	})
+	var _ = Service("alohaapi1", func() { // API name + 'api' suffix + sequential no.
+		Method("create", func() {
+			Payload(func() {
+				Attribute("price", Int)
+			})
+			HTTP(func() {
+				POST("/aloha")
+			})
+		})
+	})
+}

--- a/codegen/service/example_svc.go
+++ b/codegen/service/example_svc.go
@@ -40,11 +40,11 @@ func ExampleServiceFiles(genpkg string, root *expr.RootExpr) []*codegen.File {
 	// determine the unique API package name different from the service names
 	scope := codegen.NewNameScope()
 	for _, svc := range root.Services {
-		svc := Services.Get(svc.Name)
-		if svc == nil {
+		s := Services.Get(svc.Name)
+		if s == nil {
 			panic("unknown service, " + svc.Name) // bug
 		}
-		scope.Unique(svc.PkgName)
+		scope.Unique(s.PkgName)
 	}
 	apipkg := scope.Unique(strings.ToLower(codegen.Goify(root.API.Name, false)), "api")
 

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -129,6 +129,17 @@ func dummyMultipartFile(genpkg string, root *expr.RootExpr, svc *expr.HTTPServic
 
 		scope = codegen.NewNameScope()
 	)
+	// determine the unique API package name different from the service names
+	for _, svc := range root.Services {
+		s := HTTPServices.Get(svc.Name)
+		if s == nil {
+			panic("unknown http service, " + svc.Name) // bug
+		}
+		if s.Service == nil {
+			panic("unknown service, " + svc.Name) // bug
+		}
+		scope.Unique(s.Service.PkgName)
+	}
 	{
 		specs := []*codegen.ImportSpec{
 			{Path: "mime/multipart"},

--- a/http/codegen/example_server_test.go
+++ b/http/codegen/example_server_test.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"goa.design/goa/codegen"
@@ -13,41 +14,91 @@ import (
 )
 
 func TestExampleServerFiles(t *testing.T) {
-	cases := []struct {
-		Name string
-		DSL  func()
-		Code string
-	}{
-		{"no-server", ctestdata.NoServerDSL, testdata.NoServerServerHandleCode},
-		{"server-hosting-service-with-file-server", ctestdata.ServerHostingServiceWithFileServerDSL, testdata.ServerHostingServiceWithFileServerHandlerCode},
-		{"server-hosting-service-subset", ctestdata.ServerHostingServiceSubsetDSL, testdata.ServerHostingServiceSubsetServerHandleCode},
-		{"server-hosting-multiple-services", ctestdata.ServerHostingMultipleServicesDSL, testdata.ServerHostingMultipleServicesServerHandleCode},
-		{"streaming", testdata.StreamingMultipleServicesDSL, testdata.StreamingServerHandleCode},
-	}
-	for _, c := range cases {
-		t.Run(c.Name, func(t *testing.T) {
-			// reset global variable
-			HTTPServices = make(ServicesData)
-			service.Services = make(service.ServicesData)
-			example.Servers = make(example.ServersData)
-			codegen.RunDSL(t, c.DSL)
-			fs := ExampleServerFiles("", expr.Root)
-			if len(fs) == 0 {
-				t.Fatalf("got 0 files, expected 1")
-			}
-			if len(fs[0].SectionTemplates) == 0 {
-				t.Fatalf("got 0 sections, expected at least 1")
-			}
-			var buf bytes.Buffer
-			for _, s := range fs[0].SectionTemplates[1:] {
-				if err := s.Write(&buf); err != nil {
-					t.Fatal(err)
+	t.Run("package name check", func(t *testing.T) {
+		cases := []struct {
+			Name     string
+			DSL      func()
+			Expected string
+		}{
+			{
+				Name:     "conflict with API name and service names including multipart",
+				DSL:      ctestdata.ConflictWithAPINameAndServiceNamesIncludingMultipartDSL,
+				Expected: "package alohaapi2",
+			},
+		}
+		for _, c := range cases {
+			t.Run(c.Name, func(t *testing.T) {
+				// reset global variable
+				HTTPServices = make(ServicesData)
+				service.Services = make(service.ServicesData)
+				example.Servers = make(example.ServersData)
+				codegen.RunDSL(t, c.DSL)
+				if len(expr.Root.Services) != 3 {
+					t.Fatalf("got %d services, expected 3", len(expr.Root.Services))
 				}
-			}
-			code := codegen.FormatTestCode(t, "package foo\n"+buf.String())
-			if code != c.Code {
-				t.Errorf("invalid code for %s: got\n%s\ngot vs. expected:\n%s", fs[0].Path, code, codegen.Diff(t, code, c.Code))
-			}
-		})
-	}
+				fs := ExampleServerFiles("", expr.Root)
+				if len(fs) != 2 {
+					t.Fatalf("got %d example files, expected 2", len(fs))
+				}
+				for i, f := range fs {
+					if i < len(fs)-1 {
+						// Skip example http server.
+						continue
+					}
+					if len(f.SectionTemplates) == 0 {
+						t.Fatalf("got empty templates, expected not empty")
+					}
+					var b bytes.Buffer
+					if err := f.SectionTemplates[0].Write(&b); err != nil {
+						t.Fatal(err)
+					}
+					if line, err := b.ReadBytes('\n'); err != nil {
+						t.Fatal(err)
+					} else if got := string(bytes.TrimRight(line, "\n")); !reflect.DeepEqual(got, c.Expected) {
+						t.Fatalf("got %s, expected %s", got, c.Expected)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("code check", func(t *testing.T) {
+		cases := []struct {
+			Name string
+			DSL  func()
+			Code string
+		}{
+			{"no-server", ctestdata.NoServerDSL, testdata.NoServerServerHandleCode},
+			{"server-hosting-service-with-file-server", ctestdata.ServerHostingServiceWithFileServerDSL, testdata.ServerHostingServiceWithFileServerHandlerCode},
+			{"server-hosting-service-subset", ctestdata.ServerHostingServiceSubsetDSL, testdata.ServerHostingServiceSubsetServerHandleCode},
+			{"server-hosting-multiple-services", ctestdata.ServerHostingMultipleServicesDSL, testdata.ServerHostingMultipleServicesServerHandleCode},
+			{"streaming", testdata.StreamingMultipleServicesDSL, testdata.StreamingServerHandleCode},
+		}
+		for _, c := range cases {
+			t.Run(c.Name, func(t *testing.T) {
+				// reset global variable
+				HTTPServices = make(ServicesData)
+				service.Services = make(service.ServicesData)
+				example.Servers = make(example.ServersData)
+				codegen.RunDSL(t, c.DSL)
+				fs := ExampleServerFiles("", expr.Root)
+				if len(fs) == 0 {
+					t.Fatalf("got 0 files, expected 1")
+				}
+				if len(fs[0].SectionTemplates) == 0 {
+					t.Fatalf("got 0 sections, expected at least 1")
+				}
+				var buf bytes.Buffer
+				for _, s := range fs[0].SectionTemplates[1:] {
+					if err := s.Write(&buf); err != nil {
+						t.Fatal(err)
+					}
+				}
+				code := codegen.FormatTestCode(t, "package foo\n"+buf.String())
+				if code != c.Code {
+					t.Errorf("invalid code for %s: got\n%s\ngot vs. expected:\n%s", fs[0].Path, code, codegen.Diff(t, code, c.Code))
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
Generated dummy multipart file should have same package name as example service files.