### PR TITLE
V2: Fix to use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (#2474)

### DIFF
--- a/grpc/codegen/example_cli.go
+++ b/grpc/codegen/example_cli.go
@@ -89,7 +89,7 @@ const (
 	grpcCLIDoT = `func doGRPC(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
 	conn, err := grpc.Dial(host, grpc.WithInsecure())
 	if err != nil {
-    fmt.Fprintln(os.Stderr, fmt.Sprintf("could not connect to gRPC server at %s: %v", host, err))
+    fmt.Fprintf(os.Stderr, "could not connect to gRPC server at %s: %v\n", host, err)
   }
 	return cli.ParseEndpoint(conn)
 }

--- a/grpc/codegen/testdata/example_code.go
+++ b/grpc/codegen/testdata/example_code.go
@@ -241,7 +241,7 @@ const ExampleSingleHostPkgPathCLIImport = `import (
 const ExampleCLICode = `func doGRPC(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
 	conn, err := grpc.Dial(host, grpc.WithInsecure())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, fmt.Sprintf("could not connect to gRPC server at %s: %v", host, err))
+		fmt.Fprintf(os.Stderr, "could not connect to gRPC server at %s: %v\n", host, err)
 	}
 	return cli.ParseEndpoint(conn)
 }


### PR DESCRIPTION
This is backporting of #2474 to v2.