### PR TITLE
Handle explicit HTTP body with default value

### DIFF
--- a/codegen/scope.go
+++ b/codegen/scope.go
@@ -172,6 +172,16 @@ func (s *NameScope) GoTypeRef(att *expr.AttributeExpr) string {
 	return goTypeRef(name, att.Type)
 }
 
+// GoTypeRefWithDefaults returns the Go code that refers to the Go type which
+// matches the given attribute type. The result of this function differs from
+// GoTypeRef when the attribute type is an object (note: not a user type) and
+// the reference is thus an inline struct definition. In this case accounting
+// for default values may cause child attributes to use non-pointer fields.
+func (s *NameScope) GoTypeRefWithDefaults(att *expr.AttributeExpr) string {
+	name := s.GoTypeNameWithDefaults(att)
+	return goTypeRef(name, att.Type)
+}
+
 // GoFullTypeRef returns the Go code that refers to the Go type which matches
 // the given attribute type defined in the given package if a user type.
 func (s *NameScope) GoFullTypeRef(att *expr.AttributeExpr, pkg string) string {
@@ -182,6 +192,18 @@ func (s *NameScope) GoFullTypeRef(att *expr.AttributeExpr, pkg string) string {
 // GoTypeName returns the Go type name of the given attribute type.
 func (s *NameScope) GoTypeName(att *expr.AttributeExpr) string {
 	return s.GoFullTypeName(att, "")
+}
+
+// GoTypeNameWithDefaults returns the Go type name of the given attribute type.
+// The result of this function differs from GoTypeName when the attribute type
+// is an object (note: not a user type) and the name is thus an inline struct
+// definition. In this case accounting for default values may cause child
+// attributes to use non-pointer fields.
+func (s *NameScope) GoTypeNameWithDefaults(att *expr.AttributeExpr) string {
+	if _, ok := att.Type.(*expr.Object); ok {
+		return s.GoTypeDef(att, false, true)
+	}
+	return s.GoTypeName(att)
 }
 
 // GoFullTypeName returns the Go type name of the given data type qualified with

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -554,10 +554,10 @@ func (a *AttributeExpr) debug(prefix string, seen map[*AttributeExpr]int, indent
 	}
 	if d := a.DefaultValue; d != nil {
 		fmt.Printf("%sdefault\n", tab)
-		fmt.Printf("%s%#v", tab+"  ", a.DefaultValue)
+		fmt.Printf("%s  %#v\n", tab, a.DefaultValue)
 	}
 	if v := a.Validation; v != nil {
-		v.Debug(indent + 1)
+		v.Debug(indent)
 	}
 	if len(a.UserExamples) > 0 {
 		fmt.Printf("%sexamples\n", tab)
@@ -747,8 +747,8 @@ func (v *ValidationExpr) Dup() *ValidationExpr {
 
 // Debug dumps the validation to STDOUT in a goa developer friendly way.
 func (v *ValidationExpr) Debug(indent int) {
-	prefix := strings.Repeat("  ", indent)
-	fmt.Printf("%svalidations\n", prefix)
+	prefix := strings.Repeat("  ", indent+1)
+	fmt.Printf("%svalidations\n", strings.Repeat("  ", indent))
 	if len(v.Values) > 0 {
 		fmt.Printf("%s- enum: %s\n", prefix, fmt.Sprintf("%v", v.Values))
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dimfeld/httptreemux/v5 v5.2.2
 	github.com/getkin/kin-openapi v0.20.0
 	github.com/go-openapi/loads v0.19.5
-	github.com/golang/protobuf v1.4.2
+	github.com/golang/protobuf v1.4.3
 	github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d
@@ -16,12 +16,11 @@ require (
 	github.com/sergi/go-diff v1.1.0
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
-	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
-	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.0.0-20200815165600-90abf76919f3
-	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
-	google.golang.org/grpc v1.30.0
-	google.golang.org/protobuf v1.25.0 // indirect
+	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102 // indirect
+	golang.org/x/sys v0.0.0-20201107080550-4d91cf3a1aaf // indirect
+	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/tools v0.0.0-20201105220310-78b158585360
+	google.golang.org/genproto v0.0.0-20201106154455-f9bfe239b0ba // indirect
+	google.golang.org/grpc v1.33.2
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/http/codegen/client_cli_test.go
+++ b/http/codegen/client_cli_test.go
@@ -36,6 +36,8 @@ func TestClientCLIFiles(t *testing.T) {
 		{"payload-array-primitive-type", testdata.PayloadBodyPrimitiveArrayStringValidateDSL, testdata.PayloadArrayPrimitiveTypeParseCode, 0, 3},
 		{"payload-array-user-type", testdata.PayloadBodyInlineArrayUserDSL, testdata.PayloadArrayUserTypeBuildCode, 1, 1},
 		{"payload-map-user-type", testdata.PayloadBodyInlineMapUserDSL, testdata.PayloadMapUserTypeBuildCode, 1, 1},
+		{"payload-object-type", testdata.PayloadBodyInlineObjectDSL, testdata.PayloadObjectBuildCode, 1, 1},
+		{"payload-object-default-type", testdata.PayloadBodyInlineObjectDefaultDSL, testdata.PayloadObjectDefaultBuildCode, 1, 1},
 		{"map-query", testdata.PayloadMapQueryPrimitiveArrayDSL, testdata.MapQueryParseCode, 0, 3},
 		{"map-query-object", testdata.PayloadMapQueryObjectDSL, testdata.MapQueryObjectBuildCode, 1, 1},
 		{"empty-body-build", testdata.PayloadBodyPrimitiveFieldEmptyDSL, testdata.EmptyBodyBuildCode, 1, 1},

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1102,8 +1102,8 @@ func buildPayloadData(e *expr.HTTPEndpointExpr, sd *ServiceData) *PayloadData {
 				Ref: sd.Scope.GoVar("body", body),
 				AttributeData: &AttributeData{
 					VarName:  "body",
-					TypeName: sd.Scope.GoTypeName(e.Body),
-					TypeRef:  sd.Scope.GoTypeRef(e.Body),
+					TypeName: sd.Scope.GoTypeNameWithDefaults(e.Body),
+					TypeRef:  sd.Scope.GoTypeRefWithDefaults(e.Body),
 					Type:     body,
 					Required: true,
 					Example:  e.Body.Example(expr.Root.API.Random()),

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -1000,6 +1000,54 @@ func BuildMethodBodyInlineMapUserPayload(serviceBodyInlineMapUserMethodBodyInlin
 }
 `
 
+var PayloadObjectBuildCode = `// BuildMethodBodyInlineObjectPayload builds the payload for the
+// ServiceBodyInlineObject MethodBodyInlineObject endpoint from CLI flags.
+func BuildMethodBodyInlineObjectPayload(serviceBodyInlineObjectMethodBodyInlineObjectBody string) (*servicebodyinlineobject.MethodBodyInlineObjectPayload, error) {
+	var err error
+	var body struct {
+		A *string ` + "`" + `form:"a" json:"a" xml:"a"` + "`" + `
+	}
+	{
+		err = json.Unmarshal([]byte(serviceBodyInlineObjectMethodBodyInlineObjectBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"a\": \"Ullam aut.\"\n   }'")
+		}
+	}
+	v := &servicebodyinlineobject.MethodBodyInlineObjectPayload{
+		A: body.A,
+	}
+
+	return v, nil
+}
+`
+
+var PayloadObjectDefaultBuildCode = `// BuildMethodBodyInlineObjectPayload builds the payload for the
+// ServiceBodyInlineObject MethodBodyInlineObject endpoint from CLI flags.
+func BuildMethodBodyInlineObjectPayload(serviceBodyInlineObjectMethodBodyInlineObjectBody string) (*servicebodyinlineobject.MethodBodyInlineObjectPayload, error) {
+	var err error
+	var body struct {
+		A string ` + "`" + `form:"a" json:"a" xml:"a"` + "`" + `
+	}
+	{
+		err = json.Unmarshal([]byte(serviceBodyInlineObjectMethodBodyInlineObjectBody), &body)
+		if err != nil {
+			return nil, fmt.Errorf("invalid JSON for body, \nerror: %s, \nexample of valid JSON:\n%s", err, "'{\n      \"a\": \"Ullam aut.\"\n   }'")
+		}
+	}
+	v := &servicebodyinlineobject.MethodBodyInlineObjectPayload{
+		A: body.A,
+	}
+	{
+		var zero string
+		if v.A == zero {
+			v.A = "foo"
+		}
+	}
+
+	return v, nil
+}
+`
+
 var MapQueryParseCode = `// ParseEndpoint returns the endpoint and payload as specified on the command
 // line.
 func ParseEndpoint(

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -2682,6 +2682,41 @@ var PayloadBodyInlineMapUserDSL = func() {
 	})
 }
 
+var PayloadBodyInlineObjectDSL = func() {
+	Service("ServiceBodyInlineObject", func() {
+		Method("MethodBodyInlineObject", func() {
+			Payload(func() {
+				Attribute("a", String)
+			})
+			HTTP(func() {
+				POST("/")
+				Body(func() {
+					Attribute("a")
+				})
+			})
+		})
+	})
+}
+
+var PayloadBodyInlineObjectDefaultDSL = func() {
+	Service("ServiceBodyInlineObject", func() {
+		Method("MethodBodyInlineObject", func() {
+			Payload(func() {
+				Attribute("a", String, func() {
+					Default("foo")
+				})
+			})
+			HTTP(func() {
+				POST("/")
+				Body(func() {
+					Attribute("a")
+				})
+			})
+		})
+	})
+
+}
+
 var PayloadBodyInlineRecursiveUserDSL = func() {
 	var PayloadType = Type("PayloadType", func() {
 		Attribute("a", String, func() {


### PR DESCRIPTION
When generating the client CLI code that maps the given payload to the
HTTP request body.

Fix #2684