### PR TITLE
Reset payload type before inherit attributes for path params from parent service

### DIFF
--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -181,6 +181,9 @@ func (e *HTTPEndpointExpr) Prepare() {
 				// Inherit attributes for path params from parent service
 				WalkMappedAttr(c.PathParams(), func(name, _ string, _ *AttributeExpr) error {
 					if att := c.MethodExpr.Payload.Find(name); att != nil {
+						if e.MethodExpr.Payload.Type == Empty {
+							e.MethodExpr.Payload.Type = &Object{}
+						}
 						if o := AsObject(e.MethodExpr.Payload.Type); o != nil {
 							if o.Attribute(name) == nil {
 								o.Set(name, att)
@@ -849,6 +852,9 @@ func isEmpty(a *AttributeExpr) bool {
 		return false
 	}
 	if obj := AsObject(a.Type); obj != nil && len(*obj) != 0 {
+		if a.Type == Empty {
+			panic("Empty should have no attribute") // bug
+		}
 		return false
 	}
 	if len(a.Bases) != 0 || len(a.References) != 0 {

--- a/expr/http_endpoint_test.go
+++ b/expr/http_endpoint_test.go
@@ -69,6 +69,9 @@ func TestHTTPEndpointValidation(t *testing.T) {
 		"endpoint-has-parent": {
 			DSL: testdata.EndpointHasParent,
 		},
+		"endpoint-has-parent-and-other": {
+			DSL: testdata.EndpointHasParentAndOther,
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/expr/testdata/endpoint_dsls.go
+++ b/expr/testdata/endpoint_dsls.go
@@ -199,6 +199,47 @@ var EndpointHasParent = func() {
 	})
 }
 
+var EndpointHasParentAndOther = func() {
+	Service("Parent", func() {
+		HTTP(func() {
+			Path("/parents")
+			CanonicalMethod("Method")
+		})
+		Method("Method", func() {
+			Payload(func() {
+				Attribute("parent_id", Int)
+				Attribute("query_1", String)
+			})
+			HTTP(func() {
+				GET("/{parent_id}")
+				Param("query_1")
+			})
+		})
+	})
+	Service("Child", func() {
+		HTTP(func() {
+			Path("/children")
+			Parent("Parent")
+		})
+		Method("Method", func() {
+			HTTP(func() {
+				GET("")
+			})
+		})
+	})
+	Service("Other", func() {
+		HTTP(func() {
+			Path("/others")
+		})
+		Method("Method", func() {
+			HTTP(func() {
+				GET("")
+			})
+		})
+	})
+
+}
+
 var FinalizeEndpointBodyAsExtendedTypeDSL = func() {
 	var EntityData = Type("EntityData", func() {
 		Attribute("name", String)


### PR DESCRIPTION
This is backport of #2343 to v3.