### PR TITLE
Fix graceful shutdown

### DIFF
--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -309,7 +309,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 		logger.Printf("shutting down HTTP server at %q", u.Host)
 
 		{{ comment "Shutdown gracefully with a 30s timeout." }}
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		srv.Shutdown(ctx)

--- a/http/codegen/testdata/example_code.go
+++ b/http/codegen/testdata/example_code.go
@@ -78,7 +78,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		logger.Printf("shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		srv.Shutdown(ctx)
@@ -174,7 +174,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc 
 		logger.Printf("shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		srv.Shutdown(ctx)
@@ -270,7 +270,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		logger.Printf("shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		srv.Shutdown(ctx)
@@ -373,7 +373,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		logger.Printf("shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		srv.Shutdown(ctx)
@@ -477,7 +477,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, streamingServiceAEndpoint
 		logger.Printf("shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
 		srv.Shutdown(ctx)


### PR DESCRIPTION
Fixed invalid context value  passing to `context.WithTimeout`  for graceful-shutdown.

Current generated example of graceful-shutdown is calling `context.WithTimeout` with already closed context, because of that server shutdown immediately. I don't think it is intentional behavior, so fixed with passing `context.Background` to `context.WithTimeout`


### explanation
```golang
<-ctx.Done() // Closed!!

ctx, cancel := context.WithTimeout(ctx, 30*time.Second) // already closed ctx 😢 
defer cancel()

srv.Shutdown(ctx) // does not wait for timeout as intended
```


changes to examples can be reviewed in: https://github.com/goadesign/examples/pull/71
