### PR TITLE
Properly handle explicit response body

### DIFF
--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -265,7 +265,7 @@ func transformArray(source, target *expr.Array, sourceVar, targetVar string, new
 		"TargetVar":      targetVar,
 		"NewVar":         newVar,
 		"TransformAttrs": ta,
-		"LoopVar":        string(105 + strings.Count(targetVar, "[")),
+		"LoopVar":        string(rune(105 + strings.Count(targetVar, "["))),
 		"IsStruct":       expr.IsObject(target.ElemType.Type),
 	}
 	var buf bytes.Buffer
@@ -299,7 +299,7 @@ func transformMap(source, target *expr.Map, sourceVar, targetVar string, newVar 
 		"IsElemStruct":   expr.IsObject(target.ElemType.Type),
 	}
 	if depth := MapDepth(target); depth > 0 {
-		data["LoopVar"] = string(97 + depth)
+		data["LoopVar"] = string(rune(97 + depth))
 	}
 	var buf bytes.Buffer
 	if err := transformGoMapT.Execute(&buf, data); err != nil {

--- a/grpc/codegen/protobuf_transform.go
+++ b/grpc/codegen/protobuf_transform.go
@@ -364,7 +364,7 @@ func transformArray(source, target *expr.Array, sourceVar, targetVar string, new
 		"TargetVar":      targetVar,
 		"NewVar":         newVar,
 		"TransformAttrs": ta,
-		"LoopVar":        string(105 + strings.Count(targetVar, "[")),
+		"LoopVar":        string(rune(105 + strings.Count(targetVar, "["))),
 	}
 	var buf bytes.Buffer
 	if err := transformGoArrayT.Execute(&buf, data); err != nil {
@@ -439,7 +439,7 @@ func transformMap(source, target *expr.Map, sourceVar, targetVar string, newVar 
 		"LoopVar":        "",
 	}
 	if depth := codegen.MapDepth(target); depth > 0 {
-		data["LoopVar"] = string(97 + depth)
+		data["LoopVar"] = string(rune(97 + depth))
 	}
 	var buf bytes.Buffer
 	if err := transformGoMapT.Execute(&buf, data); err != nil {

--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -45,6 +45,7 @@ func TestBodyTypeInit(t *testing.T) {
 		{"body-path-user-validate", testdata.PayloadBodyPathUserValidateDSL, 2, BodyPathUserValidateInitCode},
 		{"body-primitive-array-user-validate", testdata.PayloadBodyPrimitiveArrayUserValidateDSL, 2, BodyPrimitiveArrayUserValidateInitCode},
 		{"result-body-user", testdata.ResultBodyObjectHeaderDSL, 2, ResultBodyObjectHeaderInitCode},
+		{"result-body-user-required", testdata.ResultBodyUserRequiredDSL, 3, ResultBodyUserRequiredInitCode},
 		{"result-body-inline-object", testdata.ResultBodyInlineObjectDSL, 2, ResultBodyInlineObjectInitCode},
 		{"result-explicit-body-primitive", testdata.ExplicitBodyPrimitiveResultMultipleViewsDSL, 1, ExplicitBodyPrimitiveResultMultipleViewsInitCode},
 		{"result-explicit-body-user-type", testdata.ExplicitBodyUserResultMultipleViewsDSL, 3, ExplicitBodyUserResultMultipleViewsInitCode},
@@ -183,6 +184,20 @@ func NewMethodBodyObjectHeaderResultOK(body *MethodBodyObjectHeaderResponseBody,
 	v.B = b
 
 	return v
+}
+`
+
+const ResultBodyUserRequiredInitCode = `// NewMethodBodyUserRequiredResultOK builds a "ServiceBodyUserRequired" service
+// "MethodBodyUserRequired" endpoint result from a HTTP "OK" response.
+func NewMethodBodyUserRequiredResultOK(body *MethodBodyUserRequiredResponseBody) *servicebodyuserrequired.MethodBodyUserRequiredResult {
+	v := &servicebodyuserrequired.Body{
+		A: *body.A,
+	}
+	res := &servicebodyuserrequired.MethodBodyUserRequiredResult{
+		Body: v,
+	}
+
+	return res
 }
 `
 

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -242,7 +242,7 @@ func mapQueryDecodeData(dt expr.DataType, varName string, inc int) map[string]in
 	return map[string]interface{}{
 		"Type":      dt,
 		"VarName":   varName,
-		"Loop":      string(97 + inc),
+		"Loop":      string(rune(97 + inc)),
 		"Increment": inc + 1,
 		"Depth":     codegen.MapDepth(expr.AsMap(dt)),
 	}

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -585,6 +585,26 @@ var ResultBodyObjectHeaderDSL = func() {
 	})
 }
 
+var ResultBodyUserRequiredDSL = func() {
+	var Bod = Type("body", func() {
+		Attribute("a")
+		Required("a")
+	})
+	Service("ServiceBodyUserRequired", func() {
+		Method("MethodBodyUserRequired", func() {
+			Result(func() {
+				Attribute("body", Bod)
+			})
+			HTTP(func() {
+				GET("/")
+				Response(StatusOK, func() {
+					Body("body")
+				})
+			})
+		})
+	})
+}
+
 var ResultBodyUserDSL = func() {
 	var ResultType = Type("ResultType", func() {
 		Attribute("a", String)


### PR DESCRIPTION
in client result initialization method. The code didn't account for
explicit body using a result attribute whose type contains required
attribute. The "requiredness" was lost in the function computing the
body type.

Fix #2655