### PR TITLE
Remove $ from goa command comment

### DIFF
--- a/codegen/funcs.go
+++ b/codegen/funcs.go
@@ -41,7 +41,7 @@ func TemplateFuncs() map[string]interface{} {
 
 // CommandLine return the command used to run this process.
 func CommandLine() string {
-	cmdl := "$ goa"
+	cmdl := "goa"
 	for _, arg := range os.Args {
 		if strings.HasPrefix(arg, "--cmd=") {
 			cmdl = arg[6:]

--- a/codegen/sections_test.go
+++ b/codegen/sections_test.go
@@ -63,7 +63,7 @@ import (
 // test title
 //
 // Command:
-// $ goa
+// goa
 
 package testpackage
 

--- a/codegen/service/testdata/convert_functions.go
+++ b/codegen/service/testdata/convert_functions.go
@@ -209,7 +209,7 @@ func transformObjectFieldToTestdataObjectFieldT(v *ObjectField) *testdata.Object
 var CreateExternalConvert = `// Service service type conversion functions
 //
 // Command:
-// $ goa
+// goa
 
 package service
 

--- a/codegen/service/testdata/create_functions.go
+++ b/codegen/service/testdata/create_functions.go
@@ -133,7 +133,7 @@ func (t *ObjectType) CreateFromObjectExtraT(v *testdata.ObjectExtraT) {
 var CreateAliasConvert = `// Service service type conversion functions
 //
 // Command:
-// $ goa
+// goa
 
 package service
 
@@ -153,7 +153,7 @@ func (t *StringType) CreateFromConvertModel(v *aliasd.ConvertModel) {
 var MixedCaseConvert = `// Service service type conversion functions
 //
 // Command:
-// $ goa
+// goa
 
 package service
 


### PR DESCRIPTION
Remove the `$` sign from the comment header so that tools like `grpc_tools_ruby_protoc` does not trip on the $ sign thinking that it is unclosed variable.
```
grpc_tools_ruby_protoc -I foo_service/gen/grpc/foo/pb --ruby_out=foo --grpc_out=foo foo_service/gen/grpc/foo/pb/foo.proto 
[libprotobuf FATAL google/protobuf/io/printer.cc:135]  Unclosed variable name.
terminate called after throwing an instance of 'google::protobuf::FatalException'
  what():   Unclosed variable name.
--grpc_out: protoc-gen-grpc: Plugin killed by signal 6.
``