### PR TITLE
Properly handle explicit response body

### DIFF
--- a/expr/http_response.go
+++ b/expr/http_response.go
@@ -250,6 +250,11 @@ func (r *HTTPResponseExpr) Finalize(a *HTTPEndpointExpr, svcAtt *AttributeExpr) 
 					r.Body.Validation.AddRequired(n)
 				}
 			}
+			// Wrap object with user type to simplify response rendering code.
+			r.Body.Type = &UserTypeExpr{
+				AttributeExpr: DupAtt(r.Body),
+				TypeName:      fmt.Sprintf("%s%sResponseBody", a.Service.Name(), a.Name()),
+			}
 		}
 		if r.Body.Meta == nil {
 			r.Body.Meta = svcAtt.Meta

--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -46,7 +46,9 @@ func TestBodyTypeInit(t *testing.T) {
 		{"body-primitive-array-user-validate", testdata.PayloadBodyPrimitiveArrayUserValidateDSL, 2, BodyPrimitiveArrayUserValidateInitCode},
 		{"result-body-user", testdata.ResultBodyObjectHeaderDSL, 2, ResultBodyObjectHeaderInitCode},
 		{"result-explicit-body-primitive", testdata.ExplicitBodyPrimitiveResultMultipleViewsDSL, 1, ExplicitBodyPrimitiveResultMultipleViewsInitCode},
-		{"result-explicit-body-user-type", testdata.ExplicitBodyUserResultMultipleViewsDSL, 2, ExplicitBodyUserResultMultipleViewsInitCode},
+		{"result-explicit-body-user-type", testdata.ExplicitBodyUserResultMultipleViewsDSL, 3, ExplicitBodyUserResultMultipleViewsInitCode},
+		{"result-explicit-body-object", testdata.ExplicitBodyUserResultObjectDSL, 3, ExplicitBodyObjectInitCode},
+		{"result-explicit-body-object-views", testdata.ExplicitBodyUserResultObjectMultipleViewDSL, 3, ExplicitBodyObjectViewsInitCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -213,6 +215,34 @@ func NewMethodExplicitBodyUserResultMultipleViewResulttypemultipleviewsOK(body *
 }
 `
 
+const ExplicitBodyObjectInitCode = `// NewMethodExplicitBodyUserResultObjectResulttypeOK builds a
+// "ServiceExplicitBodyUserResultObject" service
+// "MethodExplicitBodyUserResultObject" endpoint result from a HTTP "OK"
+// response.
+func NewMethodExplicitBodyUserResultObjectResulttypeOK(body *MethodExplicitBodyUserResultObjectResponseBody, c *string, b *string) *serviceexplicitbodyuserresultobjectviews.ResulttypeView {
+	v := &serviceexplicitbodyuserresultobjectviews.ResulttypeView{}
+	if body.A != nil {
+		v.A = unmarshalUserTypeResponseBodyToServiceexplicitbodyuserresultobjectviewsUserTypeView(body.A)
+	}
+	v.C = c
+	v.B = b
+	return v
+}
+`
+
+const ExplicitBodyObjectViewsInitCode = `// NewMethodExplicitBodyUserResultObjectMultipleViewResulttypemultipleviewsOK
+// builds a "ServiceExplicitBodyUserResultObjectMultipleView" service
+// "MethodExplicitBodyUserResultObjectMultipleView" endpoint result from a HTTP
+// "OK" response.
+func NewMethodExplicitBodyUserResultObjectMultipleViewResulttypemultipleviewsOK(body *MethodExplicitBodyUserResultObjectMultipleViewResponseBody, c *string) *serviceexplicitbodyuserresultobjectmultipleviewviews.ResulttypemultipleviewsView {
+	v := &serviceexplicitbodyuserresultobjectmultipleviewviews.ResulttypemultipleviewsView{}
+	if body.A != nil {
+		v.A = unmarshalUserTypeResponseBodyToServiceexplicitbodyuserresultobjectmultipleviewviewsUserTypeView(body.A)
+	}
+	v.C = c
+	return v
+}
+`
 const MixedPayloadInBodyClientTypesFile = `// MethodARequestBody is the type of the "ServiceMixedPayloadInBody" service
 // "MethodA" endpoint HTTP request body.
 type MethodARequestBody struct {

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -517,7 +517,7 @@ type (
 		ValidateRef string
 		// Example is an example value for the type.
 		Example interface{}
-		// View is the view using which the type is rendered.
+		// View is the view used to render the (result) type if any.
 		View string
 	}
 

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -773,6 +773,68 @@ var ExplicitBodyUserResultMultipleViewsDSL = func() {
 	})
 }
 
+var ExplicitBodyUserResultObjectDSL = func() {
+	var UserType = Type("UserType", func() {
+		Attribute("x", String)
+		Attribute("y", Int)
+	})
+	var ResultType = ResultType("ResultType", func() {
+		Attribute("a", UserType)
+		Attribute("b", String)
+		Attribute("c", String)
+	})
+	Service("ServiceExplicitBodyUserResultObject", func() {
+		Method("MethodExplicitBodyUserResultObject", func() {
+			Result(ResultType)
+			HTTP(func() {
+				POST("/")
+				Response(StatusOK, func() {
+					Header("c:Location")
+					Header("b:Content-Type")
+					Body(func() {
+						Attribute("a")
+					})
+				})
+			})
+		})
+	})
+}
+
+var ExplicitBodyUserResultObjectMultipleViewDSL = func() {
+	var UserType = Type("UserType", func() {
+		Attribute("x", String)
+		Attribute("y", Int)
+	})
+	var ResultType = ResultType("ResultTypeMultipleViews", func() {
+		Attribute("a", UserType)
+		Attribute("b", String)
+		Attribute("c", String)
+		View("default", func() {
+			Attribute("a")
+			Attribute("b")
+			Attribute("c")
+		})
+		View("tiny", func() {
+			Attribute("a")
+			Attribute("c")
+		})
+	})
+	Service("ServiceExplicitBodyUserResultObjectMultipleView", func() {
+		Method("MethodExplicitBodyUserResultObjectMultipleView", func() {
+			Result(ResultType)
+			HTTP(func() {
+				POST("/")
+				Response(StatusOK, func() {
+					Header("c:Location")
+					Body(func() {
+						Attribute("a")
+					})
+				})
+			})
+		})
+	})
+}
+
 var ExplicitBodyResultCollectionDSL = func() {
 	var ResultType = ResultType("ResultType", func() {
 		Attributes(func() {


### PR DESCRIPTION
when it is defined using an inline object.

Fix #2400 