### PR TITLE
Cookies

### DIFF
--- a/dsl/http.go
+++ b/dsl/http.go
@@ -470,7 +470,14 @@ func Cookie(name string, args ...interface{}) {
 //        })
 //    })
 //
-func CookieMaxAge(n int) { cookieAttribute("max-age", strconv.Itoa(n)) }
+func CookieMaxAge(n int) {
+	_, ok := eval.Current().(*expr.HTTPResponseExpr)
+	if !ok {
+		eval.IncompatibleDSL()
+		return
+	}
+	cookieAttribute("max-age", strconv.Itoa(n))
+}
 
 // CookieDomain defines the "domain" attribute of a HTTP response cookie.
 //
@@ -493,7 +500,14 @@ func CookieMaxAge(n int) { cookieAttribute("max-age", strconv.Itoa(n)) }
 //        })
 //    })
 //
-func CookieDomain(d string) { cookieAttribute("domain", d) }
+func CookieDomain(d string) {
+	_, ok := eval.Current().(*expr.HTTPResponseExpr)
+	if !ok {
+		eval.IncompatibleDSL()
+		return
+	}
+	cookieAttribute("domain", d)
+}
 
 // CookiePath defines the "path" attribute of a HTTP response cookie.
 //
@@ -516,7 +530,14 @@ func CookieDomain(d string) { cookieAttribute("domain", d) }
 //        })
 //    })
 //
-func CookiePath(p string) { cookieAttribute("path", p) }
+func CookiePath(p string) {
+	_, ok := eval.Current().(*expr.HTTPResponseExpr)
+	if !ok {
+		eval.IncompatibleDSL()
+		return
+	}
+	cookieAttribute("path", p)
+}
 
 // CookieSecure initializes the "secute" attribute of a HTTP response cookie
 // with "Secure".
@@ -538,7 +559,14 @@ func CookiePath(p string) { cookieAttribute("path", p) }
 //        })
 //    })
 //
-func CookieSecure() { cookieAttribute("secure", "Secure") }
+func CookieSecure() {
+	_, ok := eval.Current().(*expr.HTTPResponseExpr)
+	if !ok {
+		eval.IncompatibleDSL()
+		return
+	}
+	cookieAttribute("secure", "Secure")
+}
 
 // CookieHTTPOnly initializes the "http-only" attribute of a HTTP response
 // cookie with "HttpOnly".
@@ -560,7 +588,14 @@ func CookieSecure() { cookieAttribute("secure", "Secure") }
 //        })
 //    })
 //
-func CookieHTTPOnly() { cookieAttribute("http-only", "HttpOnly") }
+func CookieHTTPOnly() {
+	_, ok := eval.Current().(*expr.MappedAttributeExpr)
+	if !ok {
+		eval.IncompatibleDSL()
+		return
+	}
+	cookieAttribute("http-only", "HttpOnly")
+}
 
 // Params groups a set of Param expressions. It makes it possible to list
 // required parameters using the Required function.
@@ -1147,11 +1182,7 @@ func params(exp eval.Expression) *expr.MappedAttributeExpr {
 // cookieAttribute initialize the current attribute metadata with the details of
 // a HTTP cookie attribute for use by the HTTP code generator.
 func cookieAttribute(name, value string) {
-	c, ok := eval.Current().(*expr.MappedAttributeExpr)
-	if !ok {
-		eval.IncompatibleDSL()
-		return
-	}
+	c := eval.Current().(*expr.HTTPResponseExpr).Cookies
 	if c.Meta == nil {
 		c.Meta = expr.MetaExpr{}
 	}

--- a/dsl/security.go
+++ b/dsl/security.go
@@ -291,9 +291,7 @@ func Security(args ...interface{}) {
 // NoSecurity must appear in Method.
 func NoSecurity() {
 	security := &expr.SecurityExpr{
-		Schemes: []*expr.SchemeExpr{
-			&expr.SchemeExpr{Kind: expr.NoKind},
-		},
+		Schemes: []*expr.SchemeExpr{{Kind: expr.NoKind}},
 	}
 
 	current := eval.Current()

--- a/expr/api_test.go
+++ b/expr/api_test.go
@@ -11,36 +11,27 @@ func TestAPIExprSchemes(t *testing.T) {
 	}{
 		"default scheme": {
 			expr: APIExpr{
-				Servers: []*ServerExpr{&ServerExpr{}},
+				Servers: []*ServerExpr{{}},
 			},
 			expected: nil,
 		},
 		"single scheme": {
 			expr: APIExpr{
-				Servers: []*ServerExpr{
-					&ServerExpr{
-						Hosts: []*HostExpr{
-							{URIs: []URIExpr{"http://example.com"}},
-						},
-					},
+				Servers: []*ServerExpr{{
+					Hosts: []*HostExpr{
+						{URIs: []URIExpr{"http://example.com"}},
+					}},
 				},
 			},
 			expected: []string{"http"},
 		},
 		"multiple schemes": {
 			expr: APIExpr{
-				Servers: []*ServerExpr{
-					&ServerExpr{
-						Hosts: []*HostExpr{
-							{URIs: []URIExpr{"http://example.com"}},
-						},
-					},
-					&ServerExpr{
-						Hosts: []*HostExpr{
-							{URIs: []URIExpr{"https://example.net"}},
-						},
-					},
-				},
+				Servers: []*ServerExpr{{
+					Hosts: []*HostExpr{{URIs: []URIExpr{"http://example.com"}}},
+				}, {
+					Hosts: []*HostExpr{{URIs: []URIExpr{"https://example.net"}}},
+				}},
 			},
 			expected: []string{"http", "https"},
 		},

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -507,18 +507,16 @@ func (a *AttributeExpr) Delete(name string) {
 // Debug dumps the attribute to STDOUT in a goa developer friendly way.
 func (a *AttributeExpr) Debug(prefix string) { a.debug(prefix, make(map[*AttributeExpr]int), 0) }
 func (a *AttributeExpr) debug(prefix string, seen map[*AttributeExpr]int, indent int) {
-	for i := 0; i < indent; i++ {
-		prefix = "  " + prefix
-	}
+	prefix = strings.Repeat("  ", indent) + prefix
 	if c, ok := seen[a]; ok && c > 1 {
 		fmt.Printf("%s: ...\n", prefix)
 		return
 	}
 	seen[a]++
-	fmt.Printf("%s: %q\n", prefix, a.Type.Name())
+	fmt.Printf("%s: %s\n", prefix, a.Type.Name())
 	if o := AsObject(a.Type); o != nil {
 		for _, att := range *o {
-			att.Attribute.debug(" - "+att.Name, seen, indent+1)
+			att.Attribute.debug("- "+att.Name, seen, indent+1)
 		}
 	}
 	if a := AsArray(a.Type); a != nil {
@@ -527,6 +525,13 @@ func (a *AttributeExpr) debug(prefix string, seen map[*AttributeExpr]int, indent
 	if m := AsMap(a.Type); m != nil {
 		m.KeyType.debug(" Key", seen, indent+2)
 		m.ElemType.debug(" Elem", seen, indent+2)
+	}
+	if d := a.DefaultValue; d != nil {
+		fmt.Printf("%s: default value\n", prefix)
+		fmt.Printf("%s%#v", strings.Repeat("  ", indent+1), a.DefaultValue)
+	}
+	if v := a.Validation; v != nil {
+		v.Debug(indent + 1)
 	}
 }
 
@@ -694,6 +699,36 @@ func (v *ValidationExpr) Dup() *ValidationExpr {
 		MinLength: v.MinLength,
 		MaxLength: v.MaxLength,
 		Required:  req,
+	}
+}
+
+// Debug dumps the validation to STDOUT in a goa developer friendly way.
+func (v *ValidationExpr) Debug(indent int) {
+	prefix := strings.Repeat("  ", indent)
+	fmt.Printf("%svalidations\n", prefix)
+	if len(v.Values) > 0 {
+		fmt.Printf("%s- enum: %s\n", prefix, fmt.Sprintf("%v", v.Values))
+	}
+	if v.Format != "" {
+		fmt.Printf("%s- format: %s\n", prefix, v.Format)
+	}
+	if v.Pattern != "" {
+		fmt.Printf("%s- pattern: %s\n", prefix, v.Pattern)
+	}
+	if v.Minimum != nil {
+		fmt.Printf("%s- min: %v\n", prefix, *v.Minimum)
+	}
+	if v.Maximum != nil {
+		fmt.Printf("%s- max: %v\n", prefix, *v.Maximum)
+	}
+	if v.MinLength != nil {
+		fmt.Printf("%s- minLength: %v\n", prefix, *v.MinLength)
+	}
+	if v.MaxLength != nil {
+		fmt.Printf("%s- minLength: %v\n", prefix, *v.MaxLength)
+	}
+	if len(v.Required) > 0 {
+		fmt.Printf("%s- required: %v\n", prefix, v.Required)
 	}
 }
 

--- a/expr/http.go
+++ b/expr/http.go
@@ -16,6 +16,9 @@ type (
 		// Headers defines the HTTP request headers common to to all
 		// the API endpoints.
 		Headers *MappedAttributeExpr
+		// Cookies defines the HTTP request cookies common to to all
+		// the API endpoints.
+		Cookies *MappedAttributeExpr
 		// Consumes lists the mime types supported by the API
 		// controllers.
 		Consumes []string

--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -38,6 +38,8 @@ type (
 		Params *MappedAttributeExpr
 		// Headers defines the HTTP request headers.
 		Headers *MappedAttributeExpr
+		// Cookies defines the HTTP request cookies.
+		Cookies *MappedAttributeExpr
 		// Body describes the HTTP request body.
 		Body *AttributeExpr
 		// StreamingBody describes the body transferred through the websocket
@@ -182,14 +184,21 @@ func (e *HTTPEndpointExpr) Prepare() {
 	if e.Headers == nil {
 		e.Headers = NewEmptyMappedAttributeExpr()
 	}
+	if e.Cookies == nil {
+		e.Cookies = NewEmptyMappedAttributeExpr()
+	}
 	if e.Params == nil {
 		e.Params = NewEmptyMappedAttributeExpr()
 	}
 
-	// Inherit headers and params from parent service and API
+	// Inherit headers, cookies and params from parent service and API
 	headers := NewEmptyMappedAttributeExpr()
 	headers.Merge(Root.API.HTTP.Headers)
 	headers.Merge(e.Service.Headers)
+
+	cookies := NewEmptyMappedAttributeExpr()
+	cookies.Merge(Root.API.HTTP.Cookies)
+	cookies.Merge(e.Service.Cookies)
 
 	params := NewEmptyMappedAttributeExpr()
 	params.Merge(Root.API.HTTP.Params)

--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -650,6 +650,7 @@ func (e *HTTPEndpointExpr) Finalize() {
 	// payload attributes.
 	initAttr(e.Params, e.MethodExpr.Payload)
 	initAttr(e.Headers, e.MethodExpr.Payload)
+	initAttr(e.Cookies, e.MethodExpr.Payload)
 
 	if e.Body != nil {
 		// rename type to add RequestBody suffix so that we don't end with

--- a/expr/http_endpoint_test.go
+++ b/expr/http_endpoint_test.go
@@ -144,7 +144,7 @@ func TestHTTPEndpointValidation(t *testing.T) {
 		"endpoint-has-skip-response-encode-and-result-streaming": {
 			DSL: testdata.EndpointHasSkipResponseEncodeAndResultStreaming,
 			Error: `service "Service" HTTP endpoint "Method": Endpoint cannot use SkipResponseBodyEncodeDecode when method defines a StreamingResult.
-service "Service" HTTP endpoint "Method": HTTP endpoint response body must be empty when using SkipResponseBodyEncodeDecode. Make sure to define Headers as needed.`,
+service "Service" HTTP endpoint "Method": HTTP endpoint response body must be empty when using SkipResponseBodyEncodeDecode. Make sure to define headers and cookies as needed.`,
 		},
 		"endpoint-has-skip-encode-and-grpc": {
 			DSL:   testdata.EndpointHasSkipEncodeAndGRPC,

--- a/expr/http_response.go
+++ b/expr/http_response.go
@@ -84,6 +84,8 @@ type (
 		Description string
 		// Headers describe the HTTP response headers.
 		Headers *MappedAttributeExpr
+		// Cookies describe the HTTP response cookies.
+		Cookies *MappedAttributeExpr
 		// Response body if any
 		Body *AttributeExpr
 		// Response Content-Type header value

--- a/expr/http_response.go
+++ b/expr/http_response.go
@@ -298,6 +298,7 @@ func (r *HTTPResponseExpr) Finalize(a *HTTPEndpointExpr, svcAtt *AttributeExpr) 
 		}
 	}
 	initAttr(r.Headers, svcAtt)
+	initAttr(r.Cookies, svcAtt)
 }
 
 // Dup creates a copy of the response expression.
@@ -314,6 +315,9 @@ func (r *HTTPResponseExpr) Dup() *HTTPResponseExpr {
 	}
 	if r.Headers != nil {
 		res.Headers = DupMappedAtt(r.Headers)
+	}
+	if r.Cookies != nil {
+		res.Cookies = DupMappedAtt(r.Cookies)
 	}
 	return &res
 }

--- a/expr/http_service.go
+++ b/expr/http_service.go
@@ -27,6 +27,9 @@ type (
 		// Headers defines the HTTP request headers common to all the
 		// service endpoints.
 		Headers *MappedAttributeExpr
+		// Cookies defines the HTTP request cookies common to all the
+		// service endpoints.
+		Cookies *MappedAttributeExpr
 		// Name of parent service if any
 		ParentName string
 		// Endpoint with canonical service path

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -367,7 +367,7 @@ func (c *{{ .ClientStruct }}) {{ .EndpointInit }}({{ if .MultipartRequestEncoder
 
 // input: EndpointData
 const requestBuilderT = `{{ comment .RequestInit.Description }}
-func (c *{{ .ClientStruct }}) {{ .RequestInit.Name }}(ctx context.Context, {{ range .RequestInit.ClientArgs }}{{ .Name }} {{ .TypeRef }},{{ end }}) (*http.Request, error) {
+func (c *{{ .ClientStruct }}) {{ .RequestInit.Name }}(ctx context.Context, {{ range .RequestInit.ClientArgs }}{{ .VarName }} {{ .TypeRef }},{{ end }}) (*http.Request, error) {
 	{{- .RequestInit.ClientCode }}
 }
 `
@@ -515,7 +515,7 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 		}
 	{{- else if .Payload.Request.ClientBody }}
 		{{- if .Payload.Request.ClientBody.Init }}
-		body := {{ .Payload.Request.ClientBody.Init.Name }}({{ range .Payload.Request.ClientBody.Init.ClientArgs }}{{ if .FieldPointer }}&{{ end }}{{ .Name }}, {{ end }})
+		body := {{ .Payload.Request.ClientBody.Init.Name }}({{ range .Payload.Request.ClientBody.Init.ClientArgs }}{{ if .FieldPointer }}&{{ end }}{{ .VarName }}, {{ end }})
 		{{- else }}
 		body := p{{ if .Payload.Request.PayloadAttr }}.{{ .Payload.Request.PayloadAttr }}{{ end }}
 		{{- end }}

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -842,7 +842,7 @@ const singleResponseT = ` {{- if .ClientBody }}
         for _, c := range cookies {
 			switch c.Name {
 		{{- range .Cookies }}
-			case "{{ printf "%q" .Name }}":
+			case {{ printf "%q" .Name }}:
 				{{ .VarName }}Raw = c.Value
 		{{- end }}
 			}

--- a/http/codegen/client_cli.go
+++ b/http/codegen/client_cli.go
@@ -212,7 +212,7 @@ func makeFlags(e *EndpointData, args []*InitArgData, payload expr.DataType) ([]*
 	)
 	for i, arg := range args {
 		pInitArgs[i] = &codegen.InitArgData{
-			Name:         arg.Name,
+			Name:         arg.VarName,
 			Pointer:      arg.Pointer,
 			FieldName:    arg.FieldName,
 			FieldPointer: arg.FieldPointer,
@@ -220,13 +220,13 @@ func makeFlags(e *EndpointData, args []*InitArgData, payload expr.DataType) ([]*
 			Type:         arg.Type,
 		}
 
-		f := cli.NewFlagData(e.ServiceName, e.Method.Name, arg.Name, arg.TypeName, arg.Description, arg.Required, arg.Example, arg.DefaultValue)
+		f := cli.NewFlagData(e.ServiceName, e.Method.Name, arg.VarName, arg.TypeName, arg.Description, arg.Required, arg.Example, arg.DefaultValue)
 		flags[i] = f
 		params[i] = f.FullName
-		if arg.FieldName == "" && arg.Name != "body" {
+		if arg.FieldName == "" && arg.VarName != "body" {
 			continue
 		}
-		code, chek := cli.FieldLoadCode(f, arg.Name, arg.TypeName, arg.Validate, arg.DefaultValue, payload)
+		code, chek := cli.FieldLoadCode(f, arg.VarName, arg.TypeName, arg.Validate, arg.DefaultValue, payload)
 		check = check || chek
 		tn := arg.TypeRef
 		if f.Type == "JSON" {
@@ -236,8 +236,8 @@ func makeFlags(e *EndpointData, args []*InitArgData, payload expr.DataType) ([]*
 			tn = arg.TypeName
 		}
 		fdata = append(fdata, &cli.FieldData{
-			Name:    arg.Name,
-			VarName: arg.Name,
+			Name:    arg.VarName,
+			VarName: arg.VarName,
 			TypeRef: tn,
 			Init:    code,
 		})

--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -222,7 +222,7 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 
 // input: InitData
 const clientBodyInitT = `{{ comment .Description }}
-func {{ .Name }}({{ range .ClientArgs }}{{ .Name }} {{.TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
+func {{ .Name }}({{ range .ClientArgs }}{{ .VarName }} {{.TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
 	{{ .ClientCode }}
 	return body
 }
@@ -230,7 +230,7 @@ func {{ .Name }}({{ range .ClientArgs }}{{ .Name }} {{.TypeRef }}, {{ end }}) {{
 
 // input: InitData
 const clientTypeInitT = `{{ comment .Description }}
-func {{ .Name }}({{- range .ClientArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
+func {{ .Name }}({{- range .ClientArgs }}{{ .VarName }} {{ .TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
 {{- if .ClientCode }}
 	{{ .ClientCode }}
 	{{- if .ReturnTypeAttribute }}

--- a/http/codegen/example_cli.go
+++ b/http/codegen/example_cli.go
@@ -70,8 +70,8 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 	}
 	sections := []*codegen.SectionTemplate{
 		codegen.Header("", "main", specs),
-		&codegen.SectionTemplate{Name: "cli-http-start", Source: httpCLIStartT},
-		&codegen.SectionTemplate{
+		{Name: "cli-http-start", Source: httpCLIStartT},
+		{
 			Name:   "cli-http-streaming",
 			Source: httpCLIStreamingT,
 			Data: map[string]interface{}{
@@ -81,7 +81,7 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 				"needStream": needStream,
 			},
 		},
-		&codegen.SectionTemplate{
+		{
 			Name:   "cli-http-end",
 			Source: httpCLIEndT,
 			Data: map[string]interface{}{
@@ -93,7 +93,7 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 				"hasWebSocket": hasWebSocket,
 			},
 		},
-		&codegen.SectionTemplate{Name: "cli-http-usage", Source: httpCLIUsageT},
+		{Name: "cli-http-usage", Source: httpCLIUsageT},
 	}
 	return &codegen.File{
 		Path:             path,

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -83,17 +83,17 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 
 	sections := []*codegen.SectionTemplate{
 		codegen.Header("", "main", specs),
-		&codegen.SectionTemplate{
+		{
 			Name:   "server-http-start",
 			Source: httpSvrStartT,
 			Data: map[string]interface{}{
 				"Services": svcdata,
 			},
 		},
-		&codegen.SectionTemplate{Name: "server-http-logger", Source: httpSvrLoggerT},
-		&codegen.SectionTemplate{Name: "server-http-encoding", Source: httpSvrEncodingT},
-		&codegen.SectionTemplate{Name: "server-http-mux", Source: httpSvrMuxT},
-		&codegen.SectionTemplate{
+		{Name: "server-http-logger", Source: httpSvrLoggerT},
+		{Name: "server-http-encoding", Source: httpSvrEncodingT},
+		{Name: "server-http-mux", Source: httpSvrMuxT},
+		{
 			Name:   "server-http-init",
 			Source: httpSvrInitT,
 			Data: map[string]interface{}{
@@ -102,15 +102,15 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 			},
 			FuncMap: map[string]interface{}{"needStream": needStream, "hasWebSocket": hasWebSocket},
 		},
-		&codegen.SectionTemplate{Name: "server-http-middleware", Source: httpSvrMiddlewareT},
-		&codegen.SectionTemplate{
+		{Name: "server-http-middleware", Source: httpSvrMiddlewareT},
+		{
 			Name:   "server-http-end",
 			Source: httpSvrEndT,
 			Data: map[string]interface{}{
 				"Services": svcdata,
 			},
 		},
-		&codegen.SectionTemplate{Name: "server-http-errorhandler", Source: httpSvrErrorHandlerT},
+		{Name: "server-http-errorhandler", Source: httpSvrErrorHandlerT},
 	}
 
 	return &codegen.File{Path: fpath, SectionTemplates: sections, SkipExist: true}

--- a/http/codegen/paths.go
+++ b/http/codegen/paths.go
@@ -60,7 +60,7 @@ func pathSections(svc *expr.HTTPServiceExpr, pkg string) []*codegen.SectionTempl
 
 // input: EndpointData
 const pathT = `{{ range .Routes }}// {{ .PathInit.Description }}
-func {{ .PathInit.Name }}({{ range .PathInit.ServerArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) {{ .PathInit.ReturnTypeRef }} {
+func {{ .PathInit.Name }}({{ range .PathInit.ServerArgs }}{{ .VarName }} {{ .TypeRef }}, {{ end }}) {{ .PathInit.ReturnTypeRef }} {
 {{- .PathInit.ServerCode }}
 }
 {{ end }}`

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1254,10 +1254,10 @@ const responseT = `{{ define "response" -}}
 		{{- else }}
 			{{- if isAliased .FieldType }}
 	{{ .VarName }}raw := {{ goTypeRef .Type }}({{ if .FieldPointer }}*{{ end }}res{{ if $.ViewedResult }}.Projected{{ end }}{{ if .FieldName }}.{{ .FieldName }}{{ end }})
-	{{ template "header_conversion" (headerConversionData .Type (printf "%sraw" {{ .VarName }}) true {{ .VarName }}) }}
+	{{ template "header_conversion" (headerConversionData .Type (printf "%sraw" .VarName) true .VarName) }}
 			{{- else }}
 	{{ .VarName }}raw := res{{ if $.ViewedResult }}.Projected{{ end }}{{ if .FieldName }}.{{ .FieldName }}{{ end }}
-	{{ template "header_conversion" (headerConversionData .Type (printf "%sraw" {{ .VarName }}) (not .FieldPointer) {{ .VarName }}) }}
+	{{ template "header_conversion" (headerConversionData .Type (printf "%sraw" .VarName) (not .FieldPointer) .VarName) }}
 			{{- end }}
 		{{- end }}
 
@@ -1365,7 +1365,7 @@ func {{ .InitName }}(mux goahttp.Muxer, {{ .VarName }} {{ .FuncName }}) func(r *
 			{{- if .Payload.Request.PayloadInit }}
 				{{- range .Payload.Request.PayloadInit.ServerArgs }}
 					{{- if .FieldName }}
-			(*p).{{ .FieldName }} = {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .Name }}
+			(*p).{{ .FieldName }} = {{ if and (not .Pointer) .FieldPointer }}&{{ end }}{{ .VarName }}
 					{{- end }}
 				{{- end }}
 			{{- end }}

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1266,7 +1266,7 @@ const responseT = `{{ define "response" -}}
 		{{ .VarName }} := "{{ printValue .Type .DefaultValue }}"
 		{{- end }}
 		http.SetCookie(w, &http.Cookie{
-			Name: {{ .Name }},
+			Name: {{ printf "%q" .Name }},
 			Value: {{ .VarName }},
 			{{- if .MaxAge }}
 			MaxAge: {{ .MaxAge }},

--- a/http/codegen/server_types.go
+++ b/http/codegen/server_types.go
@@ -245,7 +245,7 @@ type {{ .VarName }} {{ .Def }}
 
 // input: InitData
 const serverTypeInitT = `{{ comment .Description }}
-func {{ .Name }}({{- range .ServerArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
+func {{ .Name }}({{- range .ServerArgs }}{{ .VarName }} {{ .TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
 {{- if .ServerCode }}
 	{{ .ServerCode }}
 	{{- if .ReturnTypeAttribute }}
@@ -266,7 +266,7 @@ func {{ .Name }}({{- range .ServerArgs }}{{ .Name }} {{ .TypeRef }}, {{ end }}) 
 
 // input: InitData
 const serverBodyInitT = `{{ comment .Description }}
-func {{ .Name }}({{ range .ServerArgs }}{{ .Name }} {{.TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
+func {{ .Name }}({{ range .ServerArgs }}{{ .VarName }} {{.TypeRef }}, {{ end }}) {{ .ReturnTypeRef }} {
 	{{ .ServerCode }}
 	return body
 }

--- a/http/codegen/server_types.go
+++ b/http/codegen/server_types.go
@@ -221,7 +221,7 @@ func fieldCode(init *InitData, typ string) string {
 	initArgs := make([]*codegen.InitArgData, len(args))
 	for i, arg := range args {
 		initArgs[i] = &codegen.InitArgData{
-			Name:         arg.Name,
+			Name:         arg.VarName,
 			Pointer:      arg.Pointer,
 			Type:         arg.Type,
 			FieldName:    arg.FieldName,

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1011,6 +1011,8 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 						break
 					}
 				}
+			}
+			if !mustValidate {
 				for _, c := range cookiesData {
 					if c.Validate != "" || c.Required || needConversion(c.Type) {
 						mustValidate = true

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -420,8 +420,6 @@ type (
 	// InitArgData represents a single constructor argument.
 	InitArgData struct {
 		*AttributeData
-		// Name is the name of
-		Name string
 		// Reference to the argument, e.g. "&body".
 		Ref string
 	}
@@ -637,9 +635,9 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 							vcode = codegen.RecursiveValidationCode(att, ctx, true, name)
 						}
 						initArgs[j] = &InitArgData{
-							Name: name,
-							Ref:  name,
+							Ref: name,
 							AttributeData: &AttributeData{
+								VarName:     name,
 								Description: att.Description,
 								FieldName:   codegen.Goify(arg, true),
 								FieldType:   patt.Type,
@@ -764,7 +762,7 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 			if err := requestInitTmpl.Execute(&buf, data); err != nil {
 				panic(err) // bug
 			}
-			clientArgs := []*InitArgData{{Name: "v", Ref: "v", AttributeData: &AttributeData{TypeRef: "interface{}"}}}
+			clientArgs := []*InitArgData{{Ref: "v", AttributeData: &AttributeData{VarName: "v", TypeRef: "interface{}"}}}
 			requestInit = &InitData{
 				Name:        name,
 				Description: fmt.Sprintf("%s instantiates a HTTP request object with method and path set to call the %q service %q endpoint", name, svc.Name, ep.Name),
@@ -1079,9 +1077,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 				}
 			}
 			serverArgs = []*InitArgData{{
-				Name: "body",
-				Ref:  sd.Scope.GoVar("body", body),
+				Ref: sd.Scope.GoVar("body", body),
 				AttributeData: &AttributeData{
+					VarName:  "body",
 					TypeName: sd.Scope.GoTypeName(e.Body),
 					TypeRef:  sd.Scope.GoTypeRef(e.Body),
 					Type:     body,
@@ -1091,9 +1089,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 				},
 			}}
 			clientArgs = []*InitArgData{{
-				Name: "body",
-				Ref:  sd.Scope.GoVar("body", body),
+				Ref: sd.Scope.GoVar("body", body),
 				AttributeData: &AttributeData{
+					VarName:  "body",
 					TypeName: sd.Scope.GoTypeName(e.Body),
 					TypeRef:  sd.Scope.GoTypeRef(e.Body),
 					Type:     body,
@@ -1106,9 +1104,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 		var args []*InitArgData
 		for _, p := range request.PathParams {
 			args = append(args, &InitArgData{
-				Name: p.VarName,
-				Ref:  p.VarName,
+				Ref: p.VarName,
 				AttributeData: &AttributeData{
+					VarName:      p.VarName,
 					Description:  p.Description,
 					FieldName:    p.FieldName,
 					FieldPointer: p.FieldPointer,
@@ -1125,9 +1123,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 		}
 		for _, p := range request.QueryParams {
 			args = append(args, &InitArgData{
-				Name: p.VarName,
-				Ref:  p.VarName,
+				Ref: p.VarName,
 				AttributeData: &AttributeData{
+					VarName:      p.VarName,
 					FieldName:    p.FieldName,
 					FieldPointer: p.FieldPointer,
 					FieldType:    p.FieldType,
@@ -1144,9 +1142,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 		}
 		for _, h := range request.Headers {
 			args = append(args, &InitArgData{
-				Name: h.VarName,
-				Ref:  h.VarName,
+				Ref: h.VarName,
 				AttributeData: &AttributeData{
+					VarName:      h.VarName,
 					FieldName:    h.FieldName,
 					FieldPointer: h.FieldPointer,
 					FieldType:    h.FieldType,
@@ -1163,9 +1161,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 		}
 		for _, c := range request.Cookies {
 			args = append(args, &InitArgData{
-				Name: c.VarName,
-				Ref:  c.VarName,
+				Ref: c.VarName,
 				AttributeData: &AttributeData{
+					VarName:      c.VarName,
 					FieldName:    c.FieldName,
 					FieldPointer: c.FieldPointer,
 					FieldType:    c.FieldType,
@@ -1196,9 +1194,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 						uref = "*" + uref
 					}
 					uarg := &InitArgData{
-						Name: sc.UsernameAttr,
-						Ref:  sc.UsernameAttr,
+						Ref: sc.UsernameAttr,
 						AttributeData: &AttributeData{
+							VarName:      sc.UsernameAttr,
 							FieldName:    sc.UsernameField,
 							FieldPointer: sc.UsernamePointer,
 							FieldType:    uatt.Type,
@@ -1218,9 +1216,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 						pref = "*" + pref
 					}
 					parg := &InitArgData{
-						Name: sc.PasswordAttr,
-						Ref:  sc.PasswordAttr,
+						Ref: sc.PasswordAttr,
 						AttributeData: &AttributeData{
+							VarName:      sc.PasswordAttr,
 							FieldName:    sc.PasswordField,
 							FieldPointer: sc.PasswordPointer,
 							FieldType:    patt.Type,
@@ -1548,9 +1546,9 @@ func buildResponses(e *expr.HTTPEndpointExpr, result *expr.AttributeExpr, viewed
 								}
 							}
 							clientArgs = []*InitArgData{{
-								Name: "body",
-								Ref:  ref,
+								Ref: ref,
 								AttributeData: &AttributeData{
+									VarName:  "body",
 									TypeRef:  sd.Scope.GoTypeRef(resp.Body),
 									Validate: vcode,
 								},
@@ -1581,9 +1579,9 @@ func buildResponses(e *expr.HTTPEndpointExpr, result *expr.AttributeExpr, viewed
 						}
 						for _, h := range headersData {
 							clientArgs = append(clientArgs, &InitArgData{
-								Name: h.VarName,
-								Ref:  h.VarName,
+								Ref: h.VarName,
 								AttributeData: &AttributeData{
+									VarName:      h.VarName,
 									FieldName:    h.FieldName,
 									FieldPointer: h.FieldPointer,
 									FieldType:    h.FieldType,
@@ -1598,9 +1596,9 @@ func buildResponses(e *expr.HTTPEndpointExpr, result *expr.AttributeExpr, viewed
 						}
 						for _, c := range cookiesData {
 							clientArgs = append(clientArgs, &InitArgData{
-								Name: c.VarName,
-								Ref:  c.VarName,
+								Ref: c.VarName,
 								AttributeData: &AttributeData{
+									VarName:      c.VarName,
 									FieldName:    c.FieldName,
 									FieldPointer: c.FieldPointer,
 									FieldType:    c.FieldType,
@@ -1702,16 +1700,15 @@ func buildErrorsData(e *expr.HTTPEndpointExpr, sd *ServiceData) []*ErrorGroupDat
 						ref = "&body"
 					}
 					args = []*InitArgData{{
-						Name:          "body",
 						Ref:           ref,
-						AttributeData: &AttributeData{TypeRef: sd.Scope.GoTypeRef(v.Response.Body)},
+						AttributeData: &AttributeData{VarName: "body", TypeRef: sd.Scope.GoTypeRef(v.Response.Body)},
 					}}
 				}
 				for _, h := range extractHeaders(v.Response.Headers, v.ErrorExpr.AttributeExpr, svcctx, sd.Scope) {
 					args = append(args, &InitArgData{
-						Name: h.VarName,
-						Ref:  h.VarName,
+						Ref: h.VarName,
 						AttributeData: &AttributeData{
+							VarName:      h.VarName,
 							FieldName:    h.FieldName,
 							FieldPointer: false,
 							FieldType:    h.FieldType,
@@ -1724,9 +1721,9 @@ func buildErrorsData(e *expr.HTTPEndpointExpr, sd *ServiceData) []*ErrorGroupDat
 				}
 				for _, c := range extractCookies(v.Response.Cookies, v.ErrorExpr.AttributeExpr, svcctx, sd.Scope) {
 					args = append(args, &InitArgData{
-						Name: c.VarName,
-						Ref:  c.VarName,
+						Ref: c.VarName,
 						AttributeData: &AttributeData{
+							VarName:      c.VarName,
 							FieldName:    c.FieldName,
 							FieldPointer: false,
 							FieldType:    c.FieldType,
@@ -1968,9 +1965,9 @@ func buildRequestBodyType(body, att *expr.AttributeExpr, e *expr.HTTPEndpointExp
 				sd.ClientTransformHelpers = codegen.AppendHelpers(sd.ClientTransformHelpers, helpers)
 			}
 			arg := InitArgData{
-				Name: sourceVar,
-				Ref:  sourceVar,
+				Ref: sourceVar,
 				AttributeData: &AttributeData{
+					VarName:  sourceVar,
 					TypeRef:  svc.Scope.GoFullTypeRef(att, svc.PkgName),
 					Type:     att.Type,
 					Validate: validateDef,
@@ -2158,9 +2155,9 @@ func buildResponseBodyType(body, att *expr.AttributeExpr, e *expr.HTTPEndpointEx
 				tref = svc.ViewScope.GoFullTypeRef(att, svc.ViewsPkg)
 			}
 			arg := InitArgData{
-				Name: sourceVar,
-				Ref:  ref,
+				Ref: ref,
 				AttributeData: &AttributeData{
+					VarName:  sourceVar,
 					TypeRef:  tref,
 					Type:     att.Type,
 					Validate: validateDef,
@@ -2652,15 +2649,15 @@ const (
 	{{- range $i, $arg := .Args }}
 		{{- $typ := (index $.PathParams $i).Attribute.Type }}
 		{{- if eq $typ.Name "array" }}
-	{{ .Name }}Slice := make([]string, len({{ .Name }}))
-	for i, v := range {{ .Name }} {
-		{{ .Name }}Slice[i] = {{ template "slice_conversion" $typ.ElemType.Type.Name }}
+	{{ .VarName }}Slice := make([]string, len({{ .VarName }}))
+	for i, v := range {{ .VarName }} {
+		{{ .VarName }}Slice[i] = {{ template "slice_conversion" $typ.ElemType.Type.Name }}
 	}
 		{{- end }}
 	{{- end }}
 	return fmt.Sprintf("{{ .PathFormat }}", {{ range $i, $arg := .Args }}
-	{{- if eq (index $.PathParams $i).Attribute.Type.Name "array" }}strings.Join({{ .Name }}Slice, ",")
-	{{- else }}{{ .Name }}
+	{{- if eq (index $.PathParams $i).Attribute.Type.Name "array" }}strings.Join({{ .VarName }}Slice, ",")
+	{{- else }}{{ .VarName }}
 	{{- end }}, {{ end }})
 {{- else }}
 	return "{{ .PathFormat }}"
@@ -2686,7 +2683,7 @@ const (
 {{- if or .Args .RequestStruct }}
 	var (
 	{{- range .Args }}
-		{{ .Name }} {{ .TypeRef }}
+		{{ .VarName }} {{ .TypeRef }}
 	{{- end }}
 	{{- if .RequestStruct }}
 		body io.Reader
@@ -2713,9 +2710,9 @@ const (
 		if p{{ if $.HasFields }}.{{ .FieldName }}{{ end }} != nil {
 		{{- end }}
 			{{- if (isAliased .FieldType) }}
-			{{ .Name }} = {{ goTypeRef .Type $.ServiceName }}({{ if .Pointer }}*{{ end }}p{{ if $.HasFields }}.{{ .FieldName }}{{ end }})
+			{{ .VarName }} = {{ goTypeRef .Type $.ServiceName }}({{ if .Pointer }}*{{ end }}p{{ if $.HasFields }}.{{ .FieldName }}{{ end }})
 			{{- else }}
-			{{ .Name }} = {{ if .Pointer }}*{{ end }}p{{ if $.HasFields }}.{{ .FieldName }}{{ end }}
+			{{ .VarName }} = {{ if .Pointer }}*{{ end }}p{{ if $.HasFields }}.{{ .FieldName }}{{ end }}
 			{{- end }}
 		{{- if .Pointer }}
 		}

--- a/http/codegen/websocket.go
+++ b/http/codegen/websocket.go
@@ -3,10 +3,217 @@ package codegen
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/expr"
 )
+
+type (
+	// WebSocketData contains the data needed to render struct type that
+	// implements the server and client stream interfaces.
+	WebSocketData struct {
+		// VarName is the name of the struct.
+		VarName string
+		// Type is type of the stream (server or client).
+		Type string
+		// Interface is the fully qualified name of the interface that
+		// the struct implements.
+		Interface string
+		// Endpoint is endpoint data that defines streaming
+		// payload/result.
+		Endpoint *EndpointData
+		// Payload is the streaming payload type sent via the stream.
+		Payload *TypeData
+		// Response is the successful response data for the streaming
+		// endpoint.
+		Response *ResponseData
+		// SendName is the name of the send function.
+		SendName string
+		// SendDesc is the description for the send function.
+		SendDesc string
+		// SendTypeName is the fully qualified type name sent through
+		// the stream.
+		SendTypeName string
+		// SendTypeRef is the fully qualified type ref sent through the
+		// stream.
+		SendTypeRef string
+		// RecvName is the name of the receive function.
+		RecvName string
+		// RecvDesc is the description for the recv function.
+		RecvDesc string
+		// RecvTypeName is the fully qualified type name received from
+		// the stream.
+		RecvTypeName string
+		// RecvTypeRef is the fully qualified type ref received from the
+		// stream.
+		RecvTypeRef string
+		// MustClose indicates whether to generate the Close() function
+		// for the stream.
+		MustClose bool
+		// PkgName is the service package name.
+		PkgName string
+		// Kind is the kind of the stream (payload, result or
+		// bidirectional).
+		Kind expr.StreamKind
+	}
+)
+
+// initWebSocketData initializes the WebSocket related data in ed.
+func initWebSocketData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData) {
+	var (
+		svrSendTypeName string
+		svrSendTypeRef  string
+		svrRecvTypeName string
+		svrRecvTypeRef  string
+		svrSendDesc     string
+		svrRecvDesc     string
+		svrPayload      *TypeData
+		cliSendDesc     string
+		cliRecvDesc     string
+		cliPayload      *TypeData
+
+		md     = ed.Method
+		svc    = sd.Service
+		svcctx = serviceContext(sd.Service.PkgName, sd.Service.Scope)
+	)
+	{
+		svrSendTypeName = ed.Result.Name
+		svrSendTypeRef = ed.Result.Ref
+		svrSendDesc = fmt.Sprintf("%s streams instances of %q to the %q endpoint websocket connection.", md.ServerStream.SendName, svrSendTypeName, md.Name)
+		cliRecvDesc = fmt.Sprintf("%s reads instances of %q from the %q endpoint websocket connection.", md.ClientStream.RecvName, svrSendTypeName, md.Name)
+		if e.MethodExpr.Stream == expr.ClientStreamKind || e.MethodExpr.Stream == expr.BidirectionalStreamKind {
+			svrRecvTypeName = sd.Scope.GoFullTypeName(e.MethodExpr.StreamingPayload, svc.PkgName)
+			svrRecvTypeRef = sd.Scope.GoFullTypeRef(e.MethodExpr.StreamingPayload, svc.PkgName)
+			svrPayload = buildRequestBodyType(e.StreamingBody, e.MethodExpr.StreamingPayload, e, true, sd)
+			if needInit(e.MethodExpr.StreamingPayload.Type) {
+				makeHTTPType(e.StreamingBody)
+				body := e.StreamingBody.Type
+				// generate constructor function to transform request body,
+				// into the method streaming payload type
+				var (
+					name       string
+					desc       string
+					serverArgs []*InitArgData
+					serverCode string
+					err        error
+				)
+				{
+					n := codegen.Goify(e.MethodExpr.Name, true)
+					p := codegen.Goify(svrPayload.Name, true)
+					// Raw payload object has type name prefixed with endpoint name. No need to
+					// prefix the type name again.
+					if strings.HasPrefix(p, n) {
+						name = fmt.Sprintf("New%s", p)
+					} else {
+						name = fmt.Sprintf("New%s%s", n, p)
+					}
+					desc = fmt.Sprintf("%s builds a %s service %s endpoint payload.", name, svc.Name, e.MethodExpr.Name)
+					if body != expr.Empty {
+						var (
+							ref    string
+							svcode string
+						)
+						{
+							ref = "body"
+							if expr.IsObject(body) {
+								ref = "&body"
+							}
+							if ut, ok := body.(expr.UserType); ok {
+								if val := ut.Attribute().Validation; val != nil {
+									httpctx := httpContext("", sd.Scope, true, true)
+									svcode = codegen.RecursiveValidationCode(ut.Attribute(), httpctx, true, "body")
+								}
+							}
+						}
+						serverArgs = []*InitArgData{{
+							Name: "body",
+							Ref:  ref,
+							AttributeData: &AttributeData{
+								TypeName: sd.Scope.GoTypeName(e.StreamingBody),
+								TypeRef:  sd.Scope.GoTypeRef(e.StreamingBody),
+								Type:     e.StreamingBody.Type,
+								Required: true,
+								Example:  e.Body.Example(expr.Root.API.Random()),
+								Validate: svcode,
+							},
+						}}
+					}
+					if body != expr.Empty {
+						var helpers []*codegen.TransformFunctionData
+						httpctx := httpContext("", sd.Scope, true, true)
+						serverCode, helpers, err = marshal(e.StreamingBody, e.MethodExpr.StreamingPayload, "body", "v", httpctx, svcctx)
+						if err == nil {
+							sd.ServerTransformHelpers = codegen.AppendHelpers(sd.ServerTransformHelpers, helpers)
+						}
+					}
+					if err != nil {
+						fmt.Println(err.Error()) // TBD validate DSL so errors are not possible
+					}
+				}
+				svrPayload.Init = &InitData{
+					Name:           name,
+					Description:    desc,
+					ServerArgs:     serverArgs,
+					ReturnTypeName: svc.Scope.GoFullTypeName(e.MethodExpr.StreamingPayload, svc.PkgName),
+					ReturnTypeRef:  svc.Scope.GoFullTypeRef(e.MethodExpr.StreamingPayload, svc.PkgName),
+					ReturnIsStruct: expr.IsObject(e.MethodExpr.StreamingPayload.Type),
+					ReturnTypePkg:  svc.PkgName,
+					ServerCode:     serverCode,
+				}
+			}
+			cliPayload = buildRequestBodyType(e.StreamingBody, e.MethodExpr.StreamingPayload, e, false, sd)
+			if cliPayload != nil {
+				sd.ClientTypeNames[cliPayload.Name] = false
+				sd.ServerTypeNames[cliPayload.Name] = false
+			}
+			if e.MethodExpr.Stream == expr.ClientStreamKind {
+				svrSendDesc = fmt.Sprintf("%s streams instances of %q to the %q endpoint websocket connection and closes the connection.", md.ServerStream.SendName, svrSendTypeName, md.Name)
+				cliRecvDesc = fmt.Sprintf("%s stops sending messages to the %q endpoint websocket connection and reads instances of %q from the connection.", md.ClientStream.RecvName, md.Name, svrSendTypeName)
+			}
+			svrRecvDesc = fmt.Sprintf("%s reads instances of %q from the %q endpoint websocket connection.", md.ServerStream.RecvName, svrRecvTypeName, md.Name)
+			cliSendDesc = fmt.Sprintf("%s streams instances of %q to the %q endpoint websocket connection.", md.ClientStream.SendName, svrRecvTypeName, md.Name)
+		}
+	}
+	ed.ServerWebSocket = &WebSocketData{
+		VarName:      md.ServerStream.VarName,
+		Interface:    fmt.Sprintf("%s.%s", svc.PkgName, md.ServerStream.Interface),
+		Endpoint:     ed,
+		Payload:      svrPayload,
+		Response:     ed.Result.Responses[0],
+		PkgName:      svc.PkgName,
+		Type:         "server",
+		Kind:         md.ServerStream.Kind,
+		SendName:     md.ServerStream.SendName,
+		SendDesc:     svrSendDesc,
+		SendTypeName: svrSendTypeName,
+		SendTypeRef:  svrSendTypeRef,
+		RecvName:     md.ServerStream.RecvName,
+		RecvDesc:     svrRecvDesc,
+		RecvTypeName: svrRecvTypeName,
+		RecvTypeRef:  svrRecvTypeRef,
+		MustClose:    md.ServerStream.MustClose,
+	}
+	ed.ClientWebSocket = &WebSocketData{
+		VarName:      md.ClientStream.VarName,
+		Interface:    fmt.Sprintf("%s.%s", svc.PkgName, md.ClientStream.Interface),
+		Endpoint:     ed,
+		Payload:      cliPayload,
+		Response:     ed.Result.Responses[0],
+		PkgName:      svc.PkgName,
+		Type:         "client",
+		Kind:         md.ClientStream.Kind,
+		SendName:     md.ClientStream.SendName,
+		SendDesc:     cliSendDesc,
+		SendTypeName: svrRecvTypeName,
+		SendTypeRef:  svrRecvTypeRef,
+		RecvName:     md.ClientStream.RecvName,
+		RecvDesc:     cliRecvDesc,
+		RecvTypeName: svrSendTypeName,
+		RecvTypeRef:  svrSendTypeRef,
+		MustClose:    md.ClientStream.MustClose,
+	}
+}
 
 // websocketServerFile returns the file implementing the WebSocket server
 // streaming implementation if any.

--- a/http/codegen/websocket.go
+++ b/http/codegen/websocket.go
@@ -127,9 +127,9 @@ func initWebSocketData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceDa
 							}
 						}
 						serverArgs = []*InitArgData{{
-							Name: "body",
-							Ref:  ref,
+							Ref: ref,
 							AttributeData: &AttributeData{
+								VarName:  "body",
 								TypeName: sd.Scope.GoTypeName(e.StreamingBody),
 								TypeRef:  sd.Scope.GoTypeRef(e.StreamingBody),
 								Type:     e.StreamingBody.Type,


### PR DESCRIPTION
This PR adds support for using HTTP cookies natively using the Goa DSL:

* Cookies defined in HTTP requests can be mapped to payload attributes.
* Cookies may also be written to HTTP responses by mapping result attributes.

When creating cookies in HTTP responses the design may also specify the value of cookies attributes such as path, domain, max-age etc.

This PR introduces the following DSL functions:

* [Cookie](https://pkg.go.dev/goa.design/goa/v3@v3.1.3/dsl?tab=doc#Cookie)
* [CookiePath](https://pkg.go.dev/goa.design/goa/v3@v3.1.3/dsl?tab=doc#CookiePath)
* [CookieDomain](https://pkg.go.dev/goa.design/goa/v3@v3.1.3/dsl?tab=doc#CookieDomain)
* [CookieMaxAge](https://pkg.go.dev/goa.design/goa/v3@v3.1.3/dsl?tab=doc#CookieMaxAge)
* [CookieSecure](https://pkg.go.dev/goa.design/goa/v3@v3.1.3/dsl?tab=doc#CookieSecure)
* [CookieHTTPOnly](https://pkg.go.dev/goa.design/goa/v3@v3.1.3/dsl?tab=doc#CookieHTTPOnly)
