### PR TITLE
v3: Files must appear in Service

### DIFF
--- a/dsl/http_file_server.go
+++ b/dsl/http_file_server.go
@@ -55,16 +55,19 @@ func Files(path, filename string, fns ...func()) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	if s, ok := eval.Current().(*expr.ServiceExpr); ok {
-		r := expr.Root.API.HTTP.ServiceFor(s)
-		server := &expr.HTTPFileServerExpr{
-			Service:      r,
-			RequestPaths: []string{path},
-			FilePath:     filename,
-		}
-		if len(fns) > 0 {
-			eval.Execute(fns[0], server)
-		}
-		r.FileServers = append(r.FileServers, server)
+	s, ok := eval.Current().(*expr.ServiceExpr)
+	if !ok {
+		eval.IncompatibleDSL()
+		return
 	}
+	r := expr.Root.API.HTTP.ServiceFor(s)
+	server := &expr.HTTPFileServerExpr{
+		Service:      r,
+		RequestPaths: []string{path},
+		FilePath:     filename,
+	}
+	if len(fns) > 0 {
+		eval.Execute(fns[0], server)
+	}
+	r.FileServers = append(r.FileServers, server)
 }

--- a/expr/http_file_server_test.go
+++ b/expr/http_file_server_test.go
@@ -1,0 +1,32 @@
+package expr_test
+
+import (
+	"strings"
+	"testing"
+
+	"goa.design/goa/v3/expr"
+	"goa.design/goa/v3/expr/testdata"
+)
+
+func TestFilesDSL(t *testing.T) {
+	cases := []struct {
+		Name  string
+		DSL   func()
+		Error string
+	}{
+		{Name: "valid", DSL: testdata.FilesValidDSL},
+		{Name: "incompatible", DSL: testdata.FilesIncompatibleDSL, Error: "invalid use of Files in API files-incompatile"},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			if c.Error == "" {
+				expr.RunDSL(t, c.DSL)
+			} else {
+				err := expr.RunInvalidDSL(t, c.DSL)
+				if !strings.HasSuffix(err.Error(), c.Error) {
+					t.Errorf("got error %q, expected has suffix %q", err.Error(), c.Error)
+				}
+			}
+		})
+	}
+}

--- a/expr/testdata/http_file_server.go
+++ b/expr/testdata/http_file_server.go
@@ -1,0 +1,17 @@
+package testdata
+
+import (
+	. "goa.design/goa/v3/dsl"
+)
+
+var FilesValidDSL = func() {
+	Service("files-dsl", func() {
+		Files("path", "filename")
+	})
+}
+
+var FilesIncompatibleDSL = func() {
+	API("files-incompatile", func() {
+		Files("path", "filename")
+	})
+}


### PR DESCRIPTION
According to the specification, `Files` DSL must appear in `Service`.
But it is available in the `API`, etc...
