### PR TITLE
Support for http.FileSystem in HTTP file servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ depend:
 	@echo INSTALLING DEPENDENCIES...
 	@go mod download
 	@go get -u -v $(DEPEND)
+	@go mod tidy
 	@echo INSTALLING PROTOC...
 	@mkdir $(PROTOC)
 	@cd $(PROTOC); \

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -253,7 +253,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 		{{-  if .Endpoints }}
 		{{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New({{ .Service.VarName }}Endpoints, mux, dec, enc, eh, nil{{ if hasWebSocket $svc }}, upgrader, nil{{ end }}{{ range .Endpoints }}{{ if .MultipartRequestDecoder }}, {{ $.APIPkg }}.{{ .MultipartRequestDecoder.FuncName }}{{ end }}{{ end }})
 		{{-  else }}
-		{{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New(nil, mux, dec, enc, eh, nil)
+		{{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New(nil, mux, dec, enc, eh, nil{{ range .FileServers }}, nil{{ end }})
 		{{-  end }}
 	{{- end }}
 	{{- if .Services }}
@@ -269,7 +269,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	}
 	// Configure the mux.
 	{{- range .Services }}
-		{{ .Service.PkgName }}svr.Mount(mux{{ if .Endpoints }}, {{ .Service.VarName }}Server{{ end }})
+		{{ .Service.PkgName }}svr.Mount(mux, {{ .Service.VarName }}Server)
 	{{- end }}
 `
 

--- a/http/codegen/server_mount_test.go
+++ b/http/codegen/server_mount_test.go
@@ -20,11 +20,11 @@ func TestServerMount(t *testing.T) {
 		{"simple routing constructor", testdata.ServerSimpleRoutingDSL, testdata.ServerSimpleRoutingConstructorCode, 2, 6},
 		{"simple routing with a redirect constructor", testdata.ServerSimpleRoutingWithRedirectDSL, testdata.ServerSimpleRoutingConstructorCode, 1, 6},
 		{"multiple files constructor", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesConstructorCode, 1, 6},
-		{"multiple files mounter", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
+		{"multiple files mounter", testdata.ServerMultipleFilesDSL, testdata.ServerMultipleFilesMounterCode, 1, 10},
 		{"multiple files constructor /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathConstructorCode, 1, 6},
-		{"multiple files mounter /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathMounterCode, 1, 9},
+		{"multiple files mounter /w prefix path", testdata.ServerMultipleFilesWithPrefixPathDSL, testdata.ServerMultipleFilesWithPrefixPathMounterCode, 1, 10},
 		{"multiple files with a redirect constructor", testdata.ServerMultipleFilesWithRedirectDSL, testdata.ServerMultipleFilesWithRedirectConstructorCode, 1, 6},
-		{"multiple files with a redirect mounter", testdata.ServerMultipleFilesWithRedirectDSL, testdata.ServerMultipleFilesMounterCode, 1, 9},
+		{"multiple files with a redirect mounter", testdata.ServerMultipleFilesWithRedirectDSL, testdata.ServerMultipleFilesMounterCode, 1, 10},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -187,6 +187,11 @@ type (
 		PathParam string
 		// Redirect defines a redirect for the endpoint.
 		Redirect *RedirectData
+		// VarName is the name of the variable that holds the file server.
+		VarName string
+		// ArgName is the name of the argument used to initialize the
+		// file server.
+		ArgName string
 	}
 
 	// RedirectData lists the data needed to generate a redirect.
@@ -621,6 +626,8 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 			IsDir:        s.IsDir(),
 			PathParam:    pp,
 			Redirect:     redirect,
+			VarName:      scope.Unique(codegen.Goify(s.FilePath, true)),
+			ArgName:      scope.Unique(fmt.Sprintf("fileSystem%s", codegen.Goify(s.FilePath, true))),
 		}
 		rd.FileServers = append(rd.FileServers, data)
 	}

--- a/http/codegen/testdata/example_code.go
+++ b/http/codegen/testdata/example_code.go
@@ -134,7 +134,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc 
 	)
 	{
 		eh := errorHandler(logger)
-		serviceServer = servicesvr.New(nil, mux, dec, enc, eh, nil)
+		serviceServer = servicesvr.New(nil, mux, dec, enc, eh, nil, nil)
 		if debug {
 			servers := goahttp.Servers{
 				serviceServer,
@@ -143,7 +143,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc 
 		}
 	}
 	// Configure the mux.
-	servicesvr.Mount(mux)
+	servicesvr.Mount(mux, serviceServer)
 
 	// Wrap the multiplexer with additional middlewares. Middlewares mounted
 	// here apply to all the service endpoints.

--- a/http/codegen/testdata/server_dsls.go
+++ b/http/codegen/testdata/server_dsls.go
@@ -210,6 +210,7 @@ var ServerMultipleFilesDSL = func() {
 	Service("ServiceFileServer", func() {
 		Files("/file.json", "/path/to/file.json")
 		Files("/", "/path/to/file.json")
+		Files("/file.json", "file.json")
 		Files("/{wildcard}", "/path/to/folder")
 	})
 }
@@ -221,6 +222,7 @@ var ServerMultipleFilesWithPrefixPathDSL = func() {
 		})
 		Files("/file.json", "/path/to/file.json")
 		Files("/", "/path/to/file.json")
+		Files("/file.json", "file.json")
 		Files("/{wildcard}", "/path/to/folder")
 	})
 }
@@ -231,6 +233,7 @@ var ServerMultipleFilesWithRedirectDSL = func() {
 			Redirect("/redirect/dest", StatusMovedPermanently)
 		})
 		Files("/", "/path/to/file.json")
+		Files("/file.json", "file.json")
 		Files("/{wildcard}", "/path/to/folder")
 	})
 }

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -160,6 +160,9 @@ func Mount(mux goahttp.Muxer) {
 	MountPathToFileJSON2(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "/path/to/file.json")
 	}))
+	MountFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "file.json")
+	}))
 	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upath := path.Clean(r.URL.Path)
 		rpath := upath
@@ -175,6 +178,9 @@ func Mount(mux goahttp.Muxer) {
 	}))
 	MountPathToFileJSON2(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "/path/to/file.json")
+	}))
+	MountFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "file.json")
 	}))
 	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upath := path.Clean(r.URL.Path)
@@ -194,6 +200,9 @@ func Mount(mux goahttp.Muxer) {
 	}))
 	MountPathToFileJSON2(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "/path/to/file.json")
+	}))
+	MountFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "file.json")
 	}))
 	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upath := path.Clean(r.URL.Path)

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -154,42 +154,19 @@ func New(
 
 var ServerMultipleFilesConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
 func Mount(mux goahttp.Muxer) {
-	MountPathToFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "/path/to/file.json")
-	}))
-	MountPathToFileJSON2(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "/path/to/file.json")
-	}))
-	MountFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "file.json")
-	}))
-	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upath := path.Clean(r.URL.Path)
-		rpath := upath
-		http.ServeFile(w, r, path.Join("/path/to/folder", rpath))
-	}))
+	MountPathToFileJSON(mux, goahttp.ReplacePrefix("/file.json", "/path/to/file.json", http.FileServer(http.Dir("."))))
+	MountPathToFileJSON2(mux, goahttp.ReplacePrefix("/", "/path/to/file.json", http.FileServer(http.Dir("."))))
+	MountFileJSON(mux, http.FileServer(http.Dir(".")))
+	MountPathToFolder(mux, goahttp.ReplacePrefix("/", "/path/to/folder", http.FileServer(http.Dir("."))))
 }
 `
 
 var ServerMultipleFilesWithPrefixPathConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
 func Mount(mux goahttp.Muxer) {
-	MountPathToFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "/path/to/file.json")
-	}))
-	MountPathToFileJSON2(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "/path/to/file.json")
-	}))
-	MountFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "file.json")
-	}))
-	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upath := path.Clean(r.URL.Path)
-		rpath := upath
-		if strings.HasPrefix(upath, "/server_file_server") {
-			rpath = upath[19:]
-		}
-		http.ServeFile(w, r, path.Join("/path/to/folder", rpath))
-	}))
+	MountPathToFileJSON(mux, goahttp.ReplacePrefix("/server_file_server/file.json", "/path/to/file.json", http.FileServer(http.Dir("."))))
+	MountPathToFileJSON2(mux, goahttp.ReplacePrefix("/server_file_server", "/path/to/file.json", http.FileServer(http.Dir("."))))
+	MountFileJSON(mux, goahttp.ReplacePrefix("/server_file_server/file.json", "/file.json", http.FileServer(http.Dir("."))))
+	MountPathToFolder(mux, goahttp.ReplacePrefix("/server_file_server", "/path/to/folder", http.FileServer(http.Dir("."))))
 }
 `
 
@@ -198,17 +175,9 @@ func Mount(mux goahttp.Muxer) {
 	MountPathToFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/redirect/dest", http.StatusMovedPermanently)
 	}))
-	MountPathToFileJSON2(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "/path/to/file.json")
-	}))
-	MountFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.ServeFile(w, r, "file.json")
-	}))
-	MountPathToFolder(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upath := path.Clean(r.URL.Path)
-		rpath := upath
-		http.ServeFile(w, r, path.Join("/path/to/folder", rpath))
-	}))
+	MountPathToFileJSON2(mux, goahttp.ReplacePrefix("/", "/path/to/file.json", http.FileServer(http.Dir("."))))
+	MountFileJSON(mux, http.FileServer(http.Dir(".")))
+	MountPathToFolder(mux, goahttp.ReplacePrefix("/", "/path/to/folder", http.FileServer(http.Dir("."))))
 }
 `
 

--- a/http/server.go
+++ b/http/server.go
@@ -1,6 +1,10 @@
 package http
 
-import "net/http"
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
 
 type (
 	// Server is the HTTP server interface used to wrap the server handlers
@@ -18,4 +22,26 @@ func (s Servers) Use(m func(http.Handler) http.Handler) {
 	for _, v := range s {
 		v.Use(m)
 	}
+}
+
+// ReplacePrefix returns a handler that serves HTTP requests by replacing the
+// prefix from the request URL's Path (and RawPath if set) and invoking the
+// handler h. The logic is the same as the standard http package StripPrefix
+// function.
+func ReplacePrefix(old, nw string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.Replace(r.URL.Path, old, nw, 1)
+		rp := strings.Replace(r.URL.RawPath, old, nw, 1)
+		if p != r.URL.Path && (r.URL.RawPath == "" || rp != r.URL.RawPath) {
+			r2 := new(http.Request)
+			*r2 = *r
+			r2.URL = new(url.URL)
+			*r2.URL = *r.URL
+			r2.URL.Path = p
+			r2.URL.RawPath = rp
+			h.ServeHTTP(w, r2)
+		} else {
+			http.NotFound(w, r)
+		}
+	})
 }


### PR DESCRIPTION
This pull request makes it possible to change the file system of a HTTP file server.

It modifies a server to use `http.FileServer()` instead of `http.ServeFile()` , and change the server initializer to receive a file system.

```go
func New(
	e *servicefileserver.Endpoints,
	mux goahttp.Muxer,
	decoder func(*http.Request) goahttp.Decoder,
	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
	errhandler func(context.Context, http.ResponseWriter, error),
	formatter func(err error) goahttp.Statuser,
	fileSystemPathToFile1JSON http.FileSystem,
) *Server {
	if fileSystemPathToFile1JSON == nil {
		fileSystemPathToFile1JSON = http.Dir(".")
	}
	return &Server{
		Mounts: []*MountPoint{
			{"/path/to/file1.json", "GET", "/server_file_server/file1.json"},
		},
		PathToFile1JSON: http.FileServer(fileSystemPathToFile1JSON),
	}
}
```

This and #2838 have same purpose but different approach. #2338 behaves based on `design` but this is not affected by `design` and more simple.