### PR TITLE
If the 'Error' is resolved at the API, then the API 'Error' is inherited by the service

### DIFF
--- a/expr/grpc_endpoint.go
+++ b/expr/grpc_endpoint.go
@@ -110,6 +110,16 @@ func (e *GRPCEndpointExpr) Prepare() {
 		for _, v := range Root.API.GRPC.Errors {
 			if me.Name == v.Name {
 				e.GRPCErrors = append(e.GRPCErrors, v.Dup())
+				found = true
+				break
+			}
+		}
+		if found {
+			for _, v := range Root.Errors {
+				if me.Name == v.Name {
+					e.Service.ServiceExpr.Errors = append(e.Service.ServiceExpr.Errors, v)
+					break
+				}
 			}
 		}
 	}

--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -295,7 +295,17 @@ func (e *HTTPEndpointExpr) Prepare() {
 		// Lookup undefined HTTP errors in API.
 		for _, v := range Root.API.HTTP.Errors {
 			if me.Name == v.Name {
+				found = true
 				e.HTTPErrors = append(e.HTTPErrors, v.Dup())
+				break
+			}
+		}
+		if found {
+			for _, v := range Root.Errors {
+				if me.Name == v.Name {
+					e.Service.ServiceExpr.Errors = append(e.Service.ServiceExpr.Errors, v)
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
API level errors are not inherited automatically, but can be inherited if explicitly stated in a method or service.