### PR TITLE
Properly handle struct:field:type metadata

### DIFF
--- a/codegen/import.go
+++ b/codegen/import.go
@@ -34,10 +34,9 @@ func (s *ImportSpec) Code() string {
 	return fmt.Sprintf(`"%s"`, s.Path)
 }
 
-// getMetaTypeInfo gets type and import info from an attribute's metadata. struct:field:type can have 3 arguments,
-// first being the go type name, second being import path,
-// and third being the name of a qualified import, in case of name collisions.
-func getMetaTypeInfo(att *expr.AttributeExpr) (typeName string, importS *ImportSpec) {
+// GetMetaType retrieves the type and package defined by the struct:field:type
+// metadata if any.
+func GetMetaType(att *expr.AttributeExpr) (typeName string, importS *ImportSpec) {
 	if att == nil {
 		return typeName, importS
 	}
@@ -83,30 +82,30 @@ func safelyGetMetaTypeImports(att *expr.AttributeExpr, seen map[string]struct{})
 			}
 		}
 	case *expr.Array:
-		_, im := getMetaTypeInfo(t.ElemType)
+		_, im := GetMetaType(t.ElemType)
 		if im != nil {
 			uniqueImports[*im] = struct{}{}
 		}
 	case *expr.Map:
-		_, im := getMetaTypeInfo(t.ElemType)
+		_, im := GetMetaType(t.ElemType)
 		if im != nil {
 			uniqueImports[*im] = struct{}{}
 		}
-		_, im = getMetaTypeInfo(t.KeyType)
+		_, im = GetMetaType(t.KeyType)
 		if im != nil {
 			uniqueImports[*im] = struct{}{}
 		}
 	case *expr.Object:
 		for _, key := range *t {
 			if key != nil {
-				_, im := getMetaTypeInfo(key.Attribute)
+				_, im := GetMetaType(key.Attribute)
 				if im != nil {
 					uniqueImports[*im] = struct{}{}
 				}
 			}
 		}
 	}
-	_, im := getMetaTypeInfo(att)
+	_, im := GetMetaType(att)
 	if im != nil {
 		uniqueImports[*im] = struct{}{}
 	}

--- a/codegen/scope.go
+++ b/codegen/scope.go
@@ -98,7 +98,7 @@ func (s *NameScope) Name(name string) string {
 func (s *NameScope) GoTypeDef(att *expr.AttributeExpr, ptr, useDefault bool) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
-		if t, _ := getMetaTypeInfo(att); t != "" {
+		if t, _ := GetMetaType(att); t != "" {
 			return t
 		}
 		return GoNativeTypeName(actual)
@@ -189,7 +189,7 @@ func (s *NameScope) GoTypeName(att *expr.AttributeExpr) string {
 func (s *NameScope) GoFullTypeName(att *expr.AttributeExpr, pkg string) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
-		if t, _ := getMetaTypeInfo(att); t != "" {
+		if t, _ := GetMetaType(att); t != "" {
 			return t
 		}
 		return GoNativeTypeName(actual)

--- a/http/codegen/typedef.go
+++ b/http/codegen/typedef.go
@@ -26,6 +26,9 @@ import (
 func goTypeDef(scope *codegen.NameScope, att *expr.AttributeExpr, ptr, useDefault bool) string {
 	switch actual := att.Type.(type) {
 	case expr.Primitive:
+		if t, _ := codegen.GetMetaType(att); t != "" {
+			return t
+		}
 		return codegen.GoNativeTypeName(actual)
 	case *expr.Array:
 		d := goTypeDef(scope, actual.ElemType, ptr, useDefault)


### PR DESCRIPTION
When generating HTTP marshaling code.

Fix #2399 