### PR TITLE
v3: [OpenAPI] Convert the item type name of the array if primitive

### DIFF
--- a/http/codegen/openapi/openapi_v2_builder.go
+++ b/http/codegen/openapi/openapi_v2_builder.go
@@ -480,6 +480,17 @@ func paramFor(at *expr.AttributeExpr, name, in string, required bool) *Parameter
 
 func itemsFromExpr(at *expr.AttributeExpr) *Items {
 	items := &Items{Type: at.Type.Name()}
+	switch actual := at.Type.(type) {
+	case expr.Primitive:
+		switch actual.Kind() {
+		case expr.IntKind, expr.Int64Kind, expr.UIntKind, expr.UInt64Kind, expr.Int32Kind, expr.UInt32Kind:
+			items.Type = "integer"
+		case expr.Float32Kind, expr.Float64Kind:
+			items.Type = "number"
+		case expr.BytesKind:
+			items.Type = "string"
+		}
+	}
 	initValidations(at, items)
 	if expr.IsArray(at.Type) {
 		items.Items = itemsFromExpr(expr.AsArray(at.Type).ElemType)


### PR DESCRIPTION
The element type is incorrect in OpenAPI document when an array is specified as a parameter.

## Design

```go

package design

import (
   . "goa.design/goa/v3/dsl"
)

var _ = Service("calc", func() {
   Method("add", func() {
      Payload(func() {
         Attribute("a", ArrayOf(Int))
      })
      Result(Int)
      HTTP(func() {
         GET("/add/{a}")
         Params(func() {
            Param("a")
         })
      })
   })
})
```

## Output

openapi.yaml

**before**

```yaml
paths:
  /add:
    get:
      tags:
      - calc
      summary: add calc
      operationId: calc#add
      parameters:
      - name: a
        in: query
        required: false
        type: array
        items:
          type: int              // ← incorrect type 
        collectionFormat: multi
      responses:
        "200":
          description: OK response.
          schema:
            type: integer
            format: int64
      schemes:
      - http
```

**after**

```yaml
paths:
  /add:
    get:
      tags:
      - calc
      summary: add calc
      operationId: calc#add
      parameters:
      - name: a
        in: query
        required: false
        type: array
        items:
          type: integer          // ← ★
        collectionFormat: multi
      responses:
        "200":
          description: OK response.
          schema:
            type: integer
            format: int64
      schemes:
      - http
```