### PR TITLE
Support optional HTTP request body

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -512,17 +512,26 @@ func {{ .RequestDecoder }}(mux goahttp.Muxer, decoder func(*http.Request) goahtt
 		)
 		err = decoder(r).Decode(&body)
 		if err != nil {
+	{{- if .Payload.Request.MustHaveBody }}
 			if err == io.EOF {
 				return nil, goa.MissingPayloadError()
 			}
+	{{- else }}
+			if err == io.EOF {
+				err = nil
+			} else {
+	{{- end }}
 			return nil, goa.DecodePayloadError(err.Error())
+	{{- if not .Payload.Request.MustHaveBody }}
+			}
+	{{- end }}
 		}
-		{{- if .Payload.Request.ServerBody.ValidateRef }}
+	{{- if .Payload.Request.ServerBody.ValidateRef }}
 		{{ .Payload.Request.ServerBody.ValidateRef }}
 		if err != nil {
 			return nil, err
 		}
-		{{- end }}
+	{{- end }}
 {{- end }}
 {{- if not .MultipartRequestDecoder }}
 	{{- template "request_elements" .Payload.Request }}

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -276,6 +276,8 @@ type (
 		// attribute. This field is set when the design uses Body("name") syntax
 		// to set the request body and the payload type is an object.
 		PayloadAttr string
+		// MustHaveBody is true if the request body cannot be empty.
+		MustHaveBody bool
 		// MustValidate is true if the request body or at least one
 		// parameter or header requires validation.
 		MustValidate bool
@@ -949,6 +951,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			origin         string
 
 			mustValidate bool
+			mustHaveBody = true
 		)
 		{
 			if e.MapQueryParams != nil {
@@ -1026,6 +1029,9 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 				// transformation.
 				if o, ok := e.Body.Meta["origin:attribute"]; ok {
 					origin = o[0]
+					if !payload.IsRequired(o[0]) {
+						mustHaveBody = false
+					}
 				}
 			}
 		}
@@ -1038,6 +1044,7 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 			ClientBody:   clientBodyData,
 			PayloadAttr:  codegen.Goify(origin, true),
 			PayloadType:  e.MethodExpr.Payload.Type,
+			MustHaveBody: mustHaveBody,
 			MustValidate: mustValidate,
 			Multipart:    e.MultipartRequest,
 		}

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -3721,9 +3721,10 @@ func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if err == io.EOF {
-				return nil, goa.MissingPayloadError()
+				err = nil
+			} else {
+				return nil, goa.DecodePayloadError(err.Error())
 			}
-			return nil, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyUserRequestBody(&body)
 		if err != nil {
@@ -4137,9 +4138,10 @@ func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if err == io.EOF {
-				return nil, goa.MissingPayloadError()
+				err = nil
+			} else {
+				return nil, goa.DecodePayloadError(err.Error())
 			}
-			return nil, goa.DecodePayloadError(err.Error())
 		}
 		payload := NewMethodBodyPrimitiveArrayUserPayloadType(body)
 
@@ -4160,9 +4162,10 @@ func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if err == io.EOF {
-				return nil, goa.MissingPayloadError()
+				err = nil
+			} else {
+				return nil, goa.DecodePayloadError(err.Error())
 			}
-			return nil, goa.DecodePayloadError(err.Error())
 		}
 		payload := NewMethodBodyPrimitiveArrayUserPayloadType(body)
 


### PR DESCRIPTION
Do not fail decoding if the HTTP body is defined using an optional payload attribute name and the request body is empty.

Fix #2623 