### PR TITLE
fix client streaming with no response

### DIFF
--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -841,7 +841,7 @@ func buildRequestConvertData(request, payload *expr.AttributeExpr, md []*Metadat
 //
 // svr param indicates that the convert data is generated for server side.
 func buildResponseConvertData(response, result *expr.AttributeExpr, svcCtx *codegen.AttributeContext, hdrs, trlrs []*MetadataData, e *expr.GRPCEndpointExpr, sd *ServiceData, svr bool) *ConvertData {
-	if e.MethodExpr.IsStreaming() || (!svr && isEmpty(e.MethodExpr.Result.Type)) {
+	if !svr && (e.MethodExpr.IsStreaming() || isEmpty(e.MethodExpr.Result.Type)) {
 		return nil
 	}
 
@@ -1354,7 +1354,7 @@ func (s *{{ .VarName }}) Close() error {
 	return nil
 {{- else }}
 	{{ comment "synchronize stream" }}
-	return s.stream.SendAndClose(nil)
+	return s.stream.SendAndClose(&{{ .Endpoint.Response.ServerConvert.TgtName }}{})
 {{- end }}
 {{- end }}
 }

--- a/grpc/codegen/testdata/request_decoder_code.go
+++ b/grpc/codegen/testdata/request_decoder_code.go
@@ -163,7 +163,7 @@ func DecodeMethodMessageWithMetadataRequest(ctx context.Context, v interface{}, 
 	)
 	{
 		if vals := md.Get("Authorization"); len(vals) > 0 {
-			inMetadataRaw = vals[0]
+			inMetadataRaw := vals[0]
 
 			v, err2 := strconv.ParseInt(inMetadataRaw, 10, strconv.IntSize)
 			if err2 != nil {
@@ -202,7 +202,7 @@ func DecodeMethodMessageWithValidateRequest(ctx context.Context, v interface{}, 
 	)
 	{
 		if vals := md.Get("Authorization"); len(vals) > 0 {
-			inMetadataRaw = vals[0]
+			inMetadataRaw := vals[0]
 
 			v, err2 := strconv.ParseInt(inMetadataRaw, 10, strconv.IntSize)
 			if err2 != nil {

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -252,7 +252,7 @@ func (s *MethodClientStreamingRPCClientStream) CloseAndRecv() (string, error) {
 
 var ClientStreamingServerNoResultCloseCode = `func (s *MethodClientStreamingNoResultServerStream) Close() error {
 	// synchronize stream
-	return s.stream.SendAndClose(nil)
+	return s.stream.SendAndClose(&service_client_streaming_no_resultpb.MethodClientStreamingNoResultResponse{})
 }
 `
 


### PR DESCRIPTION
For client streaming that does not expect a response, the goa stream.Close in server was calling SendAndClose(nil). That was causing a marshalling error because even if the response of the endpoint has no value, it exists as a (empty) type. Clients ignoring the result of stream.Close have worked, but that hides a potential network or other errors when closing the stream.

Before backporting to goa v2, I'd like some feedback on this. Does it look ok?