### PR TITLE
Add support for API level error

### DIFF
--- a/dsl/error.go
+++ b/dsl/error.go
@@ -45,6 +45,8 @@ func Error(name string, args ...interface{}) {
 	}
 	erro := &expr.ErrorExpr{AttributeExpr: att, Name: name}
 	switch actual := eval.Current().(type) {
+	case *expr.APIExpr:
+		expr.Root.Errors = append(expr.Root.Errors, erro)
 	case *expr.ServiceExpr:
 		actual.Errors = append(actual.Errors, erro)
 	case *expr.MethodExpr:

--- a/dsl/response.go
+++ b/dsl/response.go
@@ -104,6 +104,14 @@ func Response(val interface{}, args ...interface{}) {
 		}
 	}
 	switch t := eval.Current().(type) {
+	case *expr.RootExpr:
+		if !ok {
+			eval.InvalidArgError("name of error", val)
+			return
+		}
+		if e := httpError(name, t, args...); e != nil {
+			t.API.HTTP.Errors = append(t.API.HTTP.Errors, e)
+		}
 	case *expr.HTTPExpr:
 		if !ok {
 			eval.InvalidArgError("name of error", val)

--- a/expr/http_response.go
+++ b/expr/http_response.go
@@ -286,7 +286,9 @@ func (r *HTTPResponseExpr) Dup() *HTTPResponseExpr {
 	if r.Body != nil {
 		res.Body = DupAtt(r.Body)
 	}
-	res.Headers = DupMappedAtt(r.Headers)
+	if r.Headers != nil {
+		res.Headers = DupMappedAtt(r.Headers)
+	}
 	return &res
 }
 

--- a/expr/http_service.go
+++ b/expr/http_service.go
@@ -163,6 +163,23 @@ func (svc *HTTPServiceExpr) EvalName() string {
 
 // Prepare initializes the error responses.
 func (svc *HTTPServiceExpr) Prepare() {
+	// Lookup undefined HTTP errors in API.
+	for _, err := range svc.ServiceExpr.Errors {
+		found := false
+		for _, herr := range svc.HTTPErrors {
+			if err.Name == herr.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			for _, herr := range Root.API.HTTP.Errors {
+				if herr.Name == err.Name {
+					svc.HTTPErrors = append(svc.HTTPErrors, herr.Dup())
+				}
+			}
+		}
+	}
 	for _, er := range svc.HTTPErrors {
 		er.Response.Prepare()
 	}

--- a/http/codegen/openapi/openapi_v2_builder.go
+++ b/http/codegen/openapi/openapi_v2_builder.go
@@ -60,15 +60,6 @@ func NewV2(root *expr.RootExpr, h *expr.HostExpr) (*V2, error) {
 		SecurityDefinitions: securitySpecFromExpr(root),
 		ExternalDocs:        docsFromExpr(root.API.Docs),
 	}
-
-	for _, he := range root.API.HTTP.Errors {
-		res := responseSpecFromExpr(s, root, he.Response, "")
-		if s.Responses == nil {
-			s.Responses = make(map[string]*Response)
-		}
-		s.Responses[he.Name] = res
-	}
-
 	for _, res := range root.API.HTTP.Services {
 		if !mustGenerate(res.Meta) || !mustGenerate(res.ServiceExpr.Meta) {
 			continue

--- a/http/codegen/server_error_encoder_test.go
+++ b/http/codegen/server_error_encoder_test.go
@@ -17,7 +17,9 @@ func TestEncodeError(t *testing.T) {
 		{"primitive-error-response", testdata.PrimitiveErrorResponseDSL, testdata.PrimitiveErrorResponseEncoderCode},
 		{"default-error-response", testdata.DefaultErrorResponseDSL, testdata.DefaultErrorResponseEncoderCode},
 		{"service-error-response", testdata.ServiceErrorResponseDSL, testdata.ServiceErrorResponseEncoderCode},
+		{"api-error-response", testdata.APIErrorResponseDSL, testdata.ServiceErrorResponseEncoderCode},
 		{"no-body-error-response", testdata.NoBodyErrorResponseDSL, testdata.NoBodyErrorResponseEncoderCode},
+		{"api-no-body-error-response", testdata.APINoBodyErrorResponseDSL, testdata.NoBodyErrorResponseEncoderCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/testdata/error_response_dsls.go
+++ b/http/codegen/testdata/error_response_dsls.go
@@ -46,6 +46,45 @@ var ServiceErrorResponseDSL = func() {
 	})
 }
 
+var APIErrorResponseDSL = func() {
+	var _ = API("test", func() {
+		Error("bad_request")
+		HTTP(func() {
+			Response(StatusBadRequest, "bad_request")
+		})
+	})
+	Service("ServiceServiceErrorResponse", func() {
+		Method("MethodServiceErrorResponse", func() {
+			Error("bad_request")
+			Error("internal_error")
+			HTTP(func() {
+				GET("/one/two")
+				Response("internal_error", StatusInternalServerError)
+			})
+		})
+	})
+}
+
+var APINoBodyErrorResponseDSL = func() {
+	var StringError = Type("StringError", func() { Attribute("header") })
+	var _ = API("test", func() {
+		Error("bad_request", StringError)
+		HTTP(func() {
+			Response("bad_request", StatusBadRequest, func() {
+				Header("header")
+			})
+		})
+	})
+	Service("ServiceNoBodyErrorResponse", func() {
+		Error("bad_request")
+		Method("MethodServiceErrorResponse", func() {
+			HTTP(func() {
+				GET("/one/two")
+			})
+		})
+	})
+}
+
 var NoBodyErrorResponseDSL = func() {
 	var StringError = Type("StringError", func() { Attribute("header") })
 	Service("ServiceNoBodyErrorResponse", func() {


### PR DESCRIPTION
This commit gives the ability to define errors and their transport
details in the API DSL. Such errors may be referred to by specific
services and methods alleviating the need to redefine the
transport details multiple times.

Example:
```Go
var _ = API("test", func() {
	Error("bad_request")
	HTTP(func() {
		Response(StatusBadRequest, "bad_request")
	})
})

Service("Service", func() {
	Method("Method", func() {
		Error("bad_request") // No need to define transport details again
		Error("internal_error") // Method specific error, requires transport details
		HTTP(func() {
			GET("/one/two")
			Response("internal_error", StatusInternalServerError) // transport details
		})
	})
})
```