### PR TITLE
v3: Create the template function for authentication in the file for each service

### DIFF
--- a/codegen/generator/example.go
+++ b/codegen/generator/example.go
@@ -25,11 +25,6 @@ func Example(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 			files = append(files, fs...)
 		}
 
-		// example auth file
-		if f := service.AuthFuncsFile(genpkg, r); f != nil {
-			files = append(files, f)
-		}
-
 		// server main
 		if fs := example.ServerFiles(genpkg, r); len(fs) != 0 {
 			files = append(files, fs...)

--- a/codegen/service/auth_funcs.go
+++ b/codegen/service/auth_funcs.go
@@ -1,10 +1,6 @@
 package service
 
 import (
-	"os"
-	"path"
-	"strings"
-
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/expr"
 )
@@ -12,56 +8,7 @@ import (
 // AuthFuncsFile returns a file that contains a dummy implementation of the
 // authorization functions needed to instantiate the service endpoints.
 func AuthFuncsFile(genpkg string, root *expr.RootExpr) *codegen.File {
-	filepath := "auth.go"
-	if _, err := os.Stat(filepath); !os.IsNotExist(err) {
-		return nil // file already exists, skip it.
-	}
-
-	var (
-		sections []*codegen.SectionTemplate
-		generate bool
-
-		scope = codegen.NewNameScope()
-	)
-	{
-		specs := []*codegen.ImportSpec{
-			{Path: "context"},
-			{Path: "fmt"},
-			codegen.GoaImport(""),
-			codegen.GoaImport("security"),
-		}
-		for _, svc := range root.Services {
-			sd := Services.Get(svc.Name)
-			specs = append(specs, &codegen.ImportSpec{
-				Path: path.Join(genpkg, codegen.SnakeCase(sd.VarName)),
-				Name: scope.Unique(sd.PkgName),
-			})
-		}
-
-		apiPkg := scope.Unique(strings.ToLower(codegen.Goify(root.API.Name, false)), "api")
-		header := codegen.Header("", apiPkg, specs)
-		sections = []*codegen.SectionTemplate{header}
-		for _, s := range root.Services {
-			svc := Services.Get(s.Name)
-			if len(svc.Schemes) > 0 {
-				generate = true
-				sections = append(sections, &codegen.SectionTemplate{
-					Name:   "security-authfuncs",
-					Source: dummyAuthFuncsT,
-					Data:   svc,
-				})
-			}
-		}
-	}
-	if len(sections) == 0 || !generate {
-		return nil
-	}
-
-	return &codegen.File{
-		Path:             filepath,
-		SectionTemplates: sections,
-		SkipExist:        true,
-	}
+	return nil
 }
 
 // data: Data

--- a/codegen/service/auth_funcs.go
+++ b/codegen/service/auth_funcs.go
@@ -1,16 +1,5 @@
 package service
 
-import (
-	"goa.design/goa/v3/codegen"
-	"goa.design/goa/v3/expr"
-)
-
-// AuthFuncsFile returns a file that contains a dummy implementation of the
-// authorization functions needed to instantiate the service endpoints.
-func AuthFuncsFile(genpkg string, root *expr.RootExpr) *codegen.File {
-	return nil
-}
-
 // data: Data
 const dummyAuthFuncsT = `{{ range .Schemes }}
 {{ printf "%sAuth implements the authorization logic for service %q for the %q security scheme." .Type $.Name .SchemeName | comment }}

--- a/codegen/service/example_svc.go
+++ b/codegen/service/example_svc.go
@@ -70,15 +70,12 @@ func exampleServiceFile(genpkg string, root *expr.RootExpr, svc *expr.ServiceExp
 		{Path: "log"},
 		{Path: "fmt"},
 		{Path: path.Join(genpkg, codegen.SnakeCase(svcName)), Name: data.PkgName},
-		{Path: "goa.design/goa/security"},
+		{Path: "goa.design/goa/v3/security"},
 	}
 	sections := []*codegen.SectionTemplate{
 		codegen.Header("", apipkg, specs),
 		{Name: "basic-service-struct", Source: svcStructT, Data: data},
 		{Name: "basic-service-init", Source: svcInitT, Data: data},
-	}
-	for _, m := range svc.Methods {
-		sections = append(sections, basicEndpointSection(m, data))
 	}
 	if len(data.Schemes) > 0 {
 		sections = append(sections, &codegen.SectionTemplate{
@@ -86,6 +83,9 @@ func exampleServiceFile(genpkg string, root *expr.RootExpr, svc *expr.ServiceExp
 			Source: dummyAuthFuncsT,
 			Data:   data,
 		})
+	}
+	for _, m := range svc.Methods {
+		sections = append(sections, basicEndpointSection(m, data))
 	}
 
 	return &codegen.File{

--- a/codegen/service/example_svc.go
+++ b/codegen/service/example_svc.go
@@ -78,6 +78,13 @@ func exampleServiceFile(genpkg string, root *expr.RootExpr, svc *expr.ServiceExp
 	for _, m := range svc.Methods {
 		sections = append(sections, basicEndpointSection(m, data))
 	}
+	if len(data.Schemes) > 0 {
+		sections = append(sections, &codegen.SectionTemplate{
+			Name:   "security-authfuncs",
+			Source: dummyAuthFuncsT,
+			Data:   data,
+		})
+	}
 
 	return &codegen.File{
 		Path:             fpath,

--- a/codegen/service/example_svc.go
+++ b/codegen/service/example_svc.go
@@ -68,7 +68,9 @@ func exampleServiceFile(genpkg string, root *expr.RootExpr, svc *expr.ServiceExp
 	specs := []*codegen.ImportSpec{
 		{Path: "context"},
 		{Path: "log"},
+		{Path: "fmt"},
 		{Path: path.Join(genpkg, codegen.SnakeCase(svcName)), Name: data.PkgName},
+		{Path: "goa.design/goa/security"},
 	}
 	sections := []*codegen.SectionTemplate{
 		codegen.Header("", apipkg, specs),


### PR DESCRIPTION
see #2361 

## Example

```go
package design

import (
	. "goa.design/goa/v3/dsl"
)

var BasicAuth = BasicAuthSecurity("basicauth")

var _ = Service("calc1", func() {
	Security(BasicAuth)
	Method("add", func() {
		Payload(func() {
			Username("username")
			Password("password")
			Field(1, "a", Int, "Left operand")
			Field(2, "b", Int, "Right operand")
			Required("a", "b")
		})
		Result(Int)
		HTTP(func() {
			GET("/add/{a}/{b}")
		})
	})
})

var _ = Service("calc2", func() {
	Security(BasicAuth)
	Method("mul", func() {
		Payload(func() {
			Username("username")
			Password("password")
			Field(1, "a", Int, "Left operand")
			Field(2, "b", Int, "Right operand")
			Required("a", "b")
		})
		Result(Int)
		HTTP(func() {
			GET("/mul/{a}/{b}")
		})
	})
})

```

## goa gen

The authentication method is in each service file.

calc1.go
```go
package calc1api

import (
	calc1 "calc/gen/calc1"
	"context"
	"fmt"
	"log"

	"goa.design/goa/v3/security"
)

// calc1 service example implementation.
// The example methods log the requests and return zero values.
type calc1srvc struct {
	logger *log.Logger
}

// NewCalc1 returns the calc1 service implementation.
func NewCalc1(logger *log.Logger) calc1.Service {
	return &calc1srvc{logger}
}

// BasicAuth implements the authorization logic for service "calc1" for the
// "basicauth" security scheme.
func (s *calc1srvc) BasicAuth(ctx context.Context, user, pass string, scheme *security.BasicScheme) (context.Context, error) {
	//
	// TBD: add authorization logic.
	//
	// In case of authorization failure this function should return
	// one of the generated error structs, e.g.:
	//
	//    return ctx, myservice.MakeUnauthorizedError("invalid token")
	//
	// Alternatively this function may return an instance of
	// goa.ServiceError with a Name field value that matches one of
	// the design error names, e.g:
	//
	//    return ctx, goa.PermanentError("unauthorized", "invalid token")
	//
	return ctx, fmt.Errorf("not implemented")
}

// Add implements add.
func (s *calc1srvc) Add(ctx context.Context, p *calc1.AddPayload) (res int, err error) {
	s.logger.Print("calc1.add")
	return
}
```
calc2.go
```go
package calc1api

import (
	calc2 "calc/gen/calc2"
	"context"
	"fmt"
	"log"

	"goa.design/goa/v3/security"
)

// calc2 service example implementation.
// The example methods log the requests and return zero values.
type calc2srvc struct {
	logger *log.Logger
}

// NewCalc2 returns the calc2 service implementation.
func NewCalc2(logger *log.Logger) calc2.Service {
	return &calc2srvc{logger}
}

// BasicAuth implements the authorization logic for service "calc2" for the
// "basicauth" security scheme.
func (s *calc2srvc) BasicAuth(ctx context.Context, user, pass string, scheme *security.BasicScheme) (context.Context, error) {
	//
	// TBD: add authorization logic.
	//
	// In case of authorization failure this function should return
	// one of the generated error structs, e.g.:
	//
	//    return ctx, myservice.MakeUnauthorizedError("invalid token")
	//
	// Alternatively this function may return an instance of
	// goa.ServiceError with a Name field value that matches one of
	// the design error names, e.g:
	//
	//    return ctx, goa.PermanentError("unauthorized", "invalid token")
	//
	return ctx, fmt.Errorf("not implemented")
}

// Mul implements mul.
func (s *calc2srvc) Mul(ctx context.Context, p *calc2.MulPayload) (res int, err error) {
	s.logger.Print("calc2.mul")
	return
}
```

