### PR TITLE
Fix duplicate generated result type definition

### DIFF
--- a/codegen/service/testdata/views_code.go
+++ b/codegen/service/testdata/views_code.go
@@ -712,3 +712,44 @@ func ValidateAnotherResultCollectionView(result AnotherResultCollectionView) (er
 	return
 }
 `
+
+const ResultWithMultipleMethodsCode = `// RT is the viewed result type that is projected based on a view.
+type RT struct {
+	// Type to project
+	Projected *RTView
+	// View to render
+	View string
+}
+
+// RTView is a type that runs validations on a projected type.
+type RTView struct {
+	A *string
+}
+
+var (
+	// RTMap is a map of attribute names in result type RT indexed by view name.
+	RTMap = map[string][]string{
+		"default": []string{
+			"a",
+		},
+	}
+)
+
+// ValidateRT runs the validations defined on the viewed result type RT.
+func ValidateRT(result *RT) (err error) {
+	switch result.View {
+	case "default", "":
+		err = ValidateRTView(result.Projected)
+	default:
+		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default"})
+	}
+	return
+}
+
+// ValidateRTView runs the validations defined on RTView using the "default"
+// view.
+func ValidateRTView(result *RTView) (err error) {
+
+	return
+}
+`

--- a/codegen/service/testdata/views_dsls.go
+++ b/codegen/service/testdata/views_dsls.go
@@ -201,6 +201,23 @@ var ResultWithRecursiveCollectionOfResultTypeDSL = func() {
 	})
 }
 
+var ResultWithMultipleMethodsDSL = func() {
+	var RT = ResultType("application/vnd.some_result", func() {
+		TypeName("RT")
+		Attributes(func() {
+			Attribute("a")
+		})
+	})
+	Service("ResultWithMultipleMethods", func() {
+		Method("A", func() {
+			Result(RT)
+		})
+		Method("B", func() {
+			Result(RT)
+		})
+	})
+}
+
 var ResultWithCustomFieldsDSL = func() {
 	var RT = ResultType("application/vnd.result", func() {
 		TypeName("RT")

--- a/codegen/service/views_test.go
+++ b/codegen/service/views_test.go
@@ -24,6 +24,7 @@ func TestViews(t *testing.T) {
 		{"result-with-recursive-result-type", testdata.ResultWithRecursiveResultTypeDSL, testdata.ResultWithRecursiveResultTypeCode},
 		{"result-type-with-custom-fields", testdata.ResultWithCustomFieldsDSL, testdata.ResultWithCustomFieldsCode},
 		{"result-with-recursive-collection-of-result-type", testdata.ResultWithRecursiveCollectionOfResultTypeDSL, testdata.ResultWithRecursiveCollectionOfResultTypeCode},
+		{"result-with-multiple-methods", testdata.ResultWithMultipleMethodsDSL, testdata.ResultWithMultipleMethodsCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {


### PR DESCRIPTION
Ensure that result types used by multiple methods get only defined once.
Note that if the result type defined multiple views and if a method
result definition specific a view explicitly then we must generate a
different result type in that case.