### PR TITLE
Support "file:system" key by Meta DSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ depend:
 	@echo INSTALLING DEPENDENCIES...
 	@go mod download
 	@go get -u -v $(DEPEND)
+	@go mod tidy
 	@echo INSTALLING PROTOC...
 	@mkdir $(PROTOC)
 	@cd $(PROTOC); \

--- a/codegen/example/testdata/dsls.go
+++ b/codegen/example/testdata/dsls.go
@@ -104,6 +104,19 @@ var ServerHostingServiceWithFileServerDSL = func() {
 	})
 }
 
+var ServerHostingServiceWithFileServerWithFileSystemDSL = func() {
+	API("ServerHostingServiceWithFileServer", func() {
+		Server("SingleHost", func() {
+			Services("Service")
+		})
+	})
+	Service("Service", func() {
+		Files("/file.json", "path.json", func() {
+			Meta("file:system", "Content", "path/to/pkg")
+		})
+	})
+}
+
 var ServerHostingServiceSubsetDSL = func() {
 	API("ServerHostingServiceSubset", func() {
 		Server("SingleHost", func() {

--- a/codegen/import.go
+++ b/codegen/import.go
@@ -64,6 +64,26 @@ func (s *ImportSpec) Code() string {
 	return fmt.Sprintf(`"%s"`, s.Path)
 }
 
+// GetMetaFileSystem retrieves the variable and package defined by the
+// file:system metadata if any.
+func GetMetaFileSystem(att *expr.HTTPFileServerExpr) (varName string, importS *ImportSpec) {
+	if att == nil {
+		return varName, importS
+	}
+	if args, ok := att.Meta["file:system"]; ok {
+		if len(args) > 0 {
+			varName = args[0]
+		}
+		if len(args) > 1 {
+			importS = &ImportSpec{Path: args[1]}
+		}
+		if len(args) > 2 {
+			importS.Name = args[2]
+		}
+	}
+	return varName, importS
+}
+
 // GetMetaType retrieves the type and package defined by the struct:field:type
 // metadata if any.
 func GetMetaType(att *expr.AttributeExpr) (typeName string, importS *ImportSpec) {

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -141,6 +141,22 @@ import (
 //        Meta("swagger:extension:x-api", `{"foo":"bar"}`)
 //    })
 //
+// - "file:system" configures the file server to use the specified file system
+// variable. The variable must implement the standard fs package FS interface.
+// Applicable to file servers only. The import path of the variable should be
+// passed in as the second parameter. If the default imported package name
+// conflicts with another, you can override that as well with the third
+// parameter.
+//
+//    var _ = Service("service", func() {
+//        Files("/file.json", "/path/to/file.json", func() {
+//            Meta("file:system", "Content", "path/to/pkg")
+//        })
+//        Files("/openapi.json", "/gen/http/openapi.json", func() {
+//            Meta("file:system", "Content", "path/to/pkg", "pkgname")
+//        })
+//    })
+//
 func Meta(name string, value ...string) {
 	appendMeta := func(meta expr.MetaExpr, name string, value ...string) expr.MetaExpr {
 		if meta == nil {

--- a/dsl/meta_test.go
+++ b/dsl/meta_test.go
@@ -21,6 +21,7 @@ func TestMetaData(t *testing.T) {
 		"attribute":  {&expr.AttributeExpr{}, "attribute_meta", []string{"attr meta", "more attr meta"}, attributeMeta, 2},
 		"method":     {&expr.MethodExpr{Name: "testmethod"}, "method", []string{"method meta"}, methodMeta, 2},
 		"resultType": {&expr.ResultTypeExpr{UserTypeExpr: &expr.UserTypeExpr{AttributeExpr: &expr.AttributeExpr{}}}, "resultTypeMeta", []string{"result type meta"}, resultTypeMeta, 2},
+		"fileServer": {&expr.HTTPFileServerExpr{}, "file:system", []string{"Content", "path/to/pkg", "pkgname"}, httpFileServerMeta, 3},
 	}
 
 	for k, tc := range cases {
@@ -58,8 +59,9 @@ func hasValue(vals []string, val string) bool {
 	}
 	return false
 }
-func apiExprMeta(e eval.Expression) expr.MetaExpr    { return e.(*expr.APIExpr).Meta }
-func userTypeMeta(e eval.Expression) expr.MetaExpr   { return e.(*expr.UserTypeExpr).Meta }
-func attributeMeta(e eval.Expression) expr.MetaExpr  { return e.(*expr.AttributeExpr).Meta }
-func methodMeta(e eval.Expression) expr.MetaExpr     { return e.(*expr.MethodExpr).Meta }
-func resultTypeMeta(e eval.Expression) expr.MetaExpr { return e.(*expr.ResultTypeExpr).Meta }
+func apiExprMeta(e eval.Expression) expr.MetaExpr        { return e.(*expr.APIExpr).Meta }
+func userTypeMeta(e eval.Expression) expr.MetaExpr       { return e.(*expr.UserTypeExpr).Meta }
+func attributeMeta(e eval.Expression) expr.MetaExpr      { return e.(*expr.AttributeExpr).Meta }
+func methodMeta(e eval.Expression) expr.MetaExpr         { return e.(*expr.MethodExpr).Meta }
+func resultTypeMeta(e eval.Expression) expr.MetaExpr     { return e.(*expr.ResultTypeExpr).Meta }
+func httpFileServerMeta(e eval.Expression) expr.MetaExpr { return e.(*expr.HTTPFileServerExpr).Meta }

--- a/expr/http_file_server.go
+++ b/expr/http_file_server.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path"
 	"strings"
+
+	"goa.design/goa/v3/eval"
 )
 
 type (
@@ -35,6 +37,17 @@ func (f *HTTPFileServerExpr) EvalName() string {
 		prefix = f.Service.EvalName() + " "
 	}
 	return prefix + suffix
+}
+
+// Validate validates the file server expression.
+func (f *HTTPFileServerExpr) Validate() error {
+	verr := new(eval.ValidationErrors)
+	if f.Redirect != nil {
+		if _, ok := f.Meta["file:system"]; ok {
+			verr.Add(f, "Cannot use 'file:system' when using Redirect.")
+		}
+	}
+	return nil
 }
 
 // Finalize normalizes the request path.

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -269,7 +269,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	}
 	// Configure the mux.
 	{{- range .Services }}
-		{{ .Service.PkgName }}svr.Mount(mux{{ if .Endpoints }}, {{ .Service.VarName }}Server{{ end }})
+		{{ .Service.PkgName }}svr.Mount(mux{{ if or .Endpoints .FileSystems }}, {{ .Service.VarName }}Server{{ end }})
 	{{- end }}
 `
 

--- a/http/codegen/example_server_test.go
+++ b/http/codegen/example_server_test.go
@@ -70,6 +70,7 @@ func TestExampleServerFiles(t *testing.T) {
 		}{
 			{"no-server", ctestdata.NoServerDSL, testdata.NoServerServerHandleCode},
 			{"server-hosting-service-with-file-server", ctestdata.ServerHostingServiceWithFileServerDSL, testdata.ServerHostingServiceWithFileServerHandlerCode},
+			{"server-hosting-service-with-file-server-with-file-system", ctestdata.ServerHostingServiceWithFileServerWithFileSystemDSL, testdata.ServerHostingServiceWithFileServerWithFileSystemHandlerCode},
 			{"server-hosting-service-subset", ctestdata.ServerHostingServiceSubsetDSL, testdata.ServerHostingServiceSubsetServerHandleCode},
 			{"server-hosting-multiple-services", ctestdata.ServerHostingMultipleServicesDSL, testdata.ServerHostingMultipleServicesServerHandleCode},
 			{"streaming", testdata.StreamingMultipleServicesDSL, testdata.StreamingServerHandleCode},

--- a/http/codegen/server_init_test.go
+++ b/http/codegen/server_init_test.go
@@ -21,6 +21,8 @@ func TestServerInit(t *testing.T) {
 		{"multiple bases", testdata.ServerMultiBasesDSL, testdata.ServerMultiBasesConstructorCode, 2, 3},
 		{"file server", testdata.ServerFileServerDSL, testdata.ServerFileServerConstructorCode, 1, 3},
 		{"file server with a redirect", testdata.ServerFileServerWithRedirectDSL, testdata.ServerFileServerConstructorCode, 1, 3},
+		{"file server with a file system", testdata.ServerFileServerWithFileSystemDSL, testdata.ServerFileServerWithFileSystemConstructorCode, 1, 3},
+		{"file server with multiple file systems", testdata.ServerFileServerWithMultipleFileSystemsDSL, testdata.ServerFileServerWithMultipleFileSystemsConstructorCode, 1, 3},
 		{"mixed", testdata.ServerMixedDSL, testdata.ServerMixedConstructorCode, 2, 3},
 		{"multipart", testdata.ServerMultipartDSL, testdata.ServerMultipartConstructorCode, 2, 4},
 		{"streaming", testdata.StreamingResultDSL, testdata.ServerStreamingConstructorCode, 3, 3},

--- a/http/codegen/server_mount_test.go
+++ b/http/codegen/server_mount_test.go
@@ -25,6 +25,10 @@ func TestServerMount(t *testing.T) {
 		{"multiple files mounter /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathMounterCode, 1, 9},
 		{"multiple files with a redirect constructor", testdata.ServerMultipleFilesWithRedirectDSL, testdata.ServerMultipleFilesWithRedirectConstructorCode, 1, 6},
 		{"multiple files with a redirect mounter", testdata.ServerMultipleFilesWithRedirectDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
+		{"multiple files with a file system constructor", testdata.ServerMultipleFilesWithFileSystemDSL, testdata.ServerMultipleFilesWithFileSystemConstructorCode, 1, 6},
+		{"multiple files with a file system mounter", testdata.ServerMultipleFilesWithFileSystemDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
+		{"multiple files with multiple file systems constructor", testdata.ServerMultipleFilesWithMultipleFileSystemsDSL, testdata.ServerMultipleFilesWithMultipleFileSystemConstructorCode, 1, 6},
+		{"multiple files with multiple file systems mounter", testdata.ServerMultipleFilesWithMultipleFileSystemsDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/testdata/example_code.go
+++ b/http/codegen/testdata/example_code.go
@@ -193,6 +193,102 @@ func errorHandler(logger *log.Logger) func(context.Context, http.ResponseWriter,
 }
 `
 
+	ServerHostingServiceWithFileServerWithFileSystemHandlerCode = `// handleHTTPServer starts configures and starts a HTTP server on the given
+// URL. It shuts down the server if any error is received in the error channel.
+func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {
+
+	// Setup goa log adapter.
+	var (
+		adapter middleware.Logger
+	)
+	{
+		adapter = middleware.NewLogger(logger)
+	}
+
+	// Provide the transport specific request decoder and response encoder.
+	// The goa http package has built-in support for JSON, XML and gob.
+	// Other encodings can be used by providing the corresponding functions,
+	// see goa.design/implement/encoding.
+	var (
+		dec = goahttp.RequestDecoder
+		enc = goahttp.ResponseEncoder
+	)
+
+	// Build the service HTTP request multiplexer and configure it to serve
+	// HTTP requests to the service endpoints.
+	var mux goahttp.Muxer
+	{
+		mux = goahttp.NewMuxer()
+	}
+
+	// Wrap the endpoints with the transport specific layers. The generated
+	// server packages contains code generated from the design which maps
+	// the service input and output data structures to HTTP requests and
+	// responses.
+	var (
+		serviceServer *servicesvr.Server
+	)
+	{
+		eh := errorHandler(logger)
+		serviceServer = servicesvr.New(nil, mux, dec, enc, eh, nil)
+		if debug {
+			servers := goahttp.Servers{
+				serviceServer,
+			}
+			servers.Use(httpmdlwr.Debug(mux, os.Stdout))
+		}
+	}
+	// Configure the mux.
+	servicesvr.Mount(mux, serviceServer)
+
+	// Wrap the multiplexer with additional middlewares. Middlewares mounted
+	// here apply to all the service endpoints.
+	var handler http.Handler = mux
+	{
+		handler = httpmdlwr.Log(adapter)(handler)
+		handler = httpmdlwr.RequestID()(handler)
+	}
+
+	// Start HTTP server using default configuration, change the code to
+	// configure the server as required by your service.
+	srv := &http.Server{Addr: u.Host, Handler: handler}
+	for _, m := range serviceServer.Mounts {
+		logger.Printf("HTTP %q mounted on %s %s", m.Method, m.Verb, m.Pattern)
+	}
+
+	(*wg).Add(1)
+	go func() {
+		defer (*wg).Done()
+
+		// Start HTTP server in a separate goroutine.
+		go func() {
+			logger.Printf("HTTP server listening on %q", u.Host)
+			errc <- srv.ListenAndServe()
+		}()
+
+		<-ctx.Done()
+		logger.Printf("shutting down HTTP server at %q", u.Host)
+
+		// Shutdown gracefully with a 30s timeout.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		_ = srv.Shutdown(ctx)
+	}()
+}
+
+// errorHandler returns a function that writes and logs the given error.
+// The function also writes and logs the error unique ID so that it's possible
+// to correlate.
+func errorHandler(logger *log.Logger) func(context.Context, http.ResponseWriter, error) {
+	return func(ctx context.Context, w http.ResponseWriter, err error) {
+		id := ctx.Value(middleware.RequestIDKey).(string)
+		_, _ = w.Write([]byte("[" + id + "] encoding: " + err.Error()))
+		logger.Printf("[%s] ERROR: %s", id, err.Error())
+	}
+}
+`
+
 	ServerHostingServiceSubsetServerHandleCode = `// handleHTTPServer starts configures and starts a HTTP server on the given
 // URL. It shuts down the server if any error is received in the error channel.
 func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service.Endpoints, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {

--- a/http/codegen/testdata/server_dsls.go
+++ b/http/codegen/testdata/server_dsls.go
@@ -168,6 +168,36 @@ var ServerFileServerWithRedirectDSL = func() {
 	})
 }
 
+var ServerFileServerWithFileSystemDSL = func() {
+	Service("ServiceFileServer", func() {
+		HTTP(func() {
+			Path("/server_file_server")
+		})
+		Files("/file1.json", "/path/to/file1.json", func() {
+			Meta("file:system", "Content", "path/to/pkg")
+		})
+		Files("/file2.json", "/path/to/file2.json")
+		Files("/file3.json", "/path/to/file3.json")
+	})
+}
+
+var ServerFileServerWithMultipleFileSystemsDSL = func() {
+	Service("ServiceFileServer", func() {
+		HTTP(func() {
+			Path("/server_file_server")
+		})
+		Files("/file1.json", "/path/to/file1.json", func() {
+			Meta("file:system", "Content", "path/to/pkg")
+		})
+		Files("/file2.json", "/path/to/file2.json", func() {
+			Meta("file:system", "Content", "path/to/pkg")
+		})
+		Files("/file3.json", "/path/to/file3.json", func() {
+			Meta("file:system", "Embed", "path/to/embed")
+		})
+	})
+}
+
 var ServerMixedDSL = func() {
 	Service("ServerMixed", func() {
 		Method("MethodMixed1", func() {
@@ -232,6 +262,30 @@ var ServerMultipleFilesWithRedirectDSL = func() {
 		})
 		Files("/", "/path/to/file.json")
 		Files("/{wildcard}", "/path/to/folder")
+	})
+}
+
+var ServerMultipleFilesWithFileSystemDSL = func() {
+	Service("ServiceFileServer", func() {
+		Files("/file.json", "file.json", func() {
+			Meta("file:system", "Content", "path/to/pkg")
+		})
+		Files("/", "/path/to/file.json")
+		Files("/{wildcard}", "/path/to/folder")
+	})
+}
+
+var ServerMultipleFilesWithMultipleFileSystemsDSL = func() {
+	Service("ServiceFileServer", func() {
+		Files("/file.json", "file.json", func() {
+			Meta("file:system", "Content", "path/to/pkg")
+		})
+		Files("/", "/path/to/file.json", func() {
+			Meta("file:system", "Content", "path/to/pkg")
+		})
+		Files("/{wildcard}", "/path/to/folder", func() {
+			Meta("file:system", "Embed", "path/to/embed")
+		})
 	})
 }
 

--- a/http/server.go
+++ b/http/server.go
@@ -1,6 +1,11 @@
 package http
 
-import "net/http"
+import (
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
 
 type (
 	// Server is the HTTP server interface used to wrap the server handlers
@@ -18,4 +23,26 @@ func (s Servers) Use(m func(http.Handler) http.Handler) {
 	for _, v := range s {
 		v.Use(m)
 	}
+}
+
+// ReplacePrefix returns a handler that serves HTTP requests by replacing the
+// prefix from the request URL's Path (and RawPath if set) and invoking the
+// handler h. The logic is the same as the standard http package StripPrefix
+// function.
+func ReplacePrefix(old, nw string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, old)
+		rp := strings.TrimPrefix(r.URL.RawPath, old)
+		if len(p) < len(r.URL.Path) && (r.URL.RawPath == "" || len(rp) < len(r.URL.RawPath)) {
+			r2 := new(http.Request)
+			*r2 = *r
+			r2.URL = new(url.URL)
+			*r2.URL = *r.URL
+			r2.URL.Path = path.Join(nw, p)
+			r2.URL.RawPath = path.Join(nw, rp)
+			h.ServeHTTP(w, r2)
+		} else {
+			http.NotFound(w, r)
+		}
+	})
 }


### PR DESCRIPTION
This pull request adds a `Meta` DSL key`"file:system"`.
It configures a file server to use the specified file system (including [`go:embed`](https://golang.org/pkg/embed/)).

Here is an example file system using `go:embed`:

```go
package pkg

import (
	"embed"
)

//go:embed file.json
var Content embed.FS
```


```go
package api

import (
	"embed"
)

//go:embed gen/http/openapi.json
var Embed embed.FS
```

and the key can be used like below:

```go
var _ = Service("service", func() {
	Files("/file.json", "file.json", func() {
		Meta("file:system", "Content", "path/to/pkg")
	})
	Files("/openapi.json", "/gen/http/openapi.json", func() {
		Meta("file:system", "Embed", "path/to/api", "embedpkg")
	})
})
```

* `"Content"` (and `"Embed"`) is the variable name that holds [`fs.FS`](https://golang.org/pkg/io/fs/#FS)
* `"path/to/pkg"` (and `"path/to/api"`) is the package name containing the variable
* `"embedpkg"`is the optional package alias

The generated server struct lists file servers using the file systems:

```go
type Server struct {
	Mounts  []*MountPoint
	Content http.Handler
	Embed   http.Hsndler
}
```

and the server initializer sets them:

```go
func New(
	e *servicefileserver.Endpoints,
	mux goahttp.Muxer,
	decoder func(*http.Request) goahttp.Decoder,
	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
	errhandler func(context.Context, http.ResponseWriter, error),
	formatter func(err error) goahttp.Statuser,
) *Server {
	return &Server{
		Mounts: []*MountPoint{
			{"file.json", "GET", "/file.json"},
			{"/gen/http/openapi.json", "GET", "/openapi.json"},
		},
		Content: http.FileServer(http.FS(pkg.Content)),
		Embed: http.FileServer(http.FS(embedpkg.Embed)),
	}
}
```

and the server mounter mounts them. `goahttp.ReplacePrefix()` is used if the request path and the filepath are different:

```go
func Mount(mux goahttp.Muxer, h *Server) {
	MountFileJSON(mux, h.Content)
	MountGenHTTPOpenapiJSON(mux, goahttp.ReplacePrefix("/openapi.json", "/gen/http/openapi.json", h.Embed))
}
```

This example is using [`embed.FS`](https://golang.org/pkg/embed/#FS) but of cource it supports another file system which impelements `fs.FS`.

Note: I want to discuss about this topic, and merge this pull request carefully. (I'm trying to create another implementation)