### PR TITLE
Make it easier to mount multiple servers at once

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -385,6 +385,11 @@ func {{ .MountServer }}(mux goahttp.Muxer, h *{{ .ServerStruct }}) {
 		{{- end }}
 	{{- end }}
 }
+
+{{ printf "%s configures the mux to serve the %s endpoints." .MountServer .Service.Name | comment }}
+func (s *{{ .ServerStruct }}) {{ .MountServer }}(mux goahttp.Muxer) {
+	{{ .MountServer }}(mux, s)
+}
 `
 
 // input: EndpointData

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -184,6 +184,11 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountFileJSON(mux, h.FileJSON)
 	MountPathToFolder(mux, goahttp.Replace("/", "/path/to/folder", h.PathToFolder))
 }
+
+// Mount configures the mux to serve the ServiceFileServer endpoints.
+func (s *Server) Mount(mux goahttp.Muxer) {
+	Mount(mux, s)
+}
 `
 
 var ServerMultipleFilesWithPrefixPathConstructorCode = `// Mount configures the mux to serve the ServiceFileServer endpoints.
@@ -192,6 +197,11 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountPathToFileJSON2(mux, goahttp.Replace("", "/path/to/file.json", h.PathToFileJSON2))
 	MountFileJSON(mux, goahttp.Replace("", "/file.json", h.FileJSON))
 	MountPathToFolder(mux, goahttp.Replace("/server_file_server", "/path/to/folder", h.PathToFolder))
+}
+
+// Mount configures the mux to serve the ServiceFileServer endpoints.
+func (s *Server) Mount(mux goahttp.Muxer) {
+	Mount(mux, s)
 }
 `
 
@@ -204,11 +214,21 @@ func Mount(mux goahttp.Muxer, h *Server) {
 	MountFileJSON(mux, h.FileJSON)
 	MountPathToFolder(mux, goahttp.Replace("/", "/path/to/folder", h.PathToFolder))
 }
+
+// Mount configures the mux to serve the ServiceFileServer endpoints.
+func (s *Server) Mount(mux goahttp.Muxer) {
+	Mount(mux, s)
+}
 `
 
 var ServerSimpleRoutingConstructorCode = `// Mount configures the mux to serve the ServiceSimpleRoutingServer endpoints.
 func Mount(mux goahttp.Muxer, h *Server) {
 	MountServerSimpleRoutingHandler(mux, h.ServerSimpleRouting)
+}
+
+// Mount configures the mux to serve the ServiceSimpleRoutingServer endpoints.
+func (s *Server) Mount(mux goahttp.Muxer) {
+	Mount(mux, s)
 }
 `
 

--- a/http/server.go
+++ b/http/server.go
@@ -13,6 +13,12 @@ type (
 		Use(func(http.Handler) http.Handler)
 	}
 
+	// Mounter is the interface for servers that allow mounting their endpoints
+	// into a mutex.
+	Mounter interface {
+		Mount(Muxer)
+	}
+
 	// Servers is a list of servers.
 	Servers []Server
 )
@@ -21,6 +27,15 @@ type (
 func (s Servers) Use(m func(http.Handler) http.Handler) {
 	for _, v := range s {
 		v.Use(m)
+	}
+}
+
+// Mount will go through all the servers and mount them into the Muxer. It will
+// panic unless all servers satisfy the Mounter interface.
+func (s Servers) Mount(mux Muxer) {
+	for _, v := range s {
+		m := v.(Mounter)
+		m.Mount(mux)
 	}
 }
 

--- a/http/server.go
+++ b/http/server.go
@@ -14,7 +14,7 @@ type (
 	}
 
 	// Mounter is the interface for servers that allow mounting their endpoints
-	// into a mutex.
+	// into a muxer.
 	Mounter interface {
 		Mount(Muxer)
 	}


### PR DESCRIPTION
When initialising multiple servers, we found that it was pretty easy to setup a middleware across multiple servers with `(goahttp.Server).Use`.

However, mounting multiple servers into a muxer was clunky, having to call the package-level `Mount` with each of the servers.

This aims to allow the same simplicity have to use middlewares with mounting.

Example:

```go
// Doing
s := goahttp.Server{s1, s2, s3}
s.Use(httpmiddleware.RequestID())
s.Mount(mux)

// Instead of
s := goahttp.Server{s1, s2, s3}
s.Use(httpmiddleware.RequestID())

server1.Mount(mux, s1)
server2.Mount(mux, s2)
server3.Mount(mux, s3)
```