### PR TITLE
Trim spaces for middleware.Logger (#2411)

### DIFF
--- a/middleware/log.go
+++ b/middleware/log.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 )
 
 type (
@@ -40,6 +41,6 @@ func (a *adapter) Log(keyvals ...interface{}) error {
 		vals[i/2] = v
 		fm.WriteString(fmt.Sprintf(" %s=%%+v", k))
 	}
-	a.Logger.Printf(fm.String(), vals...)
+	a.Logger.Printf(strings.TrimSpace(fm.String()), vals...)
 	return nil
 }


### PR DESCRIPTION
This is backport of #2411 to v3.