### PR TITLE
Properly generate gRPC client method name

### DIFF
--- a/grpc/codegen/client_test.go
+++ b/grpc/codegen/client_test.go
@@ -18,6 +18,7 @@ func TestClientEndpointInit(t *testing.T) {
 		{"unary-rpc-no-payload", testdata.UnaryRPCNoPayloadDSL, testdata.UnaryRPCNoPayloadClientEndpointInitCode},
 		{"unary-rpc-no-result", testdata.UnaryRPCNoResultDSL, testdata.UnaryRPCNoResultClientEndpointInitCode},
 		{"unary-rpc-with-errors", testdata.UnaryRPCWithErrorsDSL, testdata.UnaryRPCWithErrorsClientEndpointInitCode},
+		{"unary-rpc-acronym", testdata.UnaryRPCAcronymDSL, testdata.UnaryRPCAcronymClientEndpointInitCode},
 		{"server-streaming-rpc", testdata.ServerStreamingRPCDSL, testdata.ServerStreamingRPCClientEndpointInitCode},
 		{"client-streaming-rpc", testdata.ClientStreamingRPCDSL, testdata.ClientStreamingRPCClientEndpointInitCode},
 		{"client-streaming-rpc-no-result", testdata.ClientStreamingNoResultDSL, testdata.ClientStreamingNoResultClientEndpointInitCode},

--- a/grpc/codegen/proto_test.go
+++ b/grpc/codegen/proto_test.go
@@ -23,6 +23,7 @@ func TestProtoFiles(t *testing.T) {
 		{"same-service-and-message-name", testdata.MessageWithServiceNameDSL, testdata.MessageWithServiceNameProtoCode},
 		{"method-with-reserved-proto-name", testdata.MethodWithReservedNameDSL, testdata.MethodWithReservedNameProtoCode},
 		{"multiple-methods-same-return-type", testdata.MultipleMethodsSameResultCollectionDSL, testdata.MultipleMethodsSameResultCollectionProtoCode},
+		{"method-with-acronym", testdata.MethodWithAcronymDSL, testdata.MethodWithAcronymProtoCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/grpc/codegen/protobuf_test.go
+++ b/grpc/codegen/protobuf_test.go
@@ -1,0 +1,49 @@
+package codegen
+
+import "testing"
+
+func TestProtobufify(t *testing.T) {
+	cases := []struct {
+		Name       string
+		String     string
+		FirstUpper bool
+		Acronym    bool
+		Expected   string
+	}{{
+		"AllLower", "lower", false, false, "lower",
+	}, {
+		"AllLowerFirstUpper", "lower", true, false, "Lower",
+	}, {
+		"AllUpper", "UPPER", false, false, "uPPER",
+	}, {
+		"AllUpperFirstUpper", "UPPER", true, false, "UPPER",
+	}, {
+		"StartUpperThenLower", "Upper", false, false, "upper",
+	}, {
+		"StartUpperThenLowerFirstUpper", "Upper", true, false, "Upper",
+	}, {
+		"StartsWithUnderscore", "_foo", false, false, "foo",
+	}, {
+		"EndsWithUnderscore", "foo_", false, false, "foo",
+	}, {
+		"ContainsUnderscore", "foo_bar", false, false, "fooBar",
+	}, {
+		"StartsWithDigits", "123foo", false, false, "123Foo",
+	}, {
+		"EndsWithDigits", "foo123", false, false, "foo123",
+	}, {
+		"ContainsDigits", "foo123bar", false, false, "foo123Bar",
+	}, {
+		"ContainsIgnoredAcronym", "foo_jwt", false, false, "fooJwt",
+	}, {
+		"ContainsAcronym", "foo_jwt", false, true, "fooJWT",
+	}}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			got := protoBufify(c.String, c.FirstUpper, c.Acronym)
+			if got != c.Expected {
+				t.Errorf("got %q, expected %q", got, c.Expected)
+			}
+		})
+	}
+}

--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -617,7 +617,7 @@ func (d ServicesData) analyze(gs *expr.GRPCServiceExpr) *ServiceData {
 			Errors:           errors,
 			ServerStruct:     sd.ServerStruct,
 			ServerInterface:  sd.ServerInterface,
-			ClientMethodName: protoBufify(md.VarName, true, false),
+			ClientMethodName: protoBufify(md.VarName, true, true),
 			ClientStruct:     sd.ClientStruct,
 			ClientInterface:  sd.ClientInterface,
 		}

--- a/grpc/codegen/testdata/client_endpoint_init_code.go
+++ b/grpc/codegen/testdata/client_endpoint_init_code.go
@@ -102,6 +102,23 @@ func (c *Client) MethodUnaryRPCWithErrors() goa.Endpoint {
 }
 `
 
+const UnaryRPCAcronymClientEndpointInitCode = `// MethodUnaryRPCAcronymJWT calls the "MethodUnaryRPCAcronymJWT" function in
+// service_unary_rpc_acronympb.ServiceUnaryRPCAcronymClient interface.
+func (c *Client) MethodUnaryRPCAcronymJWT() goa.Endpoint {
+	return func(ctx context.Context, v interface{}) (interface{}, error) {
+		inv := goagrpc.NewInvoker(
+			BuildMethodUnaryRPCAcronymJWTFunc(c.grpccli, c.opts...),
+			nil,
+			nil)
+		res, err := inv.Invoke(ctx, v)
+		if err != nil {
+			return nil, goa.Fault(err.Error())
+		}
+		return res, nil
+	}
+}
+`
+
 const ServerStreamingRPCClientEndpointInitCode = `// MethodServerStreamingRPC calls the "MethodServerStreamingRPC" function in
 // service_server_streaming_rpcpb.ServiceServerStreamingRPCClient interface.
 func (c *Client) MethodServerStreamingRPC() goa.Endpoint {

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -85,6 +85,14 @@ var UnaryRPCWithErrorsDSL = func() {
 	})
 }
 
+var UnaryRPCAcronymDSL = func() {
+	Service("ServiceUnaryRPCAcronym", func() {
+		Method("MethodUnaryRPCAcronym_jwt", func() {
+			GRPC(func() {})
+		})
+	})
+}
+
 var UnaryRPCWithOverridingErrorsDSL = func() {
 	Service("ServiceUnaryRPCWithOverridingErrors", func() {
 		Error("overridden")
@@ -743,6 +751,14 @@ var MultipleMethodsSameResultCollectionDSL = func() {
 		})
 		Method("method_b", func() {
 			Result(CollectionOf(ResultT))
+			GRPC(func() {})
+		})
+	})
+}
+
+var MethodWithAcronymDSL = func() {
+	Service("MethodWithAcronym", func() {
+		Method("method_jwt", func() {
 			GRPC(func() {})
 		})
 	})

--- a/grpc/codegen/testdata/proto_code.go
+++ b/grpc/codegen/testdata/proto_code.go
@@ -403,3 +403,23 @@ message ResultT {
 message MethodBRequest {
 }
 `
+
+const MethodWithAcronymProtoCode = `
+syntax = "proto3";
+
+package method_with_acronym;
+
+option go_package = "method_with_acronympb";
+
+// Service is the MethodWithAcronym service interface.
+service MethodWithAcronym {
+	// MethodJWT implements method_jwt.
+	rpc MethodJWT (MethodJWTRequest) returns (MethodJWTResponse);
+}
+
+message MethodJWTRequest {
+}
+
+message MethodJWTResponse {
+}
+`


### PR DESCRIPTION
when it contains acronyms such as JWT in the client calling code.