### PR TITLE
More flexible arguments for Response DSL

### DIFF
--- a/dsl/response.go
+++ b/dsl/response.go
@@ -95,14 +95,12 @@ import (
 //
 func Response(val interface{}, args ...interface{}) {
 	name, ok := val.(string)
-	if !ok {
-		if len(args) > 0 {
-			name, ok = args[0].(string)
-			if ok {
-				arg := args[0]
-				args = append([]interface{}{val}, args[1:]...)
-				val = arg
-			}
+	if !ok && len(args) > 0 {
+		name, ok = args[0].(string)
+		if ok {
+			arg := args[0]
+			args = append([]interface{}{val}, args[1:]...)
+			val = arg
 		}
 	}
 	switch t := eval.Current().(type) {

--- a/dsl/response.go
+++ b/dsl/response.go
@@ -36,13 +36,17 @@ import (
 //
 // * Response(status, func)
 //
-// Error responses additionally accept the name of the error as first argument.
+// Error responses additionally accept the name of the error as first or second argument.
 //
 // * Response(error_name, status)
 //
 // * Response(error_name, func)
 //
 // * Response(error_name, status, func)
+//
+// * Response(status, error_name)
+//
+// * Response(status, error_name, func)
 //
 // By default (i.e. if Response only defines a status code) then:
 //
@@ -91,6 +95,16 @@ import (
 //
 func Response(val interface{}, args ...interface{}) {
 	name, ok := val.(string)
+	if !ok {
+		if len(args) > 0 {
+			name, ok = args[0].(string)
+			if ok {
+				arg := args[0]
+				args = append([]interface{}{val}, args[1:]...)
+				val = arg
+			}
+		}
+	}
 	switch t := eval.Current().(type) {
 	case *expr.HTTPExpr:
 		if !ok {

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -78,8 +78,8 @@ var UnaryRPCWithErrorsDSL = func() {
 			GRPC(func() {
 				Response("timeout", CodeCanceled)
 				Response("internal", CodeUnknown)
-				Response("bad_request", CodeInvalidArgument)
-				Response("custom_error", CodeUnknown)
+				Response(CodeInvalidArgument, "bad_request")
+				Response(CodeUnknown, "custom_error")
 			})
 		})
 	})
@@ -89,7 +89,7 @@ var UnaryRPCWithOverridingErrorsDSL = func() {
 	Service("ServiceUnaryRPCWithOverridingErrors", func() {
 		Error("overridden")
 		GRPC(func() {
-			Response("overridden", CodeCanceled)
+			Response(CodeCanceled, "overridden")
 		})
 		Method("MethodUnaryRPCWithOverridingErrors", func() {
 			Payload(String)
@@ -97,7 +97,7 @@ var UnaryRPCWithOverridingErrorsDSL = func() {
 			Error("internal")
 			GRPC(func() {
 				Response("overridden", CodeUnknown)
-				Response("internal", CodeUnknown)
+				Response(CodeUnknown, "internal")
 			})
 		})
 	})
@@ -266,7 +266,7 @@ var BidirectionalStreamingRPCWithErrorsDSL = func() {
 			GRPC(func() {
 				Response("timeout", CodeCanceled)
 				Response("internal", CodeUnknown)
-				Response("bad_request", CodeInvalidArgument)
+				Response(CodeInvalidArgument, "bad_request")
 			})
 		})
 	})

--- a/http/codegen/testdata/error_response_dsls.go
+++ b/http/codegen/testdata/error_response_dsls.go
@@ -24,7 +24,7 @@ var PrimitiveErrorResponseDSL = func() {
 			HTTP(func() {
 				GET("/one/two")
 				Response("bad_request", StatusBadRequest)
-				Response("internal_error", StatusInternalServerError)
+				Response(StatusInternalServerError, "internal_error")
 			})
 		})
 	})
@@ -34,7 +34,7 @@ var ServiceErrorResponseDSL = func() {
 	Service("ServiceServiceErrorResponse", func() {
 		Error("bad_request")
 		HTTP(func() {
-			Response("bad_request", StatusBadRequest)
+			Response(StatusBadRequest, "bad_request")
 		})
 		Method("MethodServiceErrorResponse", func() {
 			Error("internal_error")

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -2762,7 +2762,7 @@ var MultipleServicesSamePayloadAndResultDSL = func() {
 			HTTP(func() {
 				GET("/")
 				Response(StatusOK)
-				Response("something_went_wrong", StatusInternalServerError)
+				Response(StatusInternalServerError, "something_went_wrong")
 			})
 		})
 	})


### PR DESCRIPTION
This patch makes it possible to accept the name of the error as second argument of the Response DSL. It allows you to align the first argument of error responses with successful responses.

```go
Response(StatusOK)
Response(StatusNotFound, "not_found")
Response(StatusInternalServerError, "internal_server_error")
```