### PR TITLE
Properly close gRPC client streams without result (Backport #2470 to v2)

### DIFF
--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -1340,11 +1340,22 @@ func (s *{{ .VarName }}) {{ .RecvName }}() ({{ .RecvRef }}, error) {
 const streamCloseT = `
 func (s *{{ .VarName }}) Close() error {
 {{- if eq .Type "client" }}
+{{- if .Endpoint.Method.Result }}
 	{{ comment "Close the send direction of the stream" }}
 	return s.stream.CloseSend()
 {{- else }}
+	{{ comment "synchronize and report any server error" }}
+	_, err := s.stream.CloseAndRecv()
+	return err
+{{- end }}
+{{- else }}
+{{- if .Endpoint.Method.Result }}
 	{{ comment "nothing to do here" }}
 	return nil
+{{- else }}
+	{{ comment "synchronize stream" }}
+	return s.stream.SendAndClose(nil)
+{{- end }}
 {{- end }}
 }
 `

--- a/grpc/codegen/streaming_test.go
+++ b/grpc/codegen/streaming_test.go
@@ -80,7 +80,9 @@ func TestStreaming(t *testing.T) {
 		}},
 		{"client-streaming-no-result", testdata.ClientStreamingNoResultDSL, []*sectionExpectation{
 			{"server-stream-send", nil},
+			{"server-stream-close", &testdata.ClientStreamingServerNoResultCloseCode},
 			{"client-stream-recv", nil},
+			{"client-stream-close", &testdata.ClientStreamingClientNoResultCloseCode},
 		}},
 
 		// bidirectional streaming

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -251,11 +251,13 @@ func (s *MethodClientStreamingRPCClientStream) CloseAndRecv() (string, error) {
 `
 
 var ClientStreamingServerNoResultCloseCode = `func (s *MethodClientStreamingNoResultServerStream) Close() error {
+	// synchronize stream
 	return s.stream.SendAndClose(nil)
 }
 `
 
 var ClientStreamingClientNoResultCloseCode = `func (s *MethodClientStreamingNoResultClientStream) Close() error {
+	// synchronize and report any server error
 	_, err := s.stream.CloseAndRecv()
 	return err
 }

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -250,6 +250,17 @@ func (s *MethodClientStreamingRPCClientStream) CloseAndRecv() (string, error) {
 }
 `
 
+var ClientStreamingServerNoResultCloseCode = `func (s *MethodClientStreamingNoResultServerStream) Close() error {
+	return s.stream.SendAndClose(nil)
+}
+`
+
+var ClientStreamingClientNoResultCloseCode = `func (s *MethodClientStreamingNoResultClientStream) Close() error {
+	_, err := s.stream.CloseAndRecv()
+	return err
+}
+`
+
 var BidirectionalStreamingServerStructCode = `// MethodBidirectionalStreamingRPCServerStream implements the
 // servicebidirectionalstreamingrpc.MethodBidirectionalStreamingRPCServerStream
 // interface.


### PR DESCRIPTION
Backport #2470 to v2. I just did a cherry-pick followed by the fun of remembering how to test non-go.mod.

I see a failing test (TestValidateFormat) both before and after my changes, and the expected temporary test failure between my two commits. I have only run go test; I have not tested client behavior here, but see no reason to expect difficulties.