### PR TITLE
v3: Fix a bug of the file server

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -377,11 +377,11 @@ func {{ .MountServer }}(mux goahttp.Muxer{{ if .Endpoints }}, h *{{ .ServerStruc
 	{{ .MountHandler }}(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			upath := path.Clean(r.URL.Path)
 			rpath := upath
-			{{- range .RequestPaths }}
+			{{- range .RequestPaths }}{{ if ne . "/" }}
 			if strings.HasPrefix(upath, "{{ . }}") {
 				rpath = upath[{{ len . }}:]
 			}
-			{{- end }}
+			{{- end }}{{ end }}
 			http.ServeFile(w, r, path.Join({{ printf "%q" .FilePath }}, rpath))
 		}))
 	 	{{- else }}
@@ -413,8 +413,8 @@ const fileServerT = `{{ printf "%s configures the mux to serve GET request made 
 func {{ .MountHandler }}(mux goahttp.Muxer, h http.Handler) {
 	{{- if .IsDir }}
 		{{- range .RequestPaths }}
-	mux.Handle("GET", "{{ . }}/", h.ServeHTTP)
-	mux.Handle("GET", "{{ . }}/*{{ $.PathParam }}", h.ServeHTTP)
+	mux.Handle("GET", "{{ . }}{{if ne . "/"}}/{{end}}", h.ServeHTTP)
+	mux.Handle("GET", "{{ . }}{{if ne . "/"}}/{{end}}*{{ $.PathParam }}", h.ServeHTTP)
 		{{- end }}
 	{{- else }}
 		{{- range .RequestPaths }}

--- a/http/codegen/server_mount_test.go
+++ b/http/codegen/server_mount_test.go
@@ -16,7 +16,30 @@ func TestServerMount(t *testing.T) {
 		Code       string
 		SectionNum int
 	}{
-		{"multiple files", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesConstructorCode, 6},
+		{
+			Name:       "multiple files constructor",
+			DSL:        testdata.ServerMultipleFilesDSL,
+			Code:       testdata.ServerMultipleFilesConstructorCode,
+			SectionNum: 6,
+		},
+		{
+			Name:       "multiple files mounter",
+			DSL:        testdata.ServerMultipleFilesDSL,
+			Code:       testdata.ServerMultipleFilesMounterCode,
+			SectionNum: 9,
+		},
+		{
+			Name:       "multiple files constructor /w prefix path",
+			DSL:        testdata.ServerMultipleFilesWithPrefixPathDSL,
+			Code:       testdata.ServerMultipleFilesWithPrefixPathConstructorCode,
+			SectionNum: 6,
+		},
+		{
+			Name:       "multiple files mounter /w prefix path",
+			DSL:        testdata.ServerMultipleFilesWithPrefixPathDSL,
+			Code:       testdata.ServerMultipleFilesWithPrefixPathMounterCode,
+			SectionNum: 9,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -634,7 +634,9 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 		paths := make([]string, len(s.RequestPaths))
 		for i, p := range s.RequestPaths {
 			idx := strings.LastIndex(p, "/{")
-			if idx > 0 {
+			if idx == 0 {
+				paths[i] = "/"
+			} else if idx > 0 {
 				paths[i] = p[:idx]
 			} else {
 				paths[i] = p

--- a/http/codegen/testdata/server_dsls.go
+++ b/http/codegen/testdata/server_dsls.go
@@ -159,10 +159,19 @@ var ServerMultipartDSL = func() {
 
 var ServerMultipleFilesDSL = func() {
 	Service("ServiceFileServer", func() {
+		Files("/file.json", "/path/to/file.json")
+		Files("/", "/path/to/file.json")
+		Files("/{wildcard}", "/path/to/folder")
+	})
+}
+
+var ServerMultipleFilesWithPrefixPathDSL = func() {
+	Service("ServiceFileServer", func() {
 		HTTP(func() {
 			Path("/server_file_server")
 		})
 		Files("/file.json", "/path/to/file.json")
 		Files("/", "/path/to/file.json")
+		Files("/{wildcard}", "/path/to/folder")
 	})
 }

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -158,5 +158,44 @@ func Mount(mux goahttp.Muxer) {
 	MountPathToFileJSON1(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "/path/to/file.json")
 	}))
+	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upath := path.Clean(r.URL.Path)
+		rpath := upath
+		http.ServeFile(w, r, path.Join("/path/to/folder", rpath))
+	}))
+}
+`
+
+var ServerMultipleFilesWithPrefixPathConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
+func Mount(mux goahttp.Muxer) {
+	MountPathToFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "/path/to/file.json")
+	}))
+	MountPathToFileJSON1(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "/path/to/file.json")
+	}))
+	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upath := path.Clean(r.URL.Path)
+		rpath := upath
+		if strings.HasPrefix(upath, "/server_file_server") {
+			rpath = upath[19:]
+		}
+		http.ServeFile(w, r, path.Join("/path/to/folder", rpath))
+	}))
+}
+`
+
+var ServerMultipleFilesMounterCode = `// MountPathToFolder configures the mux to serve GET request made to "/".
+func MountPathToFolder(mux goahttp.Muxer, h http.Handler) {
+	mux.Handle("GET", "/", h.ServeHTTP)
+	mux.Handle("GET", "/*wildcard", h.ServeHTTP)
+}
+`
+
+var ServerMultipleFilesWithPrefixPathMounterCode = `// MountPathToFolder configures the mux to serve GET request made to
+// "/server_file_server".
+func MountPathToFolder(mux goahttp.Muxer, h http.Handler) {
+	mux.Handle("GET", "/server_file_server/", h.ServeHTTP)
+	mux.Handle("GET", "/server_file_server/*wildcard", h.ServeHTTP)
 }
 `


### PR DESCRIPTION
This patch fixes a bug of the file server when there is a wildcard in the root of the file path.

**Design**

```go
Service("ServiceFileServer", func() {
	Files("/{wildcard}", "/path/to/folder")
})
```

**Before**

```go
func MountPathToFolder(mux goahttp.Muxer, h http.Handler) {
	mux.Handle("GET", "/{wildcard}/", h.ServeHTTP)
	mux.Handle("GET", "/{wildcard}/*wildcard", h.ServeHTTP)
}
```

**After**
```go
func MountPathToFolder(mux goahttp.Muxer, h http.Handler) {
	mux.Handle("GET", "/", h.ServeHTTP)
	mux.Handle("GET", "/*wildcard", h.ServeHTTP)
}
```
