### PR TITLE
Update example in Service.go

### DIFF
--- a/dsl/service.go
+++ b/dsl/service.go
@@ -26,7 +26,7 @@ import (
 // Example:
 //
 //    var _ = Service("divider", func() {
-//        Title("divider service") // optional
+//        Description("divider service") // optional
 //
 //        Error("Unauthorized") // error that apply to all the service methods
 //        HTTP(func() {         // HTTP mapping for error responses


### PR DESCRIPTION
I've found that when using `Title` as per the example the following error is generated when I try to compile the DSL:

[design/design.go:55] invalid use of Title in service

Changing to `Description` solves the issue for me (running v3)


Description