### PR TITLE
Return encode decode errors grpc

### DIFF
--- a/dsl/error.go
+++ b/dsl/error.go
@@ -3,6 +3,53 @@ package dsl
 import (
 	"goa.design/goa/v3/eval"
 	"goa.design/goa/v3/expr"
+	pkg "goa.design/goa/v3/pkg"
+)
+
+const (
+	// The constants below make it possible for the service specific code to
+	// return error names that are consistent with the names used by the
+	// generated request and response payload validation code.
+	//
+	// Usage:
+	//
+	// var _ = Service("divider", func() {
+	//     Error(MissingField)
+	//     Error(InvalidRange)
+	//
+	//     Payload(func() {
+	//        Attribute("numerator", Int)
+	//        Attribute("denominator", Int, func() {
+	//            Minimum(1)
+	//        })
+	//        Required("numerator", "denominator")
+	//     })
+	//
+	//     HTTP(func() {
+	//        Response(MissingField, StatusBadRequest)
+	//        Response(InvalidRange, StatusBadRequest)
+	//     })
+	//
+	//     GRPC(func() {
+	//         Response(MissingField, CodeInvalidArgument)
+	//         Response(InvalidRange, CodeInvalidArgument)
+	//     })
+	// })
+
+	// InvalidFieldType is the error name for invalid field type errors.
+	InvalidFieldType = pkg.InvalidFieldType
+	// MissingField is the error name for missing field errors.
+	MissingField = pkg.MissingField
+	// InvalidEnumValue is the error name for invalid enum value errors.
+	InvalidEnumValue = pkg.InvalidEnumValue
+	// InvalidFormat is the error name for invalid format errors.
+	InvalidFormat = pkg.InvalidFormat
+	// InvalidPattern is the error name for invalid pattern errors.
+	InvalidPattern = pkg.InvalidPattern
+	// InvalidRange is the error name for invalid range errors.
+	InvalidRange = pkg.InvalidRange
+	// InvalidLength is the error name for invalid length errors.
+	InvalidLength = pkg.InvalidLength
 )
 
 // Error describes a method error return value. The description includes a

--- a/grpc/handler.go
+++ b/grpc/handler.go
@@ -79,6 +79,9 @@ func (h *unaryHandler) Handle(ctx context.Context, reqpb interface{}) (interface
 			// Decode gRPC request message and incoming metadata
 			md, _ := metadata.FromIncomingContext(ctx)
 			if req, err = h.decoder(ctx, reqpb, md); err != nil {
+				if _, ok := err.(*goa.ServiceError); ok {
+					return nil, err
+				}
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
 		}
@@ -104,6 +107,9 @@ func (h *unaryHandler) Handle(ctx context.Context, reqpb interface{}) (interface
 		if h.encoder != nil {
 			// Encode gRPC response
 			if respb, err = h.encoder(ctx, resp, &hdr, &trlr); err != nil {
+				if _, ok := err.(*goa.ServiceError); ok {
+					return nil, err
+				}
 				return nil, status.Error(codes.Unknown, err.Error())
 			}
 		}
@@ -136,6 +142,9 @@ func (h *streamHandler) Decode(ctx context.Context, reqpb interface{}) (interfac
 		if h.decoder != nil {
 			md, _ := metadata.FromIncomingContext(ctx)
 			if req, err = h.decoder(ctx, reqpb, md); err != nil {
+				if _, ok := err.(*goa.ServiceError); ok {
+					return nil, err
+				}
 				return nil, status.Error(codes.InvalidArgument, err.Error())
 			}
 		}

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -32,6 +32,23 @@ type (
 	}
 )
 
+const (
+	// InvalidFieldType is the error name for invalid field type errors.
+	InvalidFieldType = "invalid_field_type"
+	// MissingField is the error name for missing field errors.
+	MissingField = "missing_field"
+	// InvalidEnumValue is the error name for invalid enum value errors.
+	InvalidEnumValue = "invalid_enum_value"
+	// InvalidFormat is the error name for invalid format errors.
+	InvalidFormat = "invalid_format"
+	// InvalidPattern is the error name for invalid pattern errors.
+	InvalidPattern = "invalid_pattern"
+	// InvalidRange is the error name for invalid range errors.
+	InvalidRange = "invalid_range"
+	// InvalidLength is the error name for invalid length errors.
+	InvalidLength = "invalid_length"
+)
+
 // Fault creates an error given a format and values a la fmt.Printf. The error
 // has the Fault field set to true.
 func Fault(format string, v ...interface{}) *ServiceError {
@@ -81,14 +98,14 @@ func DecodePayloadError(msg string) error {
 // type of a payload field does not match the type defined in the design.
 func InvalidFieldTypeError(name string, val interface{}, expected string) error {
 	return withField(name, PermanentError(
-		"invalid_field_type", "invalid value %#v for %q, must be a %s", val, name, expected))
+		InvalidFieldType, "invalid value %#v for %q, must be a %s", val, name, expected))
 }
 
 // MissingFieldError is the error produced by the generated code when a payload
 // is missing a required field.
 func MissingFieldError(name, context string) error {
 	return withField(name, PermanentError(
-		"missing_field", "%q is missing from %s", name, context))
+		MissingField, "%q is missing from %s", name, context))
 }
 
 // InvalidEnumValueError is the error produced by the generated code when the
@@ -100,7 +117,7 @@ func InvalidEnumValueError(name string, val interface{}, allowed []interface{}) 
 		elems[i] = fmt.Sprintf("%#v", a)
 	}
 	return withField(name, PermanentError(
-		"invalid_enum_value", "value of %s must be one of %s but got value %#v", name, strings.Join(elems, ", "), val))
+		InvalidEnumValue, "value of %s must be one of %s but got value %#v", name, strings.Join(elems, ", "), val))
 }
 
 // InvalidFormatError is the error produced by the generated code when the value
@@ -108,7 +125,7 @@ func InvalidEnumValueError(name string, val interface{}, allowed []interface{}) 
 // design.
 func InvalidFormatError(name, target string, format Format, formatError error) error {
 	return withField(name, PermanentError(
-		"invalid_format", "%s must be formatted as a %s but got value %q, %s", name, format, target, formatError.Error()))
+		InvalidFormat, "%s must be formatted as a %s but got value %q, %s", name, format, target, formatError.Error()))
 }
 
 // InvalidPatternError is the error produced by the generated code when the
@@ -116,7 +133,7 @@ func InvalidFormatError(name, target string, format Format, formatError error) e
 // design.
 func InvalidPatternError(name, target string, pattern string) error {
 	return withField(name, PermanentError(
-		"invalid_pattern", "%s must match the regexp %q but got value %q", name, pattern, target))
+		InvalidPattern, "%s must match the regexp %q but got value %q", name, pattern, target))
 }
 
 // InvalidRangeError is the error produced by the generated code when the value
@@ -128,7 +145,7 @@ func InvalidRangeError(name string, target interface{}, value interface{}, min b
 		comp = "lesser or equal"
 	}
 	return withField(name, PermanentError(
-		"invalid_range", "%s must be %s than %d but got value %#v", name, comp, value, target))
+		InvalidRange, "%s must be %s than %d but got value %#v", name, comp, value, target))
 }
 
 // InvalidLengthError is the error produced by the generated code when the value
@@ -140,7 +157,7 @@ func InvalidLengthError(name string, target interface{}, ln, value int, min bool
 		comp = "lesser or equal"
 	}
 	return withField(name, PermanentError(
-		"invalid_length", "length of %s must be %s than %d but got value %#v (len=%d)", name, comp, value, target, ln))
+		InvalidLength, "length of %s must be %s than %d but got value %#v (len=%d)", name, comp, value, target, ln))
 }
 
 // NewErrorID creates a unique 8 character ID that is well suited to use as an


### PR DESCRIPTION
Without this change, goa returns a "fault" error from server even when the error was client side (e.g., goa request validation failed).

This PR makes sure that we return any validation errors during encode/decode as it is without changing them to grpc errors. I have also exported Goa's encode/decode error names so that it can be used in the design for mapping error name to a status code of choice.

NOTE: This is a **breaking** change because
* it changes the error name from "fault" to the actual error name that happened during encode/decode.
* it changes the grpc status code to "Unknown" instead of "InvalidArgument" unless the corresponding encode/decode error is mapped to a code of choice in the design (see example below)

```
Error(goa.InvalidLength)
GRPC(func() {
    Response(goa.InvalidLength, CodeInvalidArgument)
})
```