### PR TITLE
v2: Fix trailing slash in routing removed

### DIFF
--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -887,6 +887,9 @@ func (r *RouteExpr) FullPaths() []string {
 	res := make([]string, len(bases))
 	for i, b := range bases {
 		res[i] = httppath.Clean(path.Join(b, r.Path))
+		if res[i] != "/" && strings.HasSuffix(r.Path, "/") {
+			res[i] += "/"
+		}
 	}
 	return res
 }

--- a/http/codegen/paths_test.go
+++ b/http/codegen/paths_test.go
@@ -15,7 +15,9 @@ func TestPaths(t *testing.T) {
 		Code string
 	}{
 		{"single-path-no-param", testdata.PathNoParamDSL, testdata.PathNoParamCode},
+		{"single-path-no-param-trailing-slash", testdata.PathNoParamTrailingSlashDSL, testdata.PathNoParamTrailingSlashCode},
 		{"single-path-one-param", testdata.PathOneParamDSL, testdata.PathOneParamCode},
+		{"single-path-one-param-trailing-slash", testdata.PathOneParamTrailingSlashDSL, testdata.PathOneParamTrailingSlashCode},
 		{"single-path-multiple-params", testdata.PathMultipleParamsDSL, testdata.PathMultipleParamsCode},
 		{"alternative-paths", testdata.PathAlternativesDSL, testdata.PathAlternativesCode},
 		{"path-with-string-slice-param", testdata.PathStringSliceParamDSL, testdata.PathStringSliceParamCode},

--- a/http/codegen/server_handler_test.go
+++ b/http/codegen/server_handler_test.go
@@ -3,9 +3,9 @@ package codegen
 import (
 	"testing"
 
-	"goa.design/goa/v3/codegen"
-	"goa.design/goa/v3/expr"
-	"goa.design/goa/v3/http/codegen/testdata"
+	"goa.design/goa/codegen"
+	"goa.design/goa/expr"
+	"goa.design/goa/http/codegen/testdata"
 )
 
 func TestServerHandler(t *testing.T) {

--- a/http/codegen/server_handler_test.go
+++ b/http/codegen/server_handler_test.go
@@ -1,0 +1,39 @@
+package codegen
+
+import (
+	"testing"
+
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/expr"
+	"goa.design/goa/v3/http/codegen/testdata"
+)
+
+func TestServerHandler(t *testing.T) {
+	const genpkg = "gen"
+	cases := []struct {
+		Name       string
+		DSL        func()
+		Code       string
+		SectionNum int
+	}{
+		{"server simple routing", testdata.ServerSimpleRoutingDSL, testdata.ServerSimpleRoutingCode, 7},
+		{"server trailing slash routing", testdata.ServerTrailingSlashRoutingDSL, testdata.ServerTrailingSlashRoutingCode, 7},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			RunHTTPDSL(t, c.DSL)
+			fs := ServerFiles(genpkg, expr.Root)
+			if len(fs) != 2 {
+				t.Fatalf("got %d files, expected 1", len(fs))
+			}
+			sections := fs[0].SectionTemplates
+			if len(sections) < 8 {
+				t.Fatalf("got %d sections, expected at least 8", len(sections))
+			}
+			code := codegen.SectionCode(t, sections[c.SectionNum])
+			if code != c.Code {
+				t.Errorf("invalid code, got:\n%s\ngot vs. expected:\n%s", code, codegen.Diff(t, code, c.Code))
+			}
+		})
+	}
+}

--- a/http/codegen/testdata/path_dsls.go
+++ b/http/codegen/testdata/path_dsls.go
@@ -14,12 +14,33 @@ var PathNoParamDSL = func() {
 	})
 }
 
+var PathNoParamTrailingSlashDSL = func() {
+	Service("ServicePathNoParamTrailingSlash", func() {
+		Method("MethodPathNoParamTrailingSlash", func() {
+			HTTP(func() {
+				GET("/one/two/")
+			})
+		})
+	})
+}
+
 var PathOneParamDSL = func() {
 	Service("ServicePathOneParam", func() {
 		Method("MethodPathOneParam", func() {
 			Payload(String)
 			HTTP(func() {
 				GET("one/{a}/two")
+			})
+		})
+	})
+}
+
+var PathOneParamTrailingSlashDSL = func() {
+	Service("ServicePathOneParamTrailingSlash", func() {
+		Method("MethodPathOneParamTrailingSlash", func() {
+			Payload(String)
+			HTTP(func() {
+				GET("one/{a}/")
 			})
 		})
 	})

--- a/http/codegen/testdata/path_functions.go
+++ b/http/codegen/testdata/path_functions.go
@@ -6,9 +6,21 @@ func MethodPathNoParamServicePathNoParamPath() string {
 }
 `
 
+var PathNoParamTrailingSlashCode = `// MethodPathNoParamTrailingSlashServicePathNoParamTrailingSlashPath returns the URL path to the ServicePathNoParamTrailingSlash service MethodPathNoParamTrailingSlash HTTP endpoint.
+func MethodPathNoParamTrailingSlashServicePathNoParamTrailingSlashPath() string {
+	return "/one/two/"
+}
+`
+
 var PathOneParamCode = `// MethodPathOneParamServicePathOneParamPath returns the URL path to the ServicePathOneParam service MethodPathOneParam HTTP endpoint.
 func MethodPathOneParamServicePathOneParamPath(a string) string {
 	return fmt.Sprintf("/one/%v/two", a)
+}
+`
+
+var PathOneParamTrailingSlashCode = `// MethodPathOneParamTrailingSlashServicePathOneParamTrailingSlashPath returns the URL path to the ServicePathOneParamTrailingSlash service MethodPathOneParamTrailingSlash HTTP endpoint.
+func MethodPathOneParamTrailingSlashServicePathOneParamTrailingSlashPath(a string) string {
+	return fmt.Sprintf("/one/%v/", a)
 }
 `
 

--- a/http/codegen/testdata/server_dsls.go
+++ b/http/codegen/testdata/server_dsls.go
@@ -175,3 +175,23 @@ var ServerMultipleFilesWithPrefixPathDSL = func() {
 		Files("/{wildcard}", "/path/to/folder")
 	})
 }
+
+var ServerSimpleRoutingDSL = func() {
+	Service("ServiceSimpleRoutingServer", func() {
+		Method("server-simple-routing", func() {
+			HTTP(func() {
+				GET("/simple/routing")
+			})
+		})
+	})
+}
+
+var ServerTrailingSlashRoutingDSL = func() {
+	Service("ServiceTrailingSlashRoutingServer", func() {
+		Method("server-trailing-slash-routing", func() {
+			HTTP(func() {
+				GET("/trailing/slash/")
+			})
+		})
+	})
+}

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -17,7 +17,7 @@ func New(
 	return &Server{
 		Mounts: []*MountPoint{
 			{"MethodMultiEndpoints1", "GET", "/server_multi_endpoints/{id}"},
-			{"MethodMultiEndpoints2", "POST", "/server_multi_endpoints"},
+			{"MethodMultiEndpoints2", "POST", "/server_multi_endpoints/"},
 		},
 		MethodMultiEndpoints1: NewMethodMultiEndpoints1Handler(e.MethodMultiEndpoints1, mux, decoder, encoder, errhandler, formatter),
 		MethodMultiEndpoints2: NewMethodMultiEndpoints2Handler(e.MethodMultiEndpoints2, mux, decoder, encoder, errhandler, formatter),
@@ -197,5 +197,32 @@ var ServerMultipleFilesWithPrefixPathMounterCode = `// MountPathToFolder configu
 func MountPathToFolder(mux goahttp.Muxer, h http.Handler) {
 	mux.Handle("GET", "/server_file_server/", h.ServeHTTP)
 	mux.Handle("GET", "/server_file_server/*wildcard", h.ServeHTTP)
+}
+`
+
+var ServerSimpleRoutingCode = `// MountServerSimpleRoutingHandler configures the mux to serve the
+// "ServiceSimpleRoutingServer" service "server-simple-routing" endpoint.
+func MountServerSimpleRoutingHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("GET", "/simple/routing", f)
+}
+`
+
+var ServerTrailingSlashRoutingCode = `// MountServerTrailingSlashRoutingHandler configures the mux to serve the
+// "ServiceTrailingSlashRoutingServer" service "server-trailing-slash-routing"
+// endpoint.
+func MountServerTrailingSlashRoutingHandler(mux goahttp.Muxer, h http.Handler) {
+	f, ok := h.(http.HandlerFunc)
+	if !ok {
+		f = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+	mux.Handle("GET", "/trailing/slash/", f)
 }
 `


### PR DESCRIPTION
This is the backporting of #2530 to v2.

* Fix trailing slash in routing removed
* Exclude when the path is the root
* Fix a test