### PR TITLE
Structured Error

### DIFF
--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -337,7 +337,7 @@ func recurseAttribute(att *expr.AttributeExpr, attCtx *AttributeContext, nat *ex
 				buf.Write(recurseValidationCode(ut.Attribute(), attCtx, att.IsRequired(nat.Name), tgt, context, seen).Bytes())
 			} else {
 				name := attCtx.Scope.Name(nat.Attribute, attCtx.Pkg, attCtx.Pointer, attCtx.UseDefault)
-				if err := userValT.Execute(&buf, map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": attCtx.Scope.Field(nat.Attribute, nat.Name, false)}); err != nil {
+				if err := userValT.Execute(&buf, map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": nat.Name}); err != nil {
 					panic(err) // bug
 				}
 			}

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -217,8 +217,7 @@ func recurseValidationCode(att *expr.AttributeExpr, attCtx *AttributeContext, re
 			} else if hasValidations(attCtx, ut) {
 				var buf bytes.Buffer
 				name := attCtx.Scope.Name(att, ctx.Pkg, ctx.Pointer, ctx.UseDefault)
-				context := attCtx.Scope.Field(att, name, true)
-				data := map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": context}
+				data := map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": context+suf}
 				if err := userValT.Execute(&buf, data); err != nil {
 					panic(err) // bug
 				}
@@ -338,7 +337,6 @@ func recurseAttribute(att *expr.AttributeExpr, attCtx *AttributeContext, nat *ex
 				buf.Write(recurseValidationCode(ut.Attribute(), attCtx, att.IsRequired(nat.Name), tgt, context, seen).Bytes())
 			} else {
 				name := attCtx.Scope.Name(nat.Attribute, attCtx.Pkg, attCtx.Pointer, attCtx.UseDefault)
-				context := attCtx.Scope.Field(att, name, true)
 				if err := userValT.Execute(&buf, map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": context}); err != nil {
 					panic(err) // bug
 				}

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -217,7 +217,7 @@ func recurseValidationCode(att *expr.AttributeExpr, attCtx *AttributeContext, re
 			} else if hasValidations(attCtx, ut) {
 				var buf bytes.Buffer
 				name := attCtx.Scope.Name(att, ctx.Pkg, ctx.Pointer, ctx.UseDefault)
-				data := map[string]interface{}{"name": Goify(name, true), "target": tgt}
+				data := map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": context}
 				if err := userValT.Execute(&buf, data); err != nil {
 					panic(err) // bug
 				}
@@ -337,7 +337,7 @@ func recurseAttribute(att *expr.AttributeExpr, attCtx *AttributeContext, nat *ex
 				buf.Write(recurseValidationCode(ut.Attribute(), attCtx, att.IsRequired(nat.Name), tgt, context, seen).Bytes())
 			} else {
 				name := attCtx.Scope.Name(nat.Attribute, attCtx.Pkg, attCtx.Pointer, attCtx.UseDefault)
-				if err := userValT.Execute(&buf, map[string]interface{}{"name": Goify(name, true), "target": tgt}); err != nil {
+				if err := userValT.Execute(&buf, map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": context}); err != nil {
 					panic(err) // bug
 				}
 			}
@@ -459,7 +459,7 @@ const (
 }`
 
 	userValTmpl = `if err2 := Validate{{ .name }}({{ .target }}); err2 != nil {
-        err = goa.MergeErrors(err, err2)
+        err = goa.MergeErrors(err, goa.WrapError(err2, {{ .context }}))
 }`
 
 	enumValTmpl = `{{ if isset .zeroVal -}}

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -217,6 +217,7 @@ func recurseValidationCode(att *expr.AttributeExpr, attCtx *AttributeContext, re
 			} else if hasValidations(attCtx, ut) {
 				var buf bytes.Buffer
 				name := attCtx.Scope.Name(att, ctx.Pkg, ctx.Pointer, ctx.UseDefault)
+				context := attCtx.Scope.Field(att, name, true)
 				data := map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": context}
 				if err := userValT.Execute(&buf, data); err != nil {
 					panic(err) // bug
@@ -337,6 +338,7 @@ func recurseAttribute(att *expr.AttributeExpr, attCtx *AttributeContext, nat *ex
 				buf.Write(recurseValidationCode(ut.Attribute(), attCtx, att.IsRequired(nat.Name), tgt, context, seen).Bytes())
 			} else {
 				name := attCtx.Scope.Name(nat.Attribute, attCtx.Pkg, attCtx.Pointer, attCtx.UseDefault)
+				context := attCtx.Scope.Field(att, name, true)
 				if err := userValT.Execute(&buf, map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": context}); err != nil {
 					panic(err) // bug
 				}
@@ -459,7 +461,7 @@ const (
 }`
 
 	userValTmpl = `if err2 := Validate{{ .name }}({{ .target }}); err2 != nil {
-        err = goa.MergeErrors(err, goa.WrapError(err2, {{ .context }}))
+        err = goa.MergeErrors(err, goa.WrapError(err2, {{ printf "%q" .context }}))
 }`
 
 	enumValTmpl = `{{ if isset .zeroVal -}}

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -337,7 +337,7 @@ func recurseAttribute(att *expr.AttributeExpr, attCtx *AttributeContext, nat *ex
 				buf.Write(recurseValidationCode(ut.Attribute(), attCtx, att.IsRequired(nat.Name), tgt, context, seen).Bytes())
 			} else {
 				name := attCtx.Scope.Name(nat.Attribute, attCtx.Pkg, attCtx.Pointer, attCtx.UseDefault)
-				if err := userValT.Execute(&buf, map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": context}); err != nil {
+				if err := userValT.Execute(&buf, map[string]interface{}{"name": Goify(name, true), "target": tgt, "context": attCtx.Scope.Field(nat.Attribute, nat.Name, false)}); err != nil {
 					panic(err) // bug
 				}
 			}

--- a/http/error.go
+++ b/http/error.go
@@ -23,6 +23,8 @@ type (
 		Timeout bool `json:"timeout" xml:"timeout" form:"timeout"`
 		// Fault indicates whether the error is a server-side fault.
 		Fault bool `json:"fault" xml:"fault" form:"fault"`
+
+		DetailedError *goa.DetailedServiceError
 	}
 
 	// Statuser is implemented by error response object to provide the response
@@ -38,12 +40,13 @@ type (
 func NewErrorResponse(err error) Statuser {
 	if gerr, ok := err.(*goa.ServiceError); ok {
 		return &ErrorResponse{
-			Name:      gerr.Name,
-			ID:        gerr.ID,
-			Message:   gerr.Message,
-			Timeout:   gerr.Timeout,
-			Temporary: gerr.Temporary,
-			Fault:     gerr.Fault,
+			Name:          gerr.Name,
+			ID:            gerr.ID,
+			Message:       gerr.Message,
+			Timeout:       gerr.Timeout,
+			Temporary:     gerr.Temporary,
+			Fault:         gerr.Fault,
+			DetailedError: gerr.DetailedError,
 		}
 	}
 	return NewErrorResponse(goa.Fault(err.Error()))

--- a/http/error.go
+++ b/http/error.go
@@ -24,7 +24,7 @@ type (
 		// Fault indicates whether the error is a server-side fault.
 		Fault bool `json:"fault" xml:"fault" form:"fault"`
 
-		DetailedError *goa.DetailedServiceError `json:"detailedError"`
+		StructuredError *goa.StructuredServiceError `json:"structuredError" xml:"structuredError" form:"structuredError"`
 	}
 
 	// Statuser is implemented by error response object to provide the response
@@ -40,13 +40,13 @@ type (
 func NewErrorResponse(err error) Statuser {
 	if gerr, ok := err.(*goa.ServiceError); ok {
 		return &ErrorResponse{
-			Name:          gerr.Name,
-			ID:            gerr.ID,
-			Message:       gerr.Message,
-			Timeout:       gerr.Timeout,
-			Temporary:     gerr.Temporary,
-			Fault:         gerr.Fault,
-			DetailedError: gerr.DetailedError,
+			Name:            gerr.Name,
+			ID:              gerr.ID,
+			Message:         gerr.Message,
+			Timeout:         gerr.Timeout,
+			Temporary:       gerr.Temporary,
+			Fault:           gerr.Fault,
+			StructuredError: gerr.StructuredError,
 		}
 	}
 	return NewErrorResponse(goa.Fault(err.Error()))

--- a/http/error.go
+++ b/http/error.go
@@ -24,7 +24,7 @@ type (
 		// Fault indicates whether the error is a server-side fault.
 		Fault bool `json:"fault" xml:"fault" form:"fault"`
 
-		DetailedError *goa.DetailedServiceError
+		DetailedError *goa.DetailedServiceError `json:"detailedError"`
 	}
 
 	// Statuser is implemented by error response object to provide the response

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -3,6 +3,7 @@ package goa
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -30,11 +31,11 @@ type (
 
 	// DetailedServiceError provides in-depth detailed and hierarchical information on the error
 	DetailedServiceError struct {
-		Code       string
-		Message    string
-		Target     *string
-		Details    []DetailedServiceError
-		InnerError *DetailedServiceInnerError
+		Code       string                     `json:"code"`
+		Message    string                     `json:"message"`
+		Target     *string                    `json:"target"`
+		Details    []DetailedServiceError     `json:"details"`
+		InnerError *DetailedServiceInnerError `json:"innererror"`
 	}
 
 	// DetailedServiceInnerError provide context specific errors
@@ -44,6 +45,24 @@ type (
 		DynamicProperties map[string]interface{}
 	}
 )
+
+func (d DetailedServiceInnerError) MarshalJSON() ([]byte, error) {
+	propertyMap := make(map[string]interface{})
+
+	if d.Code != nil {
+		propertyMap["code"] = d.Code
+	}
+
+	if d.InnerError != nil {
+		propertyMap["innererror"] = d.InnerError
+	}
+
+	for k, v := range d.DynamicProperties {
+		propertyMap[k] = v
+	}
+
+	return json.Marshal(propertyMap)
+}
 
 // Fault creates an error given a format and values a la fmt.Printf. The error
 // has the Fault field set to true.


### PR DESCRIPTION
This PR is a proposal to extend the current error response to provide a more structured error response

At the moment the error response attempts to concatenate the error messages into one long message, which is not great when you are building APIs that does per form control error display

The proposed solution is to add a new field into the error response body, called `structuredError`. It's body will conform to what's been described in this [document](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#error--object)

For eg,

Given a request payload (recursive) and where id is a mandatory field
```
{
    "id": "a",
    "children": [
        {
            "id": "b",
            "children": [
                {"id":"1"},
                {}
            ]
        }
    ]
}
```

Will yield the following error response

```
{
    "name": "missing_field",
    "id": "DxVokN9I",
    "message": "\"id\" is missing from body",
    "temporary": false,
    "timeout": false,
    "fault": false,
    "structuredError": {
        "code": "client_error",
        "message": "client error",
        "target": "body.children[*]",
        "details": [
            {
                "code": "client_error",
                "message": "client error",
                "target": "body.children[*]",
                "details": [
                    {
                        "code": "missing_field",
                        "message": "\"id\" is missing from body",
                        "target": "id"
                    }
                ]
            }
        ]
    }
}
```

I wanted to open up this PR to have a discussion on how we possibly might get this incorporated into goa