### PR TITLE
Add missing import for gRPC insecure package

### DIFF
--- a/grpc/codegen/example_cli.go
+++ b/grpc/codegen/example_cli.go
@@ -63,6 +63,7 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 			{Path: "flag"},
 			{Path: "fmt"},
 			{Path: "google.golang.org/grpc"},
+			{Path: "google.golang.org/grpc/credentials/insecure"},
 			{Path: "os"},
 			{Path: "time"},
 			codegen.GoaImport(""),

--- a/grpc/codegen/testdata/example_code.go
+++ b/grpc/codegen/testdata/example_code.go
@@ -205,6 +205,7 @@ const ExampleCLIImport = `import (
 
 	goa "goa.design/goa/v3/pkg"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 `
 
@@ -215,6 +216,7 @@ const ExampleSingleHostCLIImport = `import (
 
 	goa "goa.design/goa/v3/pkg"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 `
 
@@ -225,6 +227,7 @@ const ExamplePkgPathCLIImport = `import (
 
 	goa "goa.design/goa/v3/pkg"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 `
 
@@ -235,6 +238,7 @@ const ExampleSingleHostPkgPathCLIImport = `import (
 
 	goa "goa.design/goa/v3/pkg"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 `
 


### PR DESCRIPTION
The gRPC insecure package is used to create the client CLI.
This package was introduced recently and supersedes the now
obsolete corresponding option. The code was updated to make
use of it but the update missed adding the import directive.