### PR TITLE
Properly handle server main handler

### DIFF
--- a/codegen/example/example_server.go
+++ b/codegen/example/example_server.go
@@ -278,7 +278,7 @@ func main() {
 			} else if u.Port() == "" {
 				u.Host += ":{{ $u.Port }}"
 			}
-			handle{{ toUpper $u.Transport.Name }}Server(ctx, u, {{ range $.Services }}{{ if .Methods }}{{ .VarName }}Endpoints, {{ end }}{{ end }}&wg, errc, logger, *dbgF)
+			handle{{ toUpper $u.Transport.Name }}Server(ctx, u, {{ range $t := $.Server.Transports }}{{ if eq $t.Type $u.Transport.Type }}{{ range $s := $t.Services }}{{ range $.Services }}{{ if eq $s .Name }}{{ if .Methods }}{{ .VarName }}Endpoints, {{ end }}{{ end }}{{ end }}{{ end }}{{ end }}{{ end }}&wg, errc, logger, *dbgF)
 		}
 	{{- end }}
 	{{ end }}

--- a/codegen/example/example_server_test.go
+++ b/codegen/example/example_server_test.go
@@ -27,6 +27,9 @@ func TestExampleServerFiles(t *testing.T) {
 		{"single-server-multiple-hosts", testdata.SingleServerMultipleHostsDSL, testdata.SingleServerMultipleHostsServerMainCode},
 		{"single-server-multiple-hosts-with-variables", testdata.SingleServerMultipleHostsWithVariablesDSL, testdata.SingleServerMultipleHostsWithVariablesServerMainCode},
 		{"service-name-with-spaces", ctestdata.NamesWithSpacesDSL, testdata.NamesWithSpacesServerMainCode},
+		{"service-for-only-http", testdata.ServiceForOnlyHTTPDSL, testdata.ServiceForOnlyHTTPServerMainCode},
+		{"sercice-for-only-grpc", testdata.ServiceForOnlyGRPCDSL, testdata.ServiceForOnlyGRPCServerMainCode},
+		{"service-for-http-and-part-of-grpc", testdata.ServiceForHTTPAndPartOfGRPCDSL, testdata.ServiceForHTTPAndPartOfGRPCServerMainCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/codegen/example/testdata/dsls.go
+++ b/codegen/example/testdata/dsls.go
@@ -208,6 +208,42 @@ var SingleServerMultipleHostsWithVariablesDSL = func() {
 	})
 }
 
+var ServiceForOnlyHTTPDSL = func() {
+	Service("Service", func() {
+		Method("Method", func() {
+			HTTP(func() {
+				GET("/")
+			})
+		})
+	})
+}
+
+var ServiceForOnlyGRPCDSL = func() {
+	Service("Service", func() {
+		Method("Method", func() {
+			GRPC(func() {})
+		})
+	})
+}
+
+var ServiceForHTTPAndPartOfGRPCDSL = func() {
+	Service("Service", func() {
+		Method("Method", func() {
+			HTTP(func() {
+				GET("/")
+			})
+			GRPC(func() {})
+		})
+	})
+	Service("AnotherService", func() {
+		Method("Method", func() {
+			HTTP(func() {
+				GET("/")
+			})
+		})
+	})
+}
+
 var ConflictWithAPINameAndServiceNamesIncludingMultipartDSL = func() {
 	var _ = API("aloha", func() {
 		Title("conflict with API name and service names including multipart")

--- a/codegen/example/testdata/example_server_code.go
+++ b/codegen/example/testdata/example_server_code.go
@@ -1180,4 +1180,308 @@ const (
 	logger.Println("exited")
 }
 `
+
+	ServiceForOnlyHTTPServerMainCode = `func main() {
+	// Define command line flags, add any other flag required to configure the
+	// service.
+	var (
+		hostF     = flag.String("host", "localhost", "Server host (valid values: localhost)")
+		domainF   = flag.String("domain", "", "Host domain name (overrides host domain specified in service design)")
+		httpPortF = flag.String("http-port", "", "HTTP port (overrides host HTTP port specified in service design)")
+		secureF   = flag.Bool("secure", false, "Use secure scheme (https or grpcs)")
+		dbgF      = flag.Bool("debug", false, "Log request and response bodies")
+	)
+	flag.Parse()
+
+	// Setup logger. Replace logger with your own log package of choice.
+	var (
+		logger *log.Logger
+	)
+	{
+		logger = log.New(os.Stderr, "[testapi] ", log.Ltime)
+	}
+
+	// Initialize the services.
+	var (
+		serviceSvc service.Service
+	)
+	{
+		serviceSvc = testapi.NewService(logger)
+	}
+
+	// Wrap the services in endpoints that can be invoked from other services
+	// potentially running in different processes.
+	var (
+		serviceEndpoints *service.Endpoints
+	)
+	{
+		serviceEndpoints = service.NewEndpoints(serviceSvc)
+	}
+
+	// Create channel used by both the signal handler and server goroutines
+	// to notify the main goroutine when to stop the server.
+	errc := make(chan error)
+
+	// Setup interrupt handler. This optional step configures the process so
+	// that SIGINT and SIGTERM signals cause the services to stop gracefully.
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		errc <- fmt.Errorf("%s", <-c)
+	}()
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start the servers and send errors (if any) to the error channel.
+	switch *hostF {
+	case "localhost":
+		{
+			addr := "http://localhost:80"
+			u, err := url.Parse(addr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid URL %#v: %s\n", addr, err)
+				os.Exit(1)
+			}
+			if *secureF {
+				u.Scheme = "https"
+			}
+			if *domainF != "" {
+				u.Host = *domainF
+			}
+			if *httpPortF != "" {
+				h := strings.Split(u.Host, ":")[0]
+				u.Host = h + ":" + *httpPortF
+			} else if u.Port() == "" {
+				u.Host += ":80"
+			}
+			handleHTTPServer(ctx, u, serviceEndpoints, &wg, errc, logger, *dbgF)
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "invalid host argument: %q (valid hosts: localhost)\n", *hostF)
+	}
+
+	// Wait for signal.
+	logger.Printf("exiting (%v)", <-errc)
+
+	// Send cancellation signal to the goroutines.
+	cancel()
+
+	wg.Wait()
+	logger.Println("exited")
+}
+`
+
+	ServiceForOnlyGRPCServerMainCode = `func main() {
+	// Define command line flags, add any other flag required to configure the
+	// service.
+	var (
+		hostF     = flag.String("host", "localhost", "Server host (valid values: localhost)")
+		domainF   = flag.String("domain", "", "Host domain name (overrides host domain specified in service design)")
+		grpcPortF = flag.String("grpc-port", "", "gRPC port (overrides host gRPC port specified in service design)")
+		secureF   = flag.Bool("secure", false, "Use secure scheme (https or grpcs)")
+		dbgF      = flag.Bool("debug", false, "Log request and response bodies")
+	)
+	flag.Parse()
+
+	// Setup logger. Replace logger with your own log package of choice.
+	var (
+		logger *log.Logger
+	)
+	{
+		logger = log.New(os.Stderr, "[testapi] ", log.Ltime)
+	}
+
+	// Initialize the services.
+	var (
+		serviceSvc service.Service
+	)
+	{
+		serviceSvc = testapi.NewService(logger)
+	}
+
+	// Wrap the services in endpoints that can be invoked from other services
+	// potentially running in different processes.
+	var (
+		serviceEndpoints *service.Endpoints
+	)
+	{
+		serviceEndpoints = service.NewEndpoints(serviceSvc)
+	}
+
+	// Create channel used by both the signal handler and server goroutines
+	// to notify the main goroutine when to stop the server.
+	errc := make(chan error)
+
+	// Setup interrupt handler. This optional step configures the process so
+	// that SIGINT and SIGTERM signals cause the services to stop gracefully.
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		errc <- fmt.Errorf("%s", <-c)
+	}()
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start the servers and send errors (if any) to the error channel.
+	switch *hostF {
+	case "localhost":
+
+		{
+			addr := "grpc://localhost:8080"
+			u, err := url.Parse(addr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid URL %#v: %s\n", addr, err)
+				os.Exit(1)
+			}
+			if *secureF {
+				u.Scheme = "grpcs"
+			}
+			if *domainF != "" {
+				u.Host = *domainF
+			}
+			if *grpcPortF != "" {
+				h := strings.Split(u.Host, ":")[0]
+				u.Host = h + ":" + *grpcPortF
+			} else if u.Port() == "" {
+				u.Host += ":8080"
+			}
+			handleGRPCServer(ctx, u, serviceEndpoints, &wg, errc, logger, *dbgF)
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "invalid host argument: %q (valid hosts: localhost)\n", *hostF)
+	}
+
+	// Wait for signal.
+	logger.Printf("exiting (%v)", <-errc)
+
+	// Send cancellation signal to the goroutines.
+	cancel()
+
+	wg.Wait()
+	logger.Println("exited")
+}
+`
+
+	ServiceForHTTPAndPartOfGRPCServerMainCode = `func main() {
+	// Define command line flags, add any other flag required to configure the
+	// service.
+	var (
+		hostF     = flag.String("host", "localhost", "Server host (valid values: localhost)")
+		domainF   = flag.String("domain", "", "Host domain name (overrides host domain specified in service design)")
+		httpPortF = flag.String("http-port", "", "HTTP port (overrides host HTTP port specified in service design)")
+		grpcPortF = flag.String("grpc-port", "", "gRPC port (overrides host gRPC port specified in service design)")
+		secureF   = flag.Bool("secure", false, "Use secure scheme (https or grpcs)")
+		dbgF      = flag.Bool("debug", false, "Log request and response bodies")
+	)
+	flag.Parse()
+
+	// Setup logger. Replace logger with your own log package of choice.
+	var (
+		logger *log.Logger
+	)
+	{
+		logger = log.New(os.Stderr, "[testapi] ", log.Ltime)
+	}
+
+	// Initialize the services.
+	var (
+		serviceSvc        service.Service
+		anotherServiceSvc anotherservice.Service
+	)
+	{
+		serviceSvc = testapi.NewService(logger)
+		anotherServiceSvc = testapi.NewAnotherService(logger)
+	}
+
+	// Wrap the services in endpoints that can be invoked from other services
+	// potentially running in different processes.
+	var (
+		serviceEndpoints        *service.Endpoints
+		anotherServiceEndpoints *anotherservice.Endpoints
+	)
+	{
+		serviceEndpoints = service.NewEndpoints(serviceSvc)
+		anotherServiceEndpoints = anotherservice.NewEndpoints(anotherServiceSvc)
+	}
+
+	// Create channel used by both the signal handler and server goroutines
+	// to notify the main goroutine when to stop the server.
+	errc := make(chan error)
+
+	// Setup interrupt handler. This optional step configures the process so
+	// that SIGINT and SIGTERM signals cause the services to stop gracefully.
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		errc <- fmt.Errorf("%s", <-c)
+	}()
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start the servers and send errors (if any) to the error channel.
+	switch *hostF {
+	case "localhost":
+		{
+			addr := "http://localhost:80"
+			u, err := url.Parse(addr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid URL %#v: %s\n", addr, err)
+				os.Exit(1)
+			}
+			if *secureF {
+				u.Scheme = "https"
+			}
+			if *domainF != "" {
+				u.Host = *domainF
+			}
+			if *httpPortF != "" {
+				h := strings.Split(u.Host, ":")[0]
+				u.Host = h + ":" + *httpPortF
+			} else if u.Port() == "" {
+				u.Host += ":80"
+			}
+			handleHTTPServer(ctx, u, serviceEndpoints, anotherServiceEndpoints, &wg, errc, logger, *dbgF)
+		}
+
+		{
+			addr := "grpc://localhost:8080"
+			u, err := url.Parse(addr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "invalid URL %#v: %s\n", addr, err)
+				os.Exit(1)
+			}
+			if *secureF {
+				u.Scheme = "grpcs"
+			}
+			if *domainF != "" {
+				u.Host = *domainF
+			}
+			if *grpcPortF != "" {
+				h := strings.Split(u.Host, ":")[0]
+				u.Host = h + ":" + *grpcPortF
+			} else if u.Port() == "" {
+				u.Host += ":8080"
+			}
+			handleGRPCServer(ctx, u, serviceEndpoints, &wg, errc, logger, *dbgF)
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "invalid host argument: %q (valid hosts: localhost)\n", *hostF)
+	}
+
+	// Wait for signal.
+	logger.Printf("exiting (%v)", <-errc)
+
+	// Send cancellation signal to the goroutines.
+	cancel()
+
+	wg.Wait()
+	logger.Println("exited")
+}
+`
 )


### PR DESCRIPTION
Generated server main handlers have to receive only endpoints for the transport.

```
// anotherServiceEndpoints is unneeded if gRPC is defined only for serviceEndpoints.
handleGRPCServer(ctx, u, serviceEndpoints, anotherServiceEndpoints, &wg, errc, logger, *dbgF)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^
```