### PR TITLE
Handle response body using method result type field.

### DIFF
--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -527,9 +527,7 @@ func (e *HTTPEndpointExpr) Finalize() {
 	// Initialize responses parent, headers and body
 	for _, r := range e.Responses {
 		r.Finalize(e, e.MethodExpr.Result)
-		if r.Body == nil {
-			r.Body = httpResponseBody(e, r)
-		}
+		r.Body = httpResponseBody(e, r)
 		r.Body.Finalize()
 	}
 

--- a/expr/http_response.go
+++ b/expr/http_response.go
@@ -226,7 +226,7 @@ func (r *HTTPResponseExpr) Finalize(a *HTTPEndpointExpr, svcAtt *AttributeExpr) 
 					if r.Body.Validation == nil {
 						r.Body.Validation = &ValidationExpr{}
 					}
-					r.Body.Validation.Required = append(r.Body.Validation.Required, n)
+					r.Body.Validation.AddRequired(n)
 				}
 			}
 		}

--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -171,7 +171,7 @@ const ExplicitBodyUserResultMultipleViewsInitCode = `// NewMethodExplicitBodyUse
 // a "ServiceExplicitBodyUserResultMultipleView" service
 // "MethodExplicitBodyUserResultMultipleView" endpoint result from a HTTP "OK"
 // response.
-func NewMethodExplicitBodyUserResultMultipleViewResulttypemultipleviewsOK(body *UserType, c *string) *serviceexplicitbodyuserresultmultipleviewviews.ResulttypemultipleviewsView {
+func NewMethodExplicitBodyUserResultMultipleViewResulttypemultipleviewsOK(body *MethodExplicitBodyUserResultMultipleViewResponseBody, c *string) *serviceexplicitbodyuserresultmultipleviewviews.ResulttypemultipleviewsView {
 	v := &serviceexplicitbodyuserresultmultipleviewviews.UserTypeView{
 		X: body.X,
 		Y: body.Y,

--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -69,6 +69,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 	for _, a := range svc.HTTPEndpoints {
 		adata := data.Endpoint(a.Name())
 		if data := adata.Payload.Request.ClientBody; data != nil {
+			if _, ok := seen[data.Name]; ok {
+				continue
+			}
+			seen[data.Name] = struct{}{}
 			if data.Def != "" {
 				sections = append(sections, &codegen.SectionTemplate{
 					Name:   "client-request-body",
@@ -85,6 +89,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 		}
 		if adata.ClientStream != nil {
 			if data := adata.ClientStream.Payload; data != nil {
+				if _, ok := seen[data.Name]; ok {
+					continue
+				}
+				seen[data.Name] = struct{}{}
 				if data.Def != "" {
 					sections = append(sections, &codegen.SectionTemplate{
 						Name:   "client-request-body",
@@ -107,6 +115,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 		adata := data.Endpoint(a.Name())
 		for _, resp := range adata.Result.Responses {
 			if data := resp.ClientBody; data != nil {
+				if _, ok := seen[data.Name]; ok {
+					continue
+				}
+				seen[data.Name] = struct{}{}
 				if data.Def != "" {
 					sections = append(sections, &codegen.SectionTemplate{
 						Name:   "client-response-body",
@@ -127,6 +139,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 		for _, gerr := range adata.Errors {
 			for _, herr := range gerr.Errors {
 				if data := herr.Response.ClientBody; data != nil {
+					if _, ok := seen[data.Name]; ok {
+						continue
+					}
+					seen[data.Name] = struct{}{}
 					if data.Def != "" {
 						sections = append(sections, &codegen.SectionTemplate{
 							Name:   "client-error-body",
@@ -143,6 +159,11 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 	}
 
 	for _, data := range data.ClientBodyAttributeTypes {
+		if _, ok := seen[data.Name]; ok {
+			continue
+		}
+		seen[data.Name] = struct{}{}
+
 		if data.Def != "" {
 			sections = append(sections, &codegen.SectionTemplate{
 				Name:   "client-body-attributes",

--- a/http/codegen/testdata/result_decode_functions.go
+++ b/http/codegen/testdata/result_decode_functions.go
@@ -200,7 +200,7 @@ func DecodeMethodExplicitBodyUserResultMultipleViewResponse(decoder func(*http.R
 		switch resp.StatusCode {
 		case http.StatusOK:
 			var (
-				body UserType
+				body MethodExplicitBodyUserResultMultipleViewResponseBody
 				err  error
 			)
 			err = decoder(resp).Decode(&body)

--- a/http/codegen/testdata/result_encode_functions.go
+++ b/http/codegen/testdata/result_encode_functions.go
@@ -743,7 +743,7 @@ func EncodeMethodExplicitBodyUserResultMultipleViewResponse(encoder func(context
 		res := v.(*serviceexplicitbodyuserresultmultipleviewviews.Resulttypemultipleviews)
 		w.Header().Set("goa-view", res.View)
 		enc := encoder(ctx, w)
-		body := NewUserType(res.Projected)
+		body := NewMethodExplicitBodyUserResultMultipleViewResponseBody(res.Projected)
 		if res.Projected.C != nil {
 			w.Header().Set("Location", *res.Projected.C)
 		}


### PR DESCRIPTION
Create a endpoint specific type to handle the case where multiple methods
with different result types use the same response body definition pointing
to the same user type field. We need different type names so that encoding
and decoding to and from the different result types use different functions
with different names as generated by the HTTP server code generator.

Fix #2344 