### PR TITLE
Fix a couple of issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ all: lint test
 travis: depend all
 
 # Install protoc
-PROTOC_VERSION=3.6.1
+PROTOC_VERSION=3.11.4
 ifeq ($(GOOS),linux)
 PROTOC=protoc-$(PROTOC_VERSION)-linux-x86_64
 PROTOC_EXEC=$(PROTOC)/bin/protoc

--- a/codegen/cli/cli.go
+++ b/codegen/cli/cli.go
@@ -376,7 +376,7 @@ func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultVa
 			code += "\n" + validate + "\n" + fmt.Sprintf("if err != nil {\n\treturn %v, err\n}", rval)
 		}
 	}
-	return fmt.Sprintf("%s%s%s", startIf, code, endIf), check
+	return fmt.Sprintf("%s%s%s", startIf, code, endIf), check || validate != ""
 }
 
 // flagType calculates the type of a flag

--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -73,7 +73,7 @@ func transformPrimitive(source, target *expr.AttributeExpr, sourceVar, targetVar
 	if newVar {
 		assign = ":="
 	}
-	if !expr.Equal(source.Type, target.Type) {
+	if source.Type.Name() != target.Type.Name() {
 		cast := ta.TargetCtx.Scope.Ref(target, ta.TargetCtx.Pkg)
 		return fmt.Sprintf("%s %s %s(%s)\n", targetVar, assign, cast, sourceVar), nil
 	}

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -113,6 +113,7 @@ func payloadBuilders(genpkg string, svc *expr.GRPCServiceExpr, data *cli.Command
 		{Path: "encoding/json"},
 		{Path: "fmt"},
 		{Path: "strconv"},
+		{Path: "goa.design/goa", Name: "goa"},
 		{Path: path.Join(genpkg, svcName), Name: sd.Service.PkgName},
 		{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: sd.PkgName},
 	}

--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -185,12 +185,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 		for _, resp := range adata.Result.Responses {
 			if init := resp.ResultInit; init != nil {
 				sections = append(sections, &codegen.SectionTemplate{
-					Name:   "client-result-init",
-					Source: clientTypeInitT,
-					Data:   init,
-					FuncMap: map[string]interface{}{
-						"fieldCode": fieldCode,
-					},
+					Name:    "client-result-init",
+					Source:  clientTypeInitT,
+					Data:    init,
+					FuncMap: map[string]interface{}{"fieldCode": fieldCode},
 				})
 			}
 		}
@@ -200,12 +198,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 			for _, herr := range gerr.Errors {
 				if init := herr.Response.ResultInit; init != nil {
 					sections = append(sections, &codegen.SectionTemplate{
-						Name:   "client-error-result-init",
-						Source: clientTypeInitT,
-						Data:   init,
-						FuncMap: map[string]interface{}{
-							"fieldCode": fieldCode,
-						},
+						Name:    "client-error-result-init",
+						Source:  clientTypeInitT,
+						Data:    init,
+						FuncMap: map[string]interface{}{"fieldCode": fieldCode},
 					})
 				}
 			}

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -1176,6 +1176,7 @@ func BuildMethodQueryStringPayload(serviceQueryStringMethodQueryStringQ string) 
 var QueryStringRequiredBuildCode = `// BuildMethodQueryStringValidatePayload builds the payload for the
 // ServiceQueryStringValidate MethodQueryStringValidate endpoint from CLI flags.
 func BuildMethodQueryStringValidatePayload(serviceQueryStringValidateMethodQueryStringValidateQ string) (*servicequerystringvalidate.MethodQueryStringValidatePayload, error) {
+	var err error
 	var q string
 	{
 		q = serviceQueryStringValidateMethodQueryStringValidateQ


### PR DESCRIPTION
1. Missing `err` variable declaration when generating HTTP CLI payload factory
method.
2. Missing 'goa' package import in gRPC CLI payload factory method.
3. Missing type case when transforming a non alias primitive type to an
aliased one.