### PR TITLE
Validate result types received via client grpc stream

### DIFF
--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -1357,6 +1357,9 @@ func (s *{{ .VarName }}) {{ .RecvName }}() ({{ .RecvRef }}, error) {
 {{- if and .Endpoint.Method.ViewedResult (eq .Type "client") }}
 	proj := {{ .RecvConvert.Init.Name }}({{ range .RecvConvert.Init.Args }}{{ .Name }}, {{ end }})
 	vres := {{ if not .Endpoint.Method.ViewedResult.IsCollection }}&{{ end }}{{ .Endpoint.Method.ViewedResult.FullName }}{Projected: proj, View: {{ if .Endpoint.Method.ViewedResult.ViewName }}"{{ .Endpoint.Method.ViewedResult.ViewName }}"{{ else }}s.view{{ end }} }
+	if err := {{ .Endpoint.Method.ViewedResult.ViewsPkg }}.Validate{{ .Endpoint.Method.Result }}(vres); err != nil {
+	  return nil, err
+	}
 	return {{ .Endpoint.ServicePkgName }}.{{ .Endpoint.Method.ViewedResult.ResultInit.Name }}(vres), nil
 {{- else }}
 {{- if .RecvConvert.Validation }}

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -89,6 +89,9 @@ func (s *MethodServerStreamingUserTypeRPCClientStream) Recv() (*serviceserverstr
 	}
 	proj := NewResultTypeView(v)
 	vres := &serviceserverstreamingusertyperpcviews.ResultType{Projected: proj, View: s.view}
+	if err := serviceserverstreamingusertyperpcviews.ValidateResultType(vres); err != nil {
+		return nil, err
+	}
 	return serviceserverstreamingusertyperpc.NewResultType(vres), nil
 }
 `
@@ -122,6 +125,9 @@ func (s *MethodServerStreamingResultTypeCollectionWithExplicitViewClientStream) 
 	}
 	proj := NewResultTypeCollection(v)
 	vres := serviceserverstreamingresulttypecollectionwithexplicitviewviews.ResultTypeCollection{Projected: proj, View: "tiny"}
+	if err := serviceserverstreamingresulttypecollectionwithexplicitviewviews.ValidateResultTypeCollection(vres); err != nil {
+		return nil, err
+	}
 	return serviceserverstreamingresulttypecollectionwithexplicitview.NewResultTypeCollection(vres), nil
 }
 `
@@ -330,6 +336,9 @@ func (s *MethodBidirectionalStreamingRPCClientStream) Recv() (*servicebidirectio
 	}
 	proj := NewIDView(v)
 	vres := &servicebidirectionalstreamingrpcviews.ID{Projected: proj, View: "default"}
+	if err := servicebidirectionalstreamingrpcviews.ValidateID(vres); err != nil {
+		return nil, err
+	}
 	return servicebidirectionalstreamingrpc.NewID(vres), nil
 }
 `


### PR DESCRIPTION
This PR fixes an issue where the generated gRPC client would not run validations on result payloads.