### PR TITLE
Primitive user types (#2272)

### DIFF
--- a/codegen/cli/cli.go
+++ b/codegen/cli/cli.go
@@ -132,23 +132,10 @@ type (
 		ReturnIsStruct bool
 		// ReturnTypeName is the fully-qualified name of the payload.
 		ReturnTypeName string
+		// ReturnTypePkg is the package name where the payload is present.
+		ReturnTypePkg string
 		// Args is the list of arguments for the constructor.
-		Args []*PayloadInitArgData
-	}
-
-	// PayloadInitArgData contains the data needed to render payload initlization
-	// arguments.
-	PayloadInitArgData struct {
-		// Name is the argument name.
-		Name string
-		// Pointer if true indicates that the argument is a pointer.
-		Pointer bool
-		// FieldName is the name of the field in the payload initialized by the
-		// argument.
-		FieldName string
-		// FieldPointer if true indicates that the field in the payload is a
-		// pointer.
-		FieldPointer bool
+		Args []*codegen.InitArgData
 	}
 )
 
@@ -301,6 +288,9 @@ func PayloadBuilderSection(buildFunction *BuildFunctionData) *codegen.SectionTem
 		Name:   "cli-build-payload",
 		Source: buildPayloadT,
 		Data:   buildFunction,
+		FuncMap: map[string]interface{}{
+			"fieldCode": fieldCode,
+		},
 	}
 }
 
@@ -331,17 +321,32 @@ func NewFlagData(svcn, en, name, typeName, description string, required bool, ex
 // FieldLoadCode returns the code used in the build payload function that
 // initializes one of the payload object fields. It returns the initialization
 // code and a boolean indicating whether the code requires an "err" variable.
-func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultValue interface{}) (string, bool) {
+func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultValue interface{}, payload expr.DataType) (string, bool) {
 	var (
 		code    string
 		check   bool
 		startIf string
 		endIf   string
+		rval    string
 	)
 	{
 		if !f.Required {
 			startIf = fmt.Sprintf("if %s != \"\" {\n", f.FullName)
 			endIf = "\n}"
+		}
+		if expr.IsPrimitive(payload) {
+			switch payload {
+			case expr.Boolean:
+				rval = "false"
+			case expr.String:
+				rval = "\"\""
+			case expr.Bytes, expr.Any:
+				rval = "nil"
+			default:
+				rval = "0"
+			}
+		} else {
+			rval = "nil"
 		}
 		if argTypeName == codegen.GoNativeTypeName(expr.String) {
 			ref := "&"
@@ -355,17 +360,17 @@ func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultVa
 			if check {
 				code += "\nif err != nil {\n"
 				if flagType(argTypeName) == "JSON" {
-					code += fmt.Sprintf(`return nil, fmt.Errorf("invalid JSON for %s, example of valid JSON:\n%%s", %q)`,
-						argName, ex)
+					code += fmt.Sprintf(`return %v, fmt.Errorf("invalid JSON for %s, example of valid JSON:\n%%s", %q)`,
+						rval, argName, ex)
 				} else {
-					code += fmt.Sprintf(`return nil, fmt.Errorf("invalid value for %s, must be %s")`,
-						argName, f.Type)
+					code += fmt.Sprintf(`return %v, fmt.Errorf("invalid value for %s, must be %s")`,
+						rval, argName, f.Type)
 				}
 				code += "\n}"
 			}
-			if validate != "" {
-				code += "\n" + validate + "\n" + "if err != nil {\n\treturn nil, err\n}"
-			}
+		}
+		if validate != "" {
+			code += "\n" + validate + "\n" + fmt.Sprintf("if err != nil {\n\treturn %v, err\n}", rval)
 		}
 	}
 	return fmt.Sprintf("%s%s%s", startIf, code, endIf), check
@@ -540,6 +545,22 @@ func generateExample(sub *SubcommandData, svc string) {
 	sub.Example = ex
 }
 
+// fieldCode generates code to initialize the data structures fields
+// from the given args. It is used only in templates.
+func fieldCode(init *PayloadInitData) string {
+	varn := "res"
+	if init.ReturnTypeAttribute == "" {
+		varn = "v"
+	}
+	// We can ignore the transform helpers as there won't be any generated
+	// because the args cannot be user types.
+	c, _, err := codegen.InitStructFields(init.Args, init.ReturnTypeName, varn, "", init.ReturnTypePkg, init.Code == "")
+	if err != nil {
+		panic(err) //bug
+	}
+	return c
+}
+
 // input: []string
 const usageT = `// UsageCommands returns the set of commands and sub-commands using the format
 //
@@ -672,49 +693,33 @@ Example:
 // input: buildFunctionData
 const buildPayloadT = `{{ printf "%s builds the payload for the %s %s endpoint from CLI flags." .Name .ServiceName .MethodName | comment }}
 func {{ .Name }}({{ range .FormalParams }}{{ . }} string, {{ end }}) ({{ .ResultType }}, error) {
-	{{- if .CheckErr }}
+{{- if .CheckErr }}
 	var err error
+{{- end }}
+{{- range .Fields }}
+	{{- if .VarName }}
+		var {{ .VarName }} {{ .TypeRef }}
+		{
+			{{ .Init }}
+		}
 	{{- end }}
-	{{- range .Fields }}
-		{{- if .VarName }}
-	var {{ .VarName }} {{ .TypeRef }}
-	{
-		{{ .Init }}
-	}
+{{- end }}
+{{- with .PayloadInit }}
+	{{- if .Code }}
+		{{ .Code }}
+		{{- if .ReturnTypeAttribute }}
+			res := &{{ .ReturnTypeName }}{
+				{{ .ReturnTypeAttribute }}: v,
+			}
 		{{- end }}
 	{{- end }}
-	{{- with .PayloadInit }}
-
-		{{- if .Code }}
-	{{ .Code }}
-			{{- if .ReturnTypeAttribute }}
-	res := &{{ .ReturnTypeName }}{
-		{{ .ReturnTypeAttribute }}: v,
-	}
-			{{- end }}
-			{{- if .ReturnIsStruct }}
-				{{- range .Args }}
-					{{- if .FieldName }}
-	{{ if $.PayloadInit.ReturnTypeAttribute }}res{{ else }}v{{ end }}.{{ .FieldName }} = {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }}
-				{{- end }}
-			{{- end }}
+	{{- if .ReturnIsStruct }}
+		{{- if not .Code }}
+		{{ if .ReturnTypeAttribute }}res{{ else }}v{{ end }} := &{{ .ReturnTypeName }}{}
 		{{- end }}
+		{{ fieldCode . }}
+	{{- end }}
 	return {{ if .ReturnTypeAttribute }}res{{ else }}v{{ end }}, nil
-
-		{{- else }}
-			{{- if .ReturnIsStruct }}
-	payload := &{{ .ReturnTypeName }}{
-				{{- range .Args }}
-					{{- if .FieldName }}
-		{{ .FieldName }}: {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }},
-					{{- end }}
-				{{- end }}
-	}
-	return payload, nil
-			{{-  end }}
-
-		{{- end }}
-
-	{{- end }}
+{{- end }}
 }
 `

--- a/codegen/funcs.go
+++ b/codegen/funcs.go
@@ -2,9 +2,33 @@ package codegen
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"strings"
 	"unicode"
+
+	"goa.design/goa/v3/expr"
+)
+
+type (
+	// InitArgData contains the data needed to render code to initialize struct
+	// fields with the given arguments.
+	InitArgData struct {
+		// Name is the argument name.
+		Name string
+		// Pointer if true indicates that the argument is a pointer.
+		Pointer bool
+		// Type is the argument type.
+		Type expr.DataType
+		// FieldName is the name of the field in the struct initialized by the
+		// argument.
+		FieldName string
+		// FieldPointer if true indicates that the field in the struct is a
+		// pointer.
+		FieldPointer bool
+		// FieldType is the type of the field in the struct.
+		FieldType expr.DataType
+	}
 )
 
 // TemplateFuncs lists common template helper functions.
@@ -225,6 +249,56 @@ func WrapText(text string, maxChars int) string {
 		}
 	}
 	return res[:len(res)-1]
+}
+
+// InitStructFields produces Go code to initialize a struct and its fields from
+// the given init arguments.
+func InitStructFields(args []*InitArgData, name, targetVar, sourcePkg, targetPkg string, mustInit bool) (string, []*TransformFunctionData, error) {
+	scope := NewNameScope()
+	scope.Unique(targetVar)
+
+	var (
+		code    string
+		helpers []*TransformFunctionData
+	)
+	for _, arg := range args {
+		switch {
+		case arg.FieldName == "":
+			// do nothing
+		case expr.Equal(arg.Type, arg.FieldType):
+			// arg type and struct field type are the same. No need to call transform
+			// to initialize the field
+			deref := ""
+			if !arg.Pointer && arg.FieldPointer && expr.IsPrimitive(arg.FieldType) {
+				deref = "&"
+			}
+			code += fmt.Sprintf("%s.%s = %s%s\n", targetVar, arg.FieldName, deref, arg.Name)
+		case expr.IsPrimitive(arg.FieldType):
+			// aliased primitive type
+			t := scope.GoFullTypeRef(&expr.AttributeExpr{Type: arg.FieldType}, targetPkg)
+			cast := fmt.Sprintf("%s(%s)", t, arg.Name)
+			if arg.Pointer {
+				cast = fmt.Sprintf("%s(*%s)", t, arg.Name)
+			}
+			if arg.FieldPointer {
+				code += fmt.Sprintf("tmp%s := %s\n%s.%s = &tmp%s\n", arg.Name, cast, targetVar, arg.FieldName, arg.Name)
+			} else {
+				code += fmt.Sprintf("%s.%s = %s\n", targetVar, arg.FieldName, cast)
+			}
+		default:
+			srcctx := NewAttributeContext(arg.Pointer, false, true, sourcePkg, scope)
+			tgtctx := NewAttributeContext(arg.FieldPointer, false, true, targetPkg, scope)
+			c, h, err := GoTransform(
+				&expr.AttributeExpr{Type: arg.Type}, &expr.AttributeExpr{Type: arg.FieldType},
+				arg.Name, fmt.Sprintf("%s.%s", targetVar, arg.FieldName), srcctx, tgtctx, "", false)
+			if err != nil {
+				return "", helpers, err
+			}
+			code += c + "\n"
+			helpers = AppendHelpers(helpers, h)
+		}
+	}
+	return code, helpers, nil
 }
 
 func runeSpacePosRev(r []rune) int {

--- a/codegen/funcs.go
+++ b/codegen/funcs.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"unicode"
 
-	"goa.design/goa/v3/expr"
+	"goa.design/goa/expr"
 )
 
 type (

--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -9,15 +9,13 @@ import (
 	"goa.design/goa/expr"
 )
 
-var transformGoArrayT, transformGoMapT, transformGoArrayElemT, transformGoMapElemT *template.Template
+var transformGoArrayT, transformGoMapT *template.Template
 
 // NOTE: can't initialize inline because https://github.com/golang/go/issues/1817
 func init() {
 	fm := template.FuncMap{"transformAttribute": transformAttribute, "transformHelperName": transformHelperName}
 	transformGoArrayT = template.Must(template.New("transformGoArray").Funcs(fm).Parse(transformGoArrayTmpl))
 	transformGoMapT = template.Must(template.New("transformGoMap").Funcs(fm).Parse(transformGoMapTmpl))
-	transformGoArrayElemT = template.Must(template.New("transformGoArrayElem").Funcs(fm).Parse(transformGoArrayElemTmpl))
-	transformGoMapElemT = template.Must(template.New("transformGoMapElem").Funcs(fm).Parse(transformGoMapElemTmpl))
 }
 
 // GoTransform produces Go code that initializes the data structure defined
@@ -40,14 +38,18 @@ func init() {
 //
 // prefix is the transformation helper function prefix
 //
-func GoTransform(source, target *expr.AttributeExpr, sourceVar, targetVar string, sourceCtx, targetCtx *AttributeContext, prefix string) (string, []*TransformFunctionData, error) {
+// newVar if true initializes a target variable with the generated Go code
+// using `:=` operator. If false, it assigns Go code to the target variable
+// using `=`.
+//
+func GoTransform(source, target *expr.AttributeExpr, sourceVar, targetVar string, sourceCtx, targetCtx *AttributeContext, prefix string, newVar bool) (string, []*TransformFunctionData, error) {
 	ta := &TransformAttrs{
 		SourceCtx: sourceCtx,
 		TargetCtx: targetCtx,
 		Prefix:    prefix,
 	}
 
-	code, err := transformAttribute(source, target, sourceVar, targetVar, true, ta)
+	code, err := transformAttribute(source, target, sourceVar, targetVar, newVar, ta)
 	if err != nil {
 		return "", nil, err
 	}
@@ -58,6 +60,24 @@ func GoTransform(source, target *expr.AttributeExpr, sourceVar, targetVar string
 	}
 
 	return strings.TrimRight(code, "\n"), funcs, nil
+}
+
+// transformPrimitive returns the code to transform source primtive type to
+// target primitive type. It returns an error if source and target are not
+// compatible for transformation.
+func transformPrimitive(source, target *expr.AttributeExpr, sourceVar, targetVar string, newVar bool, ta *TransformAttrs) (string, error) {
+	if err := IsCompatible(source.Type, target.Type, sourceVar, targetVar); err != nil {
+		return "", err
+	}
+	assign := "="
+	if newVar {
+		assign = ":="
+	}
+	if !expr.Equal(source.Type, target.Type) {
+		cast := ta.TargetCtx.Scope.Ref(target, ta.TargetCtx.Pkg)
+		return fmt.Sprintf("%s %s %s(%s)\n", targetVar, assign, cast, sourceVar), nil
+	}
+	return fmt.Sprintf("%s %s %s\n", targetVar, assign, sourceVar), nil
 }
 
 // transformAttribute returns the code to transform source attribute to target
@@ -75,16 +95,7 @@ func transformAttribute(source, target *expr.AttributeExpr, sourceVar, targetVar
 	case expr.IsObject(source.Type):
 		code, err = transformObject(source, target, sourceVar, targetVar, newVar, ta)
 	default:
-		assign := "="
-		if newVar {
-			assign = ":="
-		}
-		if _, ok := target.Type.(expr.UserType); ok {
-			// Primitive user type, these are used for error results
-			cast := ta.TargetCtx.Scope.Ref(target, ta.TargetCtx.Pkg)
-			return fmt.Sprintf("%s %s %s(%s)\n", targetVar, assign, cast, sourceVar), nil
-		}
-		code = fmt.Sprintf("%s %s %s\n", targetVar, assign, sourceVar)
+		code, err = transformPrimitive(source, target, sourceVar, targetVar, newVar, ta)
 	}
 	return
 }
@@ -95,6 +106,7 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 	var (
 		initCode     string
 		postInitCode string
+		err          error
 	)
 	{
 		// walk through primitives first to initialize the struct
@@ -102,31 +114,60 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 			if !expr.IsPrimitive(srcc.Type) {
 				return
 			}
+			// Source and/or target could be primitive user type. Make sure the
+			// aliased type is compatible for transformation.
+			if err = IsCompatible(srcc.Type, tgtc.Type, sourceVar, targetVar); err != nil {
+				return
+			}
 			var (
-				deref string
+				exp string
 
-				srcPtr   = ta.SourceCtx.IsPrimitivePointer(n, srcMatt.AttributeExpr)
-				tgtPtr   = ta.TargetCtx.IsPrimitivePointer(n, tgtMatt.AttributeExpr)
-				srcField = sourceVar + "." + GoifyAtt(srcc, srcMatt.ElemName(n), true)
-				tgtField = GoifyAtt(tgtc, tgtMatt.ElemName(n), true)
+				srcPtr     = ta.SourceCtx.IsPrimitivePointer(n, srcMatt.AttributeExpr)
+				tgtPtr     = ta.TargetCtx.IsPrimitivePointer(n, tgtMatt.AttributeExpr)
+				srcField   = sourceVar + "." + GoifyAtt(srcc, srcMatt.ElemName(n), true)
+				tgtField   = GoifyAtt(tgtc, tgtMatt.ElemName(n), true)
+				_, isSrcUT = srcc.Type.(expr.UserType)
+				_, isTgtUT = tgtc.Type.(expr.UserType)
 			)
 			{
 				switch {
-				case srcPtr && !tgtPtr:
-					if !srcMatt.IsRequired(n) {
-						postInitCode += fmt.Sprintf("if %s != nil {\n\t%s.%s = %s\n}\n", srcField, targetVar, tgtField, "*"+srcField)
+				case isSrcUT || isTgtUT:
+					deref := ""
+					if srcPtr {
+						deref = "*"
+					}
+					exp = fmt.Sprintf("%s(%s%s)", ta.TargetCtx.Scope.Ref(tgtc, ta.TargetCtx.Pkg), deref, srcField)
+					if srcPtr && !srcMatt.IsRequired(n) {
+						postInitCode += fmt.Sprintf("if %s != nil {\n", srcField)
+						if tgtPtr {
+							tmp := Goify(tgtMatt.ElemName(n), false)
+							postInitCode += fmt.Sprintf("%s := %s\n%s.%s = &%s\n", tmp, exp, targetVar, tgtField, tmp)
+						} else {
+							postInitCode += fmt.Sprintf("%s.%s = %s\n", targetVar, tgtField, exp)
+						}
+						postInitCode += "}\n"
 						return
 					}
-					deref = "*"
+				case srcPtr && !tgtPtr:
+					exp = "*" + srcField
+					if !srcMatt.IsRequired(n) {
+						postInitCode += fmt.Sprintf("if %s != nil {\n\t%s.%s = %s\n}\n", srcField, targetVar, tgtField, exp)
+						return
+					}
 				case !srcPtr && tgtPtr:
-					deref = "&"
+					exp = "&" + srcField
+				default:
+					exp = srcField
 				}
 			}
-			initCode += fmt.Sprintf("\n%s: %s%s,", tgtField, deref, srcField)
+			initCode += fmt.Sprintf("\n%s: %s,", tgtField, exp)
 		})
 		if initCode != "" {
 			initCode += "\n"
 		}
+	}
+	if err != nil {
+		return "", err
 	}
 
 	buffer := &bytes.Buffer{}
@@ -140,7 +181,6 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 
 	// iterate through attributes to initialize rest of the struct fields and
 	// handle default values
-	var err error
 	walkMatches(source, target, func(srcMatt, tgtMatt *expr.MappedAttributeExpr, srcc, tgtc *expr.AttributeExpr, n string) {
 		if err = IsCompatible(srcc.Type, tgtc.Type, sourceVar, targetVar); err != nil {
 			return
@@ -156,11 +196,13 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 			_, ok := srcc.Type.(expr.UserType)
 			switch {
 			case expr.IsArray(srcc.Type):
-				code, err = transformArrayElem(expr.AsArray(srcc.Type), expr.AsArray(tgtc.Type), srcVar, tgtVar, false, ta)
+				code, err = transformArray(expr.AsArray(srcc.Type), expr.AsArray(tgtc.Type), srcVar, tgtVar, false, ta)
 			case expr.IsMap(srcc.Type):
-				code, err = transformMapElem(expr.AsMap(srcc.Type), expr.AsMap(tgtc.Type), srcVar, tgtVar, false, ta)
+				code, err = transformMap(expr.AsMap(srcc.Type), expr.AsMap(tgtc.Type), srcVar, tgtVar, false, ta)
 			case ok:
-				code = fmt.Sprintf("%s = %s(%s)\n", tgtVar, transformHelperName(srcc, tgtc, ta), srcVar)
+				if !expr.IsPrimitive(srcc.Type) {
+					code = fmt.Sprintf("%s = %s(%s)\n", tgtVar, transformHelperName(srcc, tgtc, ta), srcVar)
+				}
 			case expr.IsObject(srcc.Type):
 				code, err = transformAttribute(srcc, tgtc, srcVar, tgtVar, false, ta)
 			}
@@ -189,7 +231,7 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 		// Default value handling. We need to handle default values if the target
 		// type uses default values (i.e. attributes with default values are
 		// non-pointers) and has a default value set.
-		if tdef := tgtc.DefaultValue; tdef != nil && ta.TargetCtx.UseDefault {
+		if tdef := tgtMatt.GetDefault(n); tdef != nil && ta.TargetCtx.UseDefault {
 			if (ta.SourceCtx.IsPrimitivePointer(n, srcMatt.AttributeExpr) || !expr.IsPrimitive(srcc.Type)) && !srcMatt.IsRequired(n) {
 				code += fmt.Sprintf("if %s == nil {\n\t", srcVar)
 				if ta.TargetCtx.IsPrimitivePointer(n, tgtMatt.AttributeExpr) && expr.IsPrimitive(tgtc.Type) {
@@ -223,38 +265,13 @@ func transformArray(source, target *expr.Array, sourceVar, targetVar string, new
 		"NewVar":         newVar,
 		"TransformAttrs": ta,
 		"LoopVar":        string(105 + strings.Count(targetVar, "[")),
+		"IsStruct":       expr.IsObject(target.ElemType.Type),
 	}
 	var buf bytes.Buffer
 	if err := transformGoArrayT.Execute(&buf, data); err != nil {
 		return "", err
 	}
 	return buf.String(), nil
-}
-
-// transformArrayElem generates Go code to transform an object field of type array.
-func transformArrayElem(source, target *expr.Array, sourceVar, targetVar string, newVar bool, ta *TransformAttrs) (string, error) {
-	st, tt := source.ElemType.Type, target.ElemType.Type
-	if err := IsCompatible(st, tt, sourceVar+"[0]", targetVar+"[0]"); err != nil {
-		return "", err
-	}
-	if _, ok := st.(expr.UserType); ok {
-		data := map[string]interface{}{
-			"ElemTypeRef":    ta.TargetCtx.Scope.Ref(target.ElemType, ta.TargetCtx.Pkg),
-			"SourceElem":     source.ElemType,
-			"TargetElem":     target.ElemType,
-			"SourceVar":      sourceVar,
-			"TargetVar":      targetVar,
-			"NewVar":         newVar,
-			"TransformAttrs": ta,
-			"LoopVar":        string(105 + strings.Count(targetVar, "[")),
-		}
-		var buf bytes.Buffer
-		if err := transformGoArrayElemT.Execute(&buf, data); err != nil {
-			return "", err
-		}
-		return buf.String(), nil
-	}
-	return transformArray(source, target, sourceVar, targetVar, newVar, ta)
 }
 
 // transformMap generates Go code to transform source map to target map.
@@ -277,6 +294,8 @@ func transformMap(source, target *expr.Map, sourceVar, targetVar string, newVar 
 		"NewVar":         newVar,
 		"TransformAttrs": ta,
 		"LoopVar":        "",
+		"IsKeyStruct":    expr.IsObject(target.KeyType.Type),
+		"IsElemStruct":   expr.IsObject(target.ElemType.Type),
 	}
 	if depth := MapDepth(target); depth > 0 {
 		data["LoopVar"] = string(97 + depth)
@@ -286,40 +305,6 @@ func transformMap(source, target *expr.Map, sourceVar, targetVar string, newVar 
 		return "", err
 	}
 	return buf.String(), nil
-}
-
-// transformMapElem generates Go code to transform an object field of type map.
-func transformMapElem(source, target *expr.Map, sourceVar, targetVar string, newVar bool, ta *TransformAttrs) (string, error) {
-	if err := IsCompatible(source.KeyType.Type, target.KeyType.Type, sourceVar+"[key]", targetVar+"[key]"); err != nil {
-		return "", err
-	}
-	if err := IsCompatible(source.ElemType.Type, target.ElemType.Type, sourceVar+"[*]", targetVar+"[*]"); err != nil {
-		return "", err
-	}
-	if _, ok := target.ElemType.Type.(expr.UserType); ok {
-		data := map[string]interface{}{
-			"KeyTypeRef":     ta.TargetCtx.Scope.Ref(target.KeyType, ta.TargetCtx.Pkg),
-			"ElemTypeRef":    ta.TargetCtx.Scope.Ref(target.ElemType, ta.TargetCtx.Pkg),
-			"SourceKey":      source.KeyType,
-			"TargetKey":      target.KeyType,
-			"SourceElem":     source.ElemType,
-			"TargetElem":     target.ElemType,
-			"SourceVar":      sourceVar,
-			"TargetVar":      targetVar,
-			"NewVar":         newVar,
-			"TransformAttrs": ta,
-			"LoopVar":        "",
-		}
-		if depth := MapDepth(target); depth > 0 {
-			data["LoopVar"] = string(97 + depth)
-		}
-		var buf bytes.Buffer
-		if err := transformGoMapElemT.Execute(&buf, data); err != nil {
-			return "", err
-		}
-		return buf.String(), nil
-	}
-	return transformMap(source, target, sourceVar, targetVar, newVar, ta)
 }
 
 // transformAttributeHelpers returns the Go transform functions and their definitions
@@ -337,25 +322,28 @@ func transformMapElem(source, target *expr.Map, sourceVar, targetVar string, new
 //
 func transformAttributeHelpers(source, target *expr.AttributeExpr, ta *TransformAttrs, seen map[string]*TransformFunctionData) (helpers []*TransformFunctionData, err error) {
 	// Do not generate a transform function for the top most user type.
+	var other []*TransformFunctionData
 	switch {
 	case expr.IsArray(source.Type):
-		helpers, err = transformAttributeHelpers(expr.AsArray(source.Type).ElemType, expr.AsArray(target.Type).ElemType, ta, seen)
+		if other, err = collectHelpers(expr.AsArray(source.Type).ElemType, expr.AsArray(target.Type).ElemType, true, ta, seen); err == nil {
+			helpers = append(helpers, other...)
+		}
 	case expr.IsMap(source.Type):
 		sm, tm := expr.AsMap(source.Type), expr.AsMap(target.Type)
-		helpers, err = transformAttributeHelpers(sm.ElemType, tm.ElemType, ta, seen)
-		if err == nil {
-			var other []*TransformFunctionData
-			other, err = collectHelpers(sm.KeyType, tm.KeyType, true, ta, seen)
+		if other, err = collectHelpers(sm.ElemType, tm.ElemType, true, ta, seen); err == nil {
 			helpers = append(helpers, other...)
+			if other, err = collectHelpers(sm.KeyType, tm.KeyType, true, ta, seen); err == nil {
+				helpers = append(helpers, other...)
+			}
 		}
 	case expr.IsObject(source.Type):
 		walkMatches(source, target, func(srcMatt, _ *expr.MappedAttributeExpr, srcc, tgtc *expr.AttributeExpr, n string) {
 			if err != nil {
 				return
 			}
-			var hs []*TransformFunctionData
-			hs, err = collectHelpers(srcc, tgtc, srcMatt.IsRequired(n), ta, seen)
-			helpers = append(helpers, hs...)
+			if other, err = collectHelpers(srcc, tgtc, srcMatt.IsRequired(n), ta, seen); err == nil {
+				helpers = append(helpers, other...)
+			}
 		})
 	}
 	return
@@ -371,31 +359,34 @@ func collectHelpers(source, target *expr.AttributeExpr, req bool, ta *TransformA
 	if _, ok := seen[name]; ok {
 		return
 	}
-	if _, ok := source.Type.(expr.UserType); ok {
+	if _, ok := source.Type.(expr.UserType); ok && expr.IsObject(source.Type) {
 		var h *TransformFunctionData
 		if h, err = generateHelper(source, target, req, ta, seen); h != nil {
 			helpers = append(helpers, h)
 		}
 	}
+	var other []*TransformFunctionData
 	switch {
 	case expr.IsArray(source.Type):
-		helpers, err = collectHelpers(expr.AsArray(source.Type).ElemType, expr.AsArray(target.Type).ElemType, req, ta, seen)
+		if other, err = collectHelpers(expr.AsArray(source.Type).ElemType, expr.AsArray(target.Type).ElemType, req, ta, seen); err == nil {
+			helpers = append(helpers, other...)
+		}
 	case expr.IsMap(source.Type):
 		sm, tm := expr.AsMap(source.Type), expr.AsMap(target.Type)
-		helpers, err = collectHelpers(sm.ElemType, tm.ElemType, req, ta, seen)
-		if err == nil {
-			var other []*TransformFunctionData
-			other, err = collectHelpers(sm.KeyType, tm.KeyType, req, ta, seen)
+		if other, err = collectHelpers(sm.ElemType, tm.ElemType, req, ta, seen); err == nil {
 			helpers = append(helpers, other...)
+			if other, err = collectHelpers(sm.KeyType, tm.KeyType, req, ta, seen); err == nil {
+				helpers = append(helpers, other...)
+			}
 		}
 	case expr.IsObject(source.Type):
 		walkMatches(source, target, func(srcMatt, _ *expr.MappedAttributeExpr, srcc, tgtc *expr.AttributeExpr, n string) {
 			if err != nil {
 				return
 			}
-			var hs []*TransformFunctionData
-			hs, err = collectHelpers(srcc, tgtc, srcMatt.IsRequired(n), ta, seen)
-			helpers = append(helpers, hs...)
+			if other, err = collectHelpers(srcc, tgtc, srcMatt.IsRequired(n), ta, seen); err == nil {
+				helpers = append(helpers, other...)
+			}
 		})
 	}
 	return
@@ -414,7 +405,7 @@ func generateHelper(source, target *expr.AttributeExpr, req bool, ta *TransformA
 	if err != nil {
 		return nil, err
 	}
-	if !req {
+	if !req && !expr.IsPrimitive(source.Type) {
 		code = "if v == nil {\n\treturn nil\n}\n" + code
 	}
 	tfd := &TransformFunctionData{
@@ -465,28 +456,27 @@ func transformHelperName(source, target *expr.AttributeExpr, ta *TransformAttrs)
 const (
 	transformGoArrayTmpl = `{{ .TargetVar }} {{ if .NewVar }}:={{ else }}={{ end }} make([]{{ .ElemTypeRef }}, len({{ .SourceVar }}))
 for {{ .LoopVar }}, val := range {{ .SourceVar }} {
-  {{ transformAttribute .SourceElem .TargetElem "val" (printf "%s[%s]" .TargetVar .LoopVar) false .TransformAttrs -}}
-}
-`
-
-	transformGoArrayElemTmpl = `{{ .TargetVar }} {{ if .NewVar }}:={{ else }}={{ end }} make([]{{ .ElemTypeRef }}, len({{ .SourceVar }}))
-for {{ .LoopVar }}, val := range {{ .SourceVar }} {
-  {{ .TargetVar }}[{{ .LoopVar }}] = {{ transformHelperName .SourceElem .TargetElem .TransformAttrs }}(val)
+{{ if .IsStruct -}}
+	{{ .TargetVar }}[{{ .LoopVar }}] = {{ transformHelperName .SourceElem .TargetElem .TransformAttrs }}(val)
+{{ else -}}
+	{{ transformAttribute .SourceElem .TargetElem "val" (printf "%s[%s]" .TargetVar .LoopVar) false .TransformAttrs -}}
+{{ end -}}
 }
 `
 
 	transformGoMapTmpl = `{{ .TargetVar }} {{ if .NewVar }}:={{ else }}={{ end }} make(map[{{ .KeyTypeRef }}]{{ .ElemTypeRef }}, len({{ .SourceVar }}))
 for key, val := range {{ .SourceVar }} {
+{{ if .IsKeyStruct -}}
+	tk := {{ transformHelperName .SourceKey .TargetKey .TransformAttrs -}}(val)
+{{ else -}}
   {{ transformAttribute .SourceKey .TargetKey "key" "tk" true .TransformAttrs -}}
-  {{ transformAttribute .SourceElem .TargetElem "val" (printf "tv%s" .LoopVar) true .TransformAttrs -}}
-  {{ .TargetVar }}[tk] = {{ printf "tv%s" .LoopVar }}
-}
-`
-
-	transformGoMapElemTmpl = `{{ .TargetVar }} {{ if .NewVar }}:={{ else }}={{ end }} make(map[{{ .KeyTypeRef }}]{{ .ElemTypeRef }}, len({{ .SourceVar }}))
-for key, val := range {{ .SourceVar }} {
-  {{ transformAttribute .SourceKey .TargetKey "key" "tk" true .TransformAttrs -}}
-  {{ .TargetVar }}[tk] = {{ transformHelperName .SourceElem .TargetElem .TransformAttrs }}(val)
+{{ end -}}
+{{ if .IsElemStruct -}}
+	{{ .TargetVar }}[tk] = {{ transformHelperName .SourceElem .TargetElem .TransformAttrs -}}(val)
+{{ else -}}
+	{{ transformAttribute .SourceElem .TargetElem "val" (printf "tv%s" .LoopVar) true .TransformAttrs -}}
+	{{ .TargetVar }}[tk] = {{ printf "tv%s" .LoopVar -}}
+{{ end -}}
 }
 `
 )

--- a/codegen/go_transform_helpers_test.go
+++ b/codegen/go_transform_helpers_test.go
@@ -12,11 +12,15 @@ func TestGoTransformHelpers(t *testing.T) {
 	var (
 		scope = NewNameScope()
 		// types to test
-		simple    = root.UserType("Simple")
-		recursive = root.UserType("Recursive")
-		composite = root.UserType("Composite")
-		deep      = root.UserType("Deep")
-		deepArray = root.UserType("DeepArray")
+		simple        = root.UserType("Simple")
+		recursive     = root.UserType("Recursive")
+		composite     = root.UserType("Composite")
+		deep          = root.UserType("Deep")
+		deepArray     = root.UserType("DeepArray")
+		simpleAlias   = root.UserType("SimpleAlias")
+		mapAlias      = root.UserType("NestedMapAlias")
+		arrayMapAlias = root.UserType("ArrayMapAlias")
+		collection    = root.UserType("ResultTypeCollection")
 		// attribute contexts used in test cases
 		defaultCtx = NewAttributeContext(false, false, true, "", scope)
 	)
@@ -30,13 +34,17 @@ func TestGoTransformHelpers(t *testing.T) {
 		{"composite", composite, []string{"transformSimpleToSimple"}},
 		{"deep", deep, []string{"transformCompositeToComposite", "transformSimpleToSimple"}},
 		{"deep-array", deepArray, []string{"transformCompositeToComposite", "transformSimpleToSimple"}},
+		{"simple-alias", simpleAlias, []string{}},
+		{"nested-map-alias", mapAlias, []string{}},
+		{"array-map-alias", arrayMapAlias, []string{}},
+		{"result-type-collection", collection, []string{"transformResultTypeToResultType"}},
 	}
 	for _, c := range tc {
 		t.Run(c.Name, func(t *testing.T) {
 			if c.Type == nil {
 				t.Fatal("source type not found in testdata")
 			}
-			_, funcs, err := GoTransform(&expr.AttributeExpr{Type: c.Type}, &expr.AttributeExpr{Type: c.Type}, "source", "target", defaultCtx, defaultCtx, "")
+			_, funcs, err := GoTransform(&expr.AttributeExpr{Type: c.Type}, &expr.AttributeExpr{Type: c.Type}, "source", "target", defaultCtx, defaultCtx, "", true)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/codegen/service/convert.go
+++ b/codegen/service/convert.go
@@ -235,7 +235,7 @@ func ConvertFile(root *expr.RootExpr, service *expr.ServiceExpr) (*codegen.File,
 		srcAtt := &expr.AttributeExpr{Type: c.User}
 		code, tf, err := codegen.GoTransform(
 			&expr.AttributeExpr{Type: c.User}, &expr.AttributeExpr{Type: dt},
-			"t", "v", srcCtx, tgtCtx, "transform")
+			"t", "v", srcCtx, tgtCtx, "transform", true)
 		if err != nil {
 			return nil, err
 		}
@@ -274,7 +274,7 @@ func ConvertFile(root *expr.RootExpr, service *expr.ServiceExpr) (*codegen.File,
 		tgtAtt := &expr.AttributeExpr{Type: c.User}
 		code, tf, err := codegen.GoTransform(
 			&expr.AttributeExpr{Type: dt}, tgtAtt,
-			"v", "temp", srcCtx, tgtCtx, "transform")
+			"v", "temp", srcCtx, tgtCtx, "transform", true)
 		if err != nil {
 			return nil, err
 		}

--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -1514,7 +1514,7 @@ func buildConstructorCode(src, tgt *expr.AttributeExpr, sourceVar, targetVar str
 	)
 	{
 		// build code for target with no result types
-		if code, helpers, err = codegen.GoTransform(src, tatt, sourceVar, targetVar, sourceCtx, targetCtx, "transform"); err != nil {
+		if code, helpers, err = codegen.GoTransform(src, tatt, sourceVar, targetVar, sourceCtx, targetCtx, "transform", true); err != nil {
 			panic(err) // bug
 		}
 	}

--- a/codegen/testdata/types_dsl.go
+++ b/codegen/testdata/types_dsl.go
@@ -212,5 +212,31 @@ var TestTypesDSL = func() {
 			})
 			Required("required_int", "required_string", "required_bytes", "required_any", "required_array", "required_map")
 		})
+
+		StringAlias = Type("StringAlias", String)
+		BoolAlias   = Type("BoolAlias", Boolean, func() {
+			Default(true)
+		})
+		IntAlias          = Type("IntAlias", Int)
+		Float32Alias      = Type("Float32Alias", Float32)
+		Float64Alias      = Type("Float64Alias", Float64)
+		Float32ArrayAlias = Type("Float32ArrayAlias", ArrayOf(Float32Alias))
+		NestedMapAlias    = Type("MapAlias", MapOf(Float64Alias, MapOf(IntAlias, MapOf(Float64Alias, UInt64))))
+		ArrayMapAlias     = Type("MapWithArrayAlias", MapOf(UInt32, Float32ArrayAlias))
+
+		_ = Type("SimpleAlias", func() {
+			Attribute("required_string", StringAlias)
+			Attribute("default_bool", BoolAlias)
+			Attribute("integer", IntAlias)
+			Required("required_string")
+		})
+
+		_ = Type("NestedMapAlias", func() {
+			Attribute("nested_map", NestedMapAlias)
+		})
+
+		_ = Type("ArrayMapAlias", func() {
+			Attribute("array_map", ArrayMapAlias)
+		})
 	)
 }

--- a/codegen/testdata/validation_code.go
+++ b/codegen/testdata/validation_code.go
@@ -359,4 +359,31 @@ const (
 	}
 }
 `
+
+	ResultTypePointerValidationCode = `func Validate() (err error) {
+	if target.Required != nil {
+		if *target.Required < 10 {
+			err = goa.MergeErrors(err, goa.InvalidRangeError("target.required", *target.Required, 10, true))
+		}
+	}
+}
+`
+
+	ResultCollectionPointerValidationCode = `func Validate() (err error) {
+	for _, e := range target {
+		if e != nil {
+			if err2 := ValidateResult(e); err2 != nil {
+				err = goa.MergeErrors(err, err2)
+			}
+		}
+	}
+}
+`
+
+	TypeWithCollectionPointerValidationCode = `func Validate() (err error) {
+	if err2 := ValidateResultCollection(target.Collection); err2 != nil {
+		err = goa.MergeErrors(err, err2)
+	}
+}
+`
 )

--- a/codegen/testdata/validation_types_dsl.go
+++ b/codegen/testdata/validation_types_dsl.go
@@ -95,5 +95,23 @@ var ValidationTypesDSL = func() {
 			})
 			Required("required_map")
 		})
+
+		Result = ResultType("application/vnd.goa.result", func() {
+			TypeName("Result")
+			Attributes(func() {
+				Attribute("required", Int, func() {
+					Minimum(10)
+				})
+			})
+		})
+
+		_ = Type("Collection", CollectionOf(Result))
+
+		_ = ResultType("application/vnd.goa.collection", func() {
+			TypeName("TypeWithCollection")
+			Attributes(func() {
+				Attribute("collection", CollectionOf(Result))
+			})
+		})
 	)
 }

--- a/codegen/validation_test.go
+++ b/codegen/validation_test.go
@@ -19,6 +19,9 @@ func TestRecursiveValidationCode(t *testing.T) {
 		arrayUT  = root.UserType("ArrayUserType")
 		arrayT   = root.UserType("Array")
 		mapT     = root.UserType("Map")
+		rtT      = root.UserType("Result")
+		rtcolT   = root.UserType("Collection")
+		colT     = root.UserType("TypeWithCollection")
 	)
 	cases := []struct {
 		Name       string
@@ -47,6 +50,10 @@ func TestRecursiveValidationCode(t *testing.T) {
 		{"map-required", mapT, true, false, false, testdata.MapRequiredValidationCode},
 		{"map-pointer", mapT, false, true, false, testdata.MapPointerValidationCode},
 		{"map-use-default", mapT, false, false, true, testdata.MapUseDefaultValidationCode},
+		{"result-type-pointer", rtT, false, true, false, testdata.ResultTypePointerValidationCode},
+		{"collection-required", rtcolT, true, false, false, testdata.ResultCollectionPointerValidationCode},
+		{"collection-pointer", rtcolT, false, true, false, testdata.ResultCollectionPointerValidationCode},
+		{"type-with-collection-pointer", colT, false, true, false, testdata.TypeWithCollectionPointerValidationCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -429,7 +429,13 @@ func (a *AttributeExpr) HasDefaultValue(attName string) bool {
 // exist or if the child attribute does not have a default value.
 func (a *AttributeExpr) GetDefault(attName string) interface{} {
 	if o := AsObject(a.Type); o != nil {
-		return o.Attribute(attName).DefaultValue
+		att := o.Attribute(attName)
+		if att.DefaultValue != nil {
+			return att.DefaultValue
+		}
+		if ut, ok := att.Type.(UserType); ok && !IsObject(ut) {
+			return ut.Attribute().DefaultValue
+		}
 	}
 	return nil
 }

--- a/expr/types.go
+++ b/expr/types.go
@@ -303,9 +303,15 @@ func equal(dt, dt2 DataType, seen ...map[string]*[]*bool) *[]*bool {
 		s[key] = pres
 		if IsObject(actual) {
 			*pres = *equal(AsObject(dt), AsObject(dt2), s)
-		} else {
-			// User types can also be arrays (CollectionOf)
+		} else if IsMap(actual) {
+			// Map aliased as UserType
+			*pres = *equal(AsMap(dt), AsMap(dt2), s)
+		} else if IsArray(actual) {
+			// Array aliased as UserType or CollectionOf
 			*pres = *equal(AsArray(dt), AsArray(dt2), s)
+		} else {
+			// Primitive type aliased as UserType
+			*pres = *equal(dt, dt2, s)
 		}
 		return pres
 	}
@@ -702,8 +708,12 @@ func toReflectType(dtype DataType) reflect.Type {
 		return reflect.TypeOf("")
 	case BytesKind:
 		return reflect.TypeOf([]byte{})
-	case ObjectKind, UserTypeKind, ResultTypeKind:
+	case ObjectKind:
 		return reflect.TypeOf(map[string]interface{}{})
+	case UserTypeKind:
+		return toReflectType(dtype.(*UserTypeExpr).Attribute().Type)
+	case ResultTypeKind:
+		return toReflectType(dtype.(*ResultTypeExpr).Attribute().Type)
 	case ArrayKind:
 		return reflect.SliceOf(toReflectType(dtype.(*Array).ElemType.Type))
 	case MapKind:

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -145,20 +145,22 @@ func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.Buil
 		fdata     []*cli.FieldData
 		flags     = make([]*cli.FlagData, len(args))
 		params    = make([]string, len(args))
-		pInitArgs = make([]*cli.PayloadInitArgData, len(args))
+		pInitArgs = make([]*codegen.InitArgData, len(args))
 		check     bool
 		pinit     *cli.PayloadInitData
 	)
 	for i, arg := range args {
-		pInitArgs[i] = &cli.PayloadInitArgData{
+		pInitArgs[i] = &codegen.InitArgData{
 			Name:      arg.Name,
 			FieldName: arg.FieldName,
+			FieldType: arg.FieldType,
+			Type:      arg.Type,
 		}
 
 		f := cli.NewFlagData(e.ServiceName, e.Method.Name, arg.Name, arg.TypeName, arg.Description, arg.Required, arg.Example)
 		flags[i] = f
 		params[i] = f.FullName
-		code, chek := cli.FieldLoadCode(f, arg.Name, arg.TypeName, arg.Validate, arg.DefaultValue)
+		code, chek := cli.FieldLoadCode(f, arg.Name, arg.TypeName, arg.Validate, arg.DefaultValue, e.PayloadType)
 		check = check || chek
 		tn := arg.TypeRef
 		if f.Type == "JSON" {
@@ -181,6 +183,7 @@ func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.Buil
 		pinit = &cli.PayloadInitData{
 			Code:           e.Request.ServerConvert.Init.Code,
 			ReturnIsStruct: e.Request.ServerConvert.Init.ReturnIsStruct,
+			ReturnTypePkg:  e.Request.ServerConvert.Init.ReturnTypePkg,
 			Args:           pInitArgs,
 		}
 	}

--- a/grpc/codegen/client_types_test.go
+++ b/grpc/codegen/client_types_test.go
@@ -16,6 +16,7 @@ func TestClientTypeFiles(t *testing.T) {
 		Code string
 	}{
 		{"payload-with-nested-types", testdata.PayloadWithNestedTypesDSL, testdata.PayloadWithNestedTypesClientTypeCode},
+		{"payload-with-alias-type", testdata.PayloadWithAliasTypeDSL, testdata.PayloadWithAliasTypeClientTypeCode},
 		{"result-collection", testdata.ResultWithCollectionDSL, testdata.ResultWithCollectionClientTypeCode},
 		{"with-errors", testdata.UnaryRPCWithErrorsDSL, testdata.WithErrorsClientTypeCode},
 	}

--- a/grpc/codegen/proto_test.go
+++ b/grpc/codegen/proto_test.go
@@ -54,6 +54,7 @@ func TestMessageDefSection(t *testing.T) {
 		Code string
 	}{
 		{"user-type-with-primitives", testdata.MessageUserTypeWithPrimitivesDSL, testdata.MessageUserTypeWithPrimitivesMessageCode},
+		{"use-type-with-alias", testdata.MessageUserTypeWithAliasMessageDSL, testdata.MessageUserTypeWithAliasMessageCode},
 		{"user-type-with-nested-user-types", testdata.MessageUserTypeWithNestedUserTypesDSL, testdata.MessageUserTypeWithNestedUserTypesCode},
 		{"result-type-collection", testdata.MessageResultTypeCollectionDSL, testdata.MessageResultTypeCollectionCode},
 		{"user-type-with-collection", testdata.MessageUserTypeWithCollectionDSL, testdata.MessageUserTypeWithCollectionCode},

--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -239,6 +239,9 @@ func protoBufMessageDef(att *expr.AttributeExpr, sd *ServiceData) string {
 	case *expr.Map:
 		return fmt.Sprintf("map<%s, %s>", protoBufMessageDef(actual.KeyType, sd), protoBufMessageDef(actual.ElemType, sd))
 	case expr.UserType:
+		if prim := getPrimitive(att); prim != nil {
+			return protoBufMessageDef(prim, sd)
+		}
 		return protoBufMessageName(att, sd.Scope)
 	case *expr.Object:
 		var ss []string
@@ -253,7 +256,11 @@ func protoBufMessageDef(att *expr.AttributeExpr, sd *ServiceData) string {
 			{
 				fn = codegen.SnakeCase(protoBufify(nat.Name, false))
 				fnum = rpcTag(nat.Attribute)
-				typ = protoBufMessageDef(nat.Attribute, sd)
+				if prim := getPrimitive(nat.Attribute); prim != nil {
+					typ = protoBufMessageDef(prim, sd)
+				} else {
+					typ = protoBufMessageDef(nat.Attribute, sd)
+				}
 				if nat.Attribute.Description != "" {
 					desc = codegen.Comment(nat.Attribute.Description) + "\n\t"
 				}

--- a/grpc/codegen/protobuf_transform_test.go
+++ b/grpc/codegen/protobuf_transform_test.go
@@ -133,7 +133,7 @@ func TestProtoBufTransform(t *testing.T) {
 						source = makeProtoBufMessage(expr.DupAtt(source), source.Type.Name(), sd)
 						srcCtx = pbCtx
 					}
-					code, _, err := protoBufTransform(source, target, "source", "target", srcCtx, tgtCtx, c.ToProto)
+					code, _, err := protoBufTransform(source, target, "source", "target", srcCtx, tgtCtx, c.ToProto, true)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/grpc/codegen/server_types_test.go
+++ b/grpc/codegen/server_types_test.go
@@ -16,6 +16,7 @@ func TestServerTypeFiles(t *testing.T) {
 		Code string
 	}{
 		{"payload-with-nested-types", testdata.PayloadWithNestedTypesDSL, testdata.PayloadWithNestedTypesServerTypeCode},
+		{"payload-with-alias-type", testdata.PayloadWithAliasTypeDSL, testdata.PayloadWithAliasTypeServerTypeCode},
 		{"result-collection", testdata.ResultWithCollectionDSL, testdata.ResultWithCollectionServerTypeCode},
 		{"with-errors", testdata.UnaryRPCWithErrorsDSL, testdata.WithErrorsServerTypeCode},
 	}

--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -71,6 +71,8 @@ type (
 		ServicePkgName string
 		// Method is the data for the underlying method expression.
 		Method *service.MethodData
+		// PayloadType is the type of the payload.
+		PayloadType expr.DataType
 		// PayloadRef is the fully qualified reference to the method payload.
 		PayloadRef string
 		// ResultRef is the fully qualified reference to the method result.
@@ -122,6 +124,8 @@ type (
 		// FieldName is the name of the struct field that holds the
 		// metadata value if any, empty string otherwise.
 		FieldName string
+		// FieldType is the type of the struct field.
+		FieldType expr.DataType
 		// VarName is the name of the Go variable used to read or
 		// convert the metadata value.
 		VarName string
@@ -265,6 +269,8 @@ type (
 		// ReturnTypeRef is the qualified (including the package name)
 		// reference to the return type.
 		ReturnTypeRef string
+		// ReturnTypePkg is the package where the return type is present.
+		ReturnTypePkg string
 		// ReturnIsStruct is true if the return type is a struct.
 		ReturnIsStruct bool
 		// Code is the transformation code.
@@ -282,10 +288,15 @@ type (
 		// FieldName is the name of the data structure field that should
 		// be initialized with the argument if any.
 		FieldName string
+		// FieldType is the type of the data structure field that should be
+		// initialized with the argument if any.
+		FieldType expr.DataType
 		// TypeName is the argument type name.
 		TypeName string
 		// TypeRef is the argument type reference.
 		TypeRef string
+		// Type is the argument type. It is never an aliased user type.
+		Type expr.DataType
 		// Pointer is true if a pointer to the arg should be used.
 		Pointer bool
 		// Required is true if the arg is required to build the payload.
@@ -526,8 +537,10 @@ func (d ServicesData) analyze(gs *expr.GRPCServiceExpr) *ServiceData {
 					Name:      m.VarName,
 					Ref:       m.VarName,
 					FieldName: m.FieldName,
+					FieldType: m.FieldType,
 					TypeName:  m.TypeName,
 					TypeRef:   m.TypeRef,
+					Type:      m.Type,
 					Pointer:   m.Pointer,
 					Required:  m.Required,
 					Validate:  m.Validate,
@@ -591,6 +604,7 @@ func (d ServicesData) analyze(gs *expr.GRPCServiceExpr) *ServiceData {
 			PkgName:         sd.PkgName,
 			ServicePkgName:  svc.PkgName,
 			Method:          md,
+			PayloadType:     e.MethodExpr.Payload.Type,
 			PayloadRef:      payloadRef,
 			ResultRef:       resultRef,
 			ViewedResultRef: viewedResultRef,
@@ -625,6 +639,9 @@ func collectMessages(at *expr.AttributeExpr, sd *ServiceData, seen map[string]st
 	case expr.UserType:
 		if _, ok := seen[dt.Name()]; ok {
 			return nil
+		}
+		if prim := getPrimitive(at); prim != nil {
+			return
 		}
 		att := dt.Attribute()
 		if rt, ok := dt.(*expr.ResultTypeExpr); ok {
@@ -795,8 +812,10 @@ func buildRequestConvertData(request, payload *expr.AttributeExpr, md []*Metadat
 					Name:      m.VarName,
 					Ref:       m.VarName,
 					FieldName: m.FieldName,
+					FieldType: m.FieldType,
 					TypeName:  m.TypeName,
 					TypeRef:   m.TypeRef,
+					Type:      m.Type,
 					Pointer:   m.Pointer,
 					Required:  m.Required,
 					Validate:  m.Validate,
@@ -879,8 +898,10 @@ func buildResponseConvertData(response, result *expr.AttributeExpr, svcCtx *code
 				Name:      m.VarName,
 				Ref:       m.VarName,
 				FieldName: m.FieldName,
+				FieldType: m.FieldType,
 				TypeName:  m.TypeName,
 				TypeRef:   m.TypeRef,
+				Type:      m.Type,
 				Pointer:   m.Pointer,
 				Required:  m.Required,
 				Validate:  m.Validate,
@@ -893,8 +914,10 @@ func buildResponseConvertData(response, result *expr.AttributeExpr, svcCtx *code
 				Name:      m.VarName,
 				Ref:       m.VarName,
 				FieldName: m.FieldName,
+				FieldType: m.FieldType,
 				TypeName:  m.TypeName,
 				TypeRef:   m.TypeRef,
+				Type:      m.Type,
 				Pointer:   m.Pointer,
 				Required:  m.Required,
 				Validate:  m.Validate,
@@ -954,7 +977,7 @@ func buildInitData(source, target *expr.AttributeExpr, sourceVar, targetVar stri
 			srcCtx = svcCtx
 			tgtCtx = pbCtx
 		}
-		code, helpers, err = protoBufTransform(source, target, sourceVar, targetVar, srcCtx, tgtCtx, proto)
+		code, helpers, err = protoBufTransform(source, target, sourceVar, targetVar, srcCtx, tgtCtx, proto, true)
 		if err != nil {
 			fmt.Println(err.Error()) // TBD validate DSL so errors are not possible
 			return nil
@@ -977,6 +1000,7 @@ func buildInitData(source, target *expr.AttributeExpr, sourceVar, targetVar stri
 		ReturnVarName:  targetVar,
 		ReturnTypeRef:  tgtCtx.Scope.Ref(target, tgtCtx.Pkg),
 		ReturnIsStruct: isStruct,
+		ReturnTypePkg:  tgtCtx.Pkg,
 		Code:           code,
 		Args:           args,
 	}
@@ -1186,6 +1210,7 @@ func extractMetadata(a *expr.MappedAttributeExpr, service *expr.AttributeExpr, s
 			arr     = expr.AsArray(c.Type)
 			mp      = expr.AsMap(c.Type)
 			typeRef = scope.GoTypeRef(c)
+			ft      = service.Type
 		)
 		{
 			varn = scope.Name(codegen.Goify(name, false))
@@ -1194,6 +1219,7 @@ func extractMetadata(a *expr.MappedAttributeExpr, service *expr.AttributeExpr, s
 				fieldName = ""
 			} else {
 				pointer = service.IsPrimitivePointer(name, true)
+				ft = service.Find(name).Type
 			}
 			if pointer {
 				typeRef = "*" + typeRef
@@ -1204,6 +1230,7 @@ func extractMetadata(a *expr.MappedAttributeExpr, service *expr.AttributeExpr, s
 			AttributeName: name,
 			Description:   c.Description,
 			FieldName:     fieldName,
+			FieldType:     ft,
 			VarName:       varn,
 			Required:      required,
 			Type:          c.Type,
@@ -1244,6 +1271,17 @@ func resultContext(e *expr.GRPCEndpointExpr, sd *ServiceData) (*expr.AttributeEx
 		return vresAtt, codegen.NewAttributeContext(true, false, true, svc.ViewsPkg, svc.ViewScope)
 	}
 	return e.MethodExpr.Result, serviceTypeContext(svc.PkgName, svc.Scope)
+}
+
+// getPrimitive returns the primitive expression if the given expression is an alias to one
+func getPrimitive(att *expr.AttributeExpr) *expr.AttributeExpr {
+	if ut, ok := att.Type.(*expr.UserTypeExpr); ok {
+		if _, ok := ut.Type.(expr.Primitive); ok {
+			return ut.AttributeExpr
+		}
+		return getPrimitive(ut.AttributeExpr)
+	}
+	return nil
 }
 
 // isEmpty returns true if given type is empty.

--- a/grpc/codegen/testdata/client_type_code.go
+++ b/grpc/codegen/testdata/client_type_code.go
@@ -102,6 +102,34 @@ func svcServicepayloadwithnestedtypesBParamsToServicePayloadWithNestedTypespbBPa
 }
 `
 
+const PayloadWithAliasTypeClientTypeCode = `// NewMethodMessageUserTypeWithAliasRequest builds the gRPC request type from
+// the payload of the "MethodMessageUserTypeWithAlias" endpoint of the
+// "ServiceMessageUserTypeWithAlias" service.
+func NewMethodMessageUserTypeWithAliasRequest(payload *servicemessageusertypewithalias.PayloadAliasT) *service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasRequest {
+	message := &service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasRequest{
+		IntAliasField: int(payload.IntAliasField),
+	}
+	if payload.OptionalIntAliasField != nil {
+		message.OptionalIntAliasField = int(*payload.OptionalIntAliasField)
+	}
+	return message
+}
+
+// NewMethodMessageUserTypeWithAliasResult builds the result type of the
+// "MethodMessageUserTypeWithAlias" endpoint of the
+// "ServiceMessageUserTypeWithAlias" service from the gRPC response type.
+func NewMethodMessageUserTypeWithAliasResult(message *service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasResponse) *servicemessageusertypewithalias.PayloadAliasT {
+	result := &servicemessageusertypewithalias.PayloadAliasT{
+		IntAliasField: servicemessageusertypewithalias.IntAlias(message.IntAliasField),
+	}
+	if message.OptionalIntAliasField != nil {
+		optionalIntAliasFieldptr := servicemessageusertypewithalias.IntAlias(message.OptionalIntAliasField)
+		result.OptionalIntAliasField = &optionalIntAliasFieldptr
+	}
+	return result
+}
+`
+
 const ResultWithCollectionClientTypeCode = `// NewMethodResultWithCollectionRequest builds the gRPC request type from the
 // payload of the "MethodResultWithCollection" endpoint of the
 // "ServiceResultWithCollection" service.

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -308,6 +308,33 @@ var MessageUserTypeWithPrimitivesDSL = func() {
 	})
 }
 
+var MessageUserTypeWithAliasMessageDSL = func() {
+	var IntAlias = Type("IntAlias", Int)
+	var PayloadT = Type("PayloadT", func() {
+		Field(1, "IntAliasField", IntAlias)
+		Field(2, "OptionalIntAliasField", IntAlias)
+		Required("IntAliasField")
+	})
+	var ResultT = ResultType("application/vnd.goa.aliast", func() {
+		TypeName("ResultT")
+		Attributes(func() {
+			Attribute("IntAliasField", Int, func() {
+				Meta("rpc:tag", "1")
+			})
+			Attribute("OptionalIntAliasField", Int, func() {
+				Meta("rpc:tag", "2")
+			})
+		})
+	})
+	Service("ServiceMessageUserTypeWithAlias", func() {
+		Method("MethodMessageUserTypeWithAlias", func() {
+			Payload(PayloadT)
+			Result(ResultT)
+			GRPC(func() {})
+		})
+	})
+}
+
 var MessageUserTypeWithNestedUserTypesDSL = func() {
 	var UTLevel2 = Type("UTLevel2", func() {
 		Field(2, "Int64Field", Int64)
@@ -479,6 +506,22 @@ var PayloadWithNestedTypesDSL = func() {
 			GRPC(func() {
 				Response(CodeOK)
 			})
+		})
+	})
+}
+
+var PayloadWithAliasTypeDSL = func() {
+	var IntAlias = Type("IntAlias", Int)
+	var PayloadAliasT = Type("PayloadAliasT", func() {
+		Field(1, "IntAliasField", IntAlias)
+		Field(2, "OptionalIntAliasField", IntAlias)
+		Required("IntAliasField")
+	})
+	Service("ServiceMessageUserTypeWithAlias", func() {
+		Method("MethodMessageUserTypeWithAlias", func() {
+			Payload(PayloadAliasT)
+			Result(PayloadAliasT)
+			GRPC(func() {})
 		})
 	})
 }

--- a/grpc/codegen/testdata/proto_code.go
+++ b/grpc/codegen/testdata/proto_code.go
@@ -189,6 +189,18 @@ message MethodMessageUserTypeWithPrimitivesResponse {
 }
 `
 
+const MessageUserTypeWithAliasMessageCode = `
+message MethodMessageUserTypeWithAliasRequest {
+	sint32 int_alias_field = 1;
+	sint32 optional_int_alias_field = 2;
+}
+
+message MethodMessageUserTypeWithAliasResponse {
+	sint32 int_alias_field = 1;
+	sint32 optional_int_alias_field = 2;
+}
+`
+
 const MessageUserTypeWithNestedUserTypesCode = `
 message MethodMessageUserTypeWithNestedUserTypesRequest {
 	bool boolean_field = 1;

--- a/grpc/codegen/testdata/server_type_code.go
+++ b/grpc/codegen/testdata/server_type_code.go
@@ -110,6 +110,34 @@ func svcServicepayloadwithnestedtypesBParamsToServicePayloadWithNestedTypespbBPa
 }
 `
 
+const PayloadWithAliasTypeServerTypeCode = `// NewMethodMessageUserTypeWithAliasPayload builds the payload of the
+// "MethodMessageUserTypeWithAlias" endpoint of the
+// "ServiceMessageUserTypeWithAlias" service from the gRPC request type.
+func NewMethodMessageUserTypeWithAliasPayload(message *service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasRequest) *servicemessageusertypewithalias.PayloadAliasT {
+	v := &servicemessageusertypewithalias.PayloadAliasT{
+		IntAliasField: servicemessageusertypewithalias.IntAlias(message.IntAliasField),
+	}
+	if message.OptionalIntAliasField != nil {
+		optionalIntAliasFieldptr := servicemessageusertypewithalias.IntAlias(message.OptionalIntAliasField)
+		v.OptionalIntAliasField = &optionalIntAliasFieldptr
+	}
+	return v
+}
+
+// NewMethodMessageUserTypeWithAliasResponse builds the gRPC response type from
+// the result of the "MethodMessageUserTypeWithAlias" endpoint of the
+// "ServiceMessageUserTypeWithAlias" service.
+func NewMethodMessageUserTypeWithAliasResponse(result *servicemessageusertypewithalias.PayloadAliasT) *service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasResponse {
+	message := &service_message_user_type_with_aliaspb.MethodMessageUserTypeWithAliasResponse{
+		IntAliasField: int(result.IntAliasField),
+	}
+	if result.OptionalIntAliasField != nil {
+		message.OptionalIntAliasField = int(*result.OptionalIntAliasField)
+	}
+	return message
+}
+`
+
 const ResultWithCollectionServerTypeCode = `// NewMethodResultWithCollectionResponse builds the gRPC response type from the
 // result of the "MethodResultWithCollection" endpoint of the
 // "ServiceResultWithCollection" service.

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -127,7 +127,12 @@ func clientEncodeDecode(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File 
 					"goTypeRef": func(dt expr.DataType) string {
 						return service.Services.Get(svc.Name()).Scope.GoTypeRef(&expr.AttributeExpr{Type: dt})
 					},
-					"isBearer": isBearer,
+					"isBearer":    isBearer,
+					"aliasedType": fieldType,
+					"isAliased": func(dt expr.DataType) bool {
+						_, ok := dt.(expr.UserType)
+						return ok
+					},
 				},
 				Data: e,
 			})
@@ -165,22 +170,42 @@ func clientEncodeDecode(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File 
 
 // typeConversionData produces the template data suitable for executing the
 // "header_conversion" template.
-func typeConversionData(dt expr.DataType, varName string, target string) map[string]interface{} {
+func typeConversionData(dt, ft expr.DataType, varName string, target string) map[string]interface{} {
+	ut, isut := ft.(expr.UserType)
+	if isut {
+		ft = ut.Attribute().Type
+	}
 	return map[string]interface{}{
-		"Type":    dt,
-		"VarName": varName,
-		"Target":  target,
+		"Type":      dt,
+		"FieldType": ft,
+		"VarName":   varName,
+		"Target":    target,
+		"IsAliased": isut,
 	}
 }
 
-func mapConversionData(dt expr.DataType, varName, sourceVar, sourceField string, newVar bool) map[string]interface{} {
+func mapConversionData(dt, ft expr.DataType, varName, sourceVar, sourceField string, newVar bool) map[string]interface{} {
+	ut, isut := ft.(expr.UserType)
+	if isut {
+		ft = ut.Attribute().Type
+	}
 	return map[string]interface{}{
 		"Type":        dt,
+		"FieldType":   ft,
 		"VarName":     varName,
 		"SourceVar":   sourceVar,
 		"SourceField": sourceField,
 		"NewVar":      newVar,
+		"IsAliased":   isut,
 	}
+}
+
+func fieldType(ft expr.DataType) expr.DataType {
+	ut, isut := ft.(expr.UserType)
+	if isut {
+		return ut.Attribute().Type
+	}
+	return ft
 }
 
 // isBearer returns true if the security scheme uses a Bearer scheme.
@@ -358,14 +383,14 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 				{{- if eq .Type.ElemType.Type.Name "string" }}
 				req.Header.Add({{ printf "%q" .Name }}, val)
 				{{- else }}
-				{{ template "type_conversion" (typeConversionData .Type.ElemType.Type "valStr" "val") }}
+				{{ template "type_conversion" (typeConversionData .Type.ElemType.Type (aliasedType .FieldType).ElemType.Type "valStr" "val") }}
 				req.Header.Add({{ printf "%q" .Name }}, valStr)
 				{{- end }}
 			}
 			{{- else if eq .Type.Name "string" }}
 			req.Header.Set({{ printf "%q" .Name }}, head)
 			{{- else }}
-			{{ template "type_conversion" (typeConversionData .Type "headStr" "head") }}
+			{{ template "type_conversion" (typeConversionData .Type .FieldType "headStr" "head") }}
 			req.Header.Set({{ printf "%q" .Name }}, headStr)
 			{{- end }}
 			{{- if (and (eq .Name "Authorization") (isBearer $.HeaderSchemes)) }}
@@ -380,14 +405,14 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 	{{- range .Payload.Request.QueryParams }}
 		{{- if .MapQueryParams }}
 		for key, value := range p{{ if .FieldName }}.{{ .FieldName }}{{ end }} {
-			{{ template "type_conversion" (typeConversionData .Type.KeyType.Type "keyStr" "key") }}
+			{{ template "type_conversion" (typeConversionData .Type.KeyType.Type (aliasedType .FieldType).KeyType.Type "keyStr" "key") }}
 			{{- if eq .Type.ElemType.Type.Name "array" }}
 			for _, val := range value {
-				{{ template "type_conversion" (typeConversionData .Type.ElemType.Type.ElemType.Type "valStr" "val") }}
+				{{ template "type_conversion" (typeConversionData .Type.ElemType.Type.ElemType.Type (aliasedType (aliasedType .FieldType).ElemType.Type).ElemType.Type "valStr" "val") }}
 				values.Add(keyStr, valStr)
 			}
 			{{- else }}
-			{{ template "type_conversion" (typeConversionData .Type.ElemType.Type "valueStr" "value") }}
+			{{ template "type_conversion" (typeConversionData .Type.ElemType.Type (aliasedType .FieldType).ElemType.Type "valueStr" "value") }}
 			values.Add(keyStr, valueStr)
 			{{- end }}
     }
@@ -397,11 +422,11 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 			}
 		{{- else if .Slice }}
 			for _, value := range p{{ if .FieldName }}.{{ .FieldName }}{{ end }} {
-				{{ template "type_conversion" (typeConversionData .Type.ElemType.Type "valueStr" "value") }}
+				{{ template "type_conversion" (typeConversionData .Type.ElemType.Type (aliasedType .FieldType).ElemType.Type "valueStr" "value") }}
 				values.Add("{{ .Name }}", valueStr)
 			}
 		{{- else if .Map }}
-			{{- template "map_conversion" (mapConversionData .Type .Name "p" .FieldName true) }}
+			{{- template "map_conversion" (mapConversionData .Type .FieldType .Name "p" .FieldName true) }}
 		{{- else if .FieldName }}
 			{{- if .FieldPointer }}
 		if p.{{ .FieldName }} != nil {
@@ -415,6 +440,13 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 			{{- end }})
 			{{- if .FieldPointer }}
 		}
+			{{- end }}
+		{{- else }}
+			{{- if eq .Type.Name "string" }}
+				values.Add("{{ .Name }}", p)
+			{{- else }}
+				{{ template "type_conversion" (typeConversionData .Type .FieldType "pStr" "p") }}
+				values.Add("{{ .Name }}", pStr)
 			{{- end }}
 		{{- end }}
 	{{- end }}
@@ -457,24 +489,24 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 {{- define "map_conversion" }}
   for k{{ if not (eq .Type.KeyType.Type.Name "string") }}Raw{{ end }}, value := range {{ .SourceVar }}{{ if .SourceField }}.{{ .SourceField }}{{ end }} {
 		{{- if not (eq .Type.KeyType.Type.Name "string") }}
-			{{- template "type_conversion" (typeConversionData .Type.KeyType.Type "k" "kRaw") }}
+			{{ template "type_conversion" (typeConversionData .Type.KeyType.Type .FieldType.KeyType.Type "k" "kRaw") }}
 		{{- end }}
 		key {{ if .NewVar }}:={{ else }}={{ end }} fmt.Sprintf("{{ .VarName }}[%s]", {{ if not .NewVar }}key, {{ end }}k)
 		{{- if eq .Type.ElemType.Type.Name "string" }}
-			values.Add(key, value)
+			values.Add(key, {{ if (isAliased .FieldType.ElemType.Type) }}string({{ end }}value{{ if (isAliased .FieldType.ElemType.Type) }}){{ end }})
 		{{- else if eq .Type.ElemType.Type.Name "map" }}
-			{{- template "map_conversion" (mapConversionData .Type.ElemType.Type "%s" "value" "" false) }}
+			{{- template "map_conversion" (mapConversionData .Type.ElemType.Type .FieldType.ElemType.Type "%s" "value" "" false) }}
 		{{- else if eq .Type.ElemType.Type.Name "array" }}
-			{{- if eq .Type.ElemType.Type.ElemType.Type.Name "string" }}
+			{{- if and (eq .Type.ElemType.Type.ElemType.Type.Name "string") (not (isAliased .FieldType.ElemType.Type.ElemType.Type)) }}
 				values[key] = value
 			{{- else }}
 				for _, val := range value {
-					{{ template "type_conversion" (typeConversionData .Type.ElemType.Type.ElemType.Type "valStr" "val") }}
+					{{ template "type_conversion" (typeConversionData .Type.ElemType.Type.ElemType.Type (aliasedType .FieldType.ElemType.Type).ElemType.Type "valStr" "val") }}
 					values.Add(key, valStr)
 				}
 			{{- end }}
 		{{- else }}
-			{{ template "type_conversion" (typeConversionData .Type.ElemType.Type "valueStr" "value") }}
+			{{ template "type_conversion" (typeConversionData .Type.ElemType.Type .FieldType.ElemType.Type "valueStr" "value") }}
 			values.Add(key, valueStr)
 		{{- end }}
 	}
@@ -482,25 +514,25 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 
 {{- define "type_conversion" }}
   {{- if eq .Type.Name "boolean" -}}
-    {{ .VarName }} := strconv.FormatBool({{ .Target }})
+    {{ .VarName }} := strconv.FormatBool({{ if .IsAliased }}bool({{ end }}{{ .Target }}{{ if .IsAliased }}){{ end }})
   {{- else if eq .Type.Name "int" -}}
-    {{ .VarName }} := strconv.Itoa({{ .Target }})
+    {{ .VarName }} := strconv.Itoa({{ if .IsAliased }}int({{ end }}{{ .Target }}{{ if .IsAliased }}){{ end }})
   {{- else if eq .Type.Name "int32" -}}
     {{ .VarName }} := strconv.FormatInt(int64({{ .Target }}), 10)
   {{- else if eq .Type.Name "int64" -}}
-    {{ .VarName }} := strconv.FormatInt({{ .Target }}, 10)
+    {{ .VarName }} := strconv.FormatInt({{ if .IsAliased }}int64({{ end }}{{ .Target }}{{ if .IsAliased }}){{ end }}, 10)
   {{- else if eq .Type.Name "uint" -}}
     {{ .VarName }} := strconv.FormatUint(uint64({{ .Target }}), 10)
   {{- else if eq .Type.Name "uint32" -}}
     {{ .VarName }} := strconv.FormatUint(uint64({{ .Target }}), 10)
   {{- else if eq .Type.Name "uint64" -}}
-    {{ .VarName }} := strconv.FormatUint({{ .Target }}, 10)
+    {{ .VarName }} := strconv.FormatUint({{ if .IsAliased }}uint64({{ end }}{{ .Target }}{{ if .IsAliased }}){{ end }}, 10)
   {{- else if eq .Type.Name "float32" -}}
     {{ .VarName }} := strconv.FormatFloat(float64({{ .Target }}), 'f', -1, 32)
   {{- else if eq .Type.Name "float64" -}}
-    {{ .VarName }} := strconv.FormatFloat({{ .Target }}, 'f', -1, 64)
+    {{ .VarName }} := strconv.FormatFloat({{ if .IsAliased }}float64({{ end }}{{ .Target }}{{ if .IsAliased }}){{ end }}, 'f', -1, 64)
 	{{- else if eq .Type.Name "string" -}}
-    {{ .VarName }} := {{ .Target }}
+    {{ .VarName }} := {{ if .IsAliased }}string({{ end }}{{ .Target }}{{ if .IsAliased }}){{ end }}
   {{- else if eq .Type.Name "bytes" -}}
     {{ .VarName }} := string({{ .Target }})
   {{- else if eq .Type.Name "any" -}}

--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -73,6 +73,8 @@ func TestClientTypes(t *testing.T) {
 		{"mixed-payload-attrs", testdata.MixedPayloadInBodyDSL, MixedPayloadInBodyClientTypesFile},
 		{"multiple-methods", testdata.MultipleMethodsDSL, MultipleMethodsClientTypesFile},
 		{"payload-extend-validate", testdata.PayloadExtendedValidateDSL, PayloadExtendedValidateClientTypesFile},
+		{"result-type-validate", testdata.ResultTypeValidateDSL, ResultTypeValidateClientTypesFile},
+		{"with-result-collection", testdata.ResultWithResultCollectionDSL, WithResultCollectionClientTypesFile},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -142,9 +144,7 @@ const BodyPrimitiveArrayUserValidateInitCode = `// NewPayloadTypeRequestBody bui
 func NewPayloadTypeRequestBody(p []*servicebodyprimitivearrayuservalidate.PayloadType) []*PayloadTypeRequestBody {
 	body := make([]*PayloadTypeRequestBody, len(p))
 	for i, val := range p {
-		body[i] = &PayloadTypeRequestBody{
-			A: val.A,
-		}
+		body[i] = marshalServicebodyprimitivearrayuservalidatePayloadTypeToPayloadTypeRequestBody(val)
 	}
 	return body
 }
@@ -180,6 +180,7 @@ func NewMethodBodyObjectHeaderResultOK(body *MethodBodyObjectHeaderResponseBody,
 		A: body.A,
 	}
 	v.B = b
+
 	return v
 }
 `
@@ -194,6 +195,7 @@ func NewMethodExplicitBodyPrimitiveResultMultipleViewResulttypemultipleviewsOK(b
 		A: &v,
 	}
 	res.C = c
+
 	return res
 }
 `
@@ -211,6 +213,7 @@ func NewMethodExplicitBodyUserResultMultipleViewResulttypemultipleviewsOK(body *
 		A: v,
 	}
 	res.C = c
+
 	return res
 }
 `
@@ -226,6 +229,7 @@ func NewMethodExplicitBodyUserResultObjectResulttypeOK(body *MethodExplicitBodyU
 	}
 	v.C = c
 	v.B = b
+
 	return v
 }
 `
@@ -240,6 +244,7 @@ func NewMethodExplicitBodyUserResultObjectMultipleViewResulttypemultipleviewsOK(
 		v.A = unmarshalUserTypeResponseBodyToServiceexplicitbodyuserresultobjectmultipleviewviewsUserTypeView(body.A)
 	}
 	v.C = c
+
 	return v
 }
 `
@@ -422,6 +427,7 @@ func NewListResultOK(body *ListResponseBody) *servicea.ListResult {
 		ID:   *body.ID,
 		Name: *body.Name,
 	}
+
 	return v
 }
 
@@ -436,6 +442,7 @@ func NewListSomethingWentWrong(body *ListSomethingWentWrongResponseBody) *goa.Se
 		Timeout:   *body.Timeout,
 		Fault:     *body.Fault,
 	}
+
 	return v
 }
 
@@ -536,6 +543,7 @@ func NewListResultOK(body *ListResponseBody) *serviceb.ListResult {
 		ID:   *body.ID,
 		Name: *body.Name,
 	}
+
 	return v
 }
 
@@ -550,6 +558,7 @@ func NewListSomethingWentWrong(body *ListSomethingWentWrongResponseBody) *goa.Se
 		Timeout:   *body.Timeout,
 		Fault:     *body.Fault,
 	}
+
 	return v
 }
 
@@ -589,3 +598,109 @@ func ValidateListSomethingWentWrongResponseBody(body *ListSomethingWentWrongResp
 }
 `,
 }
+
+const ResultTypeValidateClientTypesFile = `// MethodResultTypeValidateResponseBody is the type of the
+// "ServiceResultTypeValidate" service "MethodResultTypeValidate" endpoint HTTP
+// response body.
+type MethodResultTypeValidateResponseBody struct {
+	A *string ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
+}
+
+// NewMethodResultTypeValidateResultTypeNoContent builds a
+// "ServiceResultTypeValidate" service "MethodResultTypeValidate" endpoint
+// result from a HTTP "NoContent" response.
+func NewMethodResultTypeValidateResultTypeNoContent(body *MethodResultTypeValidateResponseBody) *serviceresulttypevalidate.ResultType {
+	v := &serviceresulttypevalidate.ResultType{
+		A: body.A,
+	}
+
+	return v
+}
+
+// ValidateMethodResultTypeValidateResponseBody runs the validations defined on
+// MethodResultTypeValidateResponseBody
+func ValidateMethodResultTypeValidateResponseBody(body *MethodResultTypeValidateResponseBody) (err error) {
+	if body.A != nil {
+		if utf8.RuneCountInString(*body.A) < 5 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.a", *body.A, utf8.RuneCountInString(*body.A), 5, true))
+		}
+	}
+	return
+}
+`
+
+const WithResultCollectionClientTypesFile = `// MethodResultWithResultCollectionResponseBody is the type of the
+// "ServiceResultWithResultCollection" service
+// "MethodResultWithResultCollection" endpoint HTTP response body.
+type MethodResultWithResultCollectionResponseBody struct {
+	A *ResulttypeResponseBody ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
+}
+
+// ResulttypeResponseBody is used to define fields on response body types.
+type ResulttypeResponseBody struct {
+	X RtCollectionResponseBody ` + "`" + `form:"x,omitempty" json:"x,omitempty" xml:"x,omitempty"` + "`" + `
+}
+
+// RtCollectionResponseBody is used to define fields on response body types.
+type RtCollectionResponseBody []*RtResponseBody
+
+// RtResponseBody is used to define fields on response body types.
+type RtResponseBody struct {
+	X *string ` + "`" + `form:"x,omitempty" json:"x,omitempty" xml:"x,omitempty"` + "`" + `
+}
+
+// NewMethodResultWithResultCollectionResultOK builds a
+// "ServiceResultWithResultCollection" service
+// "MethodResultWithResultCollection" endpoint result from a HTTP "OK" response.
+func NewMethodResultWithResultCollectionResultOK(body *MethodResultWithResultCollectionResponseBody) *serviceresultwithresultcollection.MethodResultWithResultCollectionResult {
+	v := &serviceresultwithresultcollection.MethodResultWithResultCollectionResult{}
+	if body.A != nil {
+		v.A = unmarshalResulttypeResponseBodyToServiceresultwithresultcollectionResulttype(body.A)
+	}
+
+	return v
+}
+
+// ValidateMethodResultWithResultCollectionResponseBody runs the validations
+// defined on MethodResultWithResultCollectionResponseBody
+func ValidateMethodResultWithResultCollectionResponseBody(body *MethodResultWithResultCollectionResponseBody) (err error) {
+	if body.A != nil {
+		if err2 := ValidateResulttypeResponseBody(body.A); err2 != nil {
+			err = goa.MergeErrors(err, err2)
+		}
+	}
+	return
+}
+
+// ValidateResulttypeResponseBody runs the validations defined on
+// ResulttypeResponseBody
+func ValidateResulttypeResponseBody(body *ResulttypeResponseBody) (err error) {
+	if err2 := ValidateRtCollectionResponseBody(body.X); err2 != nil {
+		err = goa.MergeErrors(err, err2)
+	}
+	return
+}
+
+// ValidateRtCollectionResponseBody runs the validations defined on
+// RtCollectionResponseBody
+func ValidateRtCollectionResponseBody(body RtCollectionResponseBody) (err error) {
+	for _, e := range body {
+		if e != nil {
+			if err2 := ValidateRtResponseBody(e); err2 != nil {
+				err = goa.MergeErrors(err, err2)
+			}
+		}
+	}
+	return
+}
+
+// ValidateRtResponseBody runs the validations defined on RtResponseBody
+func ValidateRtResponseBody(body *RtResponseBody) (err error) {
+	if body.X != nil {
+		if utf8.RuneCountInString(*body.X) < 5 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("body.x", *body.X, utf8.RuneCountInString(*body.X), 5, true))
+		}
+	}
+	return
+}
+`

--- a/http/codegen/client_cli.go
+++ b/http/codegen/client_cli.go
@@ -179,7 +179,7 @@ func buildFlags(svc *ServiceData, e *EndpointData) ([]*cli.FlagData, *cli.BuildF
 		if e.Payload.Request.PayloadInit != nil {
 			args := e.Payload.Request.PayloadInit.ClientArgs
 			args = append(args, e.Payload.Request.PayloadInit.CLIArgs...)
-			flags, buildFunction = makeFlags(e, args)
+			flags, buildFunction = makeFlags(e, args, e.Payload.Request.PayloadType)
 		} else if e.Payload.Ref != "" {
 			flags = append(flags, cli.NewFlagData(svcn, en, "p", e.Method.PayloadRef, e.Method.PayloadDesc, true, e.Method.PayloadEx))
 		}
@@ -188,20 +188,22 @@ func buildFlags(svc *ServiceData, e *EndpointData) ([]*cli.FlagData, *cli.BuildF
 	return flags, buildFunction
 }
 
-func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.BuildFunctionData) {
+func makeFlags(e *EndpointData, args []*InitArgData, payload expr.DataType) ([]*cli.FlagData, *cli.BuildFunctionData) {
 	var (
 		fdata     []*cli.FieldData
 		flags     = make([]*cli.FlagData, len(args))
 		params    = make([]string, len(args))
-		pInitArgs = make([]*cli.PayloadInitArgData, len(args))
+		pInitArgs = make([]*codegen.InitArgData, len(args))
 		check     bool
 	)
 	for i, arg := range args {
-		pInitArgs[i] = &cli.PayloadInitArgData{
+		pInitArgs[i] = &codegen.InitArgData{
 			Name:         arg.Name,
 			Pointer:      arg.Pointer,
 			FieldName:    arg.FieldName,
 			FieldPointer: arg.FieldPointer,
+			FieldType:    arg.FieldType,
+			Type:         arg.Type,
 		}
 
 		f := cli.NewFlagData(e.ServiceName, e.Method.Name, arg.Name, arg.TypeName, arg.Description, arg.Required, arg.Example)
@@ -210,7 +212,7 @@ func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.Buil
 		if arg.FieldName == "" && arg.Name != "body" {
 			continue
 		}
-		code, chek := cli.FieldLoadCode(f, arg.Name, arg.TypeName, arg.Validate, arg.DefaultValue)
+		code, chek := cli.FieldLoadCode(f, arg.Name, arg.TypeName, arg.Validate, arg.DefaultValue, payload)
 		check = check || chek
 		tn := arg.TypeRef
 		if f.Type == "JSON" {
@@ -232,6 +234,7 @@ func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.Buil
 		ReturnTypeAttribute: e.Payload.Request.PayloadInit.ReturnTypeAttribute,
 		ReturnIsStruct:      e.Payload.Request.PayloadInit.ReturnIsStruct,
 		ReturnTypeName:      e.Payload.Request.PayloadInit.ReturnTypeName,
+		ReturnTypePkg:       e.Payload.Request.PayloadInit.ReturnTypePkg,
 		Args:                pInitArgs,
 	}
 

--- a/http/codegen/client_encode_test.go
+++ b/http/codegen/client_encode_test.go
@@ -156,6 +156,15 @@ func TestClientEncode(t *testing.T) {
 		{"multipart-body-user-type", testdata.PayloadMultipartUserTypeDSL, testdata.PayloadMultipartBodyUserTypeEncodeCode},
 		{"multipart-body-array-type", testdata.PayloadMultipartArrayTypeDSL, testdata.PayloadMultipartBodyArrayTypeEncodeCode},
 		{"multipart-body-map-type", testdata.PayloadMultipartMapTypeDSL, testdata.PayloadMultipartBodyMapTypeEncodeCode},
+
+		// aliases
+		{"query-int-alias", testdata.QueryIntAliasDSL, testdata.QueryIntAliasEncodeCode},
+		{"query-int-alias-validate", testdata.QueryIntAliasValidateDSL, testdata.QueryIntAliasValidateEncodeCode},
+		{"query-array-alias", testdata.QueryArrayAliasDSL, testdata.QueryArrayAliasEncodeCode},
+		{"query-array-alias-validate", testdata.QueryArrayAliasValidateDSL, testdata.QueryArrayAliasValidateEncodeCode},
+		{"query-map-alias", testdata.QueryMapAliasDSL, testdata.QueryMapAliasEncodeCode},
+		{"query-map-alias-validate", testdata.QueryMapAliasValidateDSL, testdata.QueryMapAliasValidateEncodeCode},
+		{"query-array-nested-alias-validate", testdata.QueryArrayNestedAliasValidateDSL, testdata.QueryArrayNestedAliasValidateEncodeCode},
 	}
 	golden := makeGolden(t, "testdata/payload_encode_functions.go")
 	if golden != nil {

--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -188,6 +188,9 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 					Name:   "client-result-init",
 					Source: clientTypeInitT,
 					Data:   init,
+					FuncMap: map[string]interface{}{
+						"fieldCode": fieldCode,
+					},
 				})
 			}
 		}
@@ -200,6 +203,9 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 						Name:   "client-error-result-init",
 						Source: clientTypeInitT,
 						Data:   init,
+						FuncMap: map[string]interface{}{
+							"fieldCode": fieldCode,
+						},
 					})
 				}
 			}
@@ -229,31 +235,20 @@ func {{ .Name }}({{ range .ClientArgs }}{{ .Name }} {{.TypeRef }}, {{ end }}) {{
 // input: InitData
 const clientTypeInitT = `{{ comment .Description }}
 func {{ .Name }}({{- range .ClientArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
-	{{- if .ClientCode }}
-		{{ .ClientCode }}
-		{{- if .ReturnTypeAttribute }}
+{{- if .ClientCode }}
+	{{ .ClientCode }}
+	{{- if .ReturnTypeAttribute }}
 		res := &{{ .ReturnTypeName }}{
 			{{ .ReturnTypeAttribute }}: {{ if .ReturnIsPrimitivePointer }}&{{ end }}v,
 		}
-		{{- end }}
-		{{- if .ReturnIsStruct }}
-			{{- range .ClientArgs }}
-				{{- if .FieldName }}
-			{{ if $.ReturnTypeAttribute }}res{{ else }}v{{ end }}.{{ .FieldName }} = {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }}
-				{{- end }}
-			{{- end }}
-		{{- end }}
-		return {{ if .ReturnTypeAttribute }}res{{ else }}v{{ end }}
-	{{- else }}
-		{{- if .ReturnIsStruct }}
-			return &{{ .ReturnTypeName }}{
-			{{- range .ClientArgs }}
-				{{- if .FieldName }}
-				{{ .FieldName }}: {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }},
-				{{- end }}
-			{{- end }}
-			}
-		{{- end }}
-	{{ end -}}
+	{{- end }}
+{{- end }}
+{{- if .ReturnIsStruct }}
+	{{- if not .ClientCode }}
+	{{ if .ReturnTypeAttribute }}res{{ else }}v{{ end }} := &{{ .ReturnTypeName }}{}
+	{{- end }}
+	{{ fieldCode . "client" }}
+{{- end }}
+	return {{ if .ReturnTypeAttribute }}res{{ else }}v{{ end }}
 }
 `

--- a/http/codegen/server_decode_test.go
+++ b/http/codegen/server_decode_test.go
@@ -172,6 +172,17 @@ func TestDecode(t *testing.T) {
 		{"multipart-body-array-type", testdata.PayloadMultipartArrayTypeDSL, testdata.PayloadMultipartArrayTypeDecodeCode},
 		{"multipart-body-map-type", testdata.PayloadMultipartMapTypeDSL, testdata.PayloadMultipartMapTypeDecodeCode},
 		{"with-params-and-headers-dsl", testdata.WithParamsAndHeadersBlockDSL, testdata.WithParamsAndHeadersBlockDecodeCode},
+
+		// aliases
+		{"query-int-alias", testdata.QueryIntAliasDSL, testdata.QueryIntAliasDecodeCode},
+		{"query-int-alias-validate", testdata.QueryIntAliasValidateDSL, testdata.QueryIntAliasValidateDecodeCode},
+		{"query-array-alias", testdata.QueryArrayAliasDSL, testdata.QueryArrayAliasDecodeCode},
+		{"query-array-alias-validate", testdata.QueryArrayAliasValidateDSL, testdata.QueryArrayAliasValidateDecodeCode},
+		{"query-map-alias", testdata.QueryMapAliasDSL, testdata.QueryMapAliasDecodeCode},
+		{"query-map-alias-validate", testdata.QueryMapAliasValidateDSL, testdata.QueryMapAliasValidateDecodeCode},
+		{"query-array-nested-alias-validate", testdata.QueryArrayNestedAliasValidateDSL, testdata.QueryArrayNestedAliasValidateDecodeCode},
+		{"header-int-alias", testdata.HeaderIntAliasDSL, testdata.HeaderIntAliasDecodeCode},
+		{"path-int-alias", testdata.PathIntAliasDSL, testdata.PathIntAliasDecodeCode},
 	}
 	golden := makeGolden(t, "testdata/payload_decode_functions.go")
 	if golden != nil {

--- a/http/codegen/server_types_test.go
+++ b/http/codegen/server_types_test.go
@@ -19,6 +19,8 @@ func TestServerTypes(t *testing.T) {
 		{"mixed-payload-attrs", testdata.MixedPayloadInBodyDSL, MixedPayloadInBodyServerTypesFile},
 		{"multiple-methods", testdata.MultipleMethodsDSL, MultipleMethodsServerTypesFile},
 		{"payload-extend-validate", testdata.PayloadExtendedValidateDSL, PayloadExtendedValidateServerTypesFile},
+		{"result-type-validate", testdata.ResultTypeValidateDSL, ResultTypeValidateServerTypesFile},
+		{"with-result-collection", testdata.ResultWithResultCollectionDSL, ResultWithResultCollectionServerTypesFile},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -76,6 +78,7 @@ func NewMethodAAPayload(body *MethodARequestBody) *servicemixedpayloadinbody.APa
 	if body.DupObj != nil {
 		v.DupObj = unmarshalBPayloadRequestBodyToServicemixedpayloadinbodyBPayload(body.DupObj)
 	}
+
 	return v
 }
 
@@ -135,6 +138,7 @@ func NewMethodAAPayload(body *MethodARequestBody) *servicemultiplemethods.APaylo
 	v := &servicemultiplemethods.APayload{
 		A: body.A,
 	}
+
 	return v
 }
 
@@ -146,6 +150,7 @@ func NewMethodBPayloadType(body *MethodBRequestBody) *servicemultiplemethods.Pay
 		B: body.B,
 	}
 	v.C = unmarshalAPayloadRequestBodyToServicemultiplemethodsAPayload(body.C)
+
 	return v
 }
 
@@ -205,6 +210,7 @@ func NewMethodQueryStringExtendedValidatePayloadPayload(body *MethodQueryStringE
 	}
 	v.Q = q
 	v.H = h
+
 	return v
 }
 
@@ -215,5 +221,55 @@ func ValidateMethodQueryStringExtendedValidatePayloadRequestBody(body *MethodQue
 		err = goa.MergeErrors(err, goa.MissingFieldError("body", "body"))
 	}
 	return
+}
+`
+
+const ResultTypeValidateServerTypesFile = `// MethodResultTypeValidateResponseBody is the type of the
+// "ServiceResultTypeValidate" service "MethodResultTypeValidate" endpoint HTTP
+// response body.
+type MethodResultTypeValidateResponseBody struct {
+	A *string ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
+}
+
+// NewMethodResultTypeValidateResponseBody builds the HTTP response body from
+// the result of the "MethodResultTypeValidate" endpoint of the
+// "ServiceResultTypeValidate" service.
+func NewMethodResultTypeValidateResponseBody(res *serviceresulttypevalidate.ResultType) *MethodResultTypeValidateResponseBody {
+	body := &MethodResultTypeValidateResponseBody{
+		A: res.A,
+	}
+	return body
+}
+`
+
+const ResultWithResultCollectionServerTypesFile = `// MethodResultWithResultCollectionResponseBody is the type of the
+// "ServiceResultWithResultCollection" service
+// "MethodResultWithResultCollection" endpoint HTTP response body.
+type MethodResultWithResultCollectionResponseBody struct {
+	A *ResulttypeResponseBody ` + "`" + `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"` + "`" + `
+}
+
+// ResulttypeResponseBody is used to define fields on response body types.
+type ResulttypeResponseBody struct {
+	X RtCollectionResponseBody ` + "`" + `form:"x,omitempty" json:"x,omitempty" xml:"x,omitempty"` + "`" + `
+}
+
+// RtCollectionResponseBody is used to define fields on response body types.
+type RtCollectionResponseBody []*RtResponseBody
+
+// RtResponseBody is used to define fields on response body types.
+type RtResponseBody struct {
+	X *string ` + "`" + `form:"x,omitempty" json:"x,omitempty" xml:"x,omitempty"` + "`" + `
+}
+
+// NewMethodResultWithResultCollectionResponseBody builds the HTTP response
+// body from the result of the "MethodResultWithResultCollection" endpoint of
+// the "ServiceResultWithResultCollection" service.
+func NewMethodResultWithResultCollectionResponseBody(res *serviceresultwithresultcollection.MethodResultWithResultCollectionResult) *MethodResultWithResultCollectionResponseBody {
+	body := &MethodResultWithResultCollectionResponseBody{}
+	if res.A != nil {
+		body.A = marshalServiceresultwithresultcollectionResulttypeToResulttypeResponseBody(res.A)
+	}
+	return body
 }
 `

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -22,7 +22,15 @@ var (
 	// pathInitTmpl is the template used to render path constructors code.
 	pathInitTmpl = template.Must(template.New("path-init").Funcs(template.FuncMap{"goify": codegen.Goify}).Parse(pathInitT))
 	// requestInitTmpl is the template used to render request constructors.
-	requestInitTmpl = template.Must(template.New("request-init").Parse(requestInitT))
+	requestInitTmpl = template.Must(template.New("request-init").Funcs(template.FuncMap{
+		"goTypeRef": func(dt expr.DataType, svc string) string {
+			return service.Services.Get(svc).Scope.GoTypeRef(&expr.AttributeExpr{Type: dt})
+		},
+		"isAliased": func(dt expr.DataType) bool {
+			_, ok := dt.(expr.UserType)
+			return ok
+		},
+	}).Parse(requestInitT))
 )
 
 type (
@@ -253,6 +261,8 @@ type (
 		// PayloadInit contains the data required to render the
 		// payload constructor used by server code if any.
 		PayloadInit *InitData
+		// PayloadType is the type of the payload.
+		PayloadType expr.DataType
 		// PayloadAttr sets the request body from the specified payload type
 		// attribute. This field is set when the design uses Body("name") syntax
 		// to set the request body and the payload type is an object.
@@ -352,6 +362,9 @@ type (
 		// ReturnIsPrimitivePointer indicates whether the return type is
 		// a primitive pointer.
 		ReturnIsPrimitivePointer bool
+		// ReturnTypePkg is the package where the return type is
+		// present.
+		ReturnTypePkg string
 		// ServerCode is the code that builds the payload from the
 		// request on the server when it contains user types.
 		ServerCode string
@@ -375,10 +388,15 @@ type (
 		// FieldPointer if true indicates that the data structure field is a
 		// pointer.
 		FieldPointer bool
+		// FieldType is the type of the data structure field that should
+		// be initialized with the argument if any.
+		FieldType expr.DataType
 		// TypeName is the argument type name.
 		TypeName string
 		// TypeRef is the argument type reference.
 		TypeRef string
+		// Type is the argument type. It is never an aliased user type.
+		Type expr.DataType
 		// Pointer is true if a pointer to the arg should be used.
 		Pointer bool
 		// Required is true if the arg is required to build the payload.
@@ -417,6 +435,8 @@ type (
 		// FieldPointer if true indicates that the struct field that holds the
 		// param value is a pointer.
 		FieldPointer bool
+		// FieldType is the type of the struct field.
+		FieldType expr.DataType
 		// VarName is the name of the Go variable used to read or
 		// convert the param value.
 		VarName string
@@ -467,6 +487,8 @@ type (
 		// FieldName is the name of the struct field that holds the
 		// header value if any, empty string otherwise.
 		FieldName string
+		// FieldType is the type of the struct field.
+		FieldType expr.DataType
 		// FieldPointer if true indicates that the struct field that holds the
 		// header value is a pointer.
 		FieldPointer bool
@@ -681,7 +703,9 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 					i++
 					name := fmt.Sprintf("%s%sPath%s", ep.VarName, svc.StructName, suffix)
 					for j, arg := range params {
-						att := pathParamsObj.Attribute(arg)
+						patt := pathParamsObj.Attribute(arg)
+						att := expr.DupAtt(patt)
+						makeHTTPType(att)
 						pointer := a.Params.IsPrimitivePointer(arg, true)
 						name := rd.Scope.Name(codegen.Goify(arg, false))
 						var vcode string
@@ -694,8 +718,10 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 							Description: att.Description,
 							Ref:         name,
 							FieldName:   codegen.Goify(arg, true),
+							FieldType:   patt.Type,
 							TypeName:    rd.Scope.GoTypeName(att),
 							TypeRef:     rd.Scope.GoTypeRef(att),
+							Type:        att.Type,
 							Pointer:     pointer,
 							Required:    true,
 							Example:     att.Example(expr.Root.API.Random()),
@@ -778,6 +804,7 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 			{
 				name = fmt.Sprintf("Build%sRequest", ep.VarName)
 				s := codegen.NewNameScope()
+				s.Unique("c") // 'c' is reserved as the client's receiver name.
 				for _, ca := range routes[0].PathInit.ClientArgs {
 					if ca.FieldName != "" {
 						ca.Name = s.Unique(ca.Name)
@@ -912,10 +939,57 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 	return rd
 }
 
+// makeHTTPType traverses the attribute recursively and performs these actions
+//
+// * removes aliased user type by replacing them with the underlying type
+//
+func makeHTTPType(att *expr.AttributeExpr, seen ...map[string]struct{}) {
+	if att == nil {
+		return
+	}
+	switch dt := att.Type.(type) {
+	case expr.UserType:
+		if _, ok := dt.(*expr.ResultTypeExpr); !ok && !expr.IsObject(dt) {
+			// Aliased user type. Use the underlying aliased type instead of
+			// generating new types in the client and server packages
+			att.Type = dt.Attribute().Type
+			if v := dt.Attribute().Validation; v != nil {
+				if att.Validation == nil {
+					att.Validation = v
+				} else {
+					att.Validation.Merge(v)
+				}
+			}
+		}
+		var s map[string]struct{}
+		if len(seen) > 0 {
+			s = seen[0]
+		} else {
+			s = make(map[string]struct{})
+			seen = append(seen, s)
+		}
+		if _, ok := s[dt.ID()]; ok {
+			return
+		}
+		s[dt.ID()] = struct{}{}
+		makeHTTPType(dt.Attribute(), seen...)
+	case *expr.Array:
+		makeHTTPType(dt.ElemType, seen...)
+	case *expr.Map:
+		makeHTTPType(dt.KeyType, seen...)
+		makeHTTPType(dt.ElemType, seen...)
+	case *expr.Object:
+		for _, nat := range *dt {
+			makeHTTPType(nat.Attribute, seen...)
+		}
+	}
+}
+
 // buildPayloadData returns the data structure used to describe the endpoint
 // payload including the HTTP request details. It also returns the user types
 // used by the request body type recursively if any.
 func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
+	makeHTTPType(e.Body)
 	var (
 		payload    = e.MethodExpr.Payload
 		svc        = sd.Service
@@ -958,6 +1032,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 					Name:           name,
 					VarName:        varn,
 					FieldName:      fieldName,
+					FieldType:      pAtt.Type,
 					Required:       required,
 					Type:           pAtt.Type,
 					TypeName:       sd.Scope.GoTypeName(pAtt),
@@ -1012,6 +1087,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			ServerBody:   serverBodyData,
 			ClientBody:   clientBodyData,
 			PayloadAttr:  codegen.Goify(origin, true),
+			PayloadType:  e.MethodExpr.Payload.Type,
 			MustValidate: mustValidate,
 			Multipart:    e.MultipartRequest,
 		}
@@ -1055,8 +1131,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			serverArgs = []*InitArgData{{
 				Name:     "body",
 				Ref:      sd.Scope.GoVar("body", body),
-				TypeName: sd.Scope.GoTypeName(&expr.AttributeExpr{Type: body}),
-				TypeRef:  sd.Scope.GoTypeRef(&expr.AttributeExpr{Type: body}),
+				TypeName: sd.Scope.GoTypeName(e.Body),
+				TypeRef:  sd.Scope.GoTypeRef(e.Body),
+				Type:     body,
 				Required: true,
 				Example:  e.Body.Example(expr.Root.API.Random()),
 				Validate: svcode,
@@ -1064,8 +1141,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			clientArgs = []*InitArgData{{
 				Name:     "body",
 				Ref:      sd.Scope.GoVar("body", body),
-				TypeName: sd.Scope.GoTypeName(&expr.AttributeExpr{Type: body}),
-				TypeRef:  sd.Scope.GoTypeRef(&expr.AttributeExpr{Type: body}),
+				TypeName: sd.Scope.GoTypeName(e.Body),
+				TypeRef:  sd.Scope.GoTypeRef(e.Body),
+				Type:     body,
 				Required: true,
 				Example:  e.Body.Example(expr.Root.API.Random()),
 				Validate: cvcode,
@@ -1079,8 +1157,10 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 				Ref:          p.VarName,
 				FieldName:    p.FieldName,
 				FieldPointer: p.FieldPointer,
+				FieldType:    p.FieldType,
 				TypeName:     p.TypeName,
 				TypeRef:      p.TypeRef,
+				Type:         p.Type,
 				Pointer:      p.Pointer,
 				Required:     p.Required,
 				Validate:     p.Validate,
@@ -1093,8 +1173,10 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 				Ref:          p.VarName,
 				FieldName:    p.FieldName,
 				FieldPointer: p.FieldPointer,
+				FieldType:    p.FieldType,
 				TypeName:     p.TypeName,
 				TypeRef:      p.TypeRef,
+				Type:         p.Type,
 				Pointer:      p.Pointer,
 				Required:     p.Required,
 				DefaultValue: p.DefaultValue,
@@ -1108,8 +1190,10 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 				Ref:          h.VarName,
 				FieldName:    h.FieldName,
 				FieldPointer: h.FieldPointer,
+				FieldType:    h.FieldType,
 				TypeName:     h.TypeName,
 				TypeRef:      h.TypeRef,
+				Type:         h.Type,
 				Pointer:      h.Pointer,
 				Required:     h.Required,
 				DefaultValue: h.DefaultValue,
@@ -1136,11 +1220,13 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 						Name:         sc.UsernameAttr,
 						FieldName:    sc.UsernameField,
 						FieldPointer: sc.UsernamePointer,
+						FieldType:    uatt.Type,
 						Description:  uatt.Description,
 						Ref:          sc.UsernameAttr,
 						Required:     sc.UsernameRequired,
 						TypeName:     svc.Scope.GoTypeName(uatt),
 						TypeRef:      uref,
+						Type:         uatt.Type,
 						Pointer:      sc.UsernamePointer,
 						Validate:     codegen.RecursiveValidationCode(uatt, httpsvrctx, sc.UsernameRequired, sc.UsernameAttr),
 						Example:      uatt.Example(expr.Root.API.Random()),
@@ -1154,11 +1240,13 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 						Name:         sc.PasswordAttr,
 						FieldName:    sc.PasswordField,
 						FieldPointer: sc.PasswordPointer,
+						FieldType:    patt.Type,
 						Description:  patt.Description,
 						Ref:          sc.PasswordAttr,
 						Required:     sc.PasswordRequired,
 						TypeName:     svc.Scope.GoTypeName(patt),
 						TypeRef:      pref,
+						Type:         patt.Type,
 						Pointer:      sc.PasswordPointer,
 						Validate:     codegen.RecursiveValidationCode(patt, httpsvrctx, sc.PasswordRequired, sc.PasswordAttr),
 						Example:      patt.Example(expr.Root.API.Random()),
@@ -1230,6 +1318,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			ReturnTypeRef:       svc.Scope.GoFullTypeRef(payload, svc.PkgName),
 			ReturnIsStruct:      isObject,
 			ReturnTypeAttribute: codegen.Goify(origin, true),
+			ReturnTypePkg:       svc.PkgName,
 			ServerCode:          serverCode,
 			ClientCode:          clientCode,
 		}
@@ -1341,6 +1430,7 @@ func buildResponses(e *expr.HTTPEndpointExpr, result *expr.AttributeExpr, viewed
 		}
 		notag := -1
 		for i, resp := range e.Responses {
+			makeHTTPType(resp.Body)
 			if resp.Tag[0] == "" {
 				if notag > -1 {
 					continue // we don't want more than one response with no tag
@@ -1498,9 +1588,11 @@ func buildResponses(e *expr.HTTPEndpointExpr, result *expr.AttributeExpr, viewed
 								Ref:          h.VarName,
 								FieldName:    h.FieldName,
 								FieldPointer: h.FieldPointer,
+								FieldType:    h.FieldType,
 								Required:     h.Required,
 								Pointer:      h.Pointer,
 								TypeRef:      h.TypeRef,
+								Type:         h.Type,
 								Validate:     h.Validate,
 								Example:      h.Example,
 							})
@@ -1514,6 +1606,7 @@ func buildResponses(e *expr.HTTPEndpointExpr, result *expr.AttributeExpr, viewed
 						ReturnTypeRef:            tref,
 						ReturnIsStruct:           expr.IsObject(result.Type),
 						ReturnTypeAttribute:      codegen.Goify(origin, true),
+						ReturnTypePkg:            svc.PkgName,
 						ReturnIsPrimitivePointer: pointer,
 						ClientCode:               code,
 					}
@@ -1604,7 +1697,9 @@ func buildErrorsData(e *expr.HTTPEndpointExpr, sd *ServiceData) []*ErrorGroupDat
 						Ref:          h.VarName,
 						FieldName:    h.FieldName,
 						FieldPointer: false,
+						FieldType:    h.FieldType,
 						TypeRef:      h.TypeRef,
+						Type:         h.Type,
 						Validate:     h.Validate,
 						Example:      h.Example,
 					})
@@ -1653,6 +1748,7 @@ func buildErrorsData(e *expr.HTTPEndpointExpr, sd *ServiceData) []*ErrorGroupDat
 				ReturnTypeRef:       svc.Scope.GoFullTypeRef(v.ErrorExpr.AttributeExpr, svc.PkgName),
 				ReturnIsStruct:      expr.IsObject(v.ErrorExpr.Type),
 				ReturnTypeAttribute: codegen.Goify(origin, true),
+				ReturnTypePkg:       svc.PkgName,
 				ClientCode:          code,
 			}
 		}
@@ -1768,6 +1864,7 @@ func buildStreamData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData
 			svrRecvTypeRef = sd.Scope.GoFullTypeRef(e.MethodExpr.StreamingPayload, svc.PkgName)
 			svrPayload = buildRequestBodyType(e.StreamingBody, e.MethodExpr.StreamingPayload, e, true, sd)
 			if needInit(e.MethodExpr.StreamingPayload.Type) {
+				makeHTTPType(e.StreamingBody)
 				body := e.StreamingBody.Type
 				// generate constructor function to transform request body,
 				// into the method streaming payload type
@@ -1811,6 +1908,7 @@ func buildStreamData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData
 							Ref:      ref,
 							TypeName: sd.Scope.GoTypeName(e.StreamingBody),
 							TypeRef:  sd.Scope.GoTypeRef(e.StreamingBody),
+							Type:     e.StreamingBody.Type,
 							Required: true,
 							Example:  e.Body.Example(expr.Root.API.Random()),
 							Validate: svcode,
@@ -1835,6 +1933,7 @@ func buildStreamData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData
 					ReturnTypeName: svc.Scope.GoFullTypeName(e.MethodExpr.StreamingPayload, svc.PkgName),
 					ReturnTypeRef:  svc.Scope.GoFullTypeRef(e.MethodExpr.StreamingPayload, svc.PkgName),
 					ReturnIsStruct: expr.IsObject(e.MethodExpr.StreamingPayload.Type),
+					ReturnTypePkg:  svc.PkgName,
 					ServerCode:     serverCode,
 				}
 			}
@@ -1939,7 +2038,8 @@ func buildRequestBodyType(body, att *expr.AttributeExpr, e *expr.HTTPEndpointExp
 			}
 		} else {
 			varname = sd.Scope.GoTypeRef(body)
-			validateRef = codegen.RecursiveValidationCode(body, httpctx, true, "body")
+			ctx := codegen.NewAttributeContext(false, false, !svr, "", sd.Scope)
+			validateRef = codegen.RecursiveValidationCode(body, ctx, true, "body")
 			desc = body.Description
 		}
 	}
@@ -1981,6 +2081,7 @@ func buildRequestBodyType(body, att *expr.AttributeExpr, e *expr.HTTPEndpointExp
 				Name:     sourceVar,
 				Ref:      sourceVar,
 				TypeRef:  svc.Scope.GoFullTypeRef(att, svc.PkgName),
+				Type:     att.Type,
 				Validate: validateDef,
 				Example:  att.Example(expr.Root.API.Random()),
 			}
@@ -2168,6 +2269,7 @@ func buildResponseBodyType(body, att *expr.AttributeExpr, e *expr.HTTPEndpointEx
 				Name:     sourceVar,
 				Ref:      ref,
 				TypeRef:  tref,
+				Type:     att.Type,
 				Validate: validateDef,
 				Example:  att.Example(expr.Root.API.Random()),
 			}
@@ -2198,21 +2300,29 @@ func buildResponseBodyType(body, att *expr.AttributeExpr, e *expr.HTTPEndpointEx
 func extractPathParams(a *expr.MappedAttributeExpr, service *expr.AttributeExpr, scope *codegen.NameScope) []*ParamData {
 	var params []*ParamData
 	codegen.WalkMappedAttr(a, func(name, elem string, _ bool, c *expr.AttributeExpr) error {
+		makeHTTPType(c)
 		var (
 			varn = scope.Name(codegen.Goify(name, false))
 			arr  = expr.AsArray(c.Type)
 			ctx  = serviceContext("", scope)
+			ft   = service.Type
+
+			fptr bool
 		)
 		fieldName := codegen.Goify(name, true)
 		if !expr.IsObject(service.Type) {
 			fieldName = ""
+		} else {
+			fptr = service.IsPrimitivePointer(name, true)
+			ft = service.Find(name).Type
 		}
 		params = append(params, &ParamData{
 			Name:           elem,
 			AttributeName:  name,
 			Description:    c.Description,
 			FieldName:      fieldName,
-			FieldPointer:   expr.IsObject(service.Type) && service.IsPrimitivePointer(name, true),
+			FieldPointer:   fptr,
+			FieldType:      ft,
 			VarName:        varn,
 			Required:       true,
 			Type:           c.Type,
@@ -2236,14 +2346,17 @@ func extractPathParams(a *expr.MappedAttributeExpr, service *expr.AttributeExpr,
 func extractQueryParams(a *expr.MappedAttributeExpr, service *expr.AttributeExpr, scope *codegen.NameScope) []*ParamData {
 	var params []*ParamData
 	codegen.WalkMappedAttr(a, func(name, elem string, required bool, c *expr.AttributeExpr) error {
+		makeHTTPType(c)
 		var (
 			varn    = scope.Name(codegen.Goify(name, false))
 			arr     = expr.AsArray(c.Type)
 			mp      = expr.AsMap(c.Type)
 			typeRef = scope.GoTypeRef(c)
 			ctx     = serviceContext("", scope)
+			ft      = service.Type
 
 			pointer bool
+			fptr    bool
 		)
 		if pointer = a.IsPrimitivePointer(name, true); pointer {
 			typeRef = "*" + typeRef
@@ -2251,13 +2364,17 @@ func extractQueryParams(a *expr.MappedAttributeExpr, service *expr.AttributeExpr
 		fieldName := codegen.Goify(name, true)
 		if !expr.IsObject(service.Type) {
 			fieldName = ""
+		} else {
+			fptr = service.IsPrimitivePointer(name, true)
+			ft = service.Find(name).Type
 		}
 		params = append(params, &ParamData{
 			Name:          elem,
 			AttributeName: name,
 			Description:   c.Description,
 			FieldName:     fieldName,
-			FieldPointer:  expr.IsObject(service.Type) && service.IsPrimitivePointer(name, true),
+			FieldPointer:  fptr,
+			FieldType:     ft,
 			VarName:       varn,
 			Required:      required,
 			Type:          c.Type,
@@ -2284,26 +2401,30 @@ func extractQueryParams(a *expr.MappedAttributeExpr, service *expr.AttributeExpr
 func extractHeaders(a *expr.MappedAttributeExpr, svcAtt *expr.AttributeExpr, svcCtx *codegen.AttributeContext, scope *codegen.NameScope) []*HeaderData {
 	var headers []*HeaderData
 	codegen.WalkMappedAttr(a, func(name, elem string, required bool, _ *expr.AttributeExpr) error {
-		var (
-			hattr *expr.AttributeExpr
-		)
+		var hattr *expr.AttributeExpr
 		{
 			if hattr = svcAtt.Find(name); hattr == nil {
 				hattr = svcAtt
 			}
+			hattr = expr.DupAtt(hattr)
+			makeHTTPType(hattr)
 		}
 		var (
 			varn    = scope.Name(codegen.Goify(name, false))
 			arr     = expr.AsArray(hattr.Type)
 			typeRef = scope.GoTypeRef(hattr)
+			ft      = svcAtt.Type
 
 			fieldName string
 			pointer   bool
+			fptr      bool
 		)
 		{
 			pointer = a.IsPrimitivePointer(name, true)
 			if expr.IsObject(svcAtt.Type) {
 				fieldName = codegen.Goify(name, true)
+				fptr = svcCtx.IsPrimitivePointer(name, svcAtt)
+				ft = svcAtt.Find(name).Type
 			}
 			if pointer {
 				typeRef = "*" + typeRef
@@ -2315,7 +2436,8 @@ func extractHeaders(a *expr.MappedAttributeExpr, svcAtt *expr.AttributeExpr, svc
 			Description:   hattr.Description,
 			CanonicalName: http.CanonicalHeaderKey(elem),
 			FieldName:     fieldName,
-			FieldPointer:  expr.IsObject(svcAtt.Type) && svcCtx.IsPrimitivePointer(name, svcAtt),
+			FieldPointer:  fptr,
+			FieldType:     ft,
 			VarName:       varn,
 			TypeName:      scope.GoTypeName(hattr),
 			TypeRef:       typeRef,
@@ -2394,7 +2516,11 @@ func attributeTypeData(ut expr.UserType, req, ptr, server bool, rd *ServiceData)
 			ctx = "response"
 		}
 		desc = name + " is used to define fields on " + ctx + " body types."
-		validate = codegen.RecursiveValidationCode(ut.Attribute(), hctx, true, "body")
+		if req || !req && !server {
+			// generate validations for responses client-side and for
+			// requests server-side and CLI
+			validate = codegen.RecursiveValidationCode(ut.Attribute(), hctx, true, "body")
+		}
 		if validate != "" {
 			validateRef = fmt.Sprintf("err = Validate%s(v)", name)
 		}
@@ -2425,11 +2551,7 @@ func attributeTypeData(ut expr.UserType, req, ptr, server bool, rd *ServiceData)
 //
 func httpContext(pkg string, scope *codegen.NameScope, request, svr bool) *codegen.AttributeContext {
 	marshal := !request && svr || request && !svr
-	ptr := false
-	if !marshal {
-		ptr = true
-	}
-	return codegen.NewAttributeContext(ptr, false, marshal, pkg, scope)
+	return codegen.NewAttributeContext(!marshal, false, marshal, pkg, scope)
 }
 
 // serviceContext returns an attribute context for service types.
@@ -2456,7 +2578,7 @@ func viewContext(pkg string, scope *codegen.NameScope) *codegen.AttributeContext
 // sourceCtx, targetCtx are the source and target attribute contexts
 //
 func unmarshal(source, target *expr.AttributeExpr, sourceVar, targetVar string, sourceCtx, targetCtx *codegen.AttributeContext) (string, []*codegen.TransformFunctionData, error) {
-	return codegen.GoTransform(source, target, sourceVar, targetVar, sourceCtx, targetCtx, "unmarshal")
+	return codegen.GoTransform(source, target, sourceVar, targetVar, sourceCtx, targetCtx, "unmarshal", true)
 }
 
 // marshal initializes a data structure defined by target type from a data
@@ -2471,7 +2593,7 @@ func unmarshal(source, target *expr.AttributeExpr, sourceVar, targetVar string, 
 // sourceCtx, targetCtx are the source and target attribute contexts
 //
 func marshal(source, target *expr.AttributeExpr, sourceVar, targetVar string, sourceCtx, targetCtx *codegen.AttributeContext) (string, []*codegen.TransformFunctionData, error) {
-	return codegen.GoTransform(source, target, sourceVar, targetVar, sourceCtx, targetCtx, "marshal")
+	return codegen.GoTransform(source, target, sourceVar, targetVar, sourceCtx, targetCtx, "marshal", true)
 }
 
 // needConversion returns true if the type needs to be converted from a string.
@@ -2600,7 +2722,11 @@ const (
 		{{- if .Pointer }}
 		if p{{ if $.HasFields }}.{{ .FieldName }}{{ end }} != nil {
 		{{- end }}
+			{{- if (isAliased .FieldType) }}
+			{{ .Name }} = {{ goTypeRef .Type $.ServiceName }}({{ if .Pointer }}*{{ end }}p{{ if $.HasFields }}.{{ .FieldName }}{{ end }})
+			{{- else }}
 			{{ .Name }} = {{ if .Pointer }}*{{ end }}p{{ if $.HasFields }}.{{ .FieldName }}{{ end }}
+			{{- end }}
 		{{- if .Pointer }}
 		}
 		{{- end }}

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -635,6 +635,7 @@ func BuildMethodMultiSimplePayloadPayload(serviceMultiSimple1MethodMultiSimplePa
 	v := &servicemultisimple1.MethodMultiSimplePayloadPayload{
 		A: body.A,
 	}
+
 	return v, nil
 }
 `
@@ -673,6 +674,7 @@ func BuildMethodMultiPayloadPayload(serviceMultiMethodMultiPayloadBody string, s
 	}
 	v.B = b
 	v.A = a
+
 	return v, nil
 }
 `
@@ -692,10 +694,10 @@ func BuildMethodQueryBoolPayload(serviceQueryBoolMethodQueryBoolQ string) (*serv
 			}
 		}
 	}
-	payload := &servicequerybool.MethodQueryBoolPayload{
-		Q: q,
-	}
-	return payload, nil
+	v := &servicequerybool.MethodQueryBoolPayload{}
+	v.Q = q
+
+	return v, nil
 }
 `
 
@@ -725,6 +727,7 @@ func BuildMethodBodyQueryPathObjectPayload(serviceBodyQueryPathObjectMethodBodyQ
 	}
 	v.C = &c2
 	v.B = b
+
 	return v, nil
 }
 `
@@ -940,10 +943,7 @@ func BuildMethodBodyInlineArrayUserPayload(serviceBodyInlineArrayUserMethodBodyI
 	}
 	v := make([]*servicebodyinlinearrayuser.ElemType, len(body))
 	for i, val := range body {
-		v[i] = &servicebodyinlinearrayuser.ElemType{
-			A: val.A,
-			B: val.B,
-		}
+		v[i] = marshalElemTypeRequestBodyToServicebodyinlinearrayuserElemType(val)
 	}
 	return v, nil
 }
@@ -962,15 +962,8 @@ func BuildMethodBodyInlineMapUserPayload(serviceBodyInlineMapUserMethodBodyInlin
 	}
 	v := make(map[*servicebodyinlinemapuser.KeyType]*servicebodyinlinemapuser.ElemType, len(body))
 	for key, val := range body {
-		tk := &servicebodyinlinemapuser.KeyType{
-			A: key.A,
-			B: key.B,
-		}
-		tv := &servicebodyinlinemapuser.ElemType{
-			A: val.A,
-			B: val.B,
-		}
-		v[tk] = tv
+		tk := marshalKeyTypeRequestBodyToServicebodyinlinemapuserKeyType(val)
+		v[tk] = marshalElemTypeRequestBodyToServicebodyinlinemapuserElemType(val)
 	}
 	return v, nil
 }
@@ -1096,6 +1089,10 @@ func BuildMethodMapQueryObjectPayload(serviceMapQueryObjectMethodMapQueryObjectB
 	var a string
 	{
 		a = serviceMapQueryObjectMethodMapQueryObjectA
+		err = goa.MergeErrors(err, goa.ValidatePattern("a", a, "patterna"))
+		if err != nil {
+			return nil, err
+		}
 	}
 	var c map[int][]string
 	{
@@ -1109,6 +1106,7 @@ func BuildMethodMapQueryObjectPayload(serviceMapQueryObjectMethodMapQueryObjectB
 	}
 	v.A = a
 	v.C = c
+
 	return v, nil
 }
 `
@@ -1129,10 +1127,10 @@ func BuildMethodQueryUInt32Payload(serviceQueryUInt32MethodQueryUInt32Q string) 
 			}
 		}
 	}
-	payload := &servicequeryuint32.MethodQueryUInt32Payload{
-		Q: q,
-	}
-	return payload, nil
+	v := &servicequeryuint32.MethodQueryUInt32Payload{}
+	v.Q = q
+
+	return v, nil
 }
 `
 
@@ -1152,10 +1150,10 @@ func BuildMethodQueryUIntPayload(serviceQueryUIntMethodQueryUIntQ string) (*serv
 			}
 		}
 	}
-	payload := &servicequeryuint.MethodQueryUIntPayload{
-		Q: q,
-	}
-	return payload, nil
+	v := &servicequeryuint.MethodQueryUIntPayload{}
+	v.Q = q
+
+	return v, nil
 }
 `
 
@@ -1168,10 +1166,10 @@ func BuildMethodQueryStringPayload(serviceQueryStringMethodQueryStringQ string) 
 			q = &serviceQueryStringMethodQueryStringQ
 		}
 	}
-	payload := &servicequerystring.MethodQueryStringPayload{
-		Q: q,
-	}
-	return payload, nil
+	v := &servicequerystring.MethodQueryStringPayload{}
+	v.Q = q
+
+	return v, nil
 }
 `
 
@@ -1181,11 +1179,17 @@ func BuildMethodQueryStringValidatePayload(serviceQueryStringValidateMethodQuery
 	var q string
 	{
 		q = serviceQueryStringValidateMethodQueryStringValidateQ
+		if !(q == "val") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []interface{}{"val"}))
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
-	payload := &servicequerystringvalidate.MethodQueryStringValidatePayload{
-		Q: q,
-	}
-	return payload, nil
+	v := &servicequerystringvalidate.MethodQueryStringValidatePayload{}
+	v.Q = q
+
+	return v, nil
 }
 `
 
@@ -1198,10 +1202,10 @@ func BuildMethodQueryStringDefaultPayload(serviceQueryStringDefaultMethodQuerySt
 			q = serviceQueryStringDefaultMethodQueryStringDefaultQ
 		}
 	}
-	payload := &servicequerystringdefault.MethodQueryStringDefaultPayload{
-		Q: q,
-	}
-	return payload, nil
+	v := &servicequerystringdefault.MethodQueryStringDefaultPayload{}
+	v.Q = q
+
+	return v, nil
 }
 `
 
@@ -1219,10 +1223,10 @@ func BuildMethodBodyPrimitiveArrayUserPayload(serviceBodyPrimitiveArrayUserMetho
 			}
 		}
 	}
-	payload := &servicebodyprimitivearrayuser.PayloadType{
-		A: a,
-	}
-	return payload, nil
+	v := &servicebodyprimitivearrayuser.PayloadType{}
+	v.A = a
+
+	return v, nil
 }
 `
 
@@ -1288,6 +1292,7 @@ func BuildMethodAPayload(serviceWithParamsAndHeadersBlockMethodABody string, ser
 	v.OptionalButRequiredParam = &optionalButRequiredParam
 	v.Required = required
 	v.OptionalButRequiredHeader = &optionalButRequiredHeader
+
 	return v, nil
 }
 `

--- a/http/codegen/testdata/payload_constructor_functions.go
+++ b/http/codegen/testdata/payload_constructor_functions.go
@@ -3,225 +3,250 @@ package testdata
 var PayloadQueryBoolConstructorCode = `// NewMethodQueryBoolPayload builds a ServiceQueryBool service MethodQueryBool
 // endpoint payload.
 func NewMethodQueryBoolPayload(q *bool) *servicequerybool.MethodQueryBoolPayload {
-	return &servicequerybool.MethodQueryBoolPayload{
-		Q: q,
-	}
+	v := &servicequerybool.MethodQueryBoolPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryBoolValidateConstructorCode = `// NewMethodQueryBoolValidatePayload builds a ServiceQueryBoolValidate service
 // MethodQueryBoolValidate endpoint payload.
 func NewMethodQueryBoolValidatePayload(q bool) *servicequeryboolvalidate.MethodQueryBoolValidatePayload {
-	return &servicequeryboolvalidate.MethodQueryBoolValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryboolvalidate.MethodQueryBoolValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryIntConstructorCode = `// NewMethodQueryIntPayload builds a ServiceQueryInt service MethodQueryInt
 // endpoint payload.
 func NewMethodQueryIntPayload(q *int) *servicequeryint.MethodQueryIntPayload {
-	return &servicequeryint.MethodQueryIntPayload{
-		Q: q,
-	}
+	v := &servicequeryint.MethodQueryIntPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryIntValidateConstructorCode = `// NewMethodQueryIntValidatePayload builds a ServiceQueryIntValidate service
 // MethodQueryIntValidate endpoint payload.
 func NewMethodQueryIntValidatePayload(q int) *servicequeryintvalidate.MethodQueryIntValidatePayload {
-	return &servicequeryintvalidate.MethodQueryIntValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryintvalidate.MethodQueryIntValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryInt32ConstructorCode = `// NewMethodQueryInt32Payload builds a ServiceQueryInt32 service
 // MethodQueryInt32 endpoint payload.
 func NewMethodQueryInt32Payload(q *int32) *servicequeryint32.MethodQueryInt32Payload {
-	return &servicequeryint32.MethodQueryInt32Payload{
-		Q: q,
-	}
+	v := &servicequeryint32.MethodQueryInt32Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryInt32ValidateConstructorCode = `// NewMethodQueryInt32ValidatePayload builds a ServiceQueryInt32Validate
 // service MethodQueryInt32Validate endpoint payload.
 func NewMethodQueryInt32ValidatePayload(q int32) *servicequeryint32validate.MethodQueryInt32ValidatePayload {
-	return &servicequeryint32validate.MethodQueryInt32ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryint32validate.MethodQueryInt32ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryInt64ConstructorCode = `// NewMethodQueryInt64Payload builds a ServiceQueryInt64 service
 // MethodQueryInt64 endpoint payload.
 func NewMethodQueryInt64Payload(q *int64) *servicequeryint64.MethodQueryInt64Payload {
-	return &servicequeryint64.MethodQueryInt64Payload{
-		Q: q,
-	}
+	v := &servicequeryint64.MethodQueryInt64Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryInt64ValidateConstructorCode = `// NewMethodQueryInt64ValidatePayload builds a ServiceQueryInt64Validate
 // service MethodQueryInt64Validate endpoint payload.
 func NewMethodQueryInt64ValidatePayload(q int64) *servicequeryint64validate.MethodQueryInt64ValidatePayload {
-	return &servicequeryint64validate.MethodQueryInt64ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryint64validate.MethodQueryInt64ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryUIntConstructorCode = `// NewMethodQueryUIntPayload builds a ServiceQueryUInt service MethodQueryUInt
 // endpoint payload.
 func NewMethodQueryUIntPayload(q *uint) *servicequeryuint.MethodQueryUIntPayload {
-	return &servicequeryuint.MethodQueryUIntPayload{
-		Q: q,
-	}
+	v := &servicequeryuint.MethodQueryUIntPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryUIntValidateConstructorCode = `// NewMethodQueryUIntValidatePayload builds a ServiceQueryUIntValidate service
 // MethodQueryUIntValidate endpoint payload.
 func NewMethodQueryUIntValidatePayload(q uint) *servicequeryuintvalidate.MethodQueryUIntValidatePayload {
-	return &servicequeryuintvalidate.MethodQueryUIntValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryuintvalidate.MethodQueryUIntValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryUInt32ConstructorCode = `// NewMethodQueryUInt32Payload builds a ServiceQueryUInt32 service
 // MethodQueryUInt32 endpoint payload.
 func NewMethodQueryUInt32Payload(q *uint32) *servicequeryuint32.MethodQueryUInt32Payload {
-	return &servicequeryuint32.MethodQueryUInt32Payload{
-		Q: q,
-	}
+	v := &servicequeryuint32.MethodQueryUInt32Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryUInt32ValidateConstructorCode = `// NewMethodQueryUInt32ValidatePayload builds a ServiceQueryUInt32Validate
 // service MethodQueryUInt32Validate endpoint payload.
 func NewMethodQueryUInt32ValidatePayload(q uint32) *servicequeryuint32validate.MethodQueryUInt32ValidatePayload {
-	return &servicequeryuint32validate.MethodQueryUInt32ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryuint32validate.MethodQueryUInt32ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryUInt64ConstructorCode = `// NewMethodQueryUInt64Payload builds a ServiceQueryUInt64 service
 // MethodQueryUInt64 endpoint payload.
 func NewMethodQueryUInt64Payload(q *uint64) *servicequeryuint64.MethodQueryUInt64Payload {
-	return &servicequeryuint64.MethodQueryUInt64Payload{
-		Q: q,
-	}
+	v := &servicequeryuint64.MethodQueryUInt64Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryUInt64ValidateConstructorCode = `// NewMethodQueryUInt64ValidatePayload builds a ServiceQueryUInt64Validate
 // service MethodQueryUInt64Validate endpoint payload.
 func NewMethodQueryUInt64ValidatePayload(q uint64) *servicequeryuint64validate.MethodQueryUInt64ValidatePayload {
-	return &servicequeryuint64validate.MethodQueryUInt64ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryuint64validate.MethodQueryUInt64ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryFloat32ConstructorCode = `// NewMethodQueryFloat32Payload builds a ServiceQueryFloat32 service
 // MethodQueryFloat32 endpoint payload.
 func NewMethodQueryFloat32Payload(q *float32) *servicequeryfloat32.MethodQueryFloat32Payload {
-	return &servicequeryfloat32.MethodQueryFloat32Payload{
-		Q: q,
-	}
+	v := &servicequeryfloat32.MethodQueryFloat32Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryFloat32ValidateConstructorCode = `// NewMethodQueryFloat32ValidatePayload builds a ServiceQueryFloat32Validate
 // service MethodQueryFloat32Validate endpoint payload.
 func NewMethodQueryFloat32ValidatePayload(q float32) *servicequeryfloat32validate.MethodQueryFloat32ValidatePayload {
-	return &servicequeryfloat32validate.MethodQueryFloat32ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryfloat32validate.MethodQueryFloat32ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryFloat64ConstructorCode = `// NewMethodQueryFloat64Payload builds a ServiceQueryFloat64 service
 // MethodQueryFloat64 endpoint payload.
 func NewMethodQueryFloat64Payload(q *float64) *servicequeryfloat64.MethodQueryFloat64Payload {
-	return &servicequeryfloat64.MethodQueryFloat64Payload{
-		Q: q,
-	}
+	v := &servicequeryfloat64.MethodQueryFloat64Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryFloat64ValidateConstructorCode = `// NewMethodQueryFloat64ValidatePayload builds a ServiceQueryFloat64Validate
 // service MethodQueryFloat64Validate endpoint payload.
 func NewMethodQueryFloat64ValidatePayload(q float64) *servicequeryfloat64validate.MethodQueryFloat64ValidatePayload {
-	return &servicequeryfloat64validate.MethodQueryFloat64ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryfloat64validate.MethodQueryFloat64ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryStringConstructorCode = `// NewMethodQueryStringPayload builds a ServiceQueryString service
 // MethodQueryString endpoint payload.
 func NewMethodQueryStringPayload(q *string) *servicequerystring.MethodQueryStringPayload {
-	return &servicequerystring.MethodQueryStringPayload{
-		Q: q,
-	}
+	v := &servicequerystring.MethodQueryStringPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryStringValidateConstructorCode = `// NewMethodQueryStringValidatePayload builds a ServiceQueryStringValidate
 // service MethodQueryStringValidate endpoint payload.
 func NewMethodQueryStringValidatePayload(q string) *servicequerystringvalidate.MethodQueryStringValidatePayload {
-	return &servicequerystringvalidate.MethodQueryStringValidatePayload{
-		Q: q,
-	}
+	v := &servicequerystringvalidate.MethodQueryStringValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryBytesConstructorCode = `// NewMethodQueryBytesPayload builds a ServiceQueryBytes service
 // MethodQueryBytes endpoint payload.
 func NewMethodQueryBytesPayload(q []byte) *servicequerybytes.MethodQueryBytesPayload {
-	return &servicequerybytes.MethodQueryBytesPayload{
-		Q: q,
-	}
+	v := &servicequerybytes.MethodQueryBytesPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryBytesValidateConstructorCode = `// NewMethodQueryBytesValidatePayload builds a ServiceQueryBytesValidate
 // service MethodQueryBytesValidate endpoint payload.
 func NewMethodQueryBytesValidatePayload(q []byte) *servicequerybytesvalidate.MethodQueryBytesValidatePayload {
-	return &servicequerybytesvalidate.MethodQueryBytesValidatePayload{
-		Q: q,
-	}
+	v := &servicequerybytesvalidate.MethodQueryBytesValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryAnyConstructorCode = `// NewMethodQueryAnyPayload builds a ServiceQueryAny service MethodQueryAny
 // endpoint payload.
 func NewMethodQueryAnyPayload(q interface{}) *servicequeryany.MethodQueryAnyPayload {
-	return &servicequeryany.MethodQueryAnyPayload{
-		Q: q,
-	}
+	v := &servicequeryany.MethodQueryAnyPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryAnyValidateConstructorCode = `// NewMethodQueryAnyValidatePayload builds a ServiceQueryAnyValidate service
 // MethodQueryAnyValidate endpoint payload.
 func NewMethodQueryAnyValidatePayload(q interface{}) *servicequeryanyvalidate.MethodQueryAnyValidatePayload {
-	return &servicequeryanyvalidate.MethodQueryAnyValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryanyvalidate.MethodQueryAnyValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayBoolConstructorCode = `// NewMethodQueryArrayBoolPayload builds a ServiceQueryArrayBool service
 // MethodQueryArrayBool endpoint payload.
 func NewMethodQueryArrayBoolPayload(q []bool) *servicequeryarraybool.MethodQueryArrayBoolPayload {
-	return &servicequeryarraybool.MethodQueryArrayBoolPayload{
-		Q: q,
-	}
+	v := &servicequeryarraybool.MethodQueryArrayBoolPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -229,36 +254,40 @@ var PayloadQueryArrayBoolValidateConstructorCode = `// NewMethodQueryArrayBoolVa
 // ServiceQueryArrayBoolValidate service MethodQueryArrayBoolValidate endpoint
 // payload.
 func NewMethodQueryArrayBoolValidatePayload(q []bool) *servicequeryarrayboolvalidate.MethodQueryArrayBoolValidatePayload {
-	return &servicequeryarrayboolvalidate.MethodQueryArrayBoolValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayboolvalidate.MethodQueryArrayBoolValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayIntConstructorCode = `// NewMethodQueryArrayIntPayload builds a ServiceQueryArrayInt service
 // MethodQueryArrayInt endpoint payload.
 func NewMethodQueryArrayIntPayload(q []int) *servicequeryarrayint.MethodQueryArrayIntPayload {
-	return &servicequeryarrayint.MethodQueryArrayIntPayload{
-		Q: q,
-	}
+	v := &servicequeryarrayint.MethodQueryArrayIntPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayIntValidateConstructorCode = `// NewMethodQueryArrayIntValidatePayload builds a ServiceQueryArrayIntValidate
 // service MethodQueryArrayIntValidate endpoint payload.
 func NewMethodQueryArrayIntValidatePayload(q []int) *servicequeryarrayintvalidate.MethodQueryArrayIntValidatePayload {
-	return &servicequeryarrayintvalidate.MethodQueryArrayIntValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayintvalidate.MethodQueryArrayIntValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayInt32ConstructorCode = `// NewMethodQueryArrayInt32Payload builds a ServiceQueryArrayInt32 service
 // MethodQueryArrayInt32 endpoint payload.
 func NewMethodQueryArrayInt32Payload(q []int32) *servicequeryarrayint32.MethodQueryArrayInt32Payload {
-	return &servicequeryarrayint32.MethodQueryArrayInt32Payload{
-		Q: q,
-	}
+	v := &servicequeryarrayint32.MethodQueryArrayInt32Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -266,18 +295,20 @@ var PayloadQueryArrayInt32ValidateConstructorCode = `// NewMethodQueryArrayInt32
 // ServiceQueryArrayInt32Validate service MethodQueryArrayInt32Validate
 // endpoint payload.
 func NewMethodQueryArrayInt32ValidatePayload(q []int32) *servicequeryarrayint32validate.MethodQueryArrayInt32ValidatePayload {
-	return &servicequeryarrayint32validate.MethodQueryArrayInt32ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayint32validate.MethodQueryArrayInt32ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayInt64ConstructorCode = `// NewMethodQueryArrayInt64Payload builds a ServiceQueryArrayInt64 service
 // MethodQueryArrayInt64 endpoint payload.
 func NewMethodQueryArrayInt64Payload(q []int64) *servicequeryarrayint64.MethodQueryArrayInt64Payload {
-	return &servicequeryarrayint64.MethodQueryArrayInt64Payload{
-		Q: q,
-	}
+	v := &servicequeryarrayint64.MethodQueryArrayInt64Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -285,18 +316,20 @@ var PayloadQueryArrayInt64ValidateConstructorCode = `// NewMethodQueryArrayInt64
 // ServiceQueryArrayInt64Validate service MethodQueryArrayInt64Validate
 // endpoint payload.
 func NewMethodQueryArrayInt64ValidatePayload(q []int64) *servicequeryarrayint64validate.MethodQueryArrayInt64ValidatePayload {
-	return &servicequeryarrayint64validate.MethodQueryArrayInt64ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayint64validate.MethodQueryArrayInt64ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayUIntConstructorCode = `// NewMethodQueryArrayUIntPayload builds a ServiceQueryArrayUInt service
 // MethodQueryArrayUInt endpoint payload.
 func NewMethodQueryArrayUIntPayload(q []uint) *servicequeryarrayuint.MethodQueryArrayUIntPayload {
-	return &servicequeryarrayuint.MethodQueryArrayUIntPayload{
-		Q: q,
-	}
+	v := &servicequeryarrayuint.MethodQueryArrayUIntPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -304,18 +337,20 @@ var PayloadQueryArrayUIntValidateConstructorCode = `// NewMethodQueryArrayUIntVa
 // ServiceQueryArrayUIntValidate service MethodQueryArrayUIntValidate endpoint
 // payload.
 func NewMethodQueryArrayUIntValidatePayload(q []uint) *servicequeryarrayuintvalidate.MethodQueryArrayUIntValidatePayload {
-	return &servicequeryarrayuintvalidate.MethodQueryArrayUIntValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayuintvalidate.MethodQueryArrayUIntValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayUInt32ConstructorCode = `// NewMethodQueryArrayUInt32Payload builds a ServiceQueryArrayUInt32 service
 // MethodQueryArrayUInt32 endpoint payload.
 func NewMethodQueryArrayUInt32Payload(q []uint32) *servicequeryarrayuint32.MethodQueryArrayUInt32Payload {
-	return &servicequeryarrayuint32.MethodQueryArrayUInt32Payload{
-		Q: q,
-	}
+	v := &servicequeryarrayuint32.MethodQueryArrayUInt32Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -323,18 +358,20 @@ var PayloadQueryArrayUInt32ValidateConstructorCode = `// NewMethodQueryArrayUInt
 // ServiceQueryArrayUInt32Validate service MethodQueryArrayUInt32Validate
 // endpoint payload.
 func NewMethodQueryArrayUInt32ValidatePayload(q []uint32) *servicequeryarrayuint32validate.MethodQueryArrayUInt32ValidatePayload {
-	return &servicequeryarrayuint32validate.MethodQueryArrayUInt32ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayuint32validate.MethodQueryArrayUInt32ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayUInt64ConstructorCode = `// NewMethodQueryArrayUInt64Payload builds a ServiceQueryArrayUInt64 service
 // MethodQueryArrayUInt64 endpoint payload.
 func NewMethodQueryArrayUInt64Payload(q []uint64) *servicequeryarrayuint64.MethodQueryArrayUInt64Payload {
-	return &servicequeryarrayuint64.MethodQueryArrayUInt64Payload{
-		Q: q,
-	}
+	v := &servicequeryarrayuint64.MethodQueryArrayUInt64Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -342,18 +379,20 @@ var PayloadQueryArrayUInt64ValidateConstructorCode = `// NewMethodQueryArrayUInt
 // ServiceQueryArrayUInt64Validate service MethodQueryArrayUInt64Validate
 // endpoint payload.
 func NewMethodQueryArrayUInt64ValidatePayload(q []uint64) *servicequeryarrayuint64validate.MethodQueryArrayUInt64ValidatePayload {
-	return &servicequeryarrayuint64validate.MethodQueryArrayUInt64ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayuint64validate.MethodQueryArrayUInt64ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayFloat32ConstructorCode = `// NewMethodQueryArrayFloat32Payload builds a ServiceQueryArrayFloat32 service
 // MethodQueryArrayFloat32 endpoint payload.
 func NewMethodQueryArrayFloat32Payload(q []float32) *servicequeryarrayfloat32.MethodQueryArrayFloat32Payload {
-	return &servicequeryarrayfloat32.MethodQueryArrayFloat32Payload{
-		Q: q,
-	}
+	v := &servicequeryarrayfloat32.MethodQueryArrayFloat32Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -361,18 +400,20 @@ var PayloadQueryArrayFloat32ValidateConstructorCode = `// NewMethodQueryArrayFlo
 // ServiceQueryArrayFloat32Validate service MethodQueryArrayFloat32Validate
 // endpoint payload.
 func NewMethodQueryArrayFloat32ValidatePayload(q []float32) *servicequeryarrayfloat32validate.MethodQueryArrayFloat32ValidatePayload {
-	return &servicequeryarrayfloat32validate.MethodQueryArrayFloat32ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayfloat32validate.MethodQueryArrayFloat32ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayFloat64ConstructorCode = `// NewMethodQueryArrayFloat64Payload builds a ServiceQueryArrayFloat64 service
 // MethodQueryArrayFloat64 endpoint payload.
 func NewMethodQueryArrayFloat64Payload(q []float64) *servicequeryarrayfloat64.MethodQueryArrayFloat64Payload {
-	return &servicequeryarrayfloat64.MethodQueryArrayFloat64Payload{
-		Q: q,
-	}
+	v := &servicequeryarrayfloat64.MethodQueryArrayFloat64Payload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -380,18 +421,20 @@ var PayloadQueryArrayFloat64ValidateConstructorCode = `// NewMethodQueryArrayFlo
 // ServiceQueryArrayFloat64Validate service MethodQueryArrayFloat64Validate
 // endpoint payload.
 func NewMethodQueryArrayFloat64ValidatePayload(q []float64) *servicequeryarrayfloat64validate.MethodQueryArrayFloat64ValidatePayload {
-	return &servicequeryarrayfloat64validate.MethodQueryArrayFloat64ValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayfloat64validate.MethodQueryArrayFloat64ValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayStringConstructorCode = `// NewMethodQueryArrayStringPayload builds a ServiceQueryArrayString service
 // MethodQueryArrayString endpoint payload.
 func NewMethodQueryArrayStringPayload(q []string) *servicequeryarraystring.MethodQueryArrayStringPayload {
-	return &servicequeryarraystring.MethodQueryArrayStringPayload{
-		Q: q,
-	}
+	v := &servicequeryarraystring.MethodQueryArrayStringPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -399,18 +442,20 @@ var PayloadQueryArrayStringValidateConstructorCode = `// NewMethodQueryArrayStri
 // ServiceQueryArrayStringValidate service MethodQueryArrayStringValidate
 // endpoint payload.
 func NewMethodQueryArrayStringValidatePayload(q []string) *servicequeryarraystringvalidate.MethodQueryArrayStringValidatePayload {
-	return &servicequeryarraystringvalidate.MethodQueryArrayStringValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarraystringvalidate.MethodQueryArrayStringValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayBytesConstructorCode = `// NewMethodQueryArrayBytesPayload builds a ServiceQueryArrayBytes service
 // MethodQueryArrayBytes endpoint payload.
 func NewMethodQueryArrayBytesPayload(q [][]byte) *servicequeryarraybytes.MethodQueryArrayBytesPayload {
-	return &servicequeryarraybytes.MethodQueryArrayBytesPayload{
-		Q: q,
-	}
+	v := &servicequeryarraybytes.MethodQueryArrayBytesPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -418,36 +463,40 @@ var PayloadQueryArrayBytesValidateConstructorCode = `// NewMethodQueryArrayBytes
 // ServiceQueryArrayBytesValidate service MethodQueryArrayBytesValidate
 // endpoint payload.
 func NewMethodQueryArrayBytesValidatePayload(q [][]byte) *servicequeryarraybytesvalidate.MethodQueryArrayBytesValidatePayload {
-	return &servicequeryarraybytesvalidate.MethodQueryArrayBytesValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarraybytesvalidate.MethodQueryArrayBytesValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayAnyConstructorCode = `// NewMethodQueryArrayAnyPayload builds a ServiceQueryArrayAny service
 // MethodQueryArrayAny endpoint payload.
 func NewMethodQueryArrayAnyPayload(q []interface{}) *servicequeryarrayany.MethodQueryArrayAnyPayload {
-	return &servicequeryarrayany.MethodQueryArrayAnyPayload{
-		Q: q,
-	}
+	v := &servicequeryarrayany.MethodQueryArrayAnyPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryArrayAnyValidateConstructorCode = `// NewMethodQueryArrayAnyValidatePayload builds a ServiceQueryArrayAnyValidate
 // service MethodQueryArrayAnyValidate endpoint payload.
 func NewMethodQueryArrayAnyValidatePayload(q []interface{}) *servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload {
-	return &servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload{
-		Q: q,
-	}
+	v := &servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryMapStringStringConstructorCode = `// NewMethodQueryMapStringStringPayload builds a ServiceQueryMapStringString
 // service MethodQueryMapStringString endpoint payload.
 func NewMethodQueryMapStringStringPayload(q map[string]string) *servicequerymapstringstring.MethodQueryMapStringStringPayload {
-	return &servicequerymapstringstring.MethodQueryMapStringStringPayload{
-		Q: q,
-	}
+	v := &servicequerymapstringstring.MethodQueryMapStringStringPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -455,18 +504,20 @@ var PayloadQueryMapStringStringValidateConstructorCode = `// NewMethodQueryMapSt
 // ServiceQueryMapStringStringValidate service
 // MethodQueryMapStringStringValidate endpoint payload.
 func NewMethodQueryMapStringStringValidatePayload(q map[string]string) *servicequerymapstringstringvalidate.MethodQueryMapStringStringValidatePayload {
-	return &servicequerymapstringstringvalidate.MethodQueryMapStringStringValidatePayload{
-		Q: q,
-	}
+	v := &servicequerymapstringstringvalidate.MethodQueryMapStringStringValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryMapStringBoolConstructorCode = `// NewMethodQueryMapStringBoolPayload builds a ServiceQueryMapStringBool
 // service MethodQueryMapStringBool endpoint payload.
 func NewMethodQueryMapStringBoolPayload(q map[string]bool) *servicequerymapstringbool.MethodQueryMapStringBoolPayload {
-	return &servicequerymapstringbool.MethodQueryMapStringBoolPayload{
-		Q: q,
-	}
+	v := &servicequerymapstringbool.MethodQueryMapStringBoolPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -474,18 +525,20 @@ var PayloadQueryMapStringBoolValidateConstructorCode = `// NewMethodQueryMapStri
 // ServiceQueryMapStringBoolValidate service MethodQueryMapStringBoolValidate
 // endpoint payload.
 func NewMethodQueryMapStringBoolValidatePayload(q map[string]bool) *servicequerymapstringboolvalidate.MethodQueryMapStringBoolValidatePayload {
-	return &servicequerymapstringboolvalidate.MethodQueryMapStringBoolValidatePayload{
-		Q: q,
-	}
+	v := &servicequerymapstringboolvalidate.MethodQueryMapStringBoolValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryMapBoolStringConstructorCode = `// NewMethodQueryMapBoolStringPayload builds a ServiceQueryMapBoolString
 // service MethodQueryMapBoolString endpoint payload.
 func NewMethodQueryMapBoolStringPayload(q map[bool]string) *servicequerymapboolstring.MethodQueryMapBoolStringPayload {
-	return &servicequerymapboolstring.MethodQueryMapBoolStringPayload{
-		Q: q,
-	}
+	v := &servicequerymapboolstring.MethodQueryMapBoolStringPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -493,18 +546,20 @@ var PayloadQueryMapBoolStringValidateConstructorCode = `// NewMethodQueryMapBool
 // ServiceQueryMapBoolStringValidate service MethodQueryMapBoolStringValidate
 // endpoint payload.
 func NewMethodQueryMapBoolStringValidatePayload(q map[bool]string) *servicequerymapboolstringvalidate.MethodQueryMapBoolStringValidatePayload {
-	return &servicequerymapboolstringvalidate.MethodQueryMapBoolStringValidatePayload{
-		Q: q,
-	}
+	v := &servicequerymapboolstringvalidate.MethodQueryMapBoolStringValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryMapBoolBoolConstructorCode = `// NewMethodQueryMapBoolBoolPayload builds a ServiceQueryMapBoolBool service
 // MethodQueryMapBoolBool endpoint payload.
 func NewMethodQueryMapBoolBoolPayload(q map[bool]bool) *servicequerymapboolbool.MethodQueryMapBoolBoolPayload {
-	return &servicequerymapboolbool.MethodQueryMapBoolBoolPayload{
-		Q: q,
-	}
+	v := &servicequerymapboolbool.MethodQueryMapBoolBoolPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -512,9 +567,10 @@ var PayloadQueryMapBoolBoolValidateConstructorCode = `// NewMethodQueryMapBoolBo
 // ServiceQueryMapBoolBoolValidate service MethodQueryMapBoolBoolValidate
 // endpoint payload.
 func NewMethodQueryMapBoolBoolValidatePayload(q map[bool]bool) *servicequerymapboolboolvalidate.MethodQueryMapBoolBoolValidatePayload {
-	return &servicequerymapboolboolvalidate.MethodQueryMapBoolBoolValidatePayload{
-		Q: q,
-	}
+	v := &servicequerymapboolboolvalidate.MethodQueryMapBoolBoolValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -522,9 +578,10 @@ var PayloadQueryMapStringArrayStringConstructorCode = `// NewMethodQueryMapStrin
 // ServiceQueryMapStringArrayString service MethodQueryMapStringArrayString
 // endpoint payload.
 func NewMethodQueryMapStringArrayStringPayload(q map[string][]string) *servicequerymapstringarraystring.MethodQueryMapStringArrayStringPayload {
-	return &servicequerymapstringarraystring.MethodQueryMapStringArrayStringPayload{
-		Q: q,
-	}
+	v := &servicequerymapstringarraystring.MethodQueryMapStringArrayStringPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -532,9 +589,10 @@ var PayloadQueryMapStringArrayStringValidateConstructorCode = `// NewMethodQuery
 // ServiceQueryMapStringArrayStringValidate service
 // MethodQueryMapStringArrayStringValidate endpoint payload.
 func NewMethodQueryMapStringArrayStringValidatePayload(q map[string][]string) *servicequerymapstringarraystringvalidate.MethodQueryMapStringArrayStringValidatePayload {
-	return &servicequerymapstringarraystringvalidate.MethodQueryMapStringArrayStringValidatePayload{
-		Q: q,
-	}
+	v := &servicequerymapstringarraystringvalidate.MethodQueryMapStringArrayStringValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -542,9 +600,10 @@ var PayloadQueryMapStringArrayBoolConstructorCode = `// NewMethodQueryMapStringA
 // ServiceQueryMapStringArrayBool service MethodQueryMapStringArrayBool
 // endpoint payload.
 func NewMethodQueryMapStringArrayBoolPayload(q map[string][]bool) *servicequerymapstringarraybool.MethodQueryMapStringArrayBoolPayload {
-	return &servicequerymapstringarraybool.MethodQueryMapStringArrayBoolPayload{
-		Q: q,
-	}
+	v := &servicequerymapstringarraybool.MethodQueryMapStringArrayBoolPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -552,9 +611,10 @@ var PayloadQueryMapStringArrayBoolValidateConstructorCode = `// NewMethodQueryMa
 // ServiceQueryMapStringArrayBoolValidate service
 // MethodQueryMapStringArrayBoolValidate endpoint payload.
 func NewMethodQueryMapStringArrayBoolValidatePayload(q map[string][]bool) *servicequerymapstringarrayboolvalidate.MethodQueryMapStringArrayBoolValidatePayload {
-	return &servicequerymapstringarrayboolvalidate.MethodQueryMapStringArrayBoolValidatePayload{
-		Q: q,
-	}
+	v := &servicequerymapstringarrayboolvalidate.MethodQueryMapStringArrayBoolValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -562,9 +622,10 @@ var PayloadQueryMapBoolArrayStringConstructorCode = `// NewMethodQueryMapBoolArr
 // ServiceQueryMapBoolArrayString service MethodQueryMapBoolArrayString
 // endpoint payload.
 func NewMethodQueryMapBoolArrayStringPayload(q map[bool][]string) *servicequerymapboolarraystring.MethodQueryMapBoolArrayStringPayload {
-	return &servicequerymapboolarraystring.MethodQueryMapBoolArrayStringPayload{
-		Q: q,
-	}
+	v := &servicequerymapboolarraystring.MethodQueryMapBoolArrayStringPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -572,18 +633,20 @@ var PayloadQueryMapBoolArrayStringValidateConstructorCode = `// NewMethodQueryMa
 // ServiceQueryMapBoolArrayStringValidate service
 // MethodQueryMapBoolArrayStringValidate endpoint payload.
 func NewMethodQueryMapBoolArrayStringValidatePayload(q map[bool][]string) *servicequerymapboolarraystringvalidate.MethodQueryMapBoolArrayStringValidatePayload {
-	return &servicequerymapboolarraystringvalidate.MethodQueryMapBoolArrayStringValidatePayload{
-		Q: q,
-	}
+	v := &servicequerymapboolarraystringvalidate.MethodQueryMapBoolArrayStringValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryMapBoolArrayBoolConstructorCode = `// NewMethodQueryMapBoolArrayBoolPayload builds a ServiceQueryMapBoolArrayBool
 // service MethodQueryMapBoolArrayBool endpoint payload.
 func NewMethodQueryMapBoolArrayBoolPayload(q map[bool][]bool) *servicequerymapboolarraybool.MethodQueryMapBoolArrayBoolPayload {
-	return &servicequerymapboolarraybool.MethodQueryMapBoolArrayBoolPayload{
-		Q: q,
-	}
+	v := &servicequerymapboolarraybool.MethodQueryMapBoolArrayBoolPayload{}
+	v.Q = q
+
+	return v
 }
 `
 
@@ -591,45 +654,50 @@ var PayloadQueryMapBoolArrayBoolValidateConstructorCode = `// NewMethodQueryMapB
 // ServiceQueryMapBoolArrayBoolValidate service
 // MethodQueryMapBoolArrayBoolValidate endpoint payload.
 func NewMethodQueryMapBoolArrayBoolValidatePayload(q map[bool][]bool) *servicequerymapboolarrayboolvalidate.MethodQueryMapBoolArrayBoolValidatePayload {
-	return &servicequerymapboolarrayboolvalidate.MethodQueryMapBoolArrayBoolValidatePayload{
-		Q: q,
-	}
+	v := &servicequerymapboolarrayboolvalidate.MethodQueryMapBoolArrayBoolValidatePayload{}
+	v.Q = q
+
+	return v
 }
 `
 
 var PayloadQueryStringMappedConstructorCode = `// NewMethodQueryStringMappedPayload builds a ServiceQueryStringMapped service
 // MethodQueryStringMapped endpoint payload.
 func NewMethodQueryStringMappedPayload(query *string) *servicequerystringmapped.MethodQueryStringMappedPayload {
-	return &servicequerystringmapped.MethodQueryStringMappedPayload{
-		Query: query,
-	}
+	v := &servicequerystringmapped.MethodQueryStringMappedPayload{}
+	v.Query = query
+
+	return v
 }
 `
 
 var PayloadPathStringConstructorCode = `// NewMethodPathStringPayload builds a ServicePathString service
 // MethodPathString endpoint payload.
 func NewMethodPathStringPayload(p string) *servicepathstring.MethodPathStringPayload {
-	return &servicepathstring.MethodPathStringPayload{
-		P: &p,
-	}
+	v := &servicepathstring.MethodPathStringPayload{}
+	v.P = &p
+
+	return v
 }
 `
 
 var PayloadPathStringValidateConstructorCode = `// NewMethodPathStringValidatePayload builds a ServicePathStringValidate
 // service MethodPathStringValidate endpoint payload.
 func NewMethodPathStringValidatePayload(p string) *servicepathstringvalidate.MethodPathStringValidatePayload {
-	return &servicepathstringvalidate.MethodPathStringValidatePayload{
-		P: p,
-	}
+	v := &servicepathstringvalidate.MethodPathStringValidatePayload{}
+	v.P = p
+
+	return v
 }
 `
 
 var PayloadPathArrayStringConstructorCode = `// NewMethodPathArrayStringPayload builds a ServicePathArrayString service
 // MethodPathArrayString endpoint payload.
 func NewMethodPathArrayStringPayload(p []string) *servicepatharraystring.MethodPathArrayStringPayload {
-	return &servicepatharraystring.MethodPathArrayStringPayload{
-		P: p,
-	}
+	v := &servicepatharraystring.MethodPathArrayStringPayload{}
+	v.P = p
+
+	return v
 }
 `
 
@@ -637,36 +705,40 @@ var PayloadPathArrayStringValidateConstructorCode = `// NewMethodPathArrayString
 // ServicePathArrayStringValidate service MethodPathArrayStringValidate
 // endpoint payload.
 func NewMethodPathArrayStringValidatePayload(p []string) *servicepatharraystringvalidate.MethodPathArrayStringValidatePayload {
-	return &servicepatharraystringvalidate.MethodPathArrayStringValidatePayload{
-		P: p,
-	}
+	v := &servicepatharraystringvalidate.MethodPathArrayStringValidatePayload{}
+	v.P = p
+
+	return v
 }
 `
 
 var PayloadHeaderStringConstructorCode = `// NewMethodHeaderStringPayload builds a ServiceHeaderString service
 // MethodHeaderString endpoint payload.
 func NewMethodHeaderStringPayload(h *string) *serviceheaderstring.MethodHeaderStringPayload {
-	return &serviceheaderstring.MethodHeaderStringPayload{
-		H: h,
-	}
+	v := &serviceheaderstring.MethodHeaderStringPayload{}
+	v.H = h
+
+	return v
 }
 `
 
 var PayloadHeaderStringValidateConstructorCode = `// NewMethodHeaderStringValidatePayload builds a ServiceHeaderStringValidate
 // service MethodHeaderStringValidate endpoint payload.
 func NewMethodHeaderStringValidatePayload(h *string) *serviceheaderstringvalidate.MethodHeaderStringValidatePayload {
-	return &serviceheaderstringvalidate.MethodHeaderStringValidatePayload{
-		H: h,
-	}
+	v := &serviceheaderstringvalidate.MethodHeaderStringValidatePayload{}
+	v.H = h
+
+	return v
 }
 `
 
 var PayloadHeaderArrayStringConstructorCode = `// NewMethodHeaderArrayStringPayload builds a ServiceHeaderArrayString service
 // MethodHeaderArrayString endpoint payload.
 func NewMethodHeaderArrayStringPayload(h []string) *serviceheaderarraystring.MethodHeaderArrayStringPayload {
-	return &serviceheaderarraystring.MethodHeaderArrayStringPayload{
-		H: h,
-	}
+	v := &serviceheaderarraystring.MethodHeaderArrayStringPayload{}
+	v.H = h
+
+	return v
 }
 `
 
@@ -674,9 +746,10 @@ var PayloadHeaderArrayStringValidateConstructorCode = `// NewMethodHeaderArraySt
 // ServiceHeaderArrayStringValidate service MethodHeaderArrayStringValidate
 // endpoint payload.
 func NewMethodHeaderArrayStringValidatePayload(h []string) *serviceheaderarraystringvalidate.MethodHeaderArrayStringValidatePayload {
-	return &serviceheaderarraystringvalidate.MethodHeaderArrayStringValidatePayload{
-		H: h,
-	}
+	v := &serviceheaderarraystringvalidate.MethodHeaderArrayStringValidatePayload{}
+	v.H = h
+
+	return v
 }
 `
 
@@ -687,6 +760,7 @@ func NewMethodBodyQueryObjectPayload(body *MethodBodyQueryObjectRequestBody, b *
 		A: body.A,
 	}
 	v.B = b
+
 	return v
 }
 `
@@ -699,6 +773,7 @@ func NewMethodBodyQueryObjectValidatePayload(body *MethodBodyQueryObjectValidate
 		A: *body.A,
 	}
 	v.B = b
+
 	return v
 }
 `
@@ -710,6 +785,7 @@ func NewMethodBodyQueryUserPayloadType(body *MethodBodyQueryUserRequestBody, b *
 		A: body.A,
 	}
 	v.B = b
+
 	return v
 }
 `
@@ -722,6 +798,7 @@ func NewMethodBodyQueryUserValidatePayloadType(body *MethodBodyQueryUserValidate
 		A: *body.A,
 	}
 	v.B = b
+
 	return v
 }
 `
@@ -733,6 +810,7 @@ func NewMethodBodyPathObjectPayload(body *MethodBodyPathObjectRequestBody, b str
 		A: body.A,
 	}
 	v.B = &b
+
 	return v
 }
 `
@@ -745,6 +823,7 @@ func NewMethodBodyPathObjectValidatePayload(body *MethodBodyPathObjectValidateRe
 		A: *body.A,
 	}
 	v.B = b
+
 	return v
 }
 `
@@ -756,6 +835,7 @@ func NewMethodBodyPathUserPayloadType(body *MethodBodyPathUserRequestBody, b str
 		A: body.A,
 	}
 	v.B = &b
+
 	return v
 }
 `
@@ -768,6 +848,7 @@ func NewMethodUserBodyPathValidatePayloadType(body *MethodUserBodyPathValidateRe
 		A: *body.A,
 	}
 	v.B = b
+
 	return v
 }
 `
@@ -780,6 +861,7 @@ func NewMethodBodyQueryPathObjectPayload(body *MethodBodyQueryPathObjectRequestB
 	}
 	v.C = &c2
 	v.B = b
+
 	return v
 }
 `
@@ -793,6 +875,7 @@ func NewMethodBodyQueryPathObjectValidatePayload(body *MethodBodyQueryPathObject
 	}
 	v.C = c2
 	v.B = b
+
 	return v
 }
 `
@@ -805,6 +888,7 @@ func NewMethodBodyQueryPathUserPayloadType(body *MethodBodyQueryPathUserRequestB
 	}
 	v.C = &c2
 	v.B = b
+
 	return v
 }
 `
@@ -818,6 +902,7 @@ func NewMethodBodyQueryPathUserValidatePayloadType(body *MethodBodyQueryPathUser
 	}
 	v.C = c2
 	v.B = b
+
 	return v
 }
 `
@@ -829,6 +914,7 @@ func NewMethodBodyUserInnerPayloadType(body *MethodBodyUserInnerRequestBody) *se
 	if body.Inner != nil {
 		v.Inner = unmarshalInnerTypeRequestBodyToServicebodyuserinnerInnerType(body.Inner)
 	}
+
 	return v
 }
 `
@@ -841,6 +927,7 @@ func NewMethodBodyUserInnerDefaultPayloadType(body *MethodBodyUserInnerDefaultRe
 	if body.Inner != nil {
 		v.Inner = unmarshalInnerTypeRequestBodyToServicebodyuserinnerdefaultInnerType(body.Inner)
 	}
+
 	return v
 }
 `
@@ -850,10 +937,7 @@ var PayloadBodyInlineArrayUserConstructorCode = `// NewMethodBodyInlineArrayUser
 func NewMethodBodyInlineArrayUserElemType(body []*ElemTypeRequestBody) []*servicebodyinlinearrayuser.ElemType {
 	v := make([]*servicebodyinlinearrayuser.ElemType, len(body))
 	for i, val := range body {
-		v[i] = &servicebodyinlinearrayuser.ElemType{
-			A: *val.A,
-			B: val.B,
-		}
+		v[i] = unmarshalElemTypeRequestBodyToServicebodyinlinearrayuserElemType(val)
 	}
 	return v
 }
@@ -864,15 +948,8 @@ var PayloadBodyInlineMapUserConstructorCode = `// NewMethodBodyInlineMapUserMapK
 func NewMethodBodyInlineMapUserMapKeyTypeElemType(body map[*KeyTypeRequestBody]*ElemTypeRequestBody) map[*servicebodyinlinemapuser.KeyType]*servicebodyinlinemapuser.ElemType {
 	v := make(map[*servicebodyinlinemapuser.KeyType]*servicebodyinlinemapuser.ElemType, len(body))
 	for key, val := range body {
-		tk := &servicebodyinlinemapuser.KeyType{
-			A: *key.A,
-			B: key.B,
-		}
-		tv := &servicebodyinlinemapuser.ElemType{
-			A: *val.A,
-			B: val.B,
-		}
-		v[tk] = tv
+		tk := unmarshalKeyTypeRequestBodyToServicebodyinlinemapuserKeyType(val)
+		v[tk] = unmarshalElemTypeRequestBodyToServicebodyinlinemapuserElemType(val)
 	}
 	return v
 }
@@ -886,6 +963,7 @@ func NewMethodBodyInlineRecursiveUserPayloadType(body *MethodBodyInlineRecursive
 	v.C = unmarshalPayloadTypeRequestBodyToServicebodyinlinerecursiveuserPayloadType(body.C)
 	v.A = a
 	v.B = b
+
 	return v
 }
 `

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -1624,15 +1624,16 @@ func DecodeMethodQueryMapStringBoolRequest(mux goahttp.Muxer, decoder func(*http
 							closeIdx := strings.IndexRune(keyRaw, ']')
 							keya = keyRaw[openIdx+1 : closeIdx]
 						}
-						var val bool
+						var vala bool
 						{
-							v, err2 := strconv.ParseBool(valRaw)
+							valaRaw := valRaw[0]
+							v, err2 := strconv.ParseBool(valaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
 							}
-							val = v
+							vala = v
 						}
-						q[keya] = val
+						q[keya] = vala
 					}
 				}
 			}
@@ -1672,15 +1673,16 @@ func DecodeMethodQueryMapStringBoolValidateRequest(mux goahttp.Muxer, decoder fu
 						closeIdx := strings.IndexRune(keyRaw, ']')
 						keya = keyRaw[openIdx+1 : closeIdx]
 					}
-					var val bool
+					var vala bool
 					{
-						v, err2 := strconv.ParseBool(valRaw)
+						valaRaw := valRaw[0]
+						v, err2 := strconv.ParseBool(valaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
 						}
-						val = v
+						vala = v
 					}
-					q[keya] = val
+					q[keya] = vala
 				}
 			}
 		}
@@ -1829,15 +1831,16 @@ func DecodeMethodQueryMapBoolBoolRequest(mux goahttp.Muxer, decoder func(*http.R
 							}
 							keya = v
 						}
-						var val bool
+						var vala bool
 						{
-							v, err2 := strconv.ParseBool(valRaw)
+							valaRaw := valRaw[0]
+							v, err2 := strconv.ParseBool(valaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
 							}
-							val = v
+							vala = v
 						}
-						q[keya] = val
+						q[keya] = vala
 					}
 				}
 			}
@@ -1882,15 +1885,16 @@ func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func
 						}
 						keya = v
 					}
-					var val bool
+					var vala bool
 					{
-						v, err2 := strconv.ParseBool(valRaw)
+						valaRaw := valRaw[0]
+						v, err2 := strconv.ParseBool(valaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
 						}
-						val = v
+						vala = v
 					}
-					q[keya] = val
+					q[keya] = vala
 				}
 			}
 		}
@@ -2533,15 +2537,16 @@ func DecodeMethodQueryPrimitiveMapStringBoolValidateRequest(mux goahttp.Muxer, d
 						closeIdx := strings.IndexRune(keyRaw, ']')
 						keya = keyRaw[openIdx+1 : closeIdx]
 					}
-					var val bool
+					var vala bool
 					{
-						v, err2 := strconv.ParseBool(valRaw)
+						valaRaw := valRaw[0]
+						v, err2 := strconv.ParseBool(valaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
 						}
-						val = v
+						vala = v
 					}
-					q[keya] = val
+					q[keya] = vala
 				}
 			}
 		}
@@ -3771,10 +3776,8 @@ func DecodeMethodBodyPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder f
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		if body != nil {
-			if !(*body == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", *body, []interface{}{"val"}))
-			}
+		if !(body == "val") {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", body, []interface{}{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -3802,10 +3805,8 @@ func DecodeMethodBodyPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fun
 			}
 			return nil, goa.DecodePayloadError(err.Error())
 		}
-		if body != nil {
-			if !(*body == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", *body, []interface{}{true}))
-			}
+		if !(body == true) {
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", body, []interface{}{true}))
 		}
 		if err != nil {
 			return nil, err
@@ -4705,6 +4706,433 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			return nil, err
 		}
 		payload := NewMethodAPayload(&body, path, optional, optionalButRequiredParam, required, optionalButRequiredHeader)
+
+		return payload, nil
+	}
+}
+`
+
+var QueryIntAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServiceQueryIntAlias MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			int_   *int
+			int32_ *int32
+			int64_ *int64
+			err    error
+		)
+		{
+			int_Raw := r.URL.Query().Get("int")
+			if int_Raw != "" {
+				v, err2 := strconv.ParseInt(int_Raw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int_", int_Raw, "integer"))
+				}
+				pv := int(v)
+				int_ = &pv
+			}
+		}
+		{
+			int32_Raw := r.URL.Query().Get("int32")
+			if int32_Raw != "" {
+				v, err2 := strconv.ParseInt(int32_Raw, 10, 32)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32_", int32_Raw, "integer"))
+				}
+				pv := int32(v)
+				int32_ = &pv
+			}
+		}
+		{
+			int64_Raw := r.URL.Query().Get("int64")
+			if int64_Raw != "" {
+				v, err2 := strconv.ParseInt(int64_Raw, 10, 64)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64_", int64_Raw, "integer"))
+				}
+				int64_ = &v
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(int_, int32_, int64_)
+
+		return payload, nil
+	}
+}
+`
+
+var QueryIntAliasValidateDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServiceQueryIntAliasValidate MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			int_   *int
+			int32_ *int32
+			int64_ *int64
+			err    error
+		)
+		{
+			int_Raw := r.URL.Query().Get("int")
+			if int_Raw != "" {
+				v, err2 := strconv.ParseInt(int_Raw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int_", int_Raw, "integer"))
+				}
+				pv := int(v)
+				int_ = &pv
+			}
+		}
+		if int_ != nil {
+			if *int_ < 10 {
+				err = goa.MergeErrors(err, goa.InvalidRangeError("int_", *int_, 10, true))
+			}
+		}
+		{
+			int32_Raw := r.URL.Query().Get("int32")
+			if int32_Raw != "" {
+				v, err2 := strconv.ParseInt(int32_Raw, 10, 32)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32_", int32_Raw, "integer"))
+				}
+				pv := int32(v)
+				int32_ = &pv
+			}
+		}
+		if int32_ != nil {
+			if *int32_ > 100 {
+				err = goa.MergeErrors(err, goa.InvalidRangeError("int32_", *int32_, 100, false))
+			}
+		}
+		{
+			int64_Raw := r.URL.Query().Get("int64")
+			if int64_Raw != "" {
+				v, err2 := strconv.ParseInt(int64_Raw, 10, 64)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64_", int64_Raw, "integer"))
+				}
+				int64_ = &v
+			}
+		}
+		if int64_ != nil {
+			if *int64_ < 0 {
+				err = goa.MergeErrors(err, goa.InvalidRangeError("int64_", *int64_, 0, true))
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(int_, int32_, int64_)
+
+		return payload, nil
+	}
+}
+`
+
+var QueryArrayAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServiceQueryArrayAlias MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			array []uint
+			err   error
+		)
+		{
+			arrayRaw := r.URL.Query()["array"]
+			if arrayRaw != nil {
+				array = make([]uint, len(arrayRaw))
+				for i, rv := range arrayRaw {
+					v, err2 := strconv.ParseUint(rv, 10, strconv.IntSize)
+					if err2 != nil {
+						err = goa.MergeErrors(err, goa.InvalidFieldTypeError("array", arrayRaw, "array of unsigned integers"))
+					}
+					array[i] = uint(v)
+				}
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(array)
+
+		return payload, nil
+	}
+}
+`
+
+var QueryArrayAliasValidateDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServiceQueryArrayAliasValidate MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			array []uint
+			err   error
+		)
+		{
+			arrayRaw := r.URL.Query()["array"]
+			if arrayRaw != nil {
+				array = make([]uint, len(arrayRaw))
+				for i, rv := range arrayRaw {
+					v, err2 := strconv.ParseUint(rv, 10, strconv.IntSize)
+					if err2 != nil {
+						err = goa.MergeErrors(err, goa.InvalidFieldTypeError("array", arrayRaw, "array of unsigned integers"))
+					}
+					array[i] = uint(v)
+				}
+			}
+		}
+		if len(array) < 3 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("array", array, len(array), 3, true))
+		}
+		for _, e := range array {
+			if e < 10 {
+				err = goa.MergeErrors(err, goa.InvalidRangeError("array[*]", e, 10, true))
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(array)
+
+		return payload, nil
+	}
+}
+`
+var QueryMapAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServiceQueryMapAlias MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			map_ map[float32]bool
+			err  error
+		)
+		{
+			map_Raw := r.URL.Query()
+			if len(map_Raw) != 0 {
+				for keyRaw, valRaw := range map_Raw {
+					if strings.HasPrefix(keyRaw, "map[") {
+						if map_ == nil {
+							map_ = make(map[float32]bool)
+						}
+						var keya float32
+						{
+							openIdx := strings.IndexRune(keyRaw, '[')
+							closeIdx := strings.IndexRune(keyRaw, ']')
+							keyaRaw := keyRaw[openIdx+1 : closeIdx]
+							v, err2 := strconv.ParseFloat(keyaRaw, 32)
+							if err2 != nil {
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "float"))
+							}
+							keya = float32(v)
+						}
+						var vala bool
+						{
+							valaRaw := valRaw[0]
+							v, err2 := strconv.ParseBool(valaRaw)
+							if err2 != nil {
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+							}
+							vala = v
+						}
+						map_[keya] = vala
+					}
+				}
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(map_)
+
+		return payload, nil
+	}
+}
+`
+
+var QueryMapAliasValidateDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServiceQueryMapAliasValidate MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			map_ map[float32]bool
+			err  error
+		)
+		{
+			map_Raw := r.URL.Query()
+			if len(map_Raw) != 0 {
+				for keyRaw, valRaw := range map_Raw {
+					if strings.HasPrefix(keyRaw, "map[") {
+						if map_ == nil {
+							map_ = make(map[float32]bool)
+						}
+						var keya float32
+						{
+							openIdx := strings.IndexRune(keyRaw, '[')
+							closeIdx := strings.IndexRune(keyRaw, ']')
+							keyaRaw := keyRaw[openIdx+1 : closeIdx]
+							v, err2 := strconv.ParseFloat(keyaRaw, 32)
+							if err2 != nil {
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "float"))
+							}
+							keya = float32(v)
+						}
+						var vala bool
+						{
+							valaRaw := valRaw[0]
+							v, err2 := strconv.ParseBool(valaRaw)
+							if err2 != nil {
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+							}
+							vala = v
+						}
+						map_[keya] = vala
+					}
+				}
+			}
+		}
+		if len(map_) < 5 {
+			err = goa.MergeErrors(err, goa.InvalidLengthError("map_", map_, len(map_), 5, true))
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(map_)
+
+		return payload, nil
+	}
+}
+`
+
+var QueryArrayNestedAliasValidateDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServiceQueryArrayAliasValidate MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			array []float64
+			err   error
+		)
+		{
+			arrayRaw := r.URL.Query()["array"]
+			if arrayRaw != nil {
+				array = make([]float64, len(arrayRaw))
+				for i, rv := range arrayRaw {
+					v, err2 := strconv.ParseFloat(rv, 64)
+					if err2 != nil {
+						err = goa.MergeErrors(err, goa.InvalidFieldTypeError("array", arrayRaw, "array of floats"))
+					}
+					array[i] = v
+				}
+			}
+		}
+		for _, e := range array {
+			if e < 10 {
+				err = goa.MergeErrors(err, goa.InvalidRangeError("array[*]", e, 10, true))
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(array)
+
+		return payload, nil
+	}
+}
+`
+
+var HeaderIntAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServiceHeaderIntAlias MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			int_   *int
+			int32_ *int32
+			int64_ *int64
+			err    error
+		)
+		{
+			int_Raw := r.Header.Get("int")
+			if int_Raw != "" {
+				v, err2 := strconv.ParseInt(int_Raw, 10, strconv.IntSize)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int_", int_Raw, "integer"))
+				}
+				pv := int(v)
+				int_ = &pv
+			}
+		}
+		{
+			int32_Raw := r.Header.Get("int32")
+			if int32_Raw != "" {
+				v, err2 := strconv.ParseInt(int32_Raw, 10, 32)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32_", int32_Raw, "integer"))
+				}
+				pv := int32(v)
+				int32_ = &pv
+			}
+		}
+		{
+			int64_Raw := r.Header.Get("int64")
+			if int64_Raw != "" {
+				v, err2 := strconv.ParseInt(int64_Raw, 10, 64)
+				if err2 != nil {
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64_", int64_Raw, "integer"))
+				}
+				int64_ = &v
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(int_, int32_, int64_)
+
+		return payload, nil
+	}
+}
+`
+
+var PathIntAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
+// ServicePathIntAlias MethodA endpoint.
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
+	return func(r *http.Request) (interface{}, error) {
+		var (
+			int_   int
+			int32_ int32
+			int64_ int64
+			err    error
+
+			params = mux.Vars(r)
+		)
+		{
+			int_Raw := params["int"]
+			v, err2 := strconv.ParseInt(int_Raw, 10, strconv.IntSize)
+			if err2 != nil {
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int_", int_Raw, "integer"))
+			}
+			int_ = int(v)
+		}
+		{
+			int32_Raw := params["int32"]
+			v, err2 := strconv.ParseInt(int32_Raw, 10, 32)
+			if err2 != nil {
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32_", int32_Raw, "integer"))
+			}
+			int32_ = int32(v)
+		}
+		{
+			int64_Raw := params["int64"]
+			v, err2 := strconv.ParseInt(int64_Raw, 10, 64)
+			if err2 != nil {
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64_", int64_Raw, "integer"))
+			}
+			int64_ = v
+		}
+		if err != nil {
+			return nil, err
+		}
+		payload := NewMethodAPayload(int_, int32_, int64_)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -2767,3 +2767,191 @@ var MultipleServicesSamePayloadAndResultDSL = func() {
 		})
 	})
 }
+
+var QueryIntAliasDSL = func() {
+	var IntAlias = Type("IntAlias", Int)
+	var Int32Alias = Type("Int32Alias", Int32)
+	var Int64Alias = Type("Int64Alias", Int64)
+	Service("ServiceQueryIntAlias", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("int", IntAlias)
+				Attribute("int32", Int32Alias)
+				Attribute("int64", Int64Alias)
+			})
+			HTTP(func() {
+				POST("/")
+				Params(func() {
+					Param("int")
+					Param("int32")
+					Param("int64")
+				})
+			})
+		})
+	})
+}
+
+var HeaderIntAliasDSL = func() {
+	var IntAlias = Type("IntAlias", Int)
+	var Int32Alias = Type("Int32Alias", Int32)
+	var Int64Alias = Type("Int64Alias", Int64)
+	Service("ServiceHeaderIntAlias", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("int", IntAlias)
+				Attribute("int32", Int32Alias)
+				Attribute("int64", Int64Alias)
+			})
+			HTTP(func() {
+				POST("/")
+				Headers(func() {
+					Header("int")
+					Header("int32")
+					Header("int64")
+				})
+			})
+		})
+	})
+}
+
+var PathIntAliasDSL = func() {
+	var IntAlias = Type("IntAlias", Int)
+	var Int32Alias = Type("Int32Alias", Int32)
+	var Int64Alias = Type("Int64Alias", Int64)
+	Service("ServicePathIntAlias", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("int", IntAlias)
+				Attribute("int32", Int32Alias)
+				Attribute("int64", Int64Alias)
+			})
+			HTTP(func() {
+				POST("/{int}/{int32}/{int64}")
+			})
+		})
+	})
+}
+
+var QueryIntAliasValidateDSL = func() {
+	var IntAlias = Type("IntAlias", Int, func() {
+		Minimum(10)
+	})
+	var Int32Alias = Type("Int32Alias", Int32, func() {
+		Maximum(100)
+	})
+	var Int64Alias = Type("Int64Alias", Int64, func() {
+		Minimum(0)
+	})
+	Service("ServiceQueryIntAliasValidate", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("int", IntAlias)
+				Attribute("int32", Int32Alias)
+				Attribute("int64", Int64Alias)
+			})
+			HTTP(func() {
+				POST("/")
+				Params(func() {
+					Param("int")
+					Param("int32")
+					Param("int64")
+				})
+			})
+		})
+	})
+}
+
+var QueryArrayAliasDSL = func() {
+	var ArrayAlias = Type("ArrayAlias", ArrayOf(UInt))
+	Service("ServiceQueryArrayAlias", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("array", ArrayAlias)
+			})
+			HTTP(func() {
+				POST("/")
+				Params(func() {
+					Param("array")
+				})
+			})
+		})
+	})
+}
+
+var QueryArrayAliasValidateDSL = func() {
+	var ArrayAlias = Type("ArrayAlias", ArrayOf(UInt), func() {
+		MinLength(3)
+		Elem(func() {
+			Minimum(10)
+		})
+	})
+	Service("ServiceQueryArrayAliasValidate", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("array", ArrayAlias)
+			})
+			HTTP(func() {
+				POST("/")
+				Params(func() {
+					Param("array")
+				})
+			})
+		})
+	})
+}
+
+var QueryMapAliasDSL = func() {
+	var MapAlias = Type("MapAlias", MapOf(Float32, Boolean))
+	Service("ServiceQueryMapAlias", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("map", MapAlias)
+			})
+			HTTP(func() {
+				POST("/")
+				Params(func() {
+					Param("map")
+				})
+			})
+		})
+	})
+}
+
+var QueryMapAliasValidateDSL = func() {
+	var MapAlias = Type("MapAlias", MapOf(Float32, Boolean), func() {
+		MinLength(5)
+	})
+	Service("ServiceQueryMapAliasValidate", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("map", MapAlias)
+			})
+			HTTP(func() {
+				POST("/")
+				Params(func() {
+					Param("map")
+				})
+			})
+		})
+	})
+}
+
+var QueryArrayNestedAliasValidateDSL = func() {
+	var Float64Alias = Type("Float64Alias", Float64, func() {
+		Minimum(10)
+	})
+	var ArrayAlias = Type("ArrayAlias", ArrayOf(Float64Alias))
+	Service("ServiceQueryArrayAliasValidate", func() {
+		Method("MethodA", func() {
+			Payload(func() {
+				Attribute("array", ArrayAlias)
+			})
+			HTTP(func() {
+				POST("/")
+				Params(func() {
+					Param("array")
+				})
+			})
+		})
+	})
+}

--- a/http/codegen/testdata/payload_encode_functions.go
+++ b/http/codegen/testdata/payload_encode_functions.go
@@ -1217,6 +1217,7 @@ func EncodeMethodQueryPrimitiveStringValidateRequest(encoder func(*http.Request)
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveStringValidate", "MethodQueryPrimitiveStringValidate", "string", v)
 		}
 		values := req.URL.Query()
+		values.Add("q", p)
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}
@@ -1233,6 +1234,8 @@ func EncodeMethodQueryPrimitiveBoolValidateRequest(encoder func(*http.Request) g
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveBoolValidate", "MethodQueryPrimitiveBoolValidate", "bool", v)
 		}
 		values := req.URL.Query()
+		pStr := strconv.FormatBool(p)
+		values.Add("q", pStr)
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}
@@ -1439,6 +1442,7 @@ func EncodeMethodQueryPrimitiveStringDefaultRequest(encoder func(*http.Request) 
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveStringDefault", "MethodQueryPrimitiveStringDefault", "string", v)
 		}
 		values := req.URL.Query()
+		values.Add("q", p)
 		req.URL.RawQuery = values.Encode()
 		return nil
 	}
@@ -2380,6 +2384,153 @@ func EncodeMethodMultipartMapTypeRequest(encoder func(*http.Request) goahttp.Enc
 		if err := encoder(req).Encode(p); err != nil {
 			return goahttp.ErrEncodingError("ServiceMultipartMapType", "MethodMultipartMapType", err)
 		}
+		return nil
+	}
+}
+`
+
+var QueryIntAliasEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
+// ServiceQueryIntAlias MethodA server.
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*servicequeryintalias.MethodAPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceQueryIntAlias", "MethodA", "*servicequeryintalias.MethodAPayload", v)
+		}
+		values := req.URL.Query()
+		if p.Int != nil {
+			values.Add("int", fmt.Sprintf("%v", *p.Int))
+		}
+		if p.Int32 != nil {
+			values.Add("int32", fmt.Sprintf("%v", *p.Int32))
+		}
+		if p.Int64 != nil {
+			values.Add("int64", fmt.Sprintf("%v", *p.Int64))
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+`
+
+var QueryIntAliasValidateEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
+// ServiceQueryIntAliasValidate MethodA server.
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*servicequeryintaliasvalidate.MethodAPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceQueryIntAliasValidate", "MethodA", "*servicequeryintaliasvalidate.MethodAPayload", v)
+		}
+		values := req.URL.Query()
+		if p.Int != nil {
+			values.Add("int", fmt.Sprintf("%v", *p.Int))
+		}
+		if p.Int32 != nil {
+			values.Add("int32", fmt.Sprintf("%v", *p.Int32))
+		}
+		if p.Int64 != nil {
+			values.Add("int64", fmt.Sprintf("%v", *p.Int64))
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+`
+
+var QueryArrayAliasEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
+// ServiceQueryArrayAlias MethodA server.
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*servicequeryarrayalias.MethodAPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceQueryArrayAlias", "MethodA", "*servicequeryarrayalias.MethodAPayload", v)
+		}
+		values := req.URL.Query()
+		for _, value := range p.Array {
+			valueStr := strconv.FormatUint(uint64(value), 10)
+			values.Add("array", valueStr)
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+`
+
+var QueryArrayAliasValidateEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
+// ServiceQueryArrayAliasValidate MethodA server.
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*servicequeryarrayaliasvalidate.MethodAPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceQueryArrayAliasValidate", "MethodA", "*servicequeryarrayaliasvalidate.MethodAPayload", v)
+		}
+		values := req.URL.Query()
+		for _, value := range p.Array {
+			valueStr := strconv.FormatUint(uint64(value), 10)
+			values.Add("array", valueStr)
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+`
+
+var QueryMapAliasEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
+// ServiceQueryMapAlias MethodA server.
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*servicequerymapalias.MethodAPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceQueryMapAlias", "MethodA", "*servicequerymapalias.MethodAPayload", v)
+		}
+		values := req.URL.Query()
+		for kRaw, value := range p.Map {
+			k := strconv.FormatFloat(float64(kRaw), 'f', -1, 32)
+			key := fmt.Sprintf("map[%s]", k)
+			valueStr := strconv.FormatBool(value)
+			values.Add(key, valueStr)
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+`
+
+var QueryMapAliasValidateEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
+// ServiceQueryMapAliasValidate MethodA server.
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*servicequerymapaliasvalidate.MethodAPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceQueryMapAliasValidate", "MethodA", "*servicequerymapaliasvalidate.MethodAPayload", v)
+		}
+		values := req.URL.Query()
+		for kRaw, value := range p.Map {
+			k := strconv.FormatFloat(float64(kRaw), 'f', -1, 32)
+			key := fmt.Sprintf("map[%s]", k)
+			valueStr := strconv.FormatBool(value)
+			values.Add(key, valueStr)
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+`
+
+var QueryArrayNestedAliasValidateEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
+// ServiceQueryArrayAliasValidate MethodA server.
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*servicequeryarrayaliasvalidate.MethodAPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceQueryArrayAliasValidate", "MethodA", "*servicequeryarrayaliasvalidate.MethodAPayload", v)
+		}
+		values := req.URL.Query()
+		for _, value := range p.Array {
+			valueStr := strconv.FormatFloat(float64(value), 'f', -1, 64)
+			values.Add("array", valueStr)
+		}
+		req.URL.RawQuery = values.Encode()
 		return nil
 	}
 }

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -599,6 +599,22 @@ var ResultBodyUserDSL = func() {
 	})
 }
 
+var ResultTypeValidateDSL = func() {
+	var ResultType = Type("ResultType", func() {
+		Attribute("a", String, func() {
+			MinLength(5)
+		})
+	})
+	Service("ServiceResultTypeValidate", func() {
+		Method("MethodResultTypeValidate", func() {
+			Result(ResultType)
+			HTTP(func() {
+				POST("/")
+			})
+		})
+	})
+}
+
 var ResultBodyMultipleViewsDSL = func() {
 	var ResultType = ResultType("ResultTypeMultipleViews", func() {
 		Attribute("a", String)
@@ -673,6 +689,32 @@ var ResultBodyCollectionExplicitViewDSL = func() {
 		Method("MethodBodyCollectionExplicitView", func() {
 			Result(CollectionOf(RT), func() {
 				View("tiny")
+			})
+			HTTP(func() {
+				POST("/")
+				Response(StatusOK)
+			})
+		})
+	})
+}
+
+var ResultWithResultCollectionDSL = func() {
+	var RT = ResultType("RT", func() {
+		Attributes(func() {
+			Attribute("x", String, func() {
+				MinLength(5)
+			})
+		})
+	})
+	var ResultType = ResultType("ResultType", func() {
+		Attributes(func() {
+			Attribute("x", CollectionOf(RT))
+		})
+	})
+	Service("ServiceResultWithResultCollection", func() {
+		Method("MethodResultWithResultCollection", func() {
+			Result(func() {
+				Attribute("a", ResultType)
 			})
 			HTTP(func() {
 				POST("/")


### PR DESCRIPTION
* WIP: support primitive user types

* Support aliased user types

* Fix client encoding aliased type

* Resolve rebase errors

* Add failing tests for gRPC aliased types

* Use aliased primitive for proto field type

* Convert between proto and primitive user types

* Fix primitive request body HTTP

* Fix client CLI return value for primitive user type

* Remove GoTransformToVar and add extra newVar param to GoTransform

* Fix typo

Co-authored-by: Raphael Simon <simon.raphael@gmail.com>
Co-authored-by: Michael Urman <MichaelUrman@users.noreply.github.com>