### PR TITLE
Properly close gRPC client streams without result

### DIFF
--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -1340,11 +1340,22 @@ func (s *{{ .VarName }}) {{ .RecvName }}() ({{ .RecvRef }}, error) {
 const streamCloseT = `
 func (s *{{ .VarName }}) Close() error {
 {{- if eq .Type "client" }}
+{{- if .Endpoint.Method.Result }}
 	{{ comment "Close the send direction of the stream" }}
 	return s.stream.CloseSend()
 {{- else }}
+	{{ comment "synchronize and report any server error" }}
+	_, err := s.stream.CloseAndRecv()
+	return err
+{{- end }}
+{{- else }}
+{{- if .Endpoint.Method.Result }}
 	{{ comment "nothing to do here" }}
 	return nil
+{{- else }}
+	{{ comment "synchronize stream" }}
+	return s.stream.SendAndClose(nil)
+{{- end }}
 {{- end }}
 }
 `

--- a/grpc/codegen/streaming_test.go
+++ b/grpc/codegen/streaming_test.go
@@ -80,7 +80,9 @@ func TestStreaming(t *testing.T) {
 		}},
 		{"client-streaming-no-result", testdata.ClientStreamingNoResultDSL, []*sectionExpectation{
 			{"server-stream-send", nil},
+			{"server-stream-close", &testdata.ClientStreamingServerNoResultCloseCode},
 			{"client-stream-recv", nil},
+			{"client-stream-close", &testdata.ClientStreamingClientNoResultCloseCode},
 		}},
 
 		// bidirectional streaming

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -251,11 +251,13 @@ func (s *MethodClientStreamingRPCClientStream) CloseAndRecv() (string, error) {
 `
 
 var ClientStreamingServerNoResultCloseCode = `func (s *MethodClientStreamingNoResultServerStream) Close() error {
+	// synchronize stream
 	return s.stream.SendAndClose(nil)
 }
 `
 
 var ClientStreamingClientNoResultCloseCode = `func (s *MethodClientStreamingNoResultClientStream) Close() error {
+	// synchronize and report any server error
 	_, err := s.stream.CloseAndRecv()
 	return err
 }

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -250,6 +250,17 @@ func (s *MethodClientStreamingRPCClientStream) CloseAndRecv() (string, error) {
 }
 `
 
+var ClientStreamingServerNoResultCloseCode = `func (s *MethodClientStreamingNoResultServerStream) Close() error {
+	return s.stream.SendAndClose(nil)
+}
+`
+
+var ClientStreamingClientNoResultCloseCode = `func (s *MethodClientStreamingNoResultClientStream) Close() error {
+	_, err := s.stream.CloseAndRecv()
+	return err
+}
+`
+
 var BidirectionalStreamingServerStructCode = `// MethodBidirectionalStreamingRPCServerStream implements the
 // servicebidirectionalstreamingrpc.MethodBidirectionalStreamingRPCServerStream
 // interface.


### PR DESCRIPTION
Previously a client stream without a result was not closed as described in [gRPC Basics](https://grpc.io/docs/tutorials/basic/go/), namely the [server side](https://grpc.io/docs/tutorials/basic/go/#client-side-streaming-rpc) did not call SendAndClose, and the [client side](https://grpc.io/docs/tutorials/basic/go/#client-side-streaming-rpc-1) did not call CloseAndRecv. Nor did the goa wrappers offer any way to call these methods.

This PR adds to the existing `client-streaming-no-result` test to verify that the Close methods are changed to call those respective methods, and then modifies the `streamCloseT` template to pass the test.

Testing this with a local client and server that has synchronous code that previously behaved asynchronously, this change appears to make it synchronous as expected.