### PR TITLE
Stop processing if a type is specified for 'Error' DSL in API

### DIFF
--- a/dsl/error.go
+++ b/dsl/error.go
@@ -46,6 +46,9 @@ func Error(name string, args ...interface{}) {
 	erro := &expr.ErrorExpr{AttributeExpr: att, Name: name}
 	switch actual := eval.Current().(type) {
 	case *expr.APIExpr:
+		if erro.Type != expr.ErrorResult {
+			eval.ReportError("error type cannot be specified")
+		}
 		expr.Root.Errors = append(expr.Root.Errors, erro)
 	case *expr.ServiceExpr:
 		actual.Errors = append(actual.Errors, erro)

--- a/http/codegen/server_error_encoder_test.go
+++ b/http/codegen/server_error_encoder_test.go
@@ -23,8 +23,6 @@ func TestEncodeError(t *testing.T) {
 		{"api-error-response-with-content-type", testdata.APIErrorResponseWithContentTypeDSL, testdata.ServiceErrorResponseWithContentTypeEncoderCode},
 		{"no-body-error-response", testdata.NoBodyErrorResponseDSL, testdata.NoBodyErrorResponseEncoderCode},
 		{"no-body-error-response-with-content-type", testdata.NoBodyErrorResponseWithContentTypeDSL, testdata.NoBodyErrorResponseWithContentTypeEncoderCode},
-		{"api-no-body-error-response", testdata.APINoBodyErrorResponseDSL, testdata.NoBodyErrorResponseEncoderCode},
-		{"api-no-body-error-response-with-content-type", testdata.APINoBodyErrorResponseWithContentTypeDSL, testdata.NoBodyErrorResponseWithContentTypeEncoderCode},
 		{"empty-error-response-body", testdata.EmptyErrorResponseBodyDSL, testdata.EmptyErrorResponseBodyEncoderCode},
 		{"empty-custom-error-response-body", testdata.EmptyCustomErrorResponseBodyDSL, testdata.EmptyCustomErrorResponseBodyEncoderCode},
 	}

--- a/http/codegen/testdata/error_response_dsls.go
+++ b/http/codegen/testdata/error_response_dsls.go
@@ -118,49 +118,6 @@ var APIErrorResponseWithContentTypeDSL = func() {
 	})
 }
 
-var APINoBodyErrorResponseDSL = func() {
-	var StringError = Type("StringError", func() { Attribute("header") })
-	var _ = API("test", func() {
-		Error("bad_request", StringError)
-		HTTP(func() {
-			Response("bad_request", StatusBadRequest, func() {
-				Header("header")
-			})
-		})
-	})
-	Service("ServiceNoBodyErrorResponse", func() {
-		Error("bad_request")
-		Method("MethodServiceErrorResponse", func() {
-			HTTP(func() {
-				GET("/one/two")
-			})
-		})
-	})
-}
-
-var APINoBodyErrorResponseWithContentTypeDSL = func() {
-	var StringError = ResultType("application/vnd.string.error", func() {
-		ContentType("application/xml")
-		Attribute("header")
-	})
-	var _ = API("test", func() {
-		Error("bad_request", StringError)
-		HTTP(func() {
-			Response("bad_request", StatusBadRequest, func() {
-				Header("header")
-			})
-		})
-	})
-	Service("ServiceNoBodyErrorResponse", func() {
-		Error("bad_request")
-		Method("MethodServiceErrorResponse", func() {
-			HTTP(func() {
-				GET("/one/two")
-			})
-		})
-	})
-}
-
 var NoBodyErrorResponseDSL = func() {
 	var StringError = Type("StringError", func() { Attribute("header") })
 	Service("ServiceNoBodyErrorResponse", func() {


### PR DESCRIPTION
issue: https://github.com/goadesign/goa/issues/2867 case 1

API level Error can be defined only with default ErrorResult.
(because result types are generated for each service but API level Error is not inherited to services)
This PR adds a validation to not allow Error with custom result type.

### Design
```go
package design

import (
	. "goa.design/goa/v3/dsl"
)

var _ = API("calc", func() {
	Error("DivByZero", String)
	HTTP(func() {
		Response("DivByZero", StatusInternalServerError)
	})
})
```

### goa gen
```
$ goa gen calc/design
exit status 1
[design/design.go:8] error type cannot be specified in API calc
```
