### PR TITLE
Add http.Replace() and use it for file servers

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -370,10 +370,10 @@ func {{ .MountServer }}(mux goahttp.Muxer, h *{{ .ServerStruct }}) {
 		}))
 	 	{{- else if .IsDir }}
 			{{- $filepath := addLeadingSlash .FilePath }}
-	{{ .MountHandler }}(mux, {{ range .RequestPaths }}{{if ne . $filepath }}goahttp.ReplacePrefix("{{ . }}", "{{ $filepath }}", {{ end }}{{ end }}h.{{ .VarName }}){{ range .RequestPaths }}{{ if ne . $filepath }}){{ end}}{{ end }}
+	{{ .MountHandler }}(mux, {{ range .RequestPaths }}{{if ne . $filepath }}goahttp.Replace("{{ . }}", "{{ $filepath }}", {{ end }}{{ end }}h.{{ .VarName }}){{ range .RequestPaths }}{{ if ne . $filepath }}){{ end}}{{ end }}
 		{{- else }}
 			{{- $filepath := addLeadingSlash .FilePath }}
-	{{ .MountHandler }}(mux, {{ range .RequestPaths }}{{if ne . $filepath }}goahttp.Replace("{{ $filepath }}", {{ end }}{{ end }}h.{{ .VarName }}){{ range .RequestPaths }}{{ if ne . $filepath }}){{ end}}{{ end }}
+	{{ .MountHandler }}(mux, {{ range .RequestPaths }}{{if ne . $filepath }}goahttp.Replace("", "{{ $filepath }}", {{ end }}{{ end }}h.{{ .VarName }}){{ range .RequestPaths }}{{ if ne . $filepath }}){{ end}}{{ end }}
 		{{- end }}
 	{{- end }}
 }

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -368,9 +368,12 @@ func {{ .MountServer }}(mux goahttp.Muxer, h *{{ .ServerStruct }}) {
 	{{ .MountHandler }}(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "{{ .Redirect.URL }}", {{ .Redirect.StatusCode }})
 		}))
-	 	{{- else }}
+	 	{{- else if .IsDir }}
 			{{- $filepath := addLeadingSlash .FilePath }}
 	{{ .MountHandler }}(mux, {{ range .RequestPaths }}{{if ne . $filepath }}goahttp.ReplacePrefix("{{ . }}", "{{ $filepath }}", {{ end }}{{ end }}h.{{ .VarName }}){{ range .RequestPaths }}{{ if ne . $filepath }}){{ end}}{{ end }}
+		{{- else }}
+			{{- $filepath := addLeadingSlash .FilePath }}
+	{{ .MountHandler }}(mux, {{ range .RequestPaths }}{{if ne . $filepath }}goahttp.Replace("{{ $filepath }}", {{ end }}{{ end }}h.{{ .VarName }}){{ range .RequestPaths }}{{ if ne . $filepath }}){{ end}}{{ end }}
 		{{- end }}
 	{{- end }}
 }

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -179,19 +179,19 @@ func New(
 
 var ServerMultipleFilesConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
 func Mount(mux goahttp.Muxer, h *Server) {
-	MountPathToFileJSON(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON))
-	MountPathToFileJSON2(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON2))
+	MountPathToFileJSON(mux, goahttp.Replace("", "/path/to/file.json", h.PathToFileJSON))
+	MountPathToFileJSON2(mux, goahttp.Replace("", "/path/to/file.json", h.PathToFileJSON2))
 	MountFileJSON(mux, h.FileJSON)
-	MountPathToFolder(mux, goahttp.ReplacePrefix("/", "/path/to/folder", h.PathToFolder))
+	MountPathToFolder(mux, goahttp.Replace("/", "/path/to/folder", h.PathToFolder))
 }
 `
 
 var ServerMultipleFilesWithPrefixPathConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
 func Mount(mux goahttp.Muxer, h *Server) {
-	MountPathToFileJSON(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON))
-	MountPathToFileJSON2(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON2))
-	MountFileJSON(mux, goahttp.Replace("/file.json", h.FileJSON))
-	MountPathToFolder(mux, goahttp.ReplacePrefix("/server_file_server", "/path/to/folder", h.PathToFolder))
+	MountPathToFileJSON(mux, goahttp.Replace("", "/path/to/file.json", h.PathToFileJSON))
+	MountPathToFileJSON2(mux, goahttp.Replace("", "/path/to/file.json", h.PathToFileJSON2))
+	MountFileJSON(mux, goahttp.Replace("", "/file.json", h.FileJSON))
+	MountPathToFolder(mux, goahttp.Replace("/server_file_server", "/path/to/folder", h.PathToFolder))
 }
 `
 
@@ -200,9 +200,9 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountPathToFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/redirect/dest", http.StatusMovedPermanently)
 	}))
-	MountPathToFileJSON2(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON2))
+	MountPathToFileJSON2(mux, goahttp.Replace("", "/path/to/file.json", h.PathToFileJSON2))
 	MountFileJSON(mux, h.FileJSON)
-	MountPathToFolder(mux, goahttp.ReplacePrefix("/", "/path/to/folder", h.PathToFolder))
+	MountPathToFolder(mux, goahttp.Replace("/", "/path/to/folder", h.PathToFolder))
 }
 `
 

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -179,8 +179,8 @@ func New(
 
 var ServerMultipleFilesConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
 func Mount(mux goahttp.Muxer, h *Server) {
-	MountPathToFileJSON(mux, goahttp.ReplacePrefix("/file.json", "/path/to/file.json", h.PathToFileJSON))
-	MountPathToFileJSON2(mux, goahttp.ReplacePrefix("/", "/path/to/file.json", h.PathToFileJSON2))
+	MountPathToFileJSON(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON))
+	MountPathToFileJSON2(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON2))
 	MountFileJSON(mux, h.FileJSON)
 	MountPathToFolder(mux, goahttp.ReplacePrefix("/", "/path/to/folder", h.PathToFolder))
 }
@@ -188,9 +188,9 @@ func Mount(mux goahttp.Muxer, h *Server) {
 
 var ServerMultipleFilesWithPrefixPathConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
 func Mount(mux goahttp.Muxer, h *Server) {
-	MountPathToFileJSON(mux, goahttp.ReplacePrefix("/server_file_server/file.json", "/path/to/file.json", h.PathToFileJSON))
-	MountPathToFileJSON2(mux, goahttp.ReplacePrefix("/server_file_server", "/path/to/file.json", h.PathToFileJSON2))
-	MountFileJSON(mux, goahttp.ReplacePrefix("/server_file_server/file.json", "/file.json", h.FileJSON))
+	MountPathToFileJSON(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON))
+	MountPathToFileJSON2(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON2))
+	MountFileJSON(mux, goahttp.Replace("/file.json", h.FileJSON))
 	MountPathToFolder(mux, goahttp.ReplacePrefix("/server_file_server", "/path/to/folder", h.PathToFolder))
 }
 `
@@ -200,7 +200,7 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountPathToFileJSON(mux, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/redirect/dest", http.StatusMovedPermanently)
 	}))
-	MountPathToFileJSON2(mux, goahttp.ReplacePrefix("/", "/path/to/file.json", h.PathToFileJSON2))
+	MountPathToFileJSON2(mux, goahttp.Replace("/path/to/file.json", h.PathToFileJSON2))
 	MountFileJSON(mux, h.FileJSON)
 	MountPathToFolder(mux, goahttp.ReplacePrefix("/", "/path/to/folder", h.PathToFolder))
 }

--- a/http/server.go
+++ b/http/server.go
@@ -45,3 +45,24 @@ func ReplacePrefix(old, nw string, h http.Handler) http.Handler {
 		}
 	})
 }
+
+// Replace returns a handler that serves HTTP requests by replacing the
+// the request URL's Path (and RawPath if set) and invoking the handler h.
+// The logic is the same as the standard http package StripPrefix function.
+func Replace(path string, h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if path != r.URL.Path && (r.URL.RawPath == "" || path != r.URL.RawPath) {
+			r2 := new(http.Request)
+			*r2 = *r
+			r2.URL = new(url.URL)
+			*r2.URL = *r.URL
+			r2.URL.Path = path
+			if r2.URL.RawPath != "" {
+				r2.URL.RawPath = path
+			}
+			h.ServeHTTP(w, r2)
+		} else {
+			http.NotFound(w, r)
+		}
+	})
+}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -1,0 +1,63 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReplace(t *testing.T) {
+	var (
+		h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Path", r.URL.Path)
+			w.Header().Set("X-RawPath", r.URL.RawPath)
+		})
+	)
+	cases := []struct {
+		old     string
+		nw      string
+		reqPath string
+		path    string // If empty we want a 404.
+		rawPath string
+	}{
+		{"/foo/bar", "", "/foo/bar/qux", "/qux", ""},
+		{"/foo/bar", "", "/foo/bar%2Fqux", "/qux", "%2Fqux"},
+		{"/foo/bar", "", "/foo%2Fbar/qux", "", ""}, // Escaped prefix does not match.
+		{"/foo/bar", "", "/bar", "", ""},           // No prefix match.
+		{"/foo/bar", "/baz", "/foo/bar/qux", "/baz/qux", ""},
+		{"/foo/bar", "/baz", "/foo/bar%2Fqux", "/baz/qux", "/baz%2Fqux"},
+		{"/foo/bar", "/baz", "/foo%2Fbar/qux", "", ""}, // Escaped prefix does not match.
+		{"/foo/bar", "/baz", "/bar", "", ""},           // No prefix match.
+		{"", "/baz/baz/baz", "/foo/bar/qux", "/baz/baz/baz", ""},
+		{"", "/baz/baz/baz", "/foo/bar%2Fqux", "/baz/baz/baz", "/baz/baz/baz"},
+		{"", "/baz/baz/baz", "/foo%2Fbar/qux", "/baz/baz/baz", "/baz/baz/baz"},
+		{"", "/baz/baz/baz", "/bar", "/baz/baz/baz", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.reqPath, func(t *testing.T) {
+			ts := httptest.NewServer(Replace(tc.old, tc.nw, h))
+			defer ts.Close()
+			c := ts.Client()
+			res, err := c.Get(ts.URL + tc.reqPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			res.Body.Close()
+			if tc.path == "" {
+				if res.StatusCode != http.StatusNotFound {
+					t.Errorf("got %q, want 404 Not Found", res.Status)
+				}
+				return
+			}
+			if res.StatusCode != http.StatusOK {
+				t.Fatalf("got %q, want 200 OK", res.Status)
+			}
+			if g, w := res.Header.Get("X-Path"), tc.path; g != w {
+				t.Errorf("got Path %q, want %q", g, w)
+			}
+			if g, w := res.Header.Get("X-RawPath"), tc.rawPath; g != w {
+				t.Errorf("got RawPath %q, want %q", g, w)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a fix of #2839.

I'm glad if you release v3.4.3 after merging this. Thank you.