### PR TITLE
Fix payload initialization code

### DIFF
--- a/http/codegen/server_payload_types_test.go
+++ b/http/codegen/server_payload_types_test.go
@@ -108,6 +108,7 @@ func TestPayloadConstructor(t *testing.T) {
 
 		{"body-user-inner", testdata.PayloadBodyUserInnerDSL, testdata.PayloadBodyUserInnerConstructorCode},
 		{"body-user-inner-default", testdata.PayloadBodyUserInnerDefaultDSL, testdata.PayloadBodyUserInnerDefaultConstructorCode},
+		{"body-user-inner-origin", testdata.PayloadBodyUserOriginDSL, testdata.PayloadBodyUserOriginConstructorCode},
 		{"body-inline-array-user", testdata.PayloadBodyInlineArrayUserDSL, testdata.PayloadBodyInlineArrayUserConstructorCode},
 		{"body-inline-map-user", testdata.PayloadBodyInlineMapUserDSL, testdata.PayloadBodyInlineMapUserConstructorCode},
 		{"body-inline-recursive-user", testdata.PayloadBodyInlineRecursiveUserDSL, testdata.PayloadBodyInlineRecursiveUserConstructorCode},

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1259,7 +1259,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			if o, ok := e.Body.Meta["origin:attribute"]; ok {
 				origin = o[0]
 				pAtt = expr.AsObject(payload.Type).Attribute(origin)
-				pointer = !payload.IsRequired(o[0])
+				pointer = !payload.IsRequired(o[0]) && expr.IsPrimitive(pAtt.Type)
 			}
 
 			var (

--- a/http/codegen/testdata/payload_constructor_functions.go
+++ b/http/codegen/testdata/payload_constructor_functions.go
@@ -932,6 +932,20 @@ func NewMethodBodyUserInnerDefaultPayloadType(body *MethodBodyUserInnerDefaultRe
 }
 `
 
+var PayloadBodyUserOriginConstructorCode = `// NewMethodBodyUserOriginDefaultPayload builds a ServiceBodyUserOriginDefault
+// service MethodBodyUserOriginDefault endpoint payload.
+func NewMethodBodyUserOriginDefaultPayload(body *MethodBodyUserOriginDefaultRequestBody) *servicebodyuserorigindefault.MethodBodyUserOriginDefaultPayload {
+	v := &servicebodyuserorigindefault.PayloadType{
+		A: *body.A,
+	}
+	res := &servicebodyuserorigindefault.MethodBodyUserOriginDefaultPayload{
+		Body: v,
+	}
+
+	return res
+}
+`
+
 var PayloadBodyInlineArrayUserConstructorCode = `// NewMethodBodyInlineArrayUserElemType builds a ServiceBodyInlineArrayUser
 // service MethodBodyInlineArrayUser endpoint payload.
 func NewMethodBodyInlineArrayUserElemType(body []*ElemTypeRequestBody) []*servicebodyinlinearrayuser.ElemType {

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -2564,6 +2564,24 @@ var PayloadBodyUserInnerDefaultDSL = func() {
 	})
 }
 
+var PayloadBodyUserOriginDSL = func() {
+	var PayloadType = Type("PayloadType", func() {
+		Attribute("a")
+		Required("a")
+	})
+	Service("ServiceBodyUserOriginDefault", func() {
+		Method("MethodBodyUserOriginDefault", func() {
+			Payload(func() {
+				Attribute("body", PayloadType)
+			})
+			HTTP(func() {
+				POST("/")
+				Body("body")
+			})
+		})
+	})
+}
+
 var PayloadBodyInlineArrayUserDSL = func() {
 	var ElemType = Type("ElemType", func() {
 		Attribute("a", String, func() {


### PR DESCRIPTION
when HTTP endpoint uses Body to identify a non-primitive attribute.
cc @nitinmohan87 