### PR TITLE
Handle implicit Authorization header properly

### DIFF
--- a/expr/project_test.go
+++ b/expr/project_test.go
@@ -32,7 +32,7 @@ var (
 
 func init() {
 	vobj := (*collectionLinkView)[0]
-	vobj.Attribute.Meta = map[string][]string{"view": []string{"link"}}
+	vobj.Attribute.Meta = map[string][]string{"view": {"link"}}
 }
 
 func TestProject(t *testing.T) {

--- a/expr/testdata/endpoint_dsls.go
+++ b/expr/testdata/endpoint_dsls.go
@@ -476,6 +476,39 @@ var FinalizeEndpointBodyAsPropWithExtendedTypeDSL = func() {
 	})
 }
 
+var ExplicitAuthHeaderDSL = func() {
+	var OAuth2 = OAuth2Security("authCode")
+	Service("Service", func() {
+		Method("Method", func() {
+			Security(OAuth2)
+			Payload(func() {
+				AccessToken("token", String)
+				Attribute("payload", String)
+			})
+			HTTP(func() {
+				POST("/")
+				Header("token")
+			})
+		})
+	})
+}
+
+var ImplicitAuthHeaderDSL = func() {
+	var OAuth2 = OAuth2Security("authCode")
+	Service("Service", func() {
+		Method("Method", func() {
+			Security(OAuth2)
+			Payload(func() {
+				AccessToken("token", String)
+				Attribute("payload", String)
+			})
+			HTTP(func() {
+				POST("/")
+			})
+		})
+	})
+}
+
 var GRPCEndpointWithAnyType = func() {
 	var Recursive = Type("Recursive", func() {
 		Field(1, "invalid_map_key", MapOf(Any, "Recursive"))


### PR DESCRIPTION
Fix issue where the endpoint finalizer was setting the endpoint headers
prior to looking for non-mapped payload attributes corrsponding to
Authorization header. The code now tests and
initializes at the same time. Added a test to cover this case.

Fix #2537 