### PR TITLE
Properly handle explicit body attribute

### DIFF
--- a/codegen/cli/cli.go
+++ b/codegen/cli/cli.go
@@ -130,6 +130,9 @@ type (
 		// ReturnTypeAttribute if non-empty returns an attribute in the payload
 		// type that describes the shape of the method payload.
 		ReturnTypeAttribute string
+		// ReturnTypeAttributePointer is true if the return type attribute
+		// generated struct field holds a pointer
+		ReturnTypeAttributePointer bool
 		// ReturnIsStruct if true indicates that the method payload is an object.
 		ReturnIsStruct bool
 		// ReturnTypeName is the fully-qualified name of the payload.
@@ -712,7 +715,7 @@ func {{ .Name }}({{ range .FormalParams }}{{ . }} string, {{ end }}) ({{ .Result
 		{{ .Code }}
 		{{- if .ReturnTypeAttribute }}
 			res := &{{ .ReturnTypeName }}{
-				{{ .ReturnTypeAttribute }}: v,
+				{{ .ReturnTypeAttribute }}: {{ if .ReturnTypeAttributePointer }}&{{ end }}v,
 			}
 		{{- end }}
 	{{- end }}

--- a/dsl/http.go
+++ b/dsl/http.go
@@ -735,6 +735,13 @@ func Body(args ...interface{}) {
 			// GeneratedTypes so that the type's DSLFunc is executed.
 			*expr.Root.GeneratedTypes = append(*expr.Root.GeneratedTypes, rt)
 		}
+		if len(args) > 1 {
+			var ok bool
+			fn, ok = args[1].(func())
+			if !ok {
+				eval.ReportError("second argument must be a function")
+			}
+		}
 	case expr.UserType:
 		attr = &expr.AttributeExpr{Type: a}
 		if len(args) > 1 {

--- a/expr/http_endpoint_test.go
+++ b/expr/http_endpoint_test.go
@@ -150,6 +150,10 @@ service "Service" HTTP endpoint "Method": HTTP endpoint response body must be em
 			DSL:   testdata.EndpointHasSkipEncodeAndGRPC,
 			Error: `service "Service" HTTP endpoint "Method": Endpoint cannot use SkipRequestBodyEncodeDecode and define a gRPC transport.`,
 		},
+		"endpoint-payload-missing-required": {
+			DSL:   testdata.EndpointPayloadMissingRequired,
+			Error: `service "Service" HTTP endpoint "Method": The following HTTP request body attribute is required but the corresponding method payload attribute is not: nonreq. Use 'Required' to make the attribute required in the method payload as well.`,
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/expr/testdata/endpoint_dsls.go
+++ b/expr/testdata/endpoint_dsls.go
@@ -410,6 +410,23 @@ var EndpointHasSkipEncodeAndGRPC = func() {
 	})
 }
 
+var EndpointPayloadMissingRequired = func() {
+	Service("Service", func() {
+		Method("Method", func() {
+			Payload(func() {
+				Attribute("nonreq")
+			})
+			HTTP(func() {
+				POST("/")
+				Body(func() {
+					Attribute("nonreq")
+					Required("nonreq")
+				})
+			})
+		})
+	})
+}
+
 var FinalizeEndpointBodyAsExtendedTypeDSL = func() {
 	var EntityData = Type("EntityData", func() {
 		Attribute("name", String)

--- a/http/codegen/client_cli.go
+++ b/http/codegen/client_cli.go
@@ -244,12 +244,13 @@ func makeFlags(e *EndpointData, args []*InitArgData, payload expr.DataType) ([]*
 	}
 
 	pInit := cli.PayloadInitData{
-		Code:                e.Payload.Request.PayloadInit.ClientCode,
-		ReturnTypeAttribute: e.Payload.Request.PayloadInit.ReturnTypeAttribute,
-		ReturnIsStruct:      e.Payload.Request.PayloadInit.ReturnIsStruct,
-		ReturnTypeName:      e.Payload.Request.PayloadInit.ReturnTypeName,
-		ReturnTypePkg:       e.Payload.Request.PayloadInit.ReturnTypePkg,
-		Args:                pInitArgs,
+		Code:                       e.Payload.Request.PayloadInit.ClientCode,
+		ReturnTypeAttribute:        e.Payload.Request.PayloadInit.ReturnTypeAttribute,
+		ReturnTypeAttributePointer: e.Payload.Request.PayloadInit.ReturnIsPrimitivePointer,
+		ReturnIsStruct:             e.Payload.Request.PayloadInit.ReturnIsStruct,
+		ReturnTypeName:             e.Payload.Request.PayloadInit.ReturnTypeName,
+		ReturnTypePkg:              e.Payload.Request.PayloadInit.ReturnTypePkg,
+		Args:                       pInitArgs,
 	}
 
 	return flags, &cli.BuildFunctionData{

--- a/http/codegen/server_types.go
+++ b/http/codegen/server_types.go
@@ -254,7 +254,7 @@ func {{ .Name }}({{- range .ServerArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) 
 	{{ .ServerCode }}
 	{{- if .ReturnTypeAttribute }}
 		res := &{{ .ReturnTypeName }}{
-			{{ .ReturnTypeAttribute }}: v,
+			{{ .ReturnTypeAttribute }}: {{ if .ReturnIsPrimitivePointer }}&{{ end }}v,
 		}
 	{{- end }}
 {{- end }}


### PR DESCRIPTION
When corresponding payload attribute isn't required.
Fix #2491