### PR TITLE
Handle multiple views for same result type

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -486,7 +486,6 @@ func (d ServicesData) analyze(service *expr.ServiceExpr) *Data {
 		seenErrors map[string]struct{}
 		seen       map[string]struct{}
 		seenProj   map[string]*ProjectedTypeData
-		seenViewed map[string]*ViewedResultTypeData
 	)
 	{
 		scope = codegen.NewNameScope()
@@ -497,7 +496,6 @@ func (d ServicesData) analyze(service *expr.ServiceExpr) *Data {
 		seen = make(map[string]struct{})
 		seenErrors = make(map[string]struct{})
 		seenProj = make(map[string]*ProjectedTypeData)
-		seenViewed = make(map[string]*ViewedResultTypeData)
 
 		// A function to collect user types from an error expression
 		recordError := func(er *expr.ErrorExpr) {
@@ -588,16 +586,11 @@ func (d ServicesData) analyze(service *expr.ServiceExpr) *Data {
 		for i, e := range service.Methods {
 			m := buildMethodData(e, pkgName, service, scope)
 			if rt, ok := e.Result.Type.(*expr.ResultTypeExpr); ok {
-				if vrt, ok := seenViewed[m.Result]; ok {
-					m.ViewedResult = vrt
-				} else {
-					projected := seenProj[rt.ID()]
-					projAtt := &expr.AttributeExpr{Type: projected.Type}
-					vrt := buildViewedResultType(e.Result, projAtt, viewspkg, scope, viewScope)
-					viewedRTs = append(viewedRTs, vrt)
-					seenViewed[vrt.Name] = vrt
-					m.ViewedResult = vrt
-				}
+				projected := seenProj[rt.ID()]
+				projAtt := &expr.AttributeExpr{Type: projected.Type}
+				vrt := buildViewedResultType(e.Result, projAtt, viewspkg, scope, viewScope)
+				viewedRTs = append(viewedRTs, vrt)
+				m.ViewedResult = vrt
 			}
 			methods[i] = m
 			for _, s := range m.Schemes {

--- a/codegen/service/testdata/endpoint_code.go
+++ b/codegen/service/testdata/endpoint_code.go
@@ -157,6 +157,7 @@ func NewAEndpoint(s Service) goa.Endpoint {
 const WithResultMultipleViewsEndpoint = `// Endpoints wraps the "WithResultMultipleViews" service endpoints.
 type Endpoints struct {
 	A goa.Endpoint
+	B goa.Endpoint
 }
 
 // NewEndpoints wraps the methods of the "WithResultMultipleViews" service with
@@ -164,6 +165,7 @@ type Endpoints struct {
 func NewEndpoints(s Service) *Endpoints {
 	return &Endpoints{
 		A: NewAEndpoint(s),
+		B: NewBEndpoint(s),
 	}
 }
 
@@ -171,17 +173,31 @@ func NewEndpoints(s Service) *Endpoints {
 // service endpoints.
 func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 	e.A = m(e.A)
+	e.B = m(e.B)
 }
 
 // NewAEndpoint returns an endpoint function that calls the method "A" of
 // service "WithResultMultipleViews".
 func NewAEndpoint(s Service) goa.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
-		res, view, err := s.A(ctx)
+		res, err := s.A(ctx)
 		if err != nil {
 			return nil, err
 		}
-		vres := NewViewedViewtype(res, view)
+		vres := NewViewedViewtype(res, "tiny")
+		return vres, nil
+	}
+}
+
+// NewBEndpoint returns an endpoint function that calls the method "B" of
+// service "WithResultMultipleViews".
+func NewBEndpoint(s Service) goa.Endpoint {
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		res, err := s.B(ctx)
+		if err != nil {
+			return nil, err
+		}
+		vres := NewViewedViewtype(res, "default")
 		return vres, nil
 	}
 }

--- a/codegen/service/testdata/endpoint_dsls.go
+++ b/codegen/service/testdata/endpoint_dsls.go
@@ -82,7 +82,14 @@ var WithResultMultipleViewsEndpointDSL = func() {
 	})
 	Service("WithResultMultipleViews", func() {
 		Method("A", func() {
-			Result(ViewType)
+			Result(ViewType, func() {
+				View("tiny")
+			})
+		})
+		Method("B", func() {
+			Result(ViewType, func() {
+				View("default")
+			})
 		})
 	})
 }


### PR DESCRIPTION
used in different methods when defined explcitely in method result.

Fix #2692