### PR TITLE
Primitive user types

### DIFF
--- a/grpc/codegen/client_types_test.go
+++ b/grpc/codegen/client_types_test.go
@@ -16,6 +16,7 @@ func TestClientTypeFiles(t *testing.T) {
 		Code string
 	}{
 		{"payload-with-nested-types", testdata.PayloadWithNestedTypesDSL, testdata.PayloadWithNestedTypesClientTypeCode},
+		{"payload-with-alias-type", testdata.PayloadWithAliasTypeDSL, testdata.PayloadWithAliasTypeClientTypeCode},
 		{"result-collection", testdata.ResultWithCollectionDSL, testdata.ResultWithCollectionClientTypeCode},
 		{"with-errors", testdata.UnaryRPCWithErrorsDSL, testdata.WithErrorsClientTypeCode},
 	}

--- a/grpc/codegen/proto_test.go
+++ b/grpc/codegen/proto_test.go
@@ -54,6 +54,7 @@ func TestMessageDefSection(t *testing.T) {
 		Code string
 	}{
 		{"user-type-with-primitives", testdata.MessageUserTypeWithPrimitivesDSL, testdata.MessageUserTypeWithPrimitivesMessageCode},
+		{"use-type-with-alias", testdata.MessageUserTypeWithAliasMessageDSL, testdata.MessageUserTypeWithAliasMessageCode},
 		{"user-type-with-nested-user-types", testdata.MessageUserTypeWithNestedUserTypesDSL, testdata.MessageUserTypeWithNestedUserTypesCode},
 		{"result-type-collection", testdata.MessageResultTypeCollectionDSL, testdata.MessageResultTypeCollectionCode},
 		{"user-type-with-collection", testdata.MessageUserTypeWithCollectionDSL, testdata.MessageUserTypeWithCollectionCode},

--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -239,6 +239,9 @@ func protoBufMessageDef(att *expr.AttributeExpr, sd *ServiceData) string {
 	case *expr.Map:
 		return fmt.Sprintf("map<%s, %s>", protoBufMessageDef(actual.KeyType, sd), protoBufMessageDef(actual.ElemType, sd))
 	case expr.UserType:
+		if prim := getPrimitive(att); prim != nil {
+			return protoBufMessageDef(prim, sd)
+		}
 		return protoBufMessageName(att, sd.Scope)
 	case *expr.Object:
 		var ss []string
@@ -253,7 +256,11 @@ func protoBufMessageDef(att *expr.AttributeExpr, sd *ServiceData) string {
 			{
 				fn = codegen.SnakeCase(protoBufify(nat.Name, false))
 				fnum = rpcTag(nat.Attribute)
-				typ = protoBufMessageDef(nat.Attribute, sd)
+				if prim := getPrimitive(nat.Attribute); prim != nil {
+					typ = protoBufMessageDef(prim, sd)
+				} else {
+					typ = protoBufMessageDef(nat.Attribute, sd)
+				}
 				if nat.Attribute.Description != "" {
 					desc = codegen.Comment(nat.Attribute.Description) + "\n\t"
 				}

--- a/grpc/codegen/server_types_test.go
+++ b/grpc/codegen/server_types_test.go
@@ -16,6 +16,7 @@ func TestServerTypeFiles(t *testing.T) {
 		Code string
 	}{
 		{"payload-with-nested-types", testdata.PayloadWithNestedTypesDSL, testdata.PayloadWithNestedTypesServerTypeCode},
+		{"payload-with-alias-type", testdata.PayloadWithAliasTypeDSL, testdata.PayloadWithAliasTypeServerTypeCode},
 		{"result-collection", testdata.ResultWithCollectionDSL, testdata.ResultWithCollectionServerTypeCode},
 		{"with-errors", testdata.UnaryRPCWithErrorsDSL, testdata.WithErrorsServerTypeCode},
 	}

--- a/grpc/codegen/testdata/client_type_code.go
+++ b/grpc/codegen/testdata/client_type_code.go
@@ -102,6 +102,34 @@ func svcServicepayloadwithnestedtypesBParamsToServicePayloadWithNestedTypespbBPa
 }
 `
 
+const PayloadWithAliasTypeClientTypeCode = `// NewMethodMessageUserTypeWithAliasRequest builds the gRPC request type from
+// the payload of the "MethodMessageUserTypeWithAlias" endpoint of the
+// "ServiceMessageUserTypeWithAlias" service.
+func NewMethodMessageUserTypeWithAliasRequest(payload *servicemessageusertypewithalias.PayloadAliasT) *service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasRequest {
+	message := &service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasRequest{
+		IntAliasField: int(payload.IntAliasField),
+	}
+	if payload.OptionalIntAliasField != nil {
+		message.OptionalIntAliasField = int(*payload.OptionalIntAliasField)
+	}
+	return message
+}
+
+// NewMethodMessageUserTypeWithAliasResult builds the result type of the
+// "MethodMessageUserTypeWithAlias" endpoint of the
+// "ServiceMessageUserTypeWithAlias" service from the gRPC response type.
+func NewMethodMessageUserTypeWithAliasResult(message *service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasResponse) *servicemessageusertypewithalias.PayloadAliasT {
+	result := &servicemessageusertypewithalias.PayloadAliasT{
+		IntAliasField: servicemessageusertypewithalias.IntAlias(message.IntAliasField),
+	}
+	if message.OptionalIntAliasField != nil {
+		optionalIntAliasFieldptr := servicemessageusertypewithalias.IntAlias(message.OptionalIntAliasField)
+		result.OptionalIntAliasField = &optionalIntAliasFieldptr
+	}
+	return result
+}
+`
+
 const ResultWithCollectionClientTypeCode = `// NewMethodResultWithCollectionRequest builds the gRPC request type from the
 // payload of the "MethodResultWithCollection" endpoint of the
 // "ServiceResultWithCollection" service.

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -308,6 +308,33 @@ var MessageUserTypeWithPrimitivesDSL = func() {
 	})
 }
 
+var MessageUserTypeWithAliasMessageDSL = func() {
+	var IntAlias = Type("IntAlias", Int)
+	var PayloadT = Type("PayloadT", func() {
+		Field(1, "IntAliasField", IntAlias)
+		Field(2, "OptionalIntAliasField", IntAlias)
+		Required("IntAliasField")
+	})
+	var ResultT = ResultType("application/vnd.goa.aliast", func() {
+		TypeName("ResultT")
+		Attributes(func() {
+			Attribute("IntAliasField", Int, func() {
+				Meta("rpc:tag", "1")
+			})
+			Attribute("OptionalIntAliasField", Int, func() {
+				Meta("rpc:tag", "2")
+			})
+		})
+	})
+	Service("ServiceMessageUserTypeWithAlias", func() {
+		Method("MethodMessageUserTypeWithAlias", func() {
+			Payload(PayloadT)
+			Result(ResultT)
+			GRPC(func() {})
+		})
+	})
+}
+
 var MessageUserTypeWithNestedUserTypesDSL = func() {
 	var UTLevel2 = Type("UTLevel2", func() {
 		Field(2, "Int64Field", Int64)
@@ -479,6 +506,21 @@ var PayloadWithNestedTypesDSL = func() {
 			GRPC(func() {
 				Response(CodeOK)
 			})
+		})
+	})
+}
+
+var PayloadWithAliasTypeDSL = func() {
+	var IntAlias = Type("IntAlias", Int)
+	var PayloadAliasT = Type("PayloadAliasT", func() {
+		Field(1, "IntAliasField", IntAlias)
+		Field(2, "OptionalIntAliasField", IntAlias)
+		Required("IntAliasField")
+	})
+	Service("ServiceMessageUserTypeWithAlias", func() {
+		Method("MethodMessageUserTypeWithAlias", func() {
+			Payload(PayloadAliasT)
+			GRPC(func() {})
 		})
 	})
 }

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -520,6 +520,7 @@ var PayloadWithAliasTypeDSL = func() {
 	Service("ServiceMessageUserTypeWithAlias", func() {
 		Method("MethodMessageUserTypeWithAlias", func() {
 			Payload(PayloadAliasT)
+			Result(PayloadAliasT)
 			GRPC(func() {})
 		})
 	})

--- a/grpc/codegen/testdata/proto_code.go
+++ b/grpc/codegen/testdata/proto_code.go
@@ -189,6 +189,18 @@ message MethodMessageUserTypeWithPrimitivesResponse {
 }
 `
 
+const MessageUserTypeWithAliasMessageCode = `
+message MethodMessageUserTypeWithAliasRequest {
+	sint32 int_alias_field = 1;
+	sint32 optional_int_alias_field = 2;
+}
+
+message MethodMessageUserTypeWithAliasResponse {
+	sint32 int_alias_field = 1;
+	sint32 optional_int_alias_field = 2;
+}
+`
+
 const MessageUserTypeWithNestedUserTypesCode = `
 message MethodMessageUserTypeWithNestedUserTypesRequest {
 	bool boolean_field = 1;

--- a/grpc/codegen/testdata/server_type_code.go
+++ b/grpc/codegen/testdata/server_type_code.go
@@ -110,6 +110,36 @@ func svcServicepayloadwithnestedtypesBParamsToServicePayloadWithNestedTypespbBPa
 }
 `
 
+const PayloadWithAliasTypeServerTypeCode = `// NewMethodMessageUserTypeWithAliasPayload builds the payload of the
+// "MethodMessageUserTypeWithAlias" endpoint of the
+// "ServiceMessageUserTypeWithAlias" service from the gRPC request type.
+func NewMethodMessageUserTypeWithAliasPayload(message *service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasRequest) *servicemessageusertypewithalias.PayloadAliasT {
+	v := &servicemessageusertypewithalias.PayloadAliasT{
+		IntAliasField: servicemessageusertypewithalias.IntAlias(message.IntAliasField),
+	}
+	if message.OptionalIntAliasField != nil {
+		optionalIntAliasFieldptr := servicemessageusertypewithalias.IntAlias(message.OptionalIntAliasField)
+		v.OptionalIntAliasField = &optionalIntAliasFieldptr
+	}
+	v.IntAliasField = protobufServiceMessageUserTypeWithAliaspbIntAliasToServicemessageusertypewithaliasIntAlias(message.IntAliasField)
+	v.OptionalIntAliasField = protobufServiceMessageUserTypeWithAliaspbIntAliasToServicemessageusertypewithaliasIntAlias(message.OptionalIntAliasField)
+	return v
+}
+
+// NewMethodMessageUserTypeWithAliasResponse builds the gRPC response type from
+// the result of the "MethodMessageUserTypeWithAlias" endpoint of the
+// "ServiceMessageUserTypeWithAlias" service.
+func NewMethodMessageUserTypeWithAliasResponse(result *servicemessageusertypewithalias.PayloadAliasT) *service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasResponse {
+	message := &service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasResponse{
+		IntAliasField: int(result.IntAliasField),
+	}
+	if result.OptionalIntAliasField != nil {
+		message.OptionalIntAliasField = int(*result.OptionalIntAliasField)
+	}
+	return message
+}
+`
+
 const ResultWithCollectionServerTypeCode = `// NewMethodResultWithCollectionResponse builds the gRPC response type from the
 // result of the "MethodResultWithCollection" endpoint of the
 // "ServiceResultWithCollection" service.

--- a/grpc/codegen/testdata/server_type_code.go
+++ b/grpc/codegen/testdata/server_type_code.go
@@ -121,8 +121,6 @@ func NewMethodMessageUserTypeWithAliasPayload(message *service_message_user_type
 		optionalIntAliasFieldptr := servicemessageusertypewithalias.IntAlias(message.OptionalIntAliasField)
 		v.OptionalIntAliasField = &optionalIntAliasFieldptr
 	}
-	v.IntAliasField = protobufServiceMessageUserTypeWithAliaspbIntAliasToServicemessageusertypewithaliasIntAlias(message.IntAliasField)
-	v.OptionalIntAliasField = protobufServiceMessageUserTypeWithAliaspbIntAliasToServicemessageusertypewithaliasIntAlias(message.OptionalIntAliasField)
 	return v
 }
 


### PR DESCRIPTION
As mentioned on #2272, I want this for using defined types with gRPC, but it doesn't do the trick as of 8fdffd8. (The .proto is invalid once you have a field with type like Type("MyInt", Int).)

I've extended the tests and hacked together a functional implementation; apologies if the names are using incorrect nomenclature. Note that the checks in [convertType](https://github.com/goadesign/goa/commit/600c0147e97bd7a27078abb6ba8d23ac7342c914#diff-4759ef514ebf242deaf6f6b810aa36b0R455-R458) are particularly suspect. (Elsewhere it was suggested that `ta.proto` may be logically equivalent to the intent of the strings.HasSuffix check.)