### PR TITLE
Add 3rd party codegen dependencies to `design` package

### DIFF
--- a/dsl/doc.go
+++ b/dsl/doc.go
@@ -53,3 +53,13 @@ The general structure of the DSL is shown below (partial list):
                         └── Files
 */
 package dsl
+
+import (
+	// The imports below add dependencies needed by the generated temporary
+	// code generation tool. Go cannot detect these dependencies so we must
+	// add them explicitly.
+	_ "golang.org/x/tools/go/ast/astutil"
+	_ "golang.org/x/tools/go/packages"
+	_ "golang.org/x/tools/imports"
+	_ "gopkg.in/yaml.v2"
+)


### PR DESCRIPTION
Force `go mod` to import packages at design time that are required by the
temporary tool generated by `goa`. This tool is compiled and run automatically
to produce the final generated code.
Not having these dependencies causes `goa gen` to fail on all newly created
designs with `missing go sum entry` errors. While these errors are
easily solved by adding the dependencies manually via `go get` it makes
for a poor experience (and isn't newcomer friendly).