### PR TITLE
Properly handle optional cookies

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -833,7 +833,7 @@ const requestElementsT = `{{- define "request_elements" }}
 {{- end }}
 
 {{- range .Cookies }}
-	c, err = r.Cookie("{{ .Name }}")
+	c, {{ if not .Required }}_{{ else }}err{{ end }} = r.Cookie("{{ .Name }}")
 	{{- if and (or (eq .Type.Name "string") (eq .Type.Name "any")) .Required }}
 		if err == http.ErrNoCookie {
 			err = goa.MergeErrors(err, goa.MissingFieldError("{{ .Name }}", "cookie"))

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -990,7 +990,12 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 				sd.ServerTypeNames[serverBodyData.Name] = false
 				sd.ClientTypeNames[serverBodyData.Name] = false
 			}
-			mustValidate = len(cookiesData) > 0
+			for _, p := range cookiesData {
+				if p.Required || p.Validate != "" || needConversion(p.Type) {
+					mustValidate = true
+					break
+				}
+			}
 			if !mustValidate {
 				for _, p := range paramsData {
 					if p.Validate != "" || needConversion(p.Type) {

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -3416,20 +3416,16 @@ var PayloadCookieStringDecodeCode = `// DecodeMethodCookieStringRequest returns 
 func DecodeMethodCookieStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
 	return func(r *http.Request) (interface{}, error) {
 		var (
-			c2  *string
-			err error
-			c   *http.Cookie
+			c2 *string
+			c  *http.Cookie
 		)
-		c, err = r.Cookie("c")
+		c, _ = r.Cookie("c")
 		var c2Raw string
 		if c != nil {
 			c2Raw = c.Value
 		}
 		if c2Raw != "" {
 			c2 = &c2Raw
-		}
-		if err != nil {
-			return nil, err
 		}
 		payload := NewMethodCookieStringPayload(c2)
 
@@ -3447,7 +3443,7 @@ func DecodeMethodCookieStringValidateRequest(mux goahttp.Muxer, decoder func(*ht
 			err error
 			c   *http.Cookie
 		)
-		c, err = r.Cookie("c")
+		c, _ = r.Cookie("c")
 		var c2Raw string
 		if c != nil {
 			c2Raw = c.Value
@@ -3540,11 +3536,10 @@ var PayloadCookieStringDefaultDecodeCode = `// DecodeMethodCookieStringDefaultRe
 func DecodeMethodCookieStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
 	return func(r *http.Request) (interface{}, error) {
 		var (
-			c2  string
-			err error
-			c   *http.Cookie
+			c2 string
+			c  *http.Cookie
 		)
-		c, err = r.Cookie("c")
+		c, _ = r.Cookie("c")
 		var c2Raw string
 		if c != nil {
 			c2Raw = c.Value
@@ -3553,9 +3548,6 @@ func DecodeMethodCookieStringDefaultRequest(mux goahttp.Muxer, decoder func(*htt
 			c2 = c2Raw
 		} else {
 			c2 = "def"
-		}
-		if err != nil {
-			return nil, err
 		}
 		payload := NewMethodCookieStringDefaultPayload(c2)
 
@@ -3574,7 +3566,7 @@ func DecodeMethodCookieStringDefaultValidateRequest(mux goahttp.Muxer, decoder f
 			err error
 			c   *http.Cookie
 		)
-		c, err = r.Cookie("c")
+		c, _ = r.Cookie("c")
 		var c2Raw string
 		if c != nil {
 			c2Raw = c.Value


### PR DESCRIPTION
Only capture errors when reading cookies when necessary
(i.e. when cookie attribute is required).