### PR TITLE
Add a DSL Redirect

### DIFF
--- a/dsl/http_redirect.go
+++ b/dsl/http_redirect.go
@@ -1,0 +1,56 @@
+package dsl
+
+import (
+	"goa.design/goa/v3/eval"
+	"goa.design/goa/v3/expr"
+)
+
+// Redirect indicates that HTTP requests reply to the request with a redirect.
+// The logic is the same as the standard http package Redirect function.
+//
+// Redirect must appear in a HTTP endpoint expression or a HTTP file server
+// expression.
+//
+// Redirect accepts 2 arguments and an optional DSL. The first argument is the
+// url that redirected to. The second argument is the HTTP status code.
+//
+// Example:
+//
+//    var _ = Service("service", func() {
+//        Method("method", func() {
+//            HTTP(func() {
+//                GET("/resources")
+//                Redirect("/redirect/dest", StatusMovedPermanently)
+//            })
+//        })
+//    })
+//
+//    var _ = Service("service", func() {
+//        Files("/file.json", "/path/to/file.json", func() {
+//            Redirect("/redirect/dest", StatusMovedPermanently)
+//        })
+//    })
+//
+func Redirect(url string, code int, fns ...func()) {
+	if len(fns) > 1 {
+		eval.ReportError("too many arguments given to Redirect")
+		return
+	}
+	redirect := &expr.HTTPRedirectExpr{
+		URL:        url,
+		StatusCode: code,
+	}
+	if len(fns) > 0 {
+		eval.Execute(fns[0], redirect)
+	}
+	switch actual := eval.Current().(type) {
+	case *expr.HTTPEndpointExpr:
+		redirect.Parent = actual
+		actual.Redirect = redirect
+	case *expr.HTTPFileServerExpr:
+		redirect.Parent = actual
+		actual.Redirect = redirect
+	default:
+		eval.IncompatibleDSL()
+	}
+}

--- a/dsl/http_redirect.go
+++ b/dsl/http_redirect.go
@@ -11,8 +11,8 @@ import (
 // Redirect must appear in a HTTP endpoint expression or a HTTP file server
 // expression.
 //
-// Redirect accepts 2 arguments. The first argument is the url that redirected
-// to. The second argument is the HTTP status code.
+// Redirect accepts 2 arguments. The first argument is the URL that is being
+// redirected to. The second argument is the HTTP status code.
 //
 // Example:
 //

--- a/dsl/http_redirect.go
+++ b/dsl/http_redirect.go
@@ -11,8 +11,8 @@ import (
 // Redirect must appear in a HTTP endpoint expression or a HTTP file server
 // expression.
 //
-// Redirect accepts 2 arguments and an optional DSL. The first argument is the
-// url that redirected to. The second argument is the HTTP status code.
+// Redirect accepts 2 arguments. The first argument is the url that redirected
+// to. The second argument is the HTTP status code.
 //
 // Example:
 //
@@ -31,17 +31,10 @@ import (
 //        })
 //    })
 //
-func Redirect(url string, code int, fns ...func()) {
-	if len(fns) > 1 {
-		eval.ReportError("too many arguments given to Redirect")
-		return
-	}
+func Redirect(url string, code int) {
 	redirect := &expr.HTTPRedirectExpr{
 		URL:        url,
 		StatusCode: code,
-	}
-	if len(fns) > 0 {
-		eval.Execute(fns[0], redirect)
 	}
 	switch actual := eval.Current().(type) {
 	case *expr.HTTPEndpointExpr:

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -169,8 +169,6 @@ func Meta(name string, value ...string) {
 		e.Meta = appendMeta(e.Meta, name, value...)
 	case *expr.HTTPFileServerExpr:
 		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.HTTPRedirectExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
 	case *expr.HTTPResponseExpr:
 		e.Meta = appendMeta(e.Meta, name, value...)
 	case expr.CompositeExpr:

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -169,6 +169,8 @@ func Meta(name string, value ...string) {
 		e.Meta = appendMeta(e.Meta, name, value...)
 	case *expr.HTTPFileServerExpr:
 		e.Meta = appendMeta(e.Meta, name, value...)
+	case *expr.HTTPRedirectExpr:
+		e.Meta = appendMeta(e.Meta, name, value...)
 	case *expr.HTTPResponseExpr:
 		e.Meta = appendMeta(e.Meta, name, value...)
 	case expr.CompositeExpr:

--- a/expr/http_file_server.go
+++ b/expr/http_file_server.go
@@ -20,6 +20,8 @@ type (
 		FilePath string
 		// RequestPaths is the list of HTTP paths that serve the assets.
 		RequestPaths []string
+		// Redirect defines a redirect for the endpoint.
+		Redirect *HTTPRedirectExpr
 		// Meta is a list of key/value pairs
 		Meta MetaExpr
 	}

--- a/expr/http_redirect.go
+++ b/expr/http_redirect.go
@@ -15,8 +15,6 @@ type (
 		StatusCode int
 		// Parent expression, one of HTTPEndpointExpr or HTTPFileServerExpr.
 		Parent eval.Expression
-		// Meta is a list of key/value pairs.
-		Meta MetaExpr
 	}
 )
 

--- a/expr/http_redirect.go
+++ b/expr/http_redirect.go
@@ -9,7 +9,7 @@ import (
 type (
 	// HTTPRedirectExpr defines an endpoint that replies to the request with a redirect.
 	HTTPRedirectExpr struct {
-		// URL is the URL that redirected to.
+		// URL is the URL that is being redirected to.
 		URL string
 		// StatusCode is the HTTP status code.
 		StatusCode int

--- a/expr/http_redirect.go
+++ b/expr/http_redirect.go
@@ -1,0 +1,31 @@
+package expr
+
+import (
+	"fmt"
+
+	"goa.design/goa/v3/eval"
+)
+
+type (
+	// HTTPRedirectExpr defines an endpoint that replies to the request with a redirect.
+	HTTPRedirectExpr struct {
+		// URL is the URL that redirected to.
+		URL string
+		// StatusCode is the HTTP status code.
+		StatusCode int
+		// Parent expression, one of HTTPEndpointExpr or HTTPFileServerExpr.
+		Parent eval.Expression
+		// Meta is a list of key/value pairs.
+		Meta MetaExpr
+	}
+)
+
+// EvalName returns the generic definition name used in error messages.
+func (r *HTTPRedirectExpr) EvalName() string {
+	suffix := fmt.Sprintf("redirect to %s with status code %d", r.URL, r.StatusCode)
+	var prefix string
+	if r.Parent != nil {
+		prefix = r.Parent.EvalName() + " "
+	}
+	return prefix + suffix
+}

--- a/http/codegen/handler_test.go
+++ b/http/codegen/handler_test.go
@@ -11,22 +11,23 @@ import (
 func TestHandlerInit(t *testing.T) {
 	const genpkg = "gen"
 	cases := []struct {
-		Name string
-		DSL  func()
-		Code string
+		Name      string
+		DSL       func()
+		Code      string
+		FileCount int
 	}{
-		{"no payload no result", testdata.ServerNoPayloadNoResultDSL, testdata.ServerNoPayloadNoResultHandlerConstructorCode},
-		{"payload no result", testdata.ServerPayloadNoResultDSL, testdata.ServerPayloadNoResultHandlerConstructorCode},
-		{"no payload result", testdata.ServerNoPayloadResultDSL, testdata.ServerNoPayloadResultHandlerConstructorCode},
-		{"payload result", testdata.ServerPayloadResultDSL, testdata.ServerPayloadResultHandlerConstructorCode},
-		{"payload result error", testdata.ServerPayloadResultErrorDSL, testdata.ServerPayloadResultErrorHandlerConstructorCode},
+		{"no payload no result", testdata.ServerNoPayloadNoResultDSL, testdata.ServerNoPayloadNoResultHandlerConstructorCode, 2},
+		{"payload no result", testdata.ServerPayloadNoResultDSL, testdata.ServerPayloadNoResultHandlerConstructorCode, 2},
+		{"no payload result", testdata.ServerNoPayloadResultDSL, testdata.ServerNoPayloadResultHandlerConstructorCode, 2},
+		{"payload result", testdata.ServerPayloadResultDSL, testdata.ServerPayloadResultHandlerConstructorCode, 2},
+		{"payload result error", testdata.ServerPayloadResultErrorDSL, testdata.ServerPayloadResultErrorHandlerConstructorCode, 2},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
 			RunHTTPDSL(t, c.DSL)
 			fs := ServerFiles(genpkg, expr.Root)
-			if len(fs) != 2 {
-				t.Fatalf("got %d files, expected two", len(fs))
+			if len(fs) != c.FileCount {
+				t.Fatalf("got %d files, expected %d", len(fs), c.FileCount)
 			}
 			sections := fs[0].SectionTemplates
 			if len(sections) < 7 {

--- a/http/codegen/handler_test.go
+++ b/http/codegen/handler_test.go
@@ -17,7 +17,9 @@ func TestHandlerInit(t *testing.T) {
 		FileCount int
 	}{
 		{"no payload no result", testdata.ServerNoPayloadNoResultDSL, testdata.ServerNoPayloadNoResultHandlerConstructorCode, 2},
+		{"no payload no result with a redirect", testdata.ServerNoPayloadNoResultWithRedirectDSL, testdata.ServerNoPayloadNoResultWithRedirectHandlerConstructorCode, 1},
 		{"payload no result", testdata.ServerPayloadNoResultDSL, testdata.ServerPayloadNoResultHandlerConstructorCode, 2},
+		{"payload no result with a redirect", testdata.ServerPayloadNoResultWithRedirectDSL, testdata.ServerPayloadNoResultWithRedirectHandlerConstructorCode, 2},
 		{"no payload result", testdata.ServerNoPayloadResultDSL, testdata.ServerNoPayloadResultHandlerConstructorCode, 2},
 		{"payload result", testdata.ServerPayloadResultDSL, testdata.ServerPayloadResultHandlerConstructorCode, 2},
 		{"payload result error", testdata.ServerPayloadResultErrorDSL, testdata.ServerPayloadResultErrorHandlerConstructorCode, 2},

--- a/http/codegen/server_handler_test.go
+++ b/http/codegen/server_handler_test.go
@@ -14,17 +14,18 @@ func TestServerHandler(t *testing.T) {
 		Name       string
 		DSL        func()
 		Code       string
+		FileCount  int
 		SectionNum int
 	}{
-		{"server simple routing", testdata.ServerSimpleRoutingDSL, testdata.ServerSimpleRoutingCode, 7},
-		{"server trailing slash routing", testdata.ServerTrailingSlashRoutingDSL, testdata.ServerTrailingSlashRoutingCode, 7},
+		{"server simple routing", testdata.ServerSimpleRoutingDSL, testdata.ServerSimpleRoutingCode, 2, 7},
+		{"server trailing slash routing", testdata.ServerTrailingSlashRoutingDSL, testdata.ServerTrailingSlashRoutingCode, 2, 7},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
 			RunHTTPDSL(t, c.DSL)
 			fs := ServerFiles(genpkg, expr.Root)
-			if len(fs) != 2 {
-				t.Fatalf("got %d files, expected 1", len(fs))
+			if len(fs) != c.FileCount {
+				t.Fatalf("got %d files, expected %d", len(fs), c.FileCount)
 			}
 			sections := fs[0].SectionTemplates
 			if len(sections) < 8 {

--- a/http/codegen/server_handler_test.go
+++ b/http/codegen/server_handler_test.go
@@ -19,6 +19,7 @@ func TestServerHandler(t *testing.T) {
 	}{
 		{"server simple routing", testdata.ServerSimpleRoutingDSL, testdata.ServerSimpleRoutingCode, 2, 7},
 		{"server trailing slash routing", testdata.ServerTrailingSlashRoutingDSL, testdata.ServerTrailingSlashRoutingCode, 2, 7},
+		{"server simple routing with a redirect", testdata.ServerSimpleRoutingWithRedirectDSL, testdata.ServerSimpleRoutingCode, 1, 7},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/server_init_test.go
+++ b/http/codegen/server_init_test.go
@@ -20,6 +20,7 @@ func TestServerInit(t *testing.T) {
 		{"multiple endpoints", testdata.ServerMultiEndpointsDSL, testdata.ServerMultiEndpointsConstructorCode, 2, 3},
 		{"multiple bases", testdata.ServerMultiBasesDSL, testdata.ServerMultiBasesConstructorCode, 2, 3},
 		{"file server", testdata.ServerFileServerDSL, testdata.ServerFileServerConstructorCode, 1, 3},
+		{"file server with a redirect", testdata.ServerFileServerWithRedirectDSL, testdata.ServerFileServerConstructorCode, 1, 3},
 		{"mixed", testdata.ServerMixedDSL, testdata.ServerMixedConstructorCode, 2, 3},
 		{"multipart", testdata.ServerMultipartDSL, testdata.ServerMultipartConstructorCode, 2, 4},
 		{"streaming", testdata.StreamingResultDSL, testdata.ServerStreamingConstructorCode, 3, 3},

--- a/http/codegen/server_mount_test.go
+++ b/http/codegen/server_mount_test.go
@@ -18,10 +18,13 @@ func TestServerMount(t *testing.T) {
 		SectionNum int
 	}{
 		{"simple routing constructor", testdata.ServerSimpleRoutingDSL, testdata.ServerSimpleRoutingConstructorCode, 2, 6},
+		{"simple routing with a redirect constructor", testdata.ServerSimpleRoutingWithRedirectDSL, testdata.ServerSimpleRoutingConstructorCode, 1, 6},
 		{"multiple files constructor", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesConstructorCode, 1, 6},
 		{"multiple files mounter", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
 		{"multiple files constructor /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathConstructorCode, 1, 6},
 		{"multiple files mounter /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathMounterCode, 1, 9},
+		{"multiple files with a redirect constructor", testdata.ServerMultipleFilesWithRedirectDSL, testdata.ServerMultipleFilesWithRedirectConstructorCode, 1, 6},
+		{"multiple files with a redirect mounter", testdata.ServerMultipleFilesWithRedirectDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/server_mount_test.go
+++ b/http/codegen/server_mount_test.go
@@ -14,19 +14,20 @@ func TestServerMount(t *testing.T) {
 		Name       string
 		DSL        func()
 		Code       string
+		FileCount  int
 		SectionNum int
 	}{
-		{"multiple files constructor", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesConstructorCode, 6},
-		{"multiple files mounter", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesMounterCode, 9},
-		{"multiple files constructor /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathConstructorCode, 6},
-		{"multiple files mounter /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathMounterCode, 9},
+		{"multiple files constructor", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesConstructorCode, 1, 6},
+		{"multiple files mounter", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
+		{"multiple files constructor /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathConstructorCode, 1, 6},
+		{"multiple files mounter /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathMounterCode, 1, 9},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
 			RunHTTPDSL(t, c.DSL)
 			fs := ServerFiles(genpkg, expr.Root)
-			if len(fs) != 1 {
-				t.Fatalf("got %d files, expected 1", len(fs))
+			if len(fs) != c.FileCount {
+				t.Fatalf("got %d files, expected %d", len(fs), c.FileCount)
 			}
 			sections := fs[0].SectionTemplates
 			if len(sections) < 6 {

--- a/http/codegen/server_mount_test.go
+++ b/http/codegen/server_mount_test.go
@@ -17,6 +17,7 @@ func TestServerMount(t *testing.T) {
 		FileCount  int
 		SectionNum int
 	}{
+		{"simple routing constructor", testdata.ServerSimpleRoutingDSL, testdata.ServerSimpleRoutingConstructorCode, 2, 6},
 		{"multiple files constructor", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesConstructorCode, 1, 6},
 		{"multiple files mounter", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
 		{"multiple files constructor /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathConstructorCode, 1, 6},

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -191,7 +191,7 @@ type (
 
 	// RedirectData lists the data needed to generate a redirect.
 	RedirectData struct {
-		// URL is the URL that redirected to.
+		// URL is the URL that is being redirected to.
 		URL string
 		// StatusCode is the HTTP status code.
 		StatusCode string

--- a/http/codegen/testdata/handler_init_functions.go
+++ b/http/codegen/testdata/handler_init_functions.go
@@ -34,6 +34,26 @@ func NewMethodNoPayloadNoResultHandler(
 }
 `
 
+var ServerNoPayloadNoResultWithRedirectHandlerConstructorCode = `// NewMethodNoPayloadNoResultHandler creates a HTTP handler which loads the
+// HTTP request and calls the "ServiceNoPayloadNoResult" service
+// "MethodNoPayloadNoResult" endpoint.
+func NewMethodNoPayloadNoResultHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "MethodNoPayloadNoResult")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceNoPayloadNoResult")
+		http.Redirect(w, r, "/redirect/dest", http.StatusMovedPermanently)
+	})
+}
+`
+
 var ServerPayloadNoResultHandlerConstructorCode = `// NewMethodPayloadNoResultHandler creates a HTTP handler which loads the HTTP
 // request and calls the "ServicePayloadNoResult" service
 // "MethodPayloadNoResult" endpoint.
@@ -71,6 +91,37 @@ func NewMethodPayloadNoResultHandler(
 		if err := encodeResponse(ctx, w, res); err != nil {
 			errhandler(ctx, w, err)
 		}
+	})
+}
+`
+
+var ServerPayloadNoResultWithRedirectHandlerConstructorCode = `// NewMethodPayloadNoResultHandler creates a HTTP handler which loads the HTTP
+// request and calls the "ServicePayloadNoResult" service
+// "MethodPayloadNoResult" endpoint.
+func NewMethodPayloadNoResultHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest = DecodeMethodPayloadNoResultRequest(mux, decoder)
+		encodeError   = goahttp.ErrorEncoder(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "MethodPayloadNoResult")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "ServicePayloadNoResult")
+		_, err := decodeRequest(r)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		http.Redirect(w, r, "/redirect/dest", http.StatusMovedPermanently)
 	})
 }
 `

--- a/http/codegen/testdata/server_dsls.go
+++ b/http/codegen/testdata/server_dsls.go
@@ -14,6 +14,17 @@ var ServerNoPayloadNoResultDSL = func() {
 	})
 }
 
+var ServerNoPayloadNoResultWithRedirectDSL = func() {
+	Service("ServiceNoPayloadNoResult", func() {
+		Method("MethodNoPayloadNoResult", func() {
+			HTTP(func() {
+				POST("/")
+				Redirect("/redirect/dest", StatusMovedPermanently)
+			})
+		})
+	})
+}
+
 var ServerPayloadNoResultDSL = func() {
 	Service("ServicePayloadNoResult", func() {
 		Method("MethodPayloadNoResult", func() {
@@ -22,6 +33,20 @@ var ServerPayloadNoResultDSL = func() {
 			})
 			HTTP(func() {
 				POST("/")
+			})
+		})
+	})
+}
+
+var ServerPayloadNoResultWithRedirectDSL = func() {
+	Service("ServicePayloadNoResult", func() {
+		Method("MethodPayloadNoResult", func() {
+			Payload(func() {
+				Attribute("a", Boolean)
+			})
+			HTTP(func() {
+				POST("/")
+				Redirect("/redirect/dest", StatusMovedPermanently)
 			})
 		})
 	})
@@ -130,18 +155,42 @@ var ServerFileServerDSL = func() {
 	})
 }
 
+var ServerFileServerWithRedirectDSL = func() {
+	Service("ServiceFileServer", func() {
+		HTTP(func() {
+			Path("/server_file_server")
+		})
+		Files("/file1.json", "/path/to/file1.json", func() {
+			Redirect("/redirect/dest", StatusMovedPermanently)
+		})
+		Files("/file2.json", "/path/to/file2.json")
+		Files("/file3.json", "/path/to/file3.json")
+	})
+}
+
 var ServerMixedDSL = func() {
 	Service("ServerMixed", func() {
-		Method("MethodMixed", func() {
+		Method("MethodMixed1", func() {
 			Payload(func() {
 				Attribute("id", String)
 			})
 			HTTP(func() {
-				GET("/{id}")
+				GET("/resources1/{id}")
+			})
+		})
+		Method("MethodMixed2", func() {
+			Payload(func() {
+				Attribute("id", String)
+			})
+			HTTP(func() {
+				GET("/resources2/{id}")
+				Redirect("/redirect/dest1", StatusMovedPermanently)
 			})
 		})
 		Files("/file1.json", "/path/to/file1.json")
-		Files("/file2.json", "/path/to/file2.json")
+		Files("/file2.json", "/path/to/file2.json", func() {
+			Redirect("/redirect/dest2", StatusMovedPermanently)
+		})
 	})
 }
 
@@ -176,6 +225,16 @@ var ServerMultipleFilesWithPrefixPathDSL = func() {
 	})
 }
 
+var ServerMultipleFilesWithRedirectDSL = func() {
+	Service("ServiceFileServer", func() {
+		Files("/file.json", "/path/to/file.json", func() {
+			Redirect("/redirect/dest", StatusMovedPermanently)
+		})
+		Files("/", "/path/to/file.json")
+		Files("/{wildcard}", "/path/to/folder")
+	})
+}
+
 var ServerSimpleRoutingDSL = func() {
 	Service("ServiceSimpleRoutingServer", func() {
 		Method("server-simple-routing", func() {
@@ -191,6 +250,17 @@ var ServerTrailingSlashRoutingDSL = func() {
 		Method("server-trailing-slash-routing", func() {
 			HTTP(func() {
 				GET("/trailing/slash/")
+			})
+		})
+	})
+}
+
+var ServerSimpleRoutingWithRedirectDSL = func() {
+	Service("ServiceSimpleRoutingServer", func() {
+		Method("server-simple-routing", func() {
+			HTTP(func() {
+				GET("/simple/routing")
+				Redirect("/redirect/dest", StatusMovedPermanently)
 			})
 		})
 	})

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -185,6 +185,12 @@ func Mount(mux goahttp.Muxer) {
 }
 `
 
+var ServerSimpleRoutingConstructorCode = `// Mount configures the mux to serve the ServiceSimpleRoutingServer endpoints.
+func Mount(mux goahttp.Muxer, h *Server) {
+	MountServerSimpleRoutingHandler(mux, h.ServerSimpleRouting)
+}
+`
+
 var ServerMultipleFilesMounterCode = `// MountPathToFolder configures the mux to serve GET request made to "/".
 func MountPathToFolder(mux goahttp.Muxer, h http.Handler) {
 	mux.Handle("GET", "/", h.ServeHTTP)

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -89,11 +89,13 @@ func New(
 ) *Server {
 	return &Server{
 		Mounts: []*MountPoint{
-			{"MethodMixed", "GET", "/{id}"},
+			{"MethodMixed1", "GET", "/resources1/{id}"},
+			{"MethodMixed2", "GET", "/resources2/{id}"},
 			{"/path/to/file1.json", "GET", "/file1.json"},
 			{"/path/to/file2.json", "GET", "/file2.json"},
 		},
-		MethodMixed: NewMethodMixedHandler(e.MethodMixed, mux, decoder, encoder, errhandler, formatter),
+		MethodMixed1: NewMethodMixed1Handler(e.MethodMixed1, mux, decoder, encoder, errhandler, formatter),
+		MethodMixed2: NewMethodMixed2Handler(e.MethodMixed2, mux, decoder, encoder, errhandler, formatter),
 	}
 }
 `
@@ -180,6 +182,22 @@ func Mount(mux goahttp.Muxer) {
 		if strings.HasPrefix(upath, "/server_file_server") {
 			rpath = upath[19:]
 		}
+		http.ServeFile(w, r, path.Join("/path/to/folder", rpath))
+	}))
+}
+`
+
+var ServerMultipleFilesWithRedirectConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
+func Mount(mux goahttp.Muxer) {
+	MountPathToFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/redirect/dest", http.StatusMovedPermanently)
+	}))
+	MountPathToFileJSON2(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "/path/to/file.json")
+	}))
+	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upath := path.Clean(r.URL.Path)
+		rpath := upath
 		http.ServeFile(w, r, path.Join("/path/to/folder", rpath))
 	}))
 }


### PR DESCRIPTION
This pull request adds a new DSL to define a HTTP redirect.

The DSL can be used like below:

```go
var _ = Service("service", func() {
	Method("method", func() {
		HTTP(func() {
			GET("/resources")
			Redirect("/redirect/dest", StatusMovedPermanently)
		})
	})
})

var _ = Service("service", func() {
	Files("/file.json", "/path/to/file.json", func() {
		Redirect("/redirect/dest", StatusMovedPermanently)
	})
})
```

The generated server handler initalizer for the HTTP endpoint redirect is:

```go
func NewMethodHandler(
	endpoint goa.Endpoint,
	mux goahttp.Muxer,
	decoder func(*http.Request) goahttp.Decoder,
	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
	errhandler func(context.Context, http.ResponseWriter, error),
	formatter func(err error) goahttp.Statuser,
) http.Handler {
	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
		ctx = context.WithValue(ctx, goa.MethodKey, "Method")
		ctx = context.WithValue(ctx, goa.ServiceKey, "Service")
		http.Redirect(w, r, "/redirect/dest", http.StatusMovedPermanently)
	})
}
```

and the generated server mounter for the file server redirect is:

```go
func Mount(mux goahttp.Muxer) {
	MountPathToFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		http.Redirect(w, r, "/redirect/dest", http.StatusMovedPermanently)
	}))
}
```
