### PR TITLE
Fix import path to generated protobuf package

### DIFF
--- a/grpc/codegen/client.go
+++ b/grpc/codegen/client.go
@@ -45,7 +45,7 @@ func client(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 				codegen.GoaNamedImport("grpc/pb", "goapb"),
 				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
 				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: data.PkgName},
+				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: data.PkgName},
 			}),
 		}
 		sections = append(sections, &codegen.SectionTemplate{
@@ -132,7 +132,7 @@ func clientEncodeDecode(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File 
 				codegen.GoaNamedImport("grpc", "goagrpc"),
 				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
 				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: data.PkgName},
+				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: data.PkgName},
 			}),
 		}
 		fm := transTmplFuncs(svc)

--- a/grpc/codegen/client.go
+++ b/grpc/codegen/client.go
@@ -45,7 +45,7 @@ func client(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 				codegen.GoaNamedImport("grpc/pb", "goapb"),
 				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
 				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: data.PkgName},
+				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName), Name: data.PkgName},
 			}),
 		}
 		sections = append(sections, &codegen.SectionTemplate{
@@ -132,7 +132,7 @@ func clientEncodeDecode(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File 
 				codegen.GoaNamedImport("grpc", "goagrpc"),
 				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
 				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: data.PkgName},
+				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName), Name: data.PkgName},
 			}),
 		}
 		fm := transTmplFuncs(svc)

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -76,7 +76,7 @@ func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, da
 			Name: sd.Service.PkgName + "c",
 		})
 		specs = append(specs, &codegen.ImportSpec{
-			Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName),
+			Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName),
 			Name: svcName + pbPkgName,
 		})
 	}
@@ -117,7 +117,7 @@ func payloadBuilders(genpkg string, svc *expr.GRPCServiceExpr, data *cli.Command
 		{Path: "unicode/utf8"},
 		codegen.GoaImport(""),
 		{Path: path.Join(genpkg, svcName), Name: sd.Service.PkgName},
-		{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: sd.PkgName},
+		{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName), Name: sd.PkgName},
 	}
 	sections := []*codegen.SectionTemplate{
 		codegen.Header(title, "client", specs),

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -76,7 +76,7 @@ func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, da
 			Name: sd.Service.PkgName + "c",
 		})
 		specs = append(specs, &codegen.ImportSpec{
-			Path: path.Join(genpkg, "grpc", svcName, pbPkgName),
+			Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName),
 			Name: svcName + pbPkgName,
 		})
 	}
@@ -117,7 +117,7 @@ func payloadBuilders(genpkg string, svc *expr.GRPCServiceExpr, data *cli.Command
 		{Path: "unicode/utf8"},
 		codegen.GoaImport(""),
 		{Path: path.Join(genpkg, svcName), Name: sd.Service.PkgName},
-		{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: sd.PkgName},
+		{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: sd.PkgName},
 	}
 	sections := []*codegen.SectionTemplate{
 		codegen.Header(title, "client", specs),

--- a/grpc/codegen/client_types.go
+++ b/grpc/codegen/client_types.go
@@ -78,7 +78,7 @@ func clientType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 					codegen.GoaImport(""),
 					{Path: path.Join(genpkg, svcName), Name: sd.Service.PkgName},
 					{Path: path.Join(genpkg, svcName, "views"), Name: sd.Service.ViewsPkg},
-					{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: sd.PkgName},
+					{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName), Name: sd.PkgName},
 				}),
 		}
 		for _, init := range initData {

--- a/grpc/codegen/client_types.go
+++ b/grpc/codegen/client_types.go
@@ -78,7 +78,7 @@ func clientType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 					codegen.GoaImport(""),
 					{Path: path.Join(genpkg, svcName), Name: sd.Service.PkgName},
 					{Path: path.Join(genpkg, svcName, "views"), Name: sd.Service.ViewsPkg},
-					{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: sd.PkgName},
+					{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: sd.PkgName},
 				}),
 		}
 		for _, init := range initData {

--- a/grpc/codegen/example_server.go
+++ b/grpc/codegen/example_server.go
@@ -68,7 +68,7 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 				Name: scope.Unique(sd.Service.PkgName),
 			})
 			specs = append(specs, &codegen.ImportSpec{
-				Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName),
+				Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName),
 				Name: scope.Unique(svcName + pbPkgName),
 			})
 		}

--- a/grpc/codegen/example_server.go
+++ b/grpc/codegen/example_server.go
@@ -68,7 +68,7 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 				Name: scope.Unique(sd.Service.PkgName),
 			})
 			specs = append(specs, &codegen.ImportSpec{
-				Path: path.Join(genpkg, "grpc", svcName, pbPkgName),
+				Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName),
 				Name: scope.Unique(svcName + pbPkgName),
 			})
 		}

--- a/grpc/codegen/proto.go
+++ b/grpc/codegen/proto.go
@@ -96,7 +96,7 @@ syntax = {{ printf "%q" .ProtoVersion }};
 
 package {{ .Pkg }};
 
-option go_package = "{{ .Pkg }}pb";
+option go_package = "{{ .Pkg }}pb/";
 `
 
 	// input: ServiceData

--- a/grpc/codegen/server.go
+++ b/grpc/codegen/server.go
@@ -45,7 +45,7 @@ func serverFile(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 				{Path: "google.golang.org/grpc/codes"},
 				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
 				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: data.PkgName},
+				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: data.PkgName},
 			}),
 			&codegen.SectionTemplate{Name: "server-struct", Source: serverStructT, Data: data},
 		}
@@ -136,7 +136,7 @@ func serverEncodeDecode(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File 
 				codegen.GoaNamedImport("grpc", "goagrpc"),
 				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
 				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: data.PkgName},
+				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: data.PkgName},
 			}),
 		}
 

--- a/grpc/codegen/server.go
+++ b/grpc/codegen/server.go
@@ -45,7 +45,7 @@ func serverFile(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 				{Path: "google.golang.org/grpc/codes"},
 				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
 				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: data.PkgName},
+				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName), Name: data.PkgName},
 			}),
 			&codegen.SectionTemplate{Name: "server-struct", Source: serverStructT, Data: data},
 		}
@@ -136,7 +136,7 @@ func serverEncodeDecode(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File 
 				codegen.GoaNamedImport("grpc", "goagrpc"),
 				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
 				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: data.PkgName},
+				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName), Name: data.PkgName},
 			}),
 		}
 

--- a/grpc/codegen/server_types.go
+++ b/grpc/codegen/server_types.go
@@ -79,7 +79,7 @@ func serverType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 					codegen.GoaImport(""),
 					{Path: path.Join(genpkg, svcName), Name: sd.Service.PkgName},
 					{Path: path.Join(genpkg, svcName, "views"), Name: sd.Service.ViewsPkg},
-					{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: sd.PkgName},
+					{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: sd.PkgName},
 				}),
 		}
 		for _, init := range initData {

--- a/grpc/codegen/server_types.go
+++ b/grpc/codegen/server_types.go
@@ -79,7 +79,7 @@ func serverType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 					codegen.GoaImport(""),
 					{Path: path.Join(genpkg, svcName), Name: sd.Service.PkgName},
 					{Path: path.Join(genpkg, svcName, "views"), Name: sd.Service.ViewsPkg},
-					{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName), Name: sd.PkgName},
+					{Path: path.Join(genpkg, "grpc", svcName, pbPkgName, svcName+pbPkgName), Name: sd.PkgName},
 				}),
 		}
 		for _, init := range initData {

--- a/grpc/codegen/testdata/proto_code.go
+++ b/grpc/codegen/testdata/proto_code.go
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package service_unary_rp_cs;
 
-option go_package = "service_unary_rp_cspb";
+option go_package = "service_unary_rp_cspb/";
 
 // Service is the ServiceUnaryRPCs service interface.
 service ServiceUnaryRPCs {
@@ -41,7 +41,7 @@ syntax = "proto3";
 
 package service_unary_rpc_no_payload;
 
-option go_package = "service_unary_rpc_no_payloadpb";
+option go_package = "service_unary_rpc_no_payloadpb/";
 
 // Service is the ServiceUnaryRPCNoPayload service interface.
 service ServiceUnaryRPCNoPayload {
@@ -62,7 +62,7 @@ syntax = "proto3";
 
 package service_unary_rpc_no_result;
 
-option go_package = "service_unary_rpc_no_resultpb";
+option go_package = "service_unary_rpc_no_resultpb/";
 
 // Service is the ServiceUnaryRPCNoResult service interface.
 service ServiceUnaryRPCNoResult {
@@ -83,7 +83,7 @@ syntax = "proto3";
 
 package service_server_streaming_rpc;
 
-option go_package = "service_server_streaming_rpcpb";
+option go_package = "service_server_streaming_rpcpb/";
 
 // Service is the ServiceServerStreamingRPC service interface.
 service ServiceServerStreamingRPC {
@@ -105,7 +105,7 @@ syntax = "proto3";
 
 package service_client_streaming_rpc;
 
-option go_package = "service_client_streaming_rpcpb";
+option go_package = "service_client_streaming_rpcpb/";
 
 // Service is the ServiceClientStreamingRPC service interface.
 service ServiceClientStreamingRPC {
@@ -127,7 +127,7 @@ syntax = "proto3";
 
 package service_bidirectional_streaming_rpc;
 
-option go_package = "service_bidirectional_streaming_rpcpb";
+option go_package = "service_bidirectional_streaming_rpcpb/";
 
 // Service is the ServiceBidirectionalStreamingRPC service interface.
 service ServiceBidirectionalStreamingRPC {
@@ -150,7 +150,7 @@ syntax = "proto3";
 
 package my_name_conflicts;
 
-option go_package = "my_name_conflictspb";
+option go_package = "my_name_conflictspb/";
 
 // Service is the MyNameConflicts service interface.
 service MyNameConflicts {
@@ -359,7 +359,7 @@ syntax = "proto3";
 
 package method_with_reserved_name;
 
-option go_package = "method_with_reserved_namepb";
+option go_package = "method_with_reserved_namepb/";
 
 // Service is the MethodWithReservedName service interface.
 service MethodWithReservedName {
@@ -379,7 +379,7 @@ syntax = "proto3";
 
 package multiple_methods_same_result_collection;
 
-option go_package = "multiple_methods_same_result_collectionpb";
+option go_package = "multiple_methods_same_result_collectionpb/";
 
 // Service is the MultipleMethodsSameResultCollection service interface.
 service MultipleMethodsSameResultCollection {
@@ -409,7 +409,7 @@ syntax = "proto3";
 
 package method_with_acronym;
 
-option go_package = "method_with_acronympb";
+option go_package = "method_with_acronympb/";
 
 // Service is the MethodWithAcronym service interface.
 service MethodWithAcronym {


### PR DESCRIPTION
#2792 

Wrong import path to protobuf package:
`path.Join(genpkg, "grpc", svcName, pbPkgName)`

Replaced by:
`path.Join(genpkg, "grpc", svcName, pbPkgName, svcName + pbPkgName)`