### PR TITLE
Set bearer in client request encode

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -761,7 +761,7 @@ func buildMethodData(m *expr.MethodExpr, svcPkgName string, service *expr.Servic
 	for _, req := range m.Requirements {
 		var rs SchemesData
 		for _, s := range req.Schemes {
-			sch := buildSchemeData(s, m)
+			sch := BuildSchemeData(s, m)
 			rs = rs.Append(sch)
 			schemes = schemes.Append(sch)
 		}
@@ -876,8 +876,8 @@ func initStreamData(data *MethodData, m *expr.MethodExpr, vname, rname, resultRe
 	data.StreamingPayloadEx = spayloadEx
 }
 
-// buildSchemeData builds the scheme data for the given scheme and method expr.
-func buildSchemeData(s *expr.SchemeExpr, m *expr.MethodExpr) *SchemeData {
+// BuildSchemeData builds the scheme data for the given scheme and method expr.
+func BuildSchemeData(s *expr.SchemeExpr, m *expr.MethodExpr) *SchemeData {
 	if !expr.IsObject(m.Payload.Type) {
 		return nil
 	}

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -395,12 +395,12 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 			{{- else }}
 			{
 			{{- end }}
+			head := {{ if .FieldPointer }}*{{ end }}p.{{ .FieldName }}
 			{{- if (and (eq .Name "Authorization") (isBearer $.HeaderSchemes)) }}
-		if !strings.Contains({{ if .FieldPointer }}*{{ end }}p.{{ .FieldName }}, " ") {
-			req.Header.Set({{ printf "%q" .Name }}, "Bearer "+{{ if .FieldPointer }}*{{ end }}p.{{ .FieldName }})
+		if !strings.Contains(head, " ") {
+			req.Header.Set({{ printf "%q" .Name }}, "Bearer "+head)
 		} else {
 			{{- end }}
-			head := {{ if .FieldPointer }}*{{ end }}p.{{ .FieldName }}
 			{{- if eq .Type.Name "array" }}
 			for _, val := range head {
 				{{- if eq .Type.ElemType.Type.Name "string" }}

--- a/http/codegen/client_encode_test.go
+++ b/http/codegen/client_encode_test.go
@@ -94,6 +94,7 @@ func TestClientEncode(t *testing.T) {
 
 		{"query-string-default", testdata.PayloadQueryStringDefaultDSL, testdata.PayloadQueryStringDefaultEncodeCode},
 		{"query-primitive-string-default", testdata.PayloadQueryPrimitiveStringDefaultDSL, testdata.PayloadQueryPrimitiveStringDefaultEncodeCode},
+		{"query-jwt-authorization", testdata.PayloadJWTAuthorizationQueryDSL, testdata.PayloadJWTAuthorizationQueryEncodeCode},
 
 		{"header-string", testdata.PayloadHeaderStringDSL, testdata.PayloadHeaderStringEncodeCode},
 		{"header-string-validate", testdata.PayloadHeaderStringValidateDSL, testdata.PayloadHeaderStringValidateEncodeCode},
@@ -111,6 +112,8 @@ func TestClientEncode(t *testing.T) {
 
 		{"header-string-default", testdata.PayloadHeaderStringDefaultDSL, testdata.PayloadHeaderStringDefaultEncodeCode},
 		{"header-primitive-string-default", testdata.PayloadHeaderPrimitiveStringDefaultDSL, testdata.PayloadHeaderPrimitiveStringDefaultEncodeCode},
+		{"header-jwt-authorization", testdata.PayloadJWTAuthorizationHeaderDSL, testdata.PayloadJWTAuthorizationHeaderEncodeCode},
+		{"header-jwt-custom-header", testdata.PayloadJWTAuthorizationCustomHeaderDSL, testdata.PayloadJWTAuthorizationCustomHeaderEncodeCode},
 
 		{"body-string", testdata.PayloadBodyStringDSL, testdata.PayloadBodyStringEncodeCode},
 		{"body-string-validate", testdata.PayloadBodyStringValidateDSL, testdata.PayloadBodyStringValidateEncodeCode},

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -876,6 +876,7 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 			RequestInit:     requestInit,
 			RequestEncoder:  requestEncoder,
 			ResponseDecoder: fmt.Sprintf("Decode%sResponse", ep.VarName),
+			Requirements:    reqs,
 		}
 		if a.MethodExpr.IsStreaming() {
 			initWebSocketData(ad, a, rd)

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -121,6 +121,9 @@ type (
 		// apply to the method and are encoded in the request query
 		// string.
 		QuerySchemes service.SchemesData
+		// Requirements contains the security requirements for the
+		// method.
+		Requirements service.RequirementsData
 
 		// server
 
@@ -764,14 +767,19 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 		payload := buildPayloadData(a, rd)
 
 		var (
+			reqs  service.RequirementsData
 			hsch  service.SchemesData
 			bosch service.SchemesData
 			qsch  service.SchemesData
 			basch *service.SchemeData
 		)
 		{
-			for _, req := range ep.Requirements {
-				for _, s := range req.Schemes {
+
+			for _, req := range a.Requirements {
+				var rs service.SchemesData
+				for _, sch := range req.Schemes {
+					s := service.BuildSchemeData(sch, a.MethodExpr)
+					rs = rs.Append(s)
 					switch s.Type {
 					case "Basic":
 						basch = s
@@ -786,6 +794,7 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 						}
 					}
 				}
+				reqs = append(reqs, &service.RequirementData{Schemes: rs, Scopes: req.Scopes})
 			}
 		}
 

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -1338,6 +1338,24 @@ var PayloadQueryPrimitiveStringDefaultDSL = func() {
 	})
 }
 
+var PayloadJWTAuthorizationQueryDSL = func() {
+	var JWT = JWTSecurity("jwt", func() {
+		Scope("api:read")
+	})
+	Service("ServiceHeaderPrimitiveStringDefault", func() {
+		Method("MethodHeaderPrimitiveStringDefault", func() {
+			Security(JWT)
+			Payload(func() {
+				Token("token", String)
+			})
+			HTTP(func() {
+				GET("")
+				Param("token")
+			})
+		})
+	})
+}
+
 var PayloadExtendedQueryStringDSL = func() {
 	var UT = Type("UserType", func() {
 		Attribute("q", String)
@@ -1731,6 +1749,42 @@ var PayloadHeaderPrimitiveStringDefaultDSL = func() {
 			HTTP(func() {
 				GET("")
 				Header("h")
+			})
+		})
+	})
+}
+
+var PayloadJWTAuthorizationHeaderDSL = func() {
+	var JWT = JWTSecurity("jwt", func() {
+		Scope("api:read")
+	})
+	Service("ServiceHeaderPrimitiveStringDefault", func() {
+		Method("MethodHeaderPrimitiveStringDefault", func() {
+			Security(JWT)
+			Payload(func() {
+				Token("token", String)
+			})
+			HTTP(func() {
+				GET("")
+			})
+		})
+	})
+}
+
+var PayloadJWTAuthorizationCustomHeaderDSL = func() {
+	var JWT = JWTSecurity("jwt", func() {
+		Scope("api:read")
+	})
+	Service("ServiceHeaderPrimitiveStringDefault", func() {
+		Method("MethodHeaderPrimitiveStringDefault", func() {
+			Security(JWT)
+			Payload(func() {
+				Token("token", String)
+				Required("token")
+			})
+			HTTP(func() {
+				GET("")
+				Header("token:X-Auth")
 			})
 		})
 	})

--- a/http/codegen/testdata/payload_encode_functions.go
+++ b/http/codegen/testdata/payload_encode_functions.go
@@ -1449,6 +1449,25 @@ func EncodeMethodQueryPrimitiveStringDefaultRequest(encoder func(*http.Request) 
 }
 `
 
+var PayloadJWTAuthorizationQueryEncodeCode = `// EncodeMethodHeaderPrimitiveStringDefaultRequest returns an encoder for
+// requests sent to the ServiceHeaderPrimitiveStringDefault
+// MethodHeaderPrimitiveStringDefault server.
+func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringDefault", "MethodHeaderPrimitiveStringDefault", "*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload", v)
+		}
+		values := req.URL.Query()
+		if p.Token != nil {
+			values.Add("token", *p.Token)
+		}
+		req.URL.RawQuery = values.Encode()
+		return nil
+	}
+}
+`
+
 var PayloadHeaderStringEncodeCode = `// EncodeMethodHeaderStringRequest returns an encoder for requests sent to the
 // ServiceHeaderString MethodHeaderString server.
 func EncodeMethodHeaderStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
@@ -1680,6 +1699,46 @@ func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request)
 		p, ok := v.(string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringDefault", "MethodHeaderPrimitiveStringDefault", "string", v)
+		}
+		return nil
+	}
+}
+`
+
+var PayloadJWTAuthorizationHeaderEncodeCode = `// EncodeMethodHeaderPrimitiveStringDefaultRequest returns an encoder for
+// requests sent to the ServiceHeaderPrimitiveStringDefault
+// MethodHeaderPrimitiveStringDefault server.
+func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringDefault", "MethodHeaderPrimitiveStringDefault", "*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload", v)
+		}
+		if p.Token != nil {
+			head := *p.Token
+			if !strings.Contains(head, " ") {
+				req.Header.Set("Authorization", "Bearer "+head)
+			} else {
+				req.Header.Set("Authorization", head)
+			}
+		}
+		return nil
+	}
+}
+`
+
+var PayloadJWTAuthorizationCustomHeaderEncodeCode = `// EncodeMethodHeaderPrimitiveStringDefaultRequest returns an encoder for
+// requests sent to the ServiceHeaderPrimitiveStringDefault
+// MethodHeaderPrimitiveStringDefault server.
+func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
+	return func(req *http.Request, v interface{}) error {
+		p, ok := v.(*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload)
+		if !ok {
+			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringDefault", "MethodHeaderPrimitiveStringDefault", "*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload", v)
+		}
+		{
+			head := p.Token
+			req.Header.Set("X-Auth", head)
 		}
 		return nil
 	}


### PR DESCRIPTION
HTTP client didn't encode Authorization header with Bearer scheme for JWT and OAuth2 by default. This is because, we computed scheme data from the Method requirements instead of endpoint requirements. We modify the endpoint scheme in the [HTTP endpoint finalize](https://github.com/goadesign/goa/blob/v3/expr/http_endpoint.go#L600-L633) to include "Authorization" scheme name.

This PR fixes how we compute requirement data for HTTP endpoints.