### PR TITLE
Fix potentially ignored reference

### DIFF
--- a/dsl/attribute.go
+++ b/dsl/attribute.go
@@ -138,11 +138,8 @@ func Attribute(name string, args ...interface{}) {
 
 	var attr *expr.AttributeExpr
 	{
-		for _, ref := range parent.References {
-			if att := expr.AsObject(ref).Attribute(name); att != nil {
-				attr = expr.DupAtt(att)
-				break
-			}
+		if ref := parent.Find(name); ref != nil {
+			attr = expr.DupAtt(ref)
 		}
 
 		dataType, description, fn := parseAttributeArgs(attr, args...)

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -471,6 +471,11 @@ func (a *AttributeExpr) Find(name string) *AttributeExpr {
 			return att
 		}
 	}
+	for _, ref := range a.References {
+		if att := findAttrFn(ref); att != nil {
+			return att
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
The problem manifests itself when a type definition uses an attribute
from a reference that is not a direct reference to the type but
instead a reference of a base. This PR fixes the issue by making sure
that the lookup for a corresponding attribute in a reference is
recursive through parent bases and references.