### PR TITLE
Enable ContentType DSL for HTTP error responses

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1102,6 +1102,9 @@ func {{ .ErrorEncoder }}(encoder func(context.Context, http.ResponseWriter) goah
 		case {{ printf "%q" .Name }}:
 			res := v.({{ $err.Ref }})
 			{{- with .Response}}
+				{{- if .ContentType }}
+					ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "{{ .ContentType }}")
+				{{- end }}
 				{{- template "response" . }}
 				{{- if .ServerBody }}
 				return enc.Encode(body)

--- a/http/codegen/server_error_encoder_test.go
+++ b/http/codegen/server_error_encoder_test.go
@@ -16,10 +16,14 @@ func TestEncodeError(t *testing.T) {
 	}{
 		{"primitive-error-response", testdata.PrimitiveErrorResponseDSL, testdata.PrimitiveErrorResponseEncoderCode},
 		{"default-error-response", testdata.DefaultErrorResponseDSL, testdata.DefaultErrorResponseEncoderCode},
+		{"default-error-response-with-content-type", testdata.DefaultErrorResponseWithContentTypeDSL, testdata.DefaultErrorResponseWithContentTypeEncoderCode},
 		{"service-error-response", testdata.ServiceErrorResponseDSL, testdata.ServiceErrorResponseEncoderCode},
 		{"api-error-response", testdata.APIErrorResponseDSL, testdata.ServiceErrorResponseEncoderCode},
+		{"api-error-response-with-content-type", testdata.APIErrorResponseWithContentTypeDSL, testdata.ServiceErrorResponseWithContentTypeEncoderCode},
 		{"no-body-error-response", testdata.NoBodyErrorResponseDSL, testdata.NoBodyErrorResponseEncoderCode},
+		{"no-body-error-response-with-content-type", testdata.NoBodyErrorResponseWithContentTypeDSL, testdata.NoBodyErrorResponseWithContentTypeEncoderCode},
 		{"api-no-body-error-response", testdata.APINoBodyErrorResponseDSL, testdata.NoBodyErrorResponseEncoderCode},
+		{"api-no-body-error-response-with-content-type", testdata.APINoBodyErrorResponseWithContentTypeDSL, testdata.NoBodyErrorResponseWithContentTypeEncoderCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1806,9 +1806,14 @@ func buildErrorsData(e *expr.HTTPEndpointExpr, sd *ServiceData) []*ErrorGroupDat
 					}
 				}
 			}
+			var contentType string
+			if v.Response.ContentType != expr.ErrorResultIdentifier {
+				contentType = v.Response.ContentType
+			}
 			responseData = &ResponseData{
 				StatusCode:   statusCodeToHTTPConst(v.Response.StatusCode),
 				Headers:      headers,
+				ContentType:  contentType,
 				ErrorHeader:  v.Name,
 				ServerBody:   serverBodyData,
 				ClientBody:   clientBodyData,

--- a/http/codegen/testdata/error_encoder_code.go
+++ b/http/codegen/testdata/error_encoder_code.go
@@ -71,6 +71,36 @@ func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.Re
 }
 `
 
+var DefaultErrorResponseWithContentTypeEncoderCode = `// EncodeMethodDefaultErrorResponseError returns an encoder for errors returned
+// by the MethodDefaultErrorResponse ServiceDefaultErrorResponse endpoint.
+func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		en, ok := v.(ErrorNamer)
+		if !ok {
+			return encodeError(ctx, w, v)
+		}
+		switch en.ErrorName() {
+		case "bad_request":
+			res := v.(*goa.ServiceError)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/xml")
+			enc := encoder(ctx, w)
+			var body interface{}
+			if formatter != nil {
+				body = formatter(res)
+			} else {
+				body = NewMethodDefaultErrorResponseBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", "bad_request")
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+`
+
 var ServiceErrorResponseEncoderCode = `// EncodeMethodServiceErrorResponseError returns an encoder for errors returned
 // by the MethodServiceErrorResponse ServiceServiceErrorResponse endpoint.
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
@@ -112,6 +142,48 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 }
 `
 
+var ServiceErrorResponseWithContentTypeEncoderCode = `// EncodeMethodServiceErrorResponseError returns an encoder for errors returned
+// by the MethodServiceErrorResponse ServiceServiceErrorResponse endpoint.
+func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		en, ok := v.(ErrorNamer)
+		if !ok {
+			return encodeError(ctx, w, v)
+		}
+		switch en.ErrorName() {
+		case "internal_error":
+			res := v.(*goa.ServiceError)
+			enc := encoder(ctx, w)
+			var body interface{}
+			if formatter != nil {
+				body = formatter(res)
+			} else {
+				body = NewMethodServiceErrorResponseInternalErrorResponseBody(res)
+			}
+			w.Header().Set("goa-error", "internal_error")
+			w.WriteHeader(http.StatusInternalServerError)
+			return enc.Encode(body)
+		case "bad_request":
+			res := v.(*goa.ServiceError)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/xml")
+			enc := encoder(ctx, w)
+			var body interface{}
+			if formatter != nil {
+				body = formatter(res)
+			} else {
+				body = NewMethodServiceErrorResponseBadRequestResponseBody(res)
+			}
+			w.Header().Set("goa-error", "bad_request")
+			w.WriteHeader(http.StatusBadRequest)
+			return enc.Encode(body)
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+`
+
 var NoBodyErrorResponseEncoderCode = `// EncodeMethodServiceErrorResponseError returns an encoder for errors returned
 // by the MethodServiceErrorResponse ServiceNoBodyErrorResponse endpoint.
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
@@ -124,6 +196,32 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 		switch en.ErrorName() {
 		case "bad_request":
 			res := v.(*servicenobodyerrorresponse.StringError)
+			if res.Header != nil {
+				w.Header().Set("Header", *res.Header)
+			}
+			w.Header().Set("goa-error", "bad_request")
+			w.WriteHeader(http.StatusBadRequest)
+			return nil
+		default:
+			return encodeError(ctx, w, v)
+		}
+	}
+}
+`
+
+var NoBodyErrorResponseWithContentTypeEncoderCode = `// EncodeMethodServiceErrorResponseError returns an encoder for errors returned
+// by the MethodServiceErrorResponse ServiceNoBodyErrorResponse endpoint.
+func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
+	encodeError := goahttp.ErrorEncoder(encoder, formatter)
+	return func(ctx context.Context, w http.ResponseWriter, v error) error {
+		en, ok := v.(ErrorNamer)
+		if !ok {
+			return encodeError(ctx, w, v)
+		}
+		switch en.ErrorName() {
+		case "bad_request":
+			res := v.(*servicenobodyerrorresponse.StringError)
+			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/xml")
 			if res.Header != nil {
 				w.Header().Set("Header", *res.Header)
 			}

--- a/http/codegen/testdata/error_response_dsls.go
+++ b/http/codegen/testdata/error_response_dsls.go
@@ -16,6 +16,20 @@ var DefaultErrorResponseDSL = func() {
 	})
 }
 
+var DefaultErrorResponseWithContentTypeDSL = func() {
+	Service("ServiceDefaultErrorResponse", func() {
+		Method("MethodDefaultErrorResponse", func() {
+			Error("bad_request")
+			HTTP(func() {
+				GET("/one/two")
+				Response("bad_request", StatusBadRequest, func() {
+					ContentType("application/xml")
+				})
+			})
+		})
+	})
+}
+
 var PrimitiveErrorResponseDSL = func() {
 	Service("ServicePrimitiveErrorResponse", func() {
 		Method("MethodPrimitiveErrorResponse", func() {
@@ -65,6 +79,27 @@ var APIErrorResponseDSL = func() {
 	})
 }
 
+var APIErrorResponseWithContentTypeDSL = func() {
+	var _ = API("test", func() {
+		Error("bad_request")
+		HTTP(func() {
+			Response(StatusBadRequest, "bad_request", func() {
+				ContentType("application/xml")
+			})
+		})
+	})
+	Service("ServiceServiceErrorResponse", func() {
+		Method("MethodServiceErrorResponse", func() {
+			Error("bad_request")
+			Error("internal_error")
+			HTTP(func() {
+				GET("/one/two")
+				Response("internal_error", StatusInternalServerError)
+			})
+		})
+	})
+}
+
 var APINoBodyErrorResponseDSL = func() {
 	var StringError = Type("StringError", func() { Attribute("header") })
 	var _ = API("test", func() {
@@ -85,8 +120,51 @@ var APINoBodyErrorResponseDSL = func() {
 	})
 }
 
+var APINoBodyErrorResponseWithContentTypeDSL = func() {
+	var StringError = ResultType("application/vnd.string.error", func() {
+		ContentType("application/xml")
+		Attribute("header")
+	})
+	var _ = API("test", func() {
+		Error("bad_request", StringError)
+		HTTP(func() {
+			Response("bad_request", StatusBadRequest, func() {
+				Header("header")
+			})
+		})
+	})
+	Service("ServiceNoBodyErrorResponse", func() {
+		Error("bad_request")
+		Method("MethodServiceErrorResponse", func() {
+			HTTP(func() {
+				GET("/one/two")
+			})
+		})
+	})
+}
+
 var NoBodyErrorResponseDSL = func() {
 	var StringError = Type("StringError", func() { Attribute("header") })
+	Service("ServiceNoBodyErrorResponse", func() {
+		Error("bad_request", StringError)
+		HTTP(func() {
+			Response("bad_request", StatusBadRequest, func() {
+				Header("header")
+			})
+		})
+		Method("MethodServiceErrorResponse", func() {
+			HTTP(func() {
+				GET("/one/two")
+			})
+		})
+	})
+}
+
+var NoBodyErrorResponseWithContentTypeDSL = func() {
+	var StringError = ResultType("application/vnd.string.error", func() {
+		ContentType("application/xml")
+		Attribute("header")
+	})
 	Service("ServiceNoBodyErrorResponse", func() {
 		Error("bad_request", StringError)
 		HTTP(func() {


### PR DESCRIPTION
Now It seems `ContentType` DSL is disabled for HTTP error responses. This patch enables `ContentType` DSL for HTTP error responses.