### PR TITLE
make protoc architecture section more readable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,23 +36,19 @@ travis: depend all #test-examples test-plugins
 
 # Install protoc
 PROTOC_VERSION=3.12.3
+UNZIP=unzip
 ifeq ($(GOOS),linux)
-PROTOC=protoc-$(PROTOC_VERSION)-linux-x86_64
-PROTOC_EXEC=$(PROTOC)/bin/protoc
-UNZIP=unzip
-else
-	ifeq ($(GOOS),darwin)
-PROTOC=protoc-$(PROTOC_VERSION)-osx-x86_64
-PROTOC_EXEC=$(PROTOC)/bin/protoc
-UNZIP=unzip
-	else
-		ifeq ($(GOOS),windows)
-PROTOC=protoc-$(PROTOC_VERSION)-win32
-PROTOC_EXEC="$(PROTOC)\bin\protoc.exe"
-GOPATH:=$(subst \,/,$(GOPATH))
-UNZIP=unzip
-		endif
-	endif
+	PROTOC=protoc-$(PROTOC_VERSION)-linux-x86_64
+	PROTOC_EXEC=$(PROTOC)/bin/protoc
+endif
+ifeq ($(GOOS),darwin)
+	PROTOC=protoc-$(PROTOC_VERSION)-osx-x86_64
+	PROTOC_EXEC=$(PROTOC)/bin/protoc
+endif
+ifeq ($(GOOS),windows)
+	PROTOC=protoc-$(PROTOC_VERSION)-win32
+	PROTOC_EXEC="$(PROTOC)\bin\protoc.exe"
+	GOPATH:=$(subst \,/,$(GOPATH))
 endif
 
 depend:


### PR DESCRIPTION
I was interested in using the project, and attempting to read the Makefile and came across this section. To be very honest, I'm not quite sure what the backwards compatibility of this change is - but in any modern make binary this works perfectly, and is clearly more readable than the predecessor.