### PR TITLE
v3: Fix decoding of queries with string slices set as default

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -653,7 +653,11 @@ const requestParamsHeadersT = `{{- define "request_params_headers" }}
 		}
 		{{- else if .DefaultValue }}
 		if {{ .VarName }} == nil {
-			{{ .VarName }} = {{ printf "%#v" .DefaultValue }}
+			{{ .VarName }} = []string{
+                {{- range $i, $v := .DefaultValue }}
+                    {{- if $i }}{{ print ", " }}{{ end }}
+                    {{- printf "%q" $v -}} 
+                {{- end -}} }
 		}
 		{{- end }}
 

--- a/http/codegen/server_decode_test.go
+++ b/http/codegen/server_decode_test.go
@@ -94,6 +94,7 @@ func TestDecode(t *testing.T) {
 		{"query-string-mapped", testdata.PayloadQueryStringMappedDSL, testdata.PayloadQueryStringMappedDecodeCode},
 
 		{"query-string-default", testdata.PayloadQueryStringDefaultDSL, testdata.PayloadQueryStringDefaultDecodeCode},
+		{"query-string-slice-default", testdata.PayloadQueryStringSliceDefaultDSL, testdata.PayloadQueryStringSliceDefaultDecodeCode},
 		{"query-string-default-validate", testdata.PayloadQueryStringDefaultValidateDSL, testdata.PayloadQueryStringDefaultValidateDecodeCode},
 		{"query-primitive-string-default", testdata.PayloadQueryPrimitiveStringDefaultDSL, testdata.PayloadQueryPrimitiveStringDefaultDecodeCode},
 		{"query-string-extended-payload", testdata.PayloadExtendedQueryStringDSL, testdata.PayloadExtendedQueryStringDecodeCode},

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -2802,6 +2802,25 @@ func DecodeMethodQueryStringDefaultRequest(mux goahttp.Muxer, decoder func(*http
 }
 `
 
+var PayloadQueryStringSliceDefaultDecodeCode = `// DecodeMethodQueryStringSliceDefaultRequest returns a decoder for requests
+// sent to the ServiceQueryStringSliceDefault MethodQueryStringSliceDefault
+// endpoint.
+func DecodeMethodQueryStringSliceDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			q []string
+		)
+		q = r.URL.Query()["q"]
+		if q == nil {
+			q = []string{"hello", "goodbye"}
+		}
+		payload := NewMethodQueryStringSliceDefaultPayload(q)
+
+		return payload, nil
+	}
+}
+`
+
 var PayloadQueryStringDefaultValidateDecodeCode = `// DecodeMethodQueryStringDefaultValidateRequest returns a decoder for requests
 // sent to the ServiceQueryStringDefaultValidate
 // MethodQueryStringDefaultValidate endpoint.

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -1291,6 +1291,22 @@ var PayloadQueryStringDefaultDSL = func() {
 	})
 }
 
+var PayloadQueryStringSliceDefaultDSL = func() {
+	Service("ServiceQueryStringSliceDefault", func() {
+		Method("MethodQueryStringSliceDefault", func() {
+			Payload(func() {
+				Attribute("q", ArrayOf(String), func() {
+					Default([]string{"hello", "goodbye"})
+				})
+			})
+			HTTP(func() {
+				GET("/")
+				Param("q")
+			})
+		})
+	})
+}
+
 var PayloadQueryStringDefaultValidateDSL = func() {
 	Service("ServiceQueryStringDefaultValidate", func() {
 		Method("MethodQueryStringDefaultValidate", func() {


### PR DESCRIPTION

**Design**
```go
var PayloadQueryStringSliceDefaultDSL = func() {
	Service("ServiceQueryStringSliceDefault", func() {
		Method("MethodQueryStringSliceDefault", func() {
			Payload(func() {
				Attribute("q", ArrayOf(String), func() {
					Default([]string{"hello", "goodbye"}) // string slice
				})
			})
			HTTP(func() {
				GET("/")
				Param("q")
			})
		})
	})
}
```

**before**

```go
func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
	return func(r *http.Request) (interface{}, error) {
		var (
			q []string
		)
		q = r.URL.Query()["q"]
		if q == nil {
			q = []interface{"hello", "goodbye"} // ops! r.URL.Query()["q"] returns []string
		}
		payload := NewMethodQueryStringSliceDefaultPayload(q)

		return payload, nil
	}
}
```

**after**
```go
		q = r.URL.Query()["q"]
		if q == nil {
			q = []string{"hello", "goodbye"} // correct type
		}
```