### PR TITLE
v1: Prevent directory path traversal in FileHandler

### DIFF
--- a/service.go
+++ b/service.go
@@ -422,23 +422,23 @@ func (ctrl *Controller) FileHandler(path, filename string) Handler {
 func attemptsPathTraversal(req string, path string) bool {
 	if !strings.Contains(req, "..") {
 		return false
-	} else {
-		current_path_idx := 0
-		if idx := strings.LastIndex(path, "/*"); idx > -1 && idx < len(path)-1 {
-			req = req[idx+1:]
-		}
-		for _, runeValue := range strings.FieldsFunc(req, isSlashRune) {
-			if runeValue == ".." {
-				current_path_idx--
-				if current_path_idx < 0 {
-					return true
-				}
-			} else {
-				current_path_idx++
-			}
-		}
-		return false
 	}
+
+	currentPathIdx := 0
+	if idx := strings.LastIndex(path, "/*"); idx > -1 && idx < len(path)-1 {
+		req = req[idx+1:]
+	}
+	for _, runeValue := range strings.FieldsFunc(req, isSlashRune) {
+		if runeValue == ".." {
+			currentPathIdx--
+			if currentPathIdx < 0 {
+				return true
+			}
+		} else {
+			currentPathIdx++
+		}
+	}
+	return false
 }
 
 func isSlashRune(r rune) bool {


### PR DESCRIPTION
Presently `FileHandler` allows `../` which enables directory path traversal when a `Files` endpoint is defined with a wildcard.

Example API design definition:

```
var _ = Resource("docs", func() {
	Description("Documentation endpoint")

	Origin("*", func() {
		Methods("GET", "OPTIONS")
	})

	Files("/docs/*filepath", "swagger-ui")
})
```

Example exploit:

```
curl "http://localhost/docs/..%2F..%2F..%2Fetc%2F"
```

This patch updates `FileHandler` to return `ErrNotFound` if a `../` is found in `req.URL.Path`.

I wanted to submit tests along with this but got stuck trying to make them work. If someone could provide guidance, I would be happy to make another attempt.

Existing tests do pass:

```
$ make test
Ginkgo ran 25 suites in 1m1.149089831s
Test Suite Passed
go test ./_integration_tests
ok  	github.com/goadesign/goa/_integration_tests	20.423s
```

Additionally, I've applied this patch to a local dev instance of our app and verified the changes operates as expected. A curl request such as the one does return a 404.

