### PR TITLE
Stop processing if the Error definitions in service and method are inconsistent

### DIFF
--- a/dsl/error.go
+++ b/dsl/error.go
@@ -50,6 +50,11 @@ func Error(name string, args ...interface{}) {
 	case *expr.ServiceExpr:
 		actual.Errors = append(actual.Errors, erro)
 	case *expr.MethodExpr:
+		for _, v := range actual.Service.Errors {
+			if v.Name == erro.Name && v.Type != erro.Type {
+				eval.ReportError("inconsistent definition in service and method: %s", v.Name)
+			}
+		}
 		actual.Errors = append(actual.Errors, erro)
 	default:
 		eval.IncompatibleDSL()

--- a/expr/testdata/service_validate_dsls.go
+++ b/expr/testdata/service_validate_dsls.go
@@ -13,16 +13,13 @@ var ValidErrorsDSL = func() {
 			Required("b")
 		})
 	})
-	var AType = Type("AType", func() {
-		Attribute("a", String)
-	})
 	Service("ValidErrors", func() {
 		Error("default_service_level")
 		Error("custom_errors", String, "String error")
 		Method("Method", func() {
 			Error("error1", Result)
 			Error("error2", Result)
-			Error("custom_errors", AType) // override service error
+			Error("custom_errors", String) // service error has priority (method error does not override service error)
 		})
 	})
 }


### PR DESCRIPTION
issue: https://github.com/goadesign/goa/issues/2867 case 3

When Errors of the same name with different ResultType are defined in Service and Method, only the error defined as Service will be valid.

### design

```go
package design

import (
	. "goa.design/goa/v3/dsl"
)

var _ = Service("calc", func() {
	Error("DivByZero", String)  // ← ★
	HTTP(func() {
		Response("DivByZero", StatusInternalServerError)
	})
	Method("div", func() {
		Error("DivByZero", Int) // ← ★
		Payload(func() {
			Field(1, "a", Int, "Left operand")
			Field(2, "b", Int, "Right operand")
			Required("a", "b")
		})
		Result(Int)
		HTTP(func() {
			GET("/div/{a}/{b}")
			Response("DivByZero", StatusBadRequest)
		})
	})
})
```

### goa gen

```go
$ goa gen calc/design
exit status 1
[design/design.go:13] inconsistent definition in service and method: DivByZero in service "calc" method "div"
```