### PR TITLE
Issue 2206 - swagger:example not being honoured at attribute level

### DIFF
--- a/expr/example.go
+++ b/expr/example.go
@@ -24,6 +24,11 @@ func (a *AttributeExpr) Example(r *Random) interface{} {
 		// slice.
 		return a.UserExamples[l-1].Value
 	}
+
+	if value, ok := a.Meta.Last("swagger:example"); ok && value == "false" {
+		return nil
+	}
+
 	// randomize array length first, since that's from higher level
 	if hasLengthValidation(a) {
 		return byLength(a, r)

--- a/expr/example_test.go
+++ b/expr/example_test.go
@@ -59,11 +59,13 @@ func TestExample(t *testing.T) {
 		{"with-example", testdata.WithExampleDSL, "example", ""},
 		{"with-array-example", testdata.WithArrayExampleDSL, []int{1, 2}, ""},
 		{"with-map-example", testdata.WithMapExampleDSL, map[string]int{"name": 1, "value": 2}, ""},
-		{"with-mulitple-examples", testdata.WithMultipleExamplesDSL, 100, ""},
+		{"with-multiple-examples", testdata.WithMultipleExamplesDSL, 100, ""},
 		{"overriding-example", testdata.OverridingExampleDSL, map[string]interface{}{"name": "overridden"}, ""},
 		{"with-extend", testdata.WithExtendExampleDSL, map[string]interface{}{"name": "example"}, ""},
 		{"invalid-example-type", testdata.InvalidExampleTypeDSL, nil, "example value map[int]int{1:1} is incompatible with attribute of type map in attribute"},
 		{"empty-example", testdata.EmptyExampleDSL, nil, "not enough arguments in attribute"},
+		{"hiding-example", testdata.HidingExampleDSL, nil, ""},
+		{"overriding-hidden-examples", testdata.OverridingHiddenExamplesDSL, "example", ""},
 	}
 	r := expr.NewRandom("test")
 	for _, k := range cases {
@@ -75,9 +77,12 @@ func TestExample(t *testing.T) {
 					t.Errorf("invalid example: got %v, expected %v", example, k.Expected)
 				}
 			} else {
-				err := expr.RunInvalidDSL(t, k.DSL)
-				if !strings.Contains(err.Error(), k.Error) {
-					t.Errorf("invalid error: got %q, expected %q", err.Error(), k.Error)
+				if err := expr.RunInvalidDSL(t, k.DSL); err == nil {
+					t.Error("the expected error was not returned")
+				} else {
+					if !strings.Contains(err.Error(), k.Error) {
+						t.Errorf("invalid error: got %q, expected %q", err.Error(), k.Error)
+					}
 				}
 			}
 		})

--- a/expr/root.go
+++ b/expr/root.go
@@ -278,7 +278,7 @@ func (m MetaExpr) Merge(src MetaExpr) {
 	}
 }
 
-// Return the last value for a specific key, if the key exists and
+// Last returns the last value for a specific key, if the key exists and
 // has values; otherwise return nil, with the "ok" flag set to false.
 func (m MetaExpr) Last(key string) (string, bool) {
 	v, ok := m[key]

--- a/expr/root.go
+++ b/expr/root.go
@@ -277,3 +277,19 @@ func (m MetaExpr) Merge(src MetaExpr) {
 		}
 	}
 }
+
+// Return the last value for a specific key, if the key exists and
+// has values; otherwise return nil, with the "ok" flag set to false.
+func (m MetaExpr) Last(key string) (string, bool) {
+	v, ok := m[key]
+	if !ok {
+		return "", false
+	}
+
+	l := len(v)
+	if l < 1 {
+		return "", false
+	}
+
+	return v[l-1], true
+}

--- a/expr/root_test.go
+++ b/expr/root_test.go
@@ -2,7 +2,6 @@ package expr
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"goa.design/goa/v3/eval"
@@ -88,8 +87,12 @@ func TestMetaExpr_Last(t *testing.T) {
 	for name, tc := range tt {
 		t.Run(name, func(t *testing.T) {
 			value, ok := tc.meta.Last("test:key")
-			assert.Equal(t, tc.value, value)
-			assert.Equal(t, tc.ok, ok)
+			if tc.ok != ok {
+				t.Errorf("expected ok to be %v, got %v", tc.ok, ok)
+			}
+			if tc.value != value {
+				t.Errorf("expected value to be %s, got %s", value, value)
+			}
 		})
 	}
 }

--- a/expr/root_test.go
+++ b/expr/root_test.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"goa.design/goa/v3/eval"
@@ -41,5 +42,54 @@ func TestRootExprValidate(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestMetaExpr_Last(t *testing.T) {
+	tt := map[string]struct {
+		meta  MetaExpr
+		value string
+		ok    bool
+	}{
+		"no-key": {
+			MetaExpr{},
+			"",
+			false,
+		},
+		"key-no-values": {
+			MetaExpr{
+				"test:key": []string{},
+			},
+			"",
+			false,
+		},
+		"key-with-one-value": {
+			MetaExpr{
+				"test:key": []string{
+					"value-one",
+				},
+			},
+			"value-one",
+			true,
+		},
+		"key-with-multiple-values": {
+			MetaExpr{
+				"test:key": []string{
+					"value-one",
+					"value-two",
+					"value-n",
+				},
+			},
+			"value-n",
+			true,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			value, ok := tc.meta.Last("test:key")
+			assert.Equal(t, tc.value, value)
+			assert.Equal(t, tc.ok, ok)
+		})
 	}
 }

--- a/expr/testdata/example_test_dsls.go
+++ b/expr/testdata/example_test_dsls.go
@@ -95,3 +95,24 @@ var EmptyExampleDSL = func() {
 		})
 	})
 }
+
+var HidingExampleDSL = func() {
+	Service("HidingExample", func() {
+		Method("Method", func() {
+			Payload(String, func() {
+				Meta("swagger:example", "false")
+			})
+		})
+	})
+}
+
+var OverridingHiddenExamplesDSL = func() {
+	Service("OverridingHiddenExamples", func() {
+		Meta("swagger:example", "false")
+		Method("Method", func() {
+			Payload(String, func() {
+				Example("example")
+			})
+		})
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v1.0.0
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
+	github.com/stretchr/testify v1.3.0
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
 	golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59
 	google.golang.org/grpc v1.20.1

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v1.0.0
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
-	github.com/stretchr/testify v1.3.0
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
 	golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59
 	google.golang.org/grpc v1.20.1


### PR DESCRIPTION
This is an attempted fix tothe issue reported at 2206, where `swagger:example` `false` is not being honoured at attribute level.

It seems sensible (to me) and tests are passing alright; however I didn't manage to generate from a design using the new logic.