### PR TITLE
Make it possible to format error responses

### DIFF
--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -251,9 +251,9 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	{{- end }}
 	{{- range $svc := .Services }}
 		{{-  if .Endpoints }}
-		{{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New({{ .Service.VarName }}Endpoints, mux, dec, enc, eh{{ if hasStreaming $svc }}, upgrader, nil{{ end }}{{ range .Endpoints }}{{ if .MultipartRequestDecoder }}, {{ $.APIPkg }}.{{ .MultipartRequestDecoder.FuncName }}{{ end }}{{ end }})
+		{{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New({{ .Service.VarName }}Endpoints, mux, dec, enc, eh, nil{{ if hasStreaming $svc }}, upgrader, nil{{ end }}{{ range .Endpoints }}{{ if .MultipartRequestDecoder }}, {{ $.APIPkg }}.{{ .MultipartRequestDecoder.FuncName }}{{ end }}{{ end }})
 		{{-  else }}
-		{{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New(nil, mux, dec, enc, eh)
+		{{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New(nil, mux, dec, enc, eh, nil)
 		{{-  end }}
 	{{- end }}
 	}

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -308,16 +308,17 @@ type {{ .MountPointStruct }} struct {
 `
 
 // input: ServiceData
-const serverInitT = `{{ printf "%s instantiates HTTP handlers for all the %s service endpoints." .ServerInit .Service.Name | comment }}
+const serverInitT = `{{ printf "%s instantiates HTTP handlers for all the %s service endpoints using the provided encoder and decoder. The handlers are mounted on the given mux using the HTTP verb and path defined in the design. errhandler is called whenever a response fails to be encoded. formatter is used to format errors returned by the service methods prior to encoding. Both errhandler and formatter are optional and can be nil." .ServerInit .Service.Name | comment }}
 func {{ .ServerInit }}(
 	e *{{ .Service.PkgName }}.Endpoints,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 	{{- if hasStreaming . }}
-	up goahttp.Upgrader,
-	cfn *ConnConfigurer,
+	upgrader goahttp.Upgrader,
+	configurer *ConnConfigurer,
 	{{- end }}
 	{{- range .Endpoints }}
 		{{- if .MultipartRequestDecoder }}
@@ -326,8 +327,8 @@ func {{ .ServerInit }}(
 	{{- end }}
 ) *{{ .ServerStruct }} {
 {{- if hasStreaming . }}
-	if cfn == nil {
-		cfn = &ConnConfigurer{}
+	if configurer == nil {
+		configurer = &ConnConfigurer{}
 	}
 {{- end }}
 	return &{{ .ServerStruct }}{
@@ -345,7 +346,7 @@ func {{ .ServerInit }}(
 			{{- end }}
 		},
 		{{- range .Endpoints }}
-		{{ .Method.VarName }}: {{ .HandlerInit }}(e.{{ .Method.VarName }}, mux, {{ if .MultipartRequestDecoder }}{{ .MultipartRequestDecoder.InitName }}(mux, {{ .MultipartRequestDecoder.VarName }}){{ else }}dec{{ end }}, enc, eh{{ if .ServerStream }}, up, cfn.{{ .Method.VarName }}Fn{{ end }}),
+		{{ .Method.VarName }}: {{ .HandlerInit }}(e.{{ .Method.VarName }}, mux, {{ if .MultipartRequestDecoder }}{{ .MultipartRequestDecoder.InitName }}(mux, {{ .MultipartRequestDecoder.VarName }}){{ else }}decoder{{ end }}, encoder, errhandler, formatter{{ if .ServerStream }}, upgrader, configurer.{{ .Method.VarName }}Fn{{ end }}),
 		{{- end }}
 	}
 }
@@ -428,26 +429,27 @@ const serverHandlerInitT = `{{ printf "%s creates a HTTP handler which loads the
 func {{ .HandlerInit }}(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 	{{- if .ServerStream }}
-	up goahttp.Upgrader,
-	connConfigFn goahttp.ConnConfigureFunc,
+	upgrader goahttp.Upgrader,
+	configurer goahttp.ConnConfigureFunc,
 	{{- end }}
 ) http.Handler {
 	var (
 		{{- if .ServerStream }}
 			{{- if .Payload.Ref }}
-		decodeRequest  = {{ .RequestDecoder }}(mux, dec)
+		decodeRequest  = {{ .RequestDecoder }}(mux, decoder)
 			{{- end }}
 		{{- else }}
 			{{- if .Payload.Ref }}
-		decodeRequest  = {{ .RequestDecoder }}(mux, dec)
+		decodeRequest  = {{ .RequestDecoder }}(mux, decoder)
 			{{- end }}
-		encodeResponse = {{ .ResponseEncoder }}(enc)
+		encodeResponse = {{ .ResponseEncoder }}(encoder)
 		{{- end }}
-		encodeError    = {{ if .Errors }}{{ .ErrorEncoder }}{{ else }}goahttp.ErrorEncoder{{ end }}(enc)
+		encodeError    = {{ if .Errors }}{{ .ErrorEncoder }}{{ else }}goahttp.ErrorEncoder{{ end }}(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -458,7 +460,7 @@ func {{ .HandlerInit }}(
 		payload, err := decodeRequest(r)
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -473,8 +475,8 @@ func {{ .HandlerInit }}(
 		}
 		v := &{{ .ServicePkgName }}.{{ .Method.ServerStream.EndpointStruct }}{
 			Stream: &{{ .ServerStream.VarName }}{
-				upgrader: up,
-				connConfigFn: connConfigFn,
+				upgrader: upgrader,
+				connConfigFn: configurer,
 				cancel: cancel,
 				w: w,
 				r: r,
@@ -495,13 +497,13 @@ func {{ .HandlerInit }}(
 			}
 			{{- end }}
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
 	{{- if not .ServerStream }}
 		if err := encodeResponse(ctx, w, res); err != nil {
-			eh(ctx, w, err)
+			errhandler(ctx, w, err)
 		}
 	{{- end }}
 	})
@@ -1108,8 +1110,8 @@ func {{ .ResponseEncoder }}(encoder func(context.Context, http.ResponseWriter) g
 
 // input: EndpointData
 const errorEncoderT = `{{ printf "%s returns an encoder for errors returned by the %s %s endpoint." .ErrorEncoder .Method.Name .ServiceName | comment }}
-func {{ .ErrorEncoder }}(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
-	encodeError := goahttp.ErrorEncoder(encoder)
+func {{ .ErrorEncoder }}(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
 		en, ok := v.(ErrorNamer)
 		if !ok {
@@ -1152,7 +1154,16 @@ const responseT = `{{ define "response" -}}
 			{{- end }}
 	}
 		{{- else if (index .ServerBody 0).Init }}
-	body := {{ (index .ServerBody 0).Init.Name }}({{ range (index .ServerBody 0).Init.ServerArgs }}{{ .Ref }}, {{ end }})
+			{{- if .ErrorHeader }}
+	var body interface{}
+	if formatter != nil {
+		body = formatter({{ (index (index .ServerBody 0).Init.ServerArgs 0).Ref }})
+	} else {
+			{{- end }}
+	body {{ if not .ErrorHeader}}:{{ end }}= {{ (index .ServerBody 0).Init.Name }}({{ range (index .ServerBody 0).Init.ServerArgs }}{{ .Ref }}, {{ end }})
+			{{- if .ErrorHeader }}
+	}
+			{{- end }}
 		{{- else }}
 	body := res{{ if $.ViewedResult }}.Projected{{ end }}{{ if .ResultAttr }}.{{ .ResultAttr }}{{ end }}
 		{{- end }}

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -2640,7 +2640,7 @@ type {{ .VarName }} struct {
 	{{ comment "upgrader is the websocket connection upgrader." }}
 	upgrader goahttp.Upgrader
 	{{ comment "connConfigFn is the websocket connection configurer." }}
-	connConfigFn goahttp.ConnConfigureFunc
+	configurer goahttp.ConnConfigureFunc
 	{{ comment "cancel is the context cancellation function which cancels the request context when invoked." }}
 	cancel context.CancelFunc
 	{{ comment "w is the HTTP response writer used in upgrading the connection." }}

--- a/http/codegen/testdata/error_encoder_code.go
+++ b/http/codegen/testdata/error_encoder_code.go
@@ -3,8 +3,8 @@ package testdata
 var PrimitiveErrorResponseEncoderCode = `// EncodeMethodPrimitiveErrorResponseError returns an encoder for errors
 // returned by the MethodPrimitiveErrorResponse ServicePrimitiveErrorResponse
 // endpoint.
-func EncodeMethodPrimitiveErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
-	encodeError := goahttp.ErrorEncoder(encoder)
+func EncodeMethodPrimitiveErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
 		en, ok := v.(ErrorNamer)
 		if !ok {
@@ -14,14 +14,24 @@ func EncodeMethodPrimitiveErrorResponseError(encoder func(context.Context, http.
 		case "bad_request":
 			res := v.(serviceprimitiveerrorresponse.BadRequest)
 			enc := encoder(ctx, w)
-			body := NewMethodPrimitiveErrorResponseBadRequestResponseBody(res)
+			var body interface{}
+			if formatter != nil {
+				body = formatter(res)
+			} else {
+				body = NewMethodPrimitiveErrorResponseBadRequestResponseBody(res)
+			}
 			w.Header().Set("goa-error", "bad_request")
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
 		case "internal_error":
 			res := v.(serviceprimitiveerrorresponse.InternalError)
 			enc := encoder(ctx, w)
-			body := NewMethodPrimitiveErrorResponseInternalErrorResponseBody(res)
+			var body interface{}
+			if formatter != nil {
+				body = formatter(res)
+			} else {
+				body = NewMethodPrimitiveErrorResponseInternalErrorResponseBody(res)
+			}
 			w.Header().Set("goa-error", "internal_error")
 			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
@@ -34,8 +44,8 @@ func EncodeMethodPrimitiveErrorResponseError(encoder func(context.Context, http.
 
 var DefaultErrorResponseEncoderCode = `// EncodeMethodDefaultErrorResponseError returns an encoder for errors returned
 // by the MethodDefaultErrorResponse ServiceDefaultErrorResponse endpoint.
-func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
-	encodeError := goahttp.ErrorEncoder(encoder)
+func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
 		en, ok := v.(ErrorNamer)
 		if !ok {
@@ -45,7 +55,12 @@ func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.Re
 		case "bad_request":
 			res := v.(*goa.ServiceError)
 			enc := encoder(ctx, w)
-			body := NewMethodDefaultErrorResponseBadRequestResponseBody(res)
+			var body interface{}
+			if formatter != nil {
+				body = formatter(res)
+			} else {
+				body = NewMethodDefaultErrorResponseBadRequestResponseBody(res)
+			}
 			w.Header().Set("goa-error", "bad_request")
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
@@ -58,8 +73,8 @@ func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.Re
 
 var ServiceErrorResponseEncoderCode = `// EncodeMethodServiceErrorResponseError returns an encoder for errors returned
 // by the MethodServiceErrorResponse ServiceServiceErrorResponse endpoint.
-func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
-	encodeError := goahttp.ErrorEncoder(encoder)
+func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
 		en, ok := v.(ErrorNamer)
 		if !ok {
@@ -69,14 +84,24 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 		case "internal_error":
 			res := v.(*goa.ServiceError)
 			enc := encoder(ctx, w)
-			body := NewMethodServiceErrorResponseInternalErrorResponseBody(res)
+			var body interface{}
+			if formatter != nil {
+				body = formatter(res)
+			} else {
+				body = NewMethodServiceErrorResponseInternalErrorResponseBody(res)
+			}
 			w.Header().Set("goa-error", "internal_error")
 			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "bad_request":
 			res := v.(*goa.ServiceError)
 			enc := encoder(ctx, w)
-			body := NewMethodServiceErrorResponseBadRequestResponseBody(res)
+			var body interface{}
+			if formatter != nil {
+				body = formatter(res)
+			} else {
+				body = NewMethodServiceErrorResponseBadRequestResponseBody(res)
+			}
 			w.Header().Set("goa-error", "bad_request")
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)

--- a/http/codegen/testdata/example_code.go
+++ b/http/codegen/testdata/example_code.go
@@ -38,7 +38,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 	)
 	{
 		eh := errorHandler(logger)
-		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh)
+		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
 	}
 	// Configure the mux.
 	servicesvr.Mount(mux, serviceServer)
@@ -131,7 +131,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc 
 	)
 	{
 		eh := errorHandler(logger)
-		serviceServer = servicesvr.New(nil, mux, dec, enc, eh)
+		serviceServer = servicesvr.New(nil, mux, dec, enc, eh, nil)
 	}
 	// Configure the mux.
 	servicesvr.Mount(mux)
@@ -224,7 +224,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 	)
 	{
 		eh := errorHandler(logger)
-		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh)
+		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
 	}
 	// Configure the mux.
 	servicesvr.Mount(mux, serviceServer)
@@ -318,8 +318,8 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 	)
 	{
 		eh := errorHandler(logger)
-		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh)
-		anotherServiceServer = anotherservicesvr.New(anotherServiceEndpoints, mux, dec, enc, eh)
+		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
+		anotherServiceServer = anotherservicesvr.New(anotherServiceEndpoints, mux, dec, enc, eh, nil)
 	}
 	// Configure the mux.
 	servicesvr.Mount(mux, serviceServer)
@@ -418,8 +418,8 @@ func handleHTTPServer(ctx context.Context, u *url.URL, streamingServiceAEndpoint
 	{
 		eh := errorHandler(logger)
 		upgrader := &websocket.Upgrader{}
-		streamingServiceAServer = streamingserviceasvr.New(streamingServiceAEndpoints, mux, dec, enc, eh, upgrader, nil)
-		streamingServiceBServer = streamingservicebsvr.New(streamingServiceBEndpoints, mux, dec, enc, eh, upgrader, nil)
+		streamingServiceAServer = streamingserviceasvr.New(streamingServiceAEndpoints, mux, dec, enc, eh, nil, upgrader, nil)
+		streamingServiceBServer = streamingservicebsvr.New(streamingServiceBEndpoints, mux, dec, enc, eh, nil, upgrader, nil)
 	}
 	// Configure the mux.
 	streamingserviceasvr.Mount(mux, streamingServiceAServer)

--- a/http/codegen/testdata/handler_init_functions.go
+++ b/http/codegen/testdata/handler_init_functions.go
@@ -6,13 +6,14 @@ var ServerNoPayloadNoResultHandlerConstructorCode = `// NewMethodNoPayloadNoResu
 func NewMethodNoPayloadNoResultHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) http.Handler {
 	var (
-		encodeResponse = EncodeMethodNoPayloadNoResultResponse(enc)
-		encodeError    = goahttp.ErrorEncoder(enc)
+		encodeResponse = EncodeMethodNoPayloadNoResultResponse(encoder)
+		encodeError    = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -24,12 +25,12 @@ func NewMethodNoPayloadNoResultHandler(
 
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
-			eh(ctx, w, err)
+			errhandler(ctx, w, err)
 		}
 	})
 }
@@ -41,14 +42,15 @@ var ServerPayloadNoResultHandlerConstructorCode = `// NewMethodPayloadNoResultHa
 func NewMethodPayloadNoResultHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) http.Handler {
 	var (
-		decodeRequest  = DecodeMethodPayloadNoResultRequest(mux, dec)
-		encodeResponse = EncodeMethodPayloadNoResultResponse(enc)
-		encodeError    = goahttp.ErrorEncoder(enc)
+		decodeRequest  = DecodeMethodPayloadNoResultRequest(mux, decoder)
+		encodeResponse = EncodeMethodPayloadNoResultResponse(encoder)
+		encodeError    = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -57,7 +59,7 @@ func NewMethodPayloadNoResultHandler(
 		payload, err := decodeRequest(r)
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -66,12 +68,12 @@ func NewMethodPayloadNoResultHandler(
 
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
-			eh(ctx, w, err)
+			errhandler(ctx, w, err)
 		}
 	})
 }
@@ -83,13 +85,14 @@ var ServerNoPayloadResultHandlerConstructorCode = `// NewMethodNoPayloadResultHa
 func NewMethodNoPayloadResultHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) http.Handler {
 	var (
-		encodeResponse = EncodeMethodNoPayloadResultResponse(enc)
-		encodeError    = goahttp.ErrorEncoder(enc)
+		encodeResponse = EncodeMethodNoPayloadResultResponse(encoder)
+		encodeError    = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -101,12 +104,12 @@ func NewMethodNoPayloadResultHandler(
 
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
-			eh(ctx, w, err)
+			errhandler(ctx, w, err)
 		}
 	})
 }
@@ -118,14 +121,15 @@ var ServerPayloadResultHandlerConstructorCode = `// NewMethodPayloadResultHandle
 func NewMethodPayloadResultHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) http.Handler {
 	var (
-		decodeRequest  = DecodeMethodPayloadResultRequest(mux, dec)
-		encodeResponse = EncodeMethodPayloadResultResponse(enc)
-		encodeError    = goahttp.ErrorEncoder(enc)
+		decodeRequest  = DecodeMethodPayloadResultRequest(mux, decoder)
+		encodeResponse = EncodeMethodPayloadResultResponse(encoder)
+		encodeError    = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -134,7 +138,7 @@ func NewMethodPayloadResultHandler(
 		payload, err := decodeRequest(r)
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -143,12 +147,12 @@ func NewMethodPayloadResultHandler(
 
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
-			eh(ctx, w, err)
+			errhandler(ctx, w, err)
 		}
 	})
 }
@@ -160,14 +164,15 @@ var ServerPayloadResultErrorHandlerConstructorCode = `// NewMethodPayloadResultE
 func NewMethodPayloadResultErrorHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) http.Handler {
 	var (
-		decodeRequest  = DecodeMethodPayloadResultErrorRequest(mux, dec)
-		encodeResponse = EncodeMethodPayloadResultErrorResponse(enc)
-		encodeError    = EncodeMethodPayloadResultErrorError(enc)
+		decodeRequest  = DecodeMethodPayloadResultErrorRequest(mux, decoder)
+		encodeResponse = EncodeMethodPayloadResultErrorResponse(encoder)
+		encodeError    = EncodeMethodPayloadResultErrorError(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -176,7 +181,7 @@ func NewMethodPayloadResultErrorHandler(
 		payload, err := decodeRequest(r)
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -185,12 +190,12 @@ func NewMethodPayloadResultErrorHandler(
 
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
-			eh(ctx, w, err)
+			errhandler(ctx, w, err)
 		}
 	})
 }

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -1,52 +1,67 @@
 package testdata
 
 var ServerMultiEndpointsConstructorCode = `// New instantiates HTTP handlers for all the ServiceMultiEndpoints service
-// endpoints.
+// endpoints using the provided encoder and decoder. The handlers are mounted
+// on the given mux using the HTTP verb and path defined in the design.
+// errhandler is called whenever a response fails to be encoded. formatter is
+// used to format errors returned by the service methods prior to encoding.
+// Both errhandler and formatter are optional and can be nil.
 func New(
 	e *servicemultiendpoints.Endpoints,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) *Server {
 	return &Server{
 		Mounts: []*MountPoint{
 			{"MethodMultiEndpoints1", "GET", "/server_multi_endpoints/{id}"},
 			{"MethodMultiEndpoints2", "POST", "/server_multi_endpoints"},
 		},
-		MethodMultiEndpoints1: NewMethodMultiEndpoints1Handler(e.MethodMultiEndpoints1, mux, dec, enc, eh),
-		MethodMultiEndpoints2: NewMethodMultiEndpoints2Handler(e.MethodMultiEndpoints2, mux, dec, enc, eh),
+		MethodMultiEndpoints1: NewMethodMultiEndpoints1Handler(e.MethodMultiEndpoints1, mux, decoder, encoder, errhandler, formatter),
+		MethodMultiEndpoints2: NewMethodMultiEndpoints2Handler(e.MethodMultiEndpoints2, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 `
 
 var ServerMultiBasesConstructorCode = `// New instantiates HTTP handlers for all the ServiceMultiBases service
-// endpoints.
+// endpoints using the provided encoder and decoder. The handlers are mounted
+// on the given mux using the HTTP verb and path defined in the design.
+// errhandler is called whenever a response fails to be encoded. formatter is
+// used to format errors returned by the service methods prior to encoding.
+// Both errhandler and formatter are optional and can be nil.
 func New(
 	e *servicemultibases.Endpoints,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) *Server {
 	return &Server{
 		Mounts: []*MountPoint{
 			{"MethodMultiBases", "GET", "/base_1/{id}"},
 			{"MethodMultiBases", "GET", "/base_2/{id}"},
 		},
-		MethodMultiBases: NewMethodMultiBasesHandler(e.MethodMultiBases, mux, dec, enc, eh),
+		MethodMultiBases: NewMethodMultiBasesHandler(e.MethodMultiBases, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 `
 
 var ServerFileServerConstructorCode = `// New instantiates HTTP handlers for all the ServiceFileServer service
-// endpoints.
+// endpoints using the provided encoder and decoder. The handlers are mounted
+// on the given mux using the HTTP verb and path defined in the design.
+// errhandler is called whenever a response fails to be encoded. formatter is
+// used to format errors returned by the service methods prior to encoding.
+// Both errhandler and formatter are optional and can be nil.
 func New(
 	e *servicefileserver.Endpoints,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) *Server {
 	return &Server{
 		Mounts: []*MountPoint{
@@ -58,13 +73,19 @@ func New(
 }
 `
 
-var ServerMixedConstructorCode = `// New instantiates HTTP handlers for all the ServerMixed service endpoints.
+var ServerMixedConstructorCode = `// New instantiates HTTP handlers for all the ServerMixed service endpoints
+// using the provided encoder and decoder. The handlers are mounted on the
+// given mux using the HTTP verb and path defined in the design. errhandler is
+// called whenever a response fails to be encoded. formatter is used to format
+// errors returned by the service methods prior to encoding. Both errhandler
+// and formatter are optional and can be nil.
 func New(
 	e *servermixed.Endpoints,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 ) *Server {
 	return &Server{
 		Mounts: []*MountPoint{
@@ -72,49 +93,59 @@ func New(
 			{"/path/to/file1.json", "GET", "/file1.json"},
 			{"/path/to/file2.json", "GET", "/file2.json"},
 		},
-		MethodMixed: NewMethodMixedHandler(e.MethodMixed, mux, dec, enc, eh),
+		MethodMixed: NewMethodMixedHandler(e.MethodMixed, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 `
 
 var ServerMultipartConstructorCode = `// New instantiates HTTP handlers for all the ServiceMultipart service
-// endpoints.
+// endpoints using the provided encoder and decoder. The handlers are mounted
+// on the given mux using the HTTP verb and path defined in the design.
+// errhandler is called whenever a response fails to be encoded. formatter is
+// used to format errors returned by the service methods prior to encoding.
+// Both errhandler and formatter are optional and can be nil.
 func New(
 	e *servicemultipart.Endpoints,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
 	serviceMultipartMethodMultiBasesDecoderFn ServiceMultipartMethodMultiBasesDecoderFunc,
 ) *Server {
 	return &Server{
 		Mounts: []*MountPoint{
 			{"MethodMultiBases", "GET", "/"},
 		},
-		MethodMultiBases: NewMethodMultiBasesHandler(e.MethodMultiBases, mux, NewServiceMultipartMethodMultiBasesDecoder(mux, serviceMultipartMethodMultiBasesDecoderFn), enc, eh),
+		MethodMultiBases: NewMethodMultiBasesHandler(e.MethodMultiBases, mux, NewServiceMultipartMethodMultiBasesDecoder(mux, serviceMultipartMethodMultiBasesDecoderFn), encoder, errhandler, formatter),
 	}
 }
 `
 
 var ServerStreamingConstructorCode = `// New instantiates HTTP handlers for all the StreamingResultService service
-// endpoints.
+// endpoints using the provided encoder and decoder. The handlers are mounted
+// on the given mux using the HTTP verb and path defined in the design.
+// errhandler is called whenever a response fails to be encoded. formatter is
+// used to format errors returned by the service methods prior to encoding.
+// Both errhandler and formatter are optional and can be nil.
 func New(
 	e *streamingresultservice.Endpoints,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
-	up goahttp.Upgrader,
-	cfn *ConnConfigurer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+	upgrader goahttp.Upgrader,
+	configurer *ConnConfigurer,
 ) *Server {
-	if cfn == nil {
-		cfn = &ConnConfigurer{}
+	if configurer == nil {
+		configurer = &ConnConfigurer{}
 	}
 	return &Server{
 		Mounts: []*MountPoint{
 			{"StreamingResultMethod", "GET", "/"},
 		},
-		StreamingResultMethod: NewStreamingResultMethodHandler(e.StreamingResultMethod, mux, dec, enc, eh, up, cfn.StreamingResultMethodFn),
+		StreamingResultMethod: NewStreamingResultMethodHandler(e.StreamingResultMethod, mux, decoder, encoder, errhandler, formatter, upgrader, configurer.StreamingResultMethodFn),
 	}
 }
 `

--- a/http/codegen/testdata/streaming_code.go
+++ b/http/codegen/testdata/streaming_code.go
@@ -22,15 +22,16 @@ var StreamingResultServerHandlerInitCode = `// NewStreamingResultMethodHandler c
 func NewStreamingResultMethodHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
-	up goahttp.Upgrader,
-	connConfigFn goahttp.ConnConfigureFunc,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+	upgrader goahttp.Upgrader,
+	configurer goahttp.ConnConfigureFunc,
 ) http.Handler {
 	var (
-		decodeRequest = DecodeStreamingResultMethodRequest(mux, dec)
-		encodeError   = goahttp.ErrorEncoder(enc)
+		decodeRequest = DecodeStreamingResultMethodRequest(mux, decoder)
+		encodeError   = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -39,7 +40,7 @@ func NewStreamingResultMethodHandler(
 		payload, err := decodeRequest(r)
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -50,8 +51,8 @@ func NewStreamingResultMethodHandler(
 		}
 		v := &streamingresultservice.StreamingResultMethodEndpointInput{
 			Stream: &StreamingResultMethodServerStream{
-				upgrader:     up,
-				connConfigFn: connConfigFn,
+				upgrader:     upgrader,
+				connConfigFn: configurer,
 				cancel:       cancel,
 				w:            w,
 				r:            r,
@@ -65,7 +66,7 @@ func NewStreamingResultMethodHandler(
 				return
 			}
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -168,14 +169,15 @@ var StreamingResultNoPayloadServerHandlerInitCode = `// NewStreamingResultNoPayl
 func NewStreamingResultNoPayloadMethodHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
-	up goahttp.Upgrader,
-	connConfigFn goahttp.ConnConfigureFunc,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+	upgrader goahttp.Upgrader,
+	configurer goahttp.ConnConfigureFunc,
 ) http.Handler {
 	var (
-		encodeError = goahttp.ErrorEncoder(enc)
+		encodeError = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -189,8 +191,8 @@ func NewStreamingResultNoPayloadMethodHandler(
 		}
 		v := &streamingresultnopayloadservice.StreamingResultNoPayloadMethodEndpointInput{
 			Stream: &StreamingResultNoPayloadMethodServerStream{
-				upgrader:     up,
-				connConfigFn: connConfigFn,
+				upgrader:     upgrader,
+				connConfigFn: configurer,
 				cancel:       cancel,
 				w:            w,
 				r:            r,
@@ -203,7 +205,7 @@ func NewStreamingResultNoPayloadMethodHandler(
 				return
 			}
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -939,15 +941,16 @@ var StreamingPayloadServerHandlerInitCode = `// NewStreamingPayloadMethodHandler
 func NewStreamingPayloadMethodHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
-	up goahttp.Upgrader,
-	connConfigFn goahttp.ConnConfigureFunc,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+	upgrader goahttp.Upgrader,
+	configurer goahttp.ConnConfigureFunc,
 ) http.Handler {
 	var (
-		decodeRequest = DecodeStreamingPayloadMethodRequest(mux, dec)
-		encodeError   = goahttp.ErrorEncoder(enc)
+		decodeRequest = DecodeStreamingPayloadMethodRequest(mux, decoder)
+		encodeError   = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -956,7 +959,7 @@ func NewStreamingPayloadMethodHandler(
 		payload, err := decodeRequest(r)
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -967,8 +970,8 @@ func NewStreamingPayloadMethodHandler(
 		}
 		v := &streamingpayloadservice.StreamingPayloadMethodEndpointInput{
 			Stream: &StreamingPayloadMethodServerStream{
-				upgrader:     up,
-				connConfigFn: connConfigFn,
+				upgrader:     upgrader,
+				connConfigFn: configurer,
 				cancel:       cancel,
 				w:            w,
 				r:            r,
@@ -982,7 +985,7 @@ func NewStreamingPayloadMethodHandler(
 				return
 			}
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -1114,14 +1117,15 @@ var StreamingPayloadNoPayloadServerHandlerInitCode = `// NewStreamingPayloadNoPa
 func NewStreamingPayloadNoPayloadMethodHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
-	up goahttp.Upgrader,
-	connConfigFn goahttp.ConnConfigureFunc,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+	upgrader goahttp.Upgrader,
+	configurer goahttp.ConnConfigureFunc,
 ) http.Handler {
 	var (
-		encodeError = goahttp.ErrorEncoder(enc)
+		encodeError = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -1135,8 +1139,8 @@ func NewStreamingPayloadNoPayloadMethodHandler(
 		}
 		v := &streamingpayloadnopayloadservice.StreamingPayloadNoPayloadMethodEndpointInput{
 			Stream: &StreamingPayloadNoPayloadMethodServerStream{
-				upgrader:     up,
-				connConfigFn: connConfigFn,
+				upgrader:     upgrader,
+				connConfigFn: configurer,
 				cancel:       cancel,
 				w:            w,
 				r:            r,
@@ -1149,7 +1153,7 @@ func NewStreamingPayloadNoPayloadMethodHandler(
 				return
 			}
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -2106,15 +2110,16 @@ var BidirectionalStreamingServerHandlerInitCode = `// NewBidirectionalStreamingM
 func NewBidirectionalStreamingMethodHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
-	up goahttp.Upgrader,
-	connConfigFn goahttp.ConnConfigureFunc,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+	upgrader goahttp.Upgrader,
+	configurer goahttp.ConnConfigureFunc,
 ) http.Handler {
 	var (
-		decodeRequest = DecodeBidirectionalStreamingMethodRequest(mux, dec)
-		encodeError   = goahttp.ErrorEncoder(enc)
+		decodeRequest = DecodeBidirectionalStreamingMethodRequest(mux, decoder)
+		encodeError   = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -2123,7 +2128,7 @@ func NewBidirectionalStreamingMethodHandler(
 		payload, err := decodeRequest(r)
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -2134,8 +2139,8 @@ func NewBidirectionalStreamingMethodHandler(
 		}
 		v := &bidirectionalstreamingservice.BidirectionalStreamingMethodEndpointInput{
 			Stream: &BidirectionalStreamingMethodServerStream{
-				upgrader:     up,
-				connConfigFn: connConfigFn,
+				upgrader:     upgrader,
+				connConfigFn: configurer,
 				cancel:       cancel,
 				w:            w,
 				r:            r,
@@ -2149,7 +2154,7 @@ func NewBidirectionalStreamingMethodHandler(
 				return
 			}
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}
@@ -2322,14 +2327,15 @@ var BidirectionalStreamingNoPayloadServerHandlerInitCode = `// NewBidirectionalS
 func NewBidirectionalStreamingNoPayloadMethodHandler(
 	endpoint goa.Endpoint,
 	mux goahttp.Muxer,
-	dec func(*http.Request) goahttp.Decoder,
-	enc func(context.Context, http.ResponseWriter) goahttp.Encoder,
-	eh func(context.Context, http.ResponseWriter, error),
-	up goahttp.Upgrader,
-	connConfigFn goahttp.ConnConfigureFunc,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+	upgrader goahttp.Upgrader,
+	configurer goahttp.ConnConfigureFunc,
 ) http.Handler {
 	var (
-		encodeError = goahttp.ErrorEncoder(enc)
+		encodeError = goahttp.ErrorEncoder(encoder, formatter)
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
@@ -2343,8 +2349,8 @@ func NewBidirectionalStreamingNoPayloadMethodHandler(
 		}
 		v := &bidirectionalstreamingnopayloadservice.BidirectionalStreamingNoPayloadMethodEndpointInput{
 			Stream: &BidirectionalStreamingNoPayloadMethodServerStream{
-				upgrader:     up,
-				connConfigFn: connConfigFn,
+				upgrader:     upgrader,
+				connConfigFn: configurer,
 				cancel:       cancel,
 				w:            w,
 				r:            r,
@@ -2357,7 +2363,7 @@ func NewBidirectionalStreamingNoPayloadMethodHandler(
 				return
 			}
 			if err := encodeError(ctx, w, err); err != nil {
-				eh(ctx, w, err)
+				errhandler(ctx, w, err)
 			}
 			return
 		}

--- a/http/encoding.go
+++ b/http/encoding.go
@@ -210,10 +210,13 @@ func ResponseDecoder(resp *http.Response) Decoder {
 // status code and marshals the error struct to the body using the provided
 // encoder. If the error is not a goa ServiceError struct then it is encoded
 // as a permanent internal server error.
-func ErrorEncoder(encoder func(context.Context, http.ResponseWriter) Encoder) func(context.Context, http.ResponseWriter, error) error {
+func ErrorEncoder(encoder func(context.Context, http.ResponseWriter) Encoder, formatter func(err error) Statuser) func(context.Context, http.ResponseWriter, error) error {
 	return func(ctx context.Context, w http.ResponseWriter, err error) error {
 		enc := encoder(ctx, w)
-		resp := NewErrorResponse(err)
+		if formatter == nil {
+			formatter = NewErrorResponse
+		}
+		resp := formatter(err)
 		w.WriteHeader(resp.StatusCode())
 		return enc.Encode(resp)
 	}

--- a/http/error.go
+++ b/http/error.go
@@ -7,8 +7,8 @@ import (
 )
 
 type (
-	// ErrorResponse is the data structure encoded in HTTP responses that
-	// correspond to errors created by the generated code. This struct is
+	// ErrorResponse is the default data structure encoded in HTTP responses
+	// that correspond to errors created by the generated code. This struct is
 	// mainly intended for clients to decode error responses.
 	ErrorResponse struct {
 		// Name is a name for that class of errors.
@@ -24,10 +24,18 @@ type (
 		// Fault indicates whether the error is a server-side fault.
 		Fault bool `json:"fault" xml:"fault" form:"fault"`
 	}
+
+	// Statuser is implemented by error response object to provide the response
+	// HTTP status code.
+	Statuser interface {
+		// StatusCode return the HTTP status code used to encode the response
+		// when not defined in the design.
+		StatusCode() int
+	}
 )
 
 // NewErrorResponse creates a HTTP response from the given error.
-func NewErrorResponse(err error) *ErrorResponse {
+func NewErrorResponse(err error) Statuser {
 	if gerr, ok := err.(*goa.ServiceError); ok {
 		return &ErrorResponse{
 			Name:      gerr.Name,


### PR DESCRIPTION
by allowing to pass in a formatter when creating the HTTP server and endpoints.
The formatter accepts an error and returns a struct which implements the Goa
http package `Statuser` interface. This interface defines a single method used
by the generated code to retrieve the error HTTP status code when not defined
in the design. Specifying a formatter when instantiating a HTTP server or endpoint
is optional and using the value `nil` results in using the same data structure used
prior to this PR (the Goa `http.ErrorResponse` struct).