### PR TITLE
v3: Fix a bug that caused a build error when a variable of a payload is not referenced

### DIFF
--- a/grpc/codegen/server.go
+++ b/grpc/codegen/server.go
@@ -242,7 +242,7 @@ func (s *{{ .ServerStruct }}) {{ .Method.VarName }}(
 	ctx = context.WithValue(ctx, goa.ServiceKey, {{ printf "%q" .ServiceName }})
 
 {{- if .ServerStream }}
-	p, err := s.{{ .Method.VarName }}H.Decode(ctx, {{ if .Method.StreamingPayload }}nil{{ else }}message{{ end }})
+	{{if .PayloadRef }}p{{ else }}_{{ end }}, err := s.{{ .Method.VarName }}H.Decode(ctx, {{ if .Method.StreamingPayload }}nil{{ else }}message{{ end }})
 	{{- template "handle_error" . }}
 	ep := &{{ .ServicePkgName }}.{{ .Method.VarName }}EndpointInput{
 		Stream: &{{ .ServerStream.VarName }}{stream: stream},

--- a/grpc/codegen/testdata/server_interface_code.go
+++ b/grpc/codegen/testdata/server_interface_code.go
@@ -130,7 +130,7 @@ func (s *Server) MethodClientStreamingRPC(stream service_client_streaming_rpcpb.
 	ctx := stream.Context()
 	ctx = context.WithValue(ctx, goa.MethodKey, "MethodClientStreamingRPC")
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceClientStreamingRPC")
-	p, err := s.MethodClientStreamingRPCH.Decode(ctx, nil)
+	_, err := s.MethodClientStreamingRPCH.Decode(ctx, nil)
 	if err != nil {
 		return goagrpc.EncodeError(err)
 	}
@@ -177,7 +177,7 @@ func (s *Server) MethodBidirectionalStreamingRPC(stream service_bidirectional_st
 	ctx := stream.Context()
 	ctx = context.WithValue(ctx, goa.MethodKey, "MethodBidirectionalStreamingRPC")
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceBidirectionalStreamingRPC")
-	p, err := s.MethodBidirectionalStreamingRPCH.Decode(ctx, nil)
+	_, err := s.MethodBidirectionalStreamingRPCH.Decode(ctx, nil)
 	if err != nil {
 		return goagrpc.EncodeError(err)
 	}
@@ -224,7 +224,7 @@ func (s *Server) MethodBidirectionalStreamingRPCWithErrors(stream service_bidire
 	ctx := stream.Context()
 	ctx = context.WithValue(ctx, goa.MethodKey, "MethodBidirectionalStreamingRPCWithErrors")
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceBidirectionalStreamingRPCWithErrors")
-	p, err := s.MethodBidirectionalStreamingRPCWithErrorsH.Decode(ctx, nil)
+	_, err := s.MethodBidirectionalStreamingRPCWithErrorsH.Decode(ctx, nil)
 	if err != nil {
 		if en, ok := err.(ErrorNamer); ok {
 			switch en.ErrorName() {


### PR DESCRIPTION
In gRPC, a payload variable is always prepared 
even though the payload reference might be unnecessary.

**An example of design**

```go
package design

import (
	. "goa.design/goa/v3/dsl"
)

var _ = Service("calc", func() {
	Method("add", func() {
		StreamingPayload(func() {
			Field(1, "a", Int, "Left operand")
			Field(2, "b", Int, "Right operand")
			Required("a", "b")
		})
		Result(Int)
		GRPC(func() {
		})
	})
```

**Error**

```
$ go run ./cmd/calc
# calc/gen/grpc/calc/server
gen/grpc/calc/server/server.go:56:2: p declared and not used
```

**Generated code**

```go
// Add implements the "Add" method in calcpb.CalcServer interface.
func (s *Server) Add(stream calcpb.Calc_AddServer) error {
	ctx := stream.Context()
	ctx = context.WithValue(ctx, goa.MethodKey, "add")
	ctx = context.WithValue(ctx, goa.ServiceKey, "calc")
	p, err := s.AddH.Decode(ctx, nil)  // ← var p is not referenced anywhere
	if err != nil {
		return goagrpc.EncodeError(err)
	}
	ep := &calc.AddEndpointInput{
		Stream: &AddServerStream{stream: stream},
	}
	err = s.AddH.Handle(ctx, ep)
	if err != nil {
		return goagrpc.EncodeError(err)
	}
	return nil
}
```