### PR TITLE
Fix usage of Debug in example http server

### DIFF
--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -256,6 +256,19 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 		{{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New(nil, mux, dec, enc, eh, nil)
 		{{-  end }}
 	{{- end }}
+	{{- if .Services }}
+		if debug {
+			for _, server := range []interface {
+				Use(func(http.Handler) http.Handler)
+			}{
+				{{- range $svc := .Services }}
+				{{ .Service.VarName }}Server,
+				{{- end }}
+			} {
+				server.Use(httpmdlwr.Debug(mux, os.Stdout))
+			}
+		}
+	{{- end }}
 	}
 	// Configure the mux.
 	{{- range .Services }}
@@ -268,9 +281,6 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	// here apply to all the service endpoints.
 	var handler http.Handler = mux
 	{
-		if debug {
-			handler = httpmdlwr.Debug(mux, os.Stdout)(handler)
-		}
 		handler = httpmdlwr.Log(adapter)(handler)
 		handler = httpmdlwr.RequestID()(handler)
 	}

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -258,15 +258,12 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	{{- end }}
 	{{- if .Services }}
 		if debug {
-			for _, server := range []interface {
-				Use(func(http.Handler) http.Handler)
-			}{
+			servers := goahttp.Servers{
 				{{- range $svc := .Services }}
 				{{ .Service.VarName }}Server,
 				{{- end }}
-			} {
-				server.Use(httpmdlwr.Debug(mux, os.Stdout))
 			}
+			servers.Use(httpmdlwr.Debug(mux, os.Stdout))
 		}
 	{{- end }}
 	}

--- a/http/codegen/testdata/example_code.go
+++ b/http/codegen/testdata/example_code.go
@@ -40,13 +40,10 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		eh := errorHandler(logger)
 		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
 		if debug {
-			for _, server := range []interface {
-				Use(func(http.Handler) http.Handler)
-			}{
+			servers := goahttp.Servers{
 				serviceServer,
-			} {
-				server.Use(httpmdlwr.Debug(mux, os.Stdout))
 			}
+			servers.Use(httpmdlwr.Debug(mux, os.Stdout))
 		}
 	}
 	// Configure the mux.
@@ -139,13 +136,10 @@ func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc 
 		eh := errorHandler(logger)
 		serviceServer = servicesvr.New(nil, mux, dec, enc, eh, nil)
 		if debug {
-			for _, server := range []interface {
-				Use(func(http.Handler) http.Handler)
-			}{
+			servers := goahttp.Servers{
 				serviceServer,
-			} {
-				server.Use(httpmdlwr.Debug(mux, os.Stdout))
 			}
+			servers.Use(httpmdlwr.Debug(mux, os.Stdout))
 		}
 	}
 	// Configure the mux.
@@ -238,13 +232,10 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		eh := errorHandler(logger)
 		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
 		if debug {
-			for _, server := range []interface {
-				Use(func(http.Handler) http.Handler)
-			}{
+			servers := goahttp.Servers{
 				serviceServer,
-			} {
-				server.Use(httpmdlwr.Debug(mux, os.Stdout))
 			}
+			servers.Use(httpmdlwr.Debug(mux, os.Stdout))
 		}
 	}
 	// Configure the mux.
@@ -339,14 +330,11 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
 		anotherServiceServer = anotherservicesvr.New(anotherServiceEndpoints, mux, dec, enc, eh, nil)
 		if debug {
-			for _, server := range []interface {
-				Use(func(http.Handler) http.Handler)
-			}{
+			servers := goahttp.Servers{
 				serviceServer,
 				anotherServiceServer,
-			} {
-				server.Use(httpmdlwr.Debug(mux, os.Stdout))
 			}
+			servers.Use(httpmdlwr.Debug(mux, os.Stdout))
 		}
 	}
 	// Configure the mux.
@@ -446,14 +434,11 @@ func handleHTTPServer(ctx context.Context, u *url.URL, streamingServiceAEndpoint
 		streamingServiceAServer = streamingserviceasvr.New(streamingServiceAEndpoints, mux, dec, enc, eh, nil, upgrader, nil)
 		streamingServiceBServer = streamingservicebsvr.New(streamingServiceBEndpoints, mux, dec, enc, eh, nil, upgrader, nil)
 		if debug {
-			for _, server := range []interface {
-				Use(func(http.Handler) http.Handler)
-			}{
+			servers := goahttp.Servers{
 				streamingServiceAServer,
 				streamingServiceBServer,
-			} {
-				server.Use(httpmdlwr.Debug(mux, os.Stdout))
 			}
+			servers.Use(httpmdlwr.Debug(mux, os.Stdout))
 		}
 	}
 	// Configure the mux.

--- a/http/codegen/testdata/example_code.go
+++ b/http/codegen/testdata/example_code.go
@@ -39,6 +39,15 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 	{
 		eh := errorHandler(logger)
 		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
+		if debug {
+			for _, server := range []interface {
+				Use(func(http.Handler) http.Handler)
+			}{
+				serviceServer,
+			} {
+				server.Use(httpmdlwr.Debug(mux, os.Stdout))
+			}
+		}
 	}
 	// Configure the mux.
 	servicesvr.Mount(mux, serviceServer)
@@ -47,9 +56,6 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 	// here apply to all the service endpoints.
 	var handler http.Handler = mux
 	{
-		if debug {
-			handler = httpmdlwr.Debug(mux, os.Stdout)(handler)
-		}
 		handler = httpmdlwr.Log(adapter)(handler)
 		handler = httpmdlwr.RequestID()(handler)
 	}
@@ -132,6 +138,15 @@ func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc 
 	{
 		eh := errorHandler(logger)
 		serviceServer = servicesvr.New(nil, mux, dec, enc, eh, nil)
+		if debug {
+			for _, server := range []interface {
+				Use(func(http.Handler) http.Handler)
+			}{
+				serviceServer,
+			} {
+				server.Use(httpmdlwr.Debug(mux, os.Stdout))
+			}
+		}
 	}
 	// Configure the mux.
 	servicesvr.Mount(mux)
@@ -140,9 +155,6 @@ func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc 
 	// here apply to all the service endpoints.
 	var handler http.Handler = mux
 	{
-		if debug {
-			handler = httpmdlwr.Debug(mux, os.Stdout)(handler)
-		}
 		handler = httpmdlwr.Log(adapter)(handler)
 		handler = httpmdlwr.RequestID()(handler)
 	}
@@ -225,6 +237,15 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 	{
 		eh := errorHandler(logger)
 		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
+		if debug {
+			for _, server := range []interface {
+				Use(func(http.Handler) http.Handler)
+			}{
+				serviceServer,
+			} {
+				server.Use(httpmdlwr.Debug(mux, os.Stdout))
+			}
+		}
 	}
 	// Configure the mux.
 	servicesvr.Mount(mux, serviceServer)
@@ -233,9 +254,6 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 	// here apply to all the service endpoints.
 	var handler http.Handler = mux
 	{
-		if debug {
-			handler = httpmdlwr.Debug(mux, os.Stdout)(handler)
-		}
 		handler = httpmdlwr.Log(adapter)(handler)
 		handler = httpmdlwr.RequestID()(handler)
 	}
@@ -320,6 +338,16 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		eh := errorHandler(logger)
 		serviceServer = servicesvr.New(serviceEndpoints, mux, dec, enc, eh, nil)
 		anotherServiceServer = anotherservicesvr.New(anotherServiceEndpoints, mux, dec, enc, eh, nil)
+		if debug {
+			for _, server := range []interface {
+				Use(func(http.Handler) http.Handler)
+			}{
+				serviceServer,
+				anotherServiceServer,
+			} {
+				server.Use(httpmdlwr.Debug(mux, os.Stdout))
+			}
+		}
 	}
 	// Configure the mux.
 	servicesvr.Mount(mux, serviceServer)
@@ -329,9 +357,6 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 	// here apply to all the service endpoints.
 	var handler http.Handler = mux
 	{
-		if debug {
-			handler = httpmdlwr.Debug(mux, os.Stdout)(handler)
-		}
 		handler = httpmdlwr.Log(adapter)(handler)
 		handler = httpmdlwr.RequestID()(handler)
 	}
@@ -420,6 +445,16 @@ func handleHTTPServer(ctx context.Context, u *url.URL, streamingServiceAEndpoint
 		upgrader := &websocket.Upgrader{}
 		streamingServiceAServer = streamingserviceasvr.New(streamingServiceAEndpoints, mux, dec, enc, eh, nil, upgrader, nil)
 		streamingServiceBServer = streamingservicebsvr.New(streamingServiceBEndpoints, mux, dec, enc, eh, nil, upgrader, nil)
+		if debug {
+			for _, server := range []interface {
+				Use(func(http.Handler) http.Handler)
+			}{
+				streamingServiceAServer,
+				streamingServiceBServer,
+			} {
+				server.Use(httpmdlwr.Debug(mux, os.Stdout))
+			}
+		}
 	}
 	// Configure the mux.
 	streamingserviceasvr.Mount(mux, streamingServiceAServer)
@@ -429,9 +464,6 @@ func handleHTTPServer(ctx context.Context, u *url.URL, streamingServiceAEndpoint
 	// here apply to all the service endpoints.
 	var handler http.Handler = mux
 	{
-		if debug {
-			handler = httpmdlwr.Debug(mux, os.Stdout)(handler)
-		}
 		handler = httpmdlwr.Log(adapter)(handler)
 		handler = httpmdlwr.RequestID()(handler)
 	}

--- a/http/server.go
+++ b/http/server.go
@@ -9,7 +9,7 @@ type (
 		Use(func(http.Handler) http.Handler)
 	}
 
-	// Servers is a list of server.
+	// Servers is a list of servers.
 	Servers []Server
 )
 

--- a/http/server.go
+++ b/http/server.go
@@ -1,0 +1,21 @@
+package http
+
+import "net/http"
+
+type (
+	// Server is the HTTP server interface used to wrap the server handlers
+	// with the given middleware.
+	Server interface {
+		Use(func(http.Handler) http.Handler)
+	}
+
+	// Servers is the list of server.
+	Servers []Server
+)
+
+// Use wraps the servers with the given middleware.
+func (s Servers) Use(m func(http.Handler) http.Handler) {
+	for _, v := range s {
+		v.Use(m)
+	}
+}

--- a/http/server.go
+++ b/http/server.go
@@ -9,7 +9,7 @@ type (
 		Use(func(http.Handler) http.Handler)
 	}
 
-	// Servers is the list of server.
+	// Servers is a list of server.
 	Servers []Server
 )
 


### PR DESCRIPTION
Generated example HTTP server contains the Debug middleware but request parameters are not printed. The middleware depends on httptreemux.ContextParams so it must be applied for each servers before mount them.