### PR TITLE
Properly finalize dupped child attributes

### DIFF
--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -33,6 +33,9 @@ type (
 		ZeroValue interface{}
 		// UserExample set in DSL or computed in Finalize
 		UserExamples []*ExampleExpr
+		// finalized is true if the attribute has been finalized - only
+		// applies if attribute type is and object
+		finalized bool
 	}
 
 	// ExampleExpr represents an example.
@@ -256,6 +259,14 @@ func (a *AttributeExpr) Finalize() {
 				continue
 			}
 			a.Merge(ru.Attribute())
+		}
+		if a.finalized {
+			// Avoid infinite recursion.
+			return
+		}
+		a.finalized = true
+		for _, nat := range *AsObject(a.Type) {
+			nat.Attribute.Finalize()
 		}
 	}
 }

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -34,7 +34,7 @@ type (
 		// UserExample set in DSL or computed in Finalize
 		UserExamples []*ExampleExpr
 		// finalized is true if the attribute has been finalized - only
-		// applies if attribute type is and object
+		// applies if attribute type is an object
 		finalized bool
 	}
 


### PR DESCRIPTION
Fix #2893 

The attributes created by the DSL when using Payload or Result may be
the result of a `Dup` (e.g. when customizing an existing type using an
anonymous function as in `Result(Foo, func() {...`). In this case the
child attributes of the dupped type were not being properly finalized.

