### PR TITLE
V3: Fix to use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline)

### DIFF
--- a/grpc/codegen/example_cli.go
+++ b/grpc/codegen/example_cli.go
@@ -89,7 +89,7 @@ const (
 	grpcCLIDoT = `func doGRPC(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
 	conn, err := grpc.Dial(host, grpc.WithInsecure())
 	if err != nil {
-    fmt.Fprintln(os.Stderr, fmt.Sprintf("could not connect to gRPC server at %s: %v", host, err))
+    fmt.Fprintf(os.Stderr, "could not connect to gRPC server at %s: %v\n", host, err)
   }
 	return cli.ParseEndpoint(conn)
 }

--- a/grpc/codegen/testdata/example_code.go
+++ b/grpc/codegen/testdata/example_code.go
@@ -241,7 +241,7 @@ const ExampleSingleHostPkgPathCLIImport = `import (
 const ExampleCLICode = `func doGRPC(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
 	conn, err := grpc.Dial(host, grpc.WithInsecure())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("could not connect to gRPC server at %s: %v", host, err))
+		fmt.Fprintf(os.Stderr, "could not connect to gRPC server at %s: %v\n", host, err)
 	}
 	return cli.ParseEndpoint(conn)
 }


### PR DESCRIPTION
```
LINTING CODE...
basic/cmd/calc-cli/grpc.go:15:3: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (S1038)
cellar/cmd/cellar-cli/grpc.go:15:3: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (S1038)
error/cmd/divider-cli/grpc.go:15:3: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (S1038)
security/cmd/multi_auth-cli/grpc.go:15:3: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (S1038)
streaming/cmd/chatter-cli/grpc.go:15:3: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (S1038)
tracing/cmd/calc-cli/grpc.go:26:3: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (S1038)

^ - staticcheck errors!
```