### PR TITLE
Fix potential panic in primitive pointer check

### DIFF
--- a/codegen/transformer.go
+++ b/codegen/transformer.go
@@ -181,7 +181,7 @@ func mapDepth(dt expr.DataType, depth int, seen ...map[string]struct{}) int {
 // IsPrimitivePointer returns true if the attribute with the given name is a
 // primitive pointer in the given parent attribute.
 func (a *AttributeContext) IsPrimitivePointer(name string, att *expr.AttributeExpr) bool {
-	if at := att.Find(name); at != nil && at.Type == expr.Any || at.Type == expr.Bytes {
+	if at := att.Find(name); at != nil && (at.Type == expr.Any || at.Type == expr.Bytes) {
 		return false
 	}
 	if a.Pointer {

--- a/codegen/transformer_test.go
+++ b/codegen/transformer_test.go
@@ -1,0 +1,86 @@
+package codegen
+
+import (
+	"testing"
+
+	"goa.design/goa/v3/expr"
+)
+
+func TestIsPrimitivePointer(t *testing.T) {
+	newObj := func(fieldName string, fieldType expr.DataType, req bool) *expr.AttributeExpr {
+		attr := &expr.AttributeExpr{
+			Type: &expr.Object{
+				&expr.NamedAttributeExpr{fieldName, &expr.AttributeExpr{Type: fieldType}},
+			},
+		}
+		if req {
+			attr.Validation = &expr.ValidationExpr{Required: []string{fieldName}}
+		}
+		return attr
+	}
+	tc := []struct {
+		Test     string
+		Context  *AttributeContext
+		Attr     *expr.AttributeExpr
+		Name     string
+		Expected bool
+	}{
+		{
+			Test:     "pointer attribute",
+			Context:  &AttributeContext{},
+			Attr:     newObj("foo", expr.String, false),
+			Name:     "foo",
+			Expected: true,
+		},
+		{
+			Test:     "non pointer attribute",
+			Context:  &AttributeContext{},
+			Attr:     newObj("foo", expr.String, true),
+			Name:     "foo",
+			Expected: false,
+		},
+		{
+			Test:     "pointer context with pointer attribute",
+			Context:  &AttributeContext{Pointer: true},
+			Attr:     newObj("foo", expr.String, false),
+			Name:     "foo",
+			Expected: true,
+		},
+		{
+			Test:     "pointer context with non pointer attribute",
+			Context:  &AttributeContext{Pointer: true},
+			Attr:     newObj("foo", expr.String, true),
+			Name:     "foo",
+			Expected: true,
+		},
+		{
+			Test:     "ignore required context with pointer attribute",
+			Context:  &AttributeContext{IgnoreRequired: true},
+			Attr:     newObj("foo", expr.String, false),
+			Name:     "foo",
+			Expected: false,
+		},
+		{
+			Test:     "ignore required context with non pointer attribute",
+			Context:  &AttributeContext{IgnoreRequired: true},
+			Attr:     newObj("foo", expr.String, true),
+			Name:     "foo",
+			Expected: false,
+		},
+		{
+			Test:     "missing attribute",
+			Context:  &AttributeContext{},
+			Attr:     newObj("foo", expr.String, false),
+			Name:     "bar",
+			Expected: false,
+		},
+	}
+	for _, c := range tc {
+		t.Run(c.Test, func(t *testing.T) {
+			got := c.Context.IsPrimitivePointer(c.Name, c.Attr)
+			if got != c.Expected {
+				t.Errorf("expected %v, got %v", c.Expected, got)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,17 @@ require (
 	github.com/dimfeld/httptreemux/v5 v5.0.2
 	github.com/go-openapi/loads v0.19.4
 	github.com/golang/protobuf v1.3.2
+	github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4 // indirect
 	github.com/gorilla/websocket v1.4.1
-	github.com/hashicorp/go-getter v1.4.1 // indirect
 	github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d
+	github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sergi/go-diff v1.1.0
+	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
-	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
-	golang.org/x/tools v0.0.0-20200110213125-a7a6caa82ab2 // indirect
+	golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 // indirect
+	golang.org/x/tools v0.0.0-20200110213125-a7a6caa82ab2
+	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
+	google.golang.org/grpc v1.21.1
 	gopkg.in/yaml.v2 v2.2.7
-	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
 )

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1589,7 +1589,7 @@ func buildErrorsData(e *expr.HTTPEndpointExpr, sd *ServiceData) []*ErrorGroupDat
 						Name:         h.VarName,
 						Ref:          h.VarName,
 						FieldName:    h.FieldName,
-						FieldPointer: h.FieldPointer,
+						FieldPointer: false,
 						TypeRef:      h.TypeRef,
 						Validate:     h.Validate,
 						Example:      h.Example,


### PR DESCRIPTION
when attribute is missing. Also fix problem with error response initialization
of primitive pointer fields. The generated code was using a pointer address
to the function argument to assign the field but the argument is already a
pointer.