### PR TITLE
Support server reflection service on gRPC server

### DIFF
--- a/grpc/codegen/example_server.go
+++ b/grpc/codegen/example_server.go
@@ -52,6 +52,7 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 			{Path: "goa.design/goa/middleware"},
 			{Path: "goa.design/goa/grpc/middleware", Name: "grpcmdlwr"},
 			{Path: "google.golang.org/grpc"},
+			{Path: "google.golang.org/grpc/reflection"},
 			{Path: "github.com/grpc-ecosystem/go-grpc-middleware", Name: "grpcmiddleware"},
 			{Path: "goa.design/goa/grpc", Name: "goagrpc"},
 		}
@@ -215,6 +216,8 @@ func handleGRPCServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 			logger.Printf("serving gRPC method %s", svc + "/" + m.Name)
 		}
 	}
+
+	reflection.Register(srv)
 `
 
 	// input: map[string]interface{}{"Services":[]*ServiceData}

--- a/grpc/codegen/example_server.go
+++ b/grpc/codegen/example_server.go
@@ -217,6 +217,8 @@ func handleGRPCServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 		}
 	}
 
+	// Register the server reflection service on the server.
+	// See https://grpc.github.io/grpc/core/md_doc_server-reflection.html.
 	reflection.Register(srv)
 `
 

--- a/grpc/codegen/testdata/example_code.go
+++ b/grpc/codegen/testdata/example_code.go
@@ -40,6 +40,8 @@ func handleGRPCServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		}
 	}
 
+	reflection.Register(srv)
+
 	(*wg).Add(1)
 	go func() {
 		defer (*wg).Done()
@@ -100,6 +102,8 @@ func handleGRPCServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 			logger.Printf("serving gRPC method %s", svc+"/"+m.Name)
 		}
 	}
+
+	reflection.Register(srv)
 
 	(*wg).Add(1)
 	go func() {
@@ -164,6 +168,8 @@ func handleGRPCServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 			logger.Printf("serving gRPC method %s", svc+"/"+m.Name)
 		}
 	}
+
+	reflection.Register(srv)
 
 	(*wg).Add(1)
 	go func() {

--- a/grpc/codegen/testdata/example_code.go
+++ b/grpc/codegen/testdata/example_code.go
@@ -40,6 +40,8 @@ func handleGRPCServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		}
 	}
 
+	// Register the server reflection service on the server.
+	// See https://grpc.github.io/grpc/core/md_doc_server-reflection.html.
 	reflection.Register(srv)
 
 	(*wg).Add(1)
@@ -103,6 +105,8 @@ func handleGRPCServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		}
 	}
 
+	// Register the server reflection service on the server.
+	// See https://grpc.github.io/grpc/core/md_doc_server-reflection.html.
 	reflection.Register(srv)
 
 	(*wg).Add(1)
@@ -169,6 +173,8 @@ func handleGRPCServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		}
 	}
 
+	// Register the server reflection service on the server.
+	// See https://grpc.github.io/grpc/core/md_doc_server-reflection.html.
 	reflection.Register(srv)
 
 	(*wg).Add(1)


### PR DESCRIPTION
This patch adds a support of [server reflection service](https://github.com/grpc/grpc/blob/c1d176528fd8da9dd4066d16554bcd216d29033f/doc/server-reflection.md) to the generated example gRPC server.