### PR TITLE
Make it possible to create custom encoder/decoder of html

### DIFF
--- a/http/encoding.go
+++ b/http/encoding.go
@@ -54,6 +54,7 @@ type (
 //     * application/json using package encoding/json
 //     * application/xml using package encoding/xml
 //     * application/gob using package encoding/gob
+//     * text/html and text/plain for strings
 //
 // RequestDecoder defaults to the JSON decoder if the request "Content-Type"
 // header does not match any of the supported mime type or is missing


### PR DESCRIPTION
This is a feature proposal. I want to hear your opinion.

`http.RequestDecoder` and `http.ResponseEncoder` can be used as before.

```go
var (
	dec = goahttp.RequestDecoder
	enc = goahttp.ResponseEncoder
)
```

A custom decoder can be created by `NewRequestDecoder()`.

```go
var (
	dec = NewRequestDecoder([]DecoderConstructorSet{
		{
			ContentType: "application/x-msgpack",
			Suffix:      "+msgpack",
			DecoderConstructor: func(r io.Reader) Decoder {
				return msgpack.NewDecoder(r)
			},
		},
	})
)
```

Append decoders can be used with `DefaultDecoderConstructorSets`.

```go
var (
	dec = NewRequestDecoder(append(DefaultDecoderConstructorSets, {
		ContentType: "application/x-msgpack",
		Suffix:      "+msgpack",
		DecoderConstructor: func(r io.Reader) Decoder {
			return msgpack.NewDecoder(r)
		},
	}))
)
```