### PR TITLE
Fix HTTP CLI payload factor method

### DIFF
--- a/codegen/cli/cli.go
+++ b/codegen/cli/cli.go
@@ -360,6 +360,7 @@ func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultVa
 				ref = ""
 			}
 			code = argName + " = " + ref + f.FullName
+			declErr = validate != ""
 		} else {
 			var checkErr bool
 			code, declErr, checkErr = conversionCode(f.FullName, argName, argTypeName, !f.Required && defaultValue == nil)
@@ -379,7 +380,7 @@ func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultVa
 			code += "\n" + validate + "\n" + fmt.Sprintf("if err != nil {\n\treturn %v, err\n}", rval)
 		}
 	}
-	return fmt.Sprintf("%s%s%s", startIf, code, endIf), declErr || validate != ""
+	return fmt.Sprintf("%s%s%s", startIf, code, endIf), declErr
 }
 
 // flagType calculates the type of a flag

--- a/http/codegen/client_cli_test.go
+++ b/http/codegen/client_cli_test.go
@@ -31,6 +31,7 @@ func TestClientCLIFiles(t *testing.T) {
 		{"string-required-build", testdata.PayloadQueryStringValidateDSL, testdata.QueryStringRequiredBuildCode, 1, 1},
 		{"string-default-build", testdata.PayloadQueryStringDefaultDSL, testdata.QueryStringDefaultBuildCode, 1, 1},
 		{"body-query-path-object-build", testdata.PayloadBodyQueryPathObjectDSL, testdata.BodyQueryPathObjectBuildCode, 1, 1},
+		{"param-validation-build", testdata.ParamValidateDSL, testdata.ParamValidateBuildCode, 1, 1},
 		{"payload-primitive-type", testdata.PayloadBodyPrimitiveBoolValidateDSL, testdata.PayloadPrimitiveTypeParseCode, 0, 3},
 		{"payload-array-primitive-type", testdata.PayloadBodyPrimitiveArrayStringValidateDSL, testdata.PayloadArrayPrimitiveTypeParseCode, 0, 3},
 		{"payload-array-user-type", testdata.PayloadBodyInlineArrayUserDSL, testdata.PayloadArrayUserTypeBuildCode, 1, 1},

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -732,6 +732,37 @@ func BuildMethodBodyQueryPathObjectPayload(serviceBodyQueryPathObjectMethodBodyQ
 }
 `
 
+var ParamValidateBuildCode = `// BuildMethodParamValidatePayload builds the payload for the
+// ServiceParamValidate MethodParamValidate endpoint from CLI flags.
+func BuildMethodParamValidatePayload(serviceParamValidateMethodParamValidateA string) (*serviceparamvalidate.MethodParamValidatePayload, error) {
+	var err error
+	var a *int
+	{
+		if serviceParamValidateMethodParamValidateA != "" {
+			var v int64
+			v, err = strconv.ParseInt(serviceParamValidateMethodParamValidateA, 10, 64)
+			val := int(v)
+			a = &val
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for a, must be INT")
+			}
+			if a != nil {
+				if *a < 1 {
+					err = goa.MergeErrors(err, goa.InvalidRangeError("a", *a, 1, true))
+				}
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	v := &serviceparamvalidate.MethodParamValidatePayload{}
+	v.A = a
+
+	return v, nil
+}
+`
+
 var PayloadPrimitiveTypeParseCode = `// ParseEndpoint returns the endpoint and payload as specified on the command
 // line.
 func ParseEndpoint(

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -2452,6 +2452,22 @@ var PayloadBodyQueryPathObjectDSL = func() {
 	})
 }
 
+var ParamValidateDSL = func() {
+	Service("ServiceParamValidate", func() {
+		Method("MethodParamValidate", func() {
+			Payload(func() {
+				Attribute("a", Int, func() {
+					Minimum(1)
+				})
+			})
+			HTTP(func() {
+				POST("/")
+				Param("a")
+			})
+		})
+	})
+}
+
 var PayloadBodyQueryPathObjectValidateDSL = func() {
 	Service("ServiceBodyQueryPathObjectValidate", func() {
 		Method("MethodBodyQueryPathObjectValidate", func() {


### PR DESCRIPTION
for the case when the payload is built from a HTTP param
and has validations.

Fix #2668