### PR TITLE
Support Meta "struct:field:type" in gRPC

### DIFF
--- a/codegen/testdata/types_dsl.go
+++ b/codegen/testdata/types_dsl.go
@@ -13,6 +13,20 @@ var TestTypesDSL = func() {
 			Required("required_string")
 		})
 
+		_ = Type("CustomTypes", func() {
+			Attribute("required_string", String, func() {
+				Meta("struct:field:type", "tdtypes.CustomString", "goa.design/goa/v3/codegen/testdata/tdtypes")
+			})
+			Attribute("default_bool", Boolean, func() {
+				Meta("struct:field:type", "tdtypes.CustomBool", "goa.design/goa/v3/codegen/testdata/tdtypes")
+				Default(true)
+			})
+			Attribute("integer", Int, func() {
+				Meta("struct:field:type", "tdtypes.CustomInt", "goa.design/goa/v3/codegen/testdata/tdtypes")
+			})
+			Required("required_string")
+		})
+
 		_ = Type("Required", func() {
 			Extend(Simple)
 			Required("required_string", "default_bool", "integer")

--- a/grpc/codegen/protobuf_transform_test.go
+++ b/grpc/codegen/protobuf_transform_test.go
@@ -16,9 +16,10 @@ func TestProtoBufTransform(t *testing.T) {
 		// types to test
 		primitive = expr.Int
 
-		simple   = root.UserType("Simple")
-		required = root.UserType("Required")
-		defaultT = root.UserType("Default")
+		simple     = root.UserType("Simple")
+		required   = root.UserType("Required")
+		defaultT   = root.UserType("Default")
+		customtype = root.UserType("CustomTypes")
 
 		simpleMap  = root.UserType("SimpleMap")
 		nestedMap  = root.UserType("NestedMap")
@@ -63,6 +64,8 @@ func TestProtoBufTransform(t *testing.T) {
 			{"simple-to-default", simple, defaultT, true, svcCtx, simpleSvcToDefaultProtoCode},
 			{"default-to-simple", defaultT, simple, true, svcCtx, defaultSvcToSimpleProtoCode},
 			{"required-ptr-to-simple", required, simple, true, ptrCtx, requiredPtrSvcToSimpleProtoCode},
+			{"simple-to-customtype", customtype, simple, true, svcCtx, customSvcToSimpleProtoCode},
+			{"customtype-to-customtype", customtype, customtype, true, svcCtx, customSvcToCustomProtoCode},
 
 			// maps
 			{"map-to-map", simpleMap, simpleMap, true, svcCtx, simpleMapSvcToSimpleMapProtoCode},
@@ -95,6 +98,8 @@ func TestProtoBufTransform(t *testing.T) {
 			{"simple-to-default", simple, defaultT, false, svcCtx, simpleProtoToDefaultSvcCode},
 			{"default-to-simple", defaultT, simple, false, svcCtx, defaultProtoToSimpleSvcCode},
 			{"simple-to-required-ptr", simple, required, false, ptrCtx, simpleProtoToRequiredPtrSvcCode},
+			{"simple-to-customtype", simple, customtype, false, svcCtx, simpleProtoToCustomSvcCode},
+			{"customtype-to-customtype", customtype, customtype, false, svcCtx, customProtoToCustomSvcCode},
 
 			// maps
 			{"map-to-map", simpleMap, simpleMap, false, svcCtx, simpleMapProtoToSimpleMapSvcCode},
@@ -227,6 +232,42 @@ const (
 	}
 }
 `
+
+	customSvcToSimpleProtoCode = `func transform() {
+	target := &Simple{
+		RequiredString: string(source.RequiredString),
+		DefaultBool:    bool(source.DefaultBool),
+	}
+	if source.Integer != nil {
+		target.Integer = int32(*source.Integer)
+	}
+}
+`
+
+	simpleProtoToCustomSvcCode = `func transform() {
+	target := &CustomTypes{
+		RequiredString: tdtypes.CustomString(source.RequiredString),
+		DefaultBool:    tdtypes.CustomBool(source.DefaultBool),
+	}
+	if source.Integer != 0 {
+		integerptr := tdtypes.CustomInt(source.Integer)
+		target.Integer = &integerptr
+	}
+}
+`
+
+	customSvcToCustomProtoCode = `func transform() {
+	target := &CustomTypes{
+		RequiredString: string(source.RequiredString),
+		DefaultBool:    bool(source.DefaultBool),
+	}
+	if source.Integer != nil {
+		target.Integer = int32(*source.Integer)
+	}
+}
+`
+
+	customProtoToCustomSvcCode = simpleProtoToCustomSvcCode
 
 	simpleMapSvcToSimpleMapProtoCode = `func transform() {
 	target := &SimpleMap{}


### PR DESCRIPTION
This addresses what appears to be a real bug: if you annotate a field (either streaming or non) used for gRPC, the protobuf type transformation code in convertType failed to respect Meta `struct:field:type`, resulting in the lack of type casts between the requested type and the protobuf mapping thereof, and code that doesn't compile.

It turns out that Meta `struct:field:type` is probably closer to what I wanted for #2498. The implications deserve more thought than I've given them. For example, does a shared design work cleanly across both a client and a server? Do the requested types need to be available to both, or is there a way for one side to use the default type? (Perhaps this was already considered before `struct:field:type` was introduced.)

At a raw implementation level, I'm also unclear how this approach handles the imports on the generated files. It seemed to in my superficial testing, so I'm hoping it's magic I'm not familiar with.