### PR TITLE
Implement service `PathName` where snake_cased `VarName` was used before

### DIFF
--- a/codegen/example/example_server.go
+++ b/codegen/example/example_server.go
@@ -54,7 +54,7 @@ func exampleSvrMain(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *c
 		sd := service.Services.Get(svc)
 		svcData[i] = sd
 		specs = append(specs, &codegen.ImportSpec{
-			Path: path.Join(genpkg, codegen.SnakeCase(sd.VarName)),
+			Path: path.Join(genpkg, sd.PathName),
 			Name: scope.Unique(sd.PkgName),
 		})
 	}

--- a/codegen/service/client.go
+++ b/codegen/service/client.go
@@ -16,7 +16,7 @@ const (
 func ClientFile(service *expr.ServiceExpr) *codegen.File {
 	svc := Services.Get(service.Name)
 	data := endpointData(service)
-	path := filepath.Join(codegen.Gendir, codegen.SnakeCase(svc.VarName), "client.go")
+	path := filepath.Join(codegen.Gendir, svc.PathName, "client.go")
 	var (
 		sections []*codegen.SectionTemplate
 	)

--- a/codegen/service/endpoint.go
+++ b/codegen/service/endpoint.go
@@ -59,7 +59,7 @@ const (
 // EndpointFile returns the endpoint file for the given service.
 func EndpointFile(genpkg string, service *expr.ServiceExpr) *codegen.File {
 	svc := Services.Get(service.Name)
-	svcName := codegen.SnakeCase(svc.VarName)
+	svcName := svc.PathName
 	path := filepath.Join(codegen.Gendir, svcName, "endpoints.go")
 	data := endpointData(service)
 	var (

--- a/codegen/service/example_svc.go
+++ b/codegen/service/example_svc.go
@@ -60,7 +60,7 @@ func ExampleServiceFiles(genpkg string, root *expr.RootExpr) []*codegen.File {
 // exampleServiceFile returns a basic implementation of the given service.
 func exampleServiceFile(genpkg string, root *expr.RootExpr, svc *expr.ServiceExpr, apipkg string) *codegen.File {
 	data := Services.Get(svc.Name)
-	svcName := codegen.SnakeCase(data.VarName)
+	svcName := data.PathName
 	fpath := svcName + ".go"
 	if _, err := os.Stat(fpath); !os.IsNotExist(err) {
 		return nil // file already exists, skip it.
@@ -72,7 +72,7 @@ func exampleServiceFile(genpkg string, root *expr.RootExpr, svc *expr.ServiceExp
 		{Path: "log"},
 		{Path: "fmt"},
 		{Path: "strings"},
-		{Path: path.Join(genpkg, codegen.SnakeCase(svcName)), Name: data.PkgName},
+		{Path: path.Join(genpkg, svcName), Name: data.PkgName},
 		{Path: "goa.design/goa/v3/security"},
 	}
 	sections := []*codegen.SectionTemplate{

--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -11,7 +11,7 @@ import (
 // File returns the service file for the given service.
 func File(genpkg string, service *expr.ServiceExpr) *codegen.File {
 	svc := Services.Get(service.Name)
-	svcName := codegen.SnakeCase(svc.VarName)
+	svcName := svc.PathName
 	path := filepath.Join(codegen.Gendir, svcName, "service.go")
 	header := codegen.Header(
 		service.Name+" service",

--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -44,6 +44,8 @@ type (
 		StructName string
 		// VarName is the service variable name (first letter in lowercase).
 		VarName string
+		// PathName is the service name as used in file and import paths.
+		PathName string
 		// PkgName is the name of the package containing the generated service
 		// code.
 		PkgName string
@@ -629,10 +631,12 @@ func (d ServicesData) analyze(service *expr.ServiceExpr) *Data {
 		}
 	}
 
+	varName := codegen.Goify(service.Name, false)
 	data := &Data{
 		Name:              service.Name,
 		Description:       desc,
-		VarName:           codegen.Goify(service.Name, false),
+		VarName:           varName,
+		PathName:          codegen.SnakeCase(varName),
 		StructName:        codegen.Goify(service.Name, true),
 		PkgName:           pkgName,
 		ViewsPkg:          viewspkg,

--- a/codegen/service/views.go
+++ b/codegen/service/views.go
@@ -21,7 +21,7 @@ func ViewsFile(genpkg string, service *expr.ServiceExpr) *codegen.File {
 	if len(svc.projectedTypes) == 0 {
 		return nil
 	}
-	path := filepath.Join(codegen.Gendir, codegen.SnakeCase(svc.VarName), "views", "view.go")
+	path := filepath.Join(codegen.Gendir, svc.PathName, "views", "view.go")
 	var (
 		sections []*codegen.SectionTemplate
 	)

--- a/grpc/codegen/client.go
+++ b/grpc/codegen/client.go
@@ -34,7 +34,7 @@ func client(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 		data = GRPCServices.Get(svc.Name())
 	)
 	{
-		svcName := codegen.SnakeCase(data.Service.VarName)
+		svcName := data.Service.PathName
 		fpath = filepath.Join(codegen.Gendir, "grpc", svcName, "client", "client.go")
 		sections = []*codegen.SectionTemplate{
 			codegen.Header(svc.Name()+" gRPC client", "client", []*codegen.ImportSpec{
@@ -118,7 +118,7 @@ func clientEncodeDecode(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File 
 		data = GRPCServices.Get(svc.Name())
 	)
 	{
-		svcName := codegen.SnakeCase(data.Service.VarName)
+		svcName := data.Service.PathName
 		fpath = filepath.Join(codegen.Gendir, "grpc", svcName, "client", "encode_decode.go")
 		sections = []*codegen.SectionTemplate{
 			codegen.Header(svc.Name()+" gRPC client encoders and decoders", "client", []*codegen.ImportSpec{

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -70,7 +70,7 @@ func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, da
 		if sd == nil {
 			continue
 		}
-		svcName := codegen.SnakeCase(sd.Service.VarName)
+		svcName := sd.Service.PathName
 		specs = append(specs, &codegen.ImportSpec{
 			Path: path.Join(genpkg, "grpc", svcName, "client"),
 			Name: sd.Service.PkgName + "c",
@@ -107,7 +107,7 @@ func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, da
 // use flag values as arguments.
 func payloadBuilders(genpkg string, svc *expr.GRPCServiceExpr, data *cli.CommandData) *codegen.File {
 	sd := GRPCServices.Get(svc.Name())
-	svcName := codegen.SnakeCase(sd.Service.VarName)
+	svcName := sd.Service.PathName
 	fpath := filepath.Join(codegen.Gendir, "grpc", svcName, "client", "cli.go")
 	title := svc.Name() + " gRPC client CLI support package"
 	specs := []*codegen.ImportSpec{

--- a/grpc/codegen/client_types.go
+++ b/grpc/codegen/client_types.go
@@ -69,7 +69,7 @@ func clientType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 		sections []*codegen.SectionTemplate
 	)
 	{
-		svcName := codegen.SnakeCase(sd.Service.VarName)
+		svcName := sd.Service.PathName
 		fpath = filepath.Join(codegen.Gendir, "grpc", svcName, "client", "types.go")
 		sections = []*codegen.SectionTemplate{
 			codegen.Header(svc.Name()+" gRPC client types", "client",

--- a/grpc/codegen/example_server.go
+++ b/grpc/codegen/example_server.go
@@ -58,7 +58,7 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 		}
 		for _, svc := range root.API.GRPC.Services {
 			sd := GRPCServices.Get(svc.Name())
-			svcName := codegen.SnakeCase(sd.Service.VarName)
+			svcName := sd.Service.PathName
 			specs = append(specs, &codegen.ImportSpec{
 				Path: path.Join(genpkg, "grpc", svcName, "server"),
 				Name: scope.Unique(sd.Service.PkgName + "svr"),

--- a/grpc/codegen/proto.go
+++ b/grpc/codegen/proto.go
@@ -27,7 +27,7 @@ func ProtoFiles(genpkg string, root *expr.RootExpr) []*codegen.File {
 
 func protoFile(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 	data := GRPCServices.Get(svc.Name())
-	svcName := codegen.SnakeCase(data.Service.VarName)
+	svcName := data.Service.PathName
 	path := filepath.Join(codegen.Gendir, "grpc", svcName, pbPkgName, "goadesign_goagen_"+svcName+".proto")
 
 	sections := []*codegen.SectionTemplate{

--- a/grpc/codegen/server.go
+++ b/grpc/codegen/server.go
@@ -35,7 +35,7 @@ func serverFile(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 		data = GRPCServices.Get(svc.Name())
 	)
 	{
-		svcName := codegen.SnakeCase(data.Service.VarName)
+		svcName := data.Service.PathName
 		fpath = filepath.Join(codegen.Gendir, "grpc", svcName, "server", "server.go")
 		sections = []*codegen.SectionTemplate{
 			codegen.Header(svc.Name()+" gRPC server", "server", []*codegen.ImportSpec{
@@ -121,7 +121,7 @@ func serverEncodeDecode(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File 
 		data = GRPCServices.Get(svc.Name())
 	)
 	{
-		svcName := codegen.SnakeCase(data.Service.VarName)
+		svcName := data.Service.PathName
 		fpath = filepath.Join(codegen.Gendir, "grpc", svcName, "server", "encode_decode.go")
 		title := fmt.Sprintf("%s gRPC server encoders and decoders", svc.Name())
 		sections = []*codegen.SectionTemplate{

--- a/grpc/codegen/server_types.go
+++ b/grpc/codegen/server_types.go
@@ -70,7 +70,7 @@ func serverType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 		sections []*codegen.SectionTemplate
 	)
 	{
-		svcName := codegen.SnakeCase(sd.Service.VarName)
+		svcName := sd.Service.PathName
 		fpath = filepath.Join(codegen.Gendir, "grpc", svcName, "server", "types.go")
 		sections = []*codegen.SectionTemplate{
 			codegen.Header(svc.Name()+" gRPC server types", "server",

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -29,7 +29,7 @@ func ClientFiles(genpkg string, root *expr.RootExpr) []*codegen.File {
 // clientFile returns the client HTTP transport file
 func clientFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File {
 	data := HTTPServices.Get(svc.Name())
-	svcName := codegen.SnakeCase(data.Service.VarName)
+	svcName := data.Service.PathName
 	path := filepath.Join(codegen.Gendir, "http", svcName, "client", "client.go")
 	title := fmt.Sprintf("%s client HTTP transport", svc.Name())
 	sections := []*codegen.SectionTemplate{
@@ -89,7 +89,7 @@ func clientFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File {
 // and decoding logic.
 func clientEncodeDecodeFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File {
 	data := HTTPServices.Get(svc.Name())
-	svcName := codegen.SnakeCase(data.Service.VarName)
+	svcName := data.Service.PathName
 	path := filepath.Join(codegen.Gendir, "http", svcName, "client", "encode_decode.go")
 	title := fmt.Sprintf("%s HTTP client encoders and decoders", svc.Name())
 	sections := []*codegen.SectionTemplate{

--- a/http/codegen/client_cli.go
+++ b/http/codegen/client_cli.go
@@ -124,7 +124,7 @@ func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, da
 			continue
 		}
 		specs = append(specs, &codegen.ImportSpec{
-			Path: genpkg + "/http/" + codegen.SnakeCase(sd.Service.VarName) + "/client",
+			Path: genpkg + "/http/" + sd.Service.PathName + "/client",
 			Name: sd.Service.PkgName + "c",
 		})
 	}
@@ -161,7 +161,7 @@ func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, da
 // use flag values as arguments.
 func payloadBuilders(genpkg string, svc *expr.HTTPServiceExpr, data *cli.CommandData) *codegen.File {
 	sd := HTTPServices.Get(svc.Name())
-	path := filepath.Join(codegen.Gendir, "http", codegen.SnakeCase(sd.Service.VarName), "client", "cli.go")
+	path := filepath.Join(codegen.Gendir, "http", sd.Service.PathName, "client", "cli.go")
 	title := fmt.Sprintf("%s HTTP client CLI support package", svc.Name())
 	specs := []*codegen.ImportSpec{
 		{Path: "encoding/json"},
@@ -172,7 +172,7 @@ func payloadBuilders(genpkg string, svc *expr.HTTPServiceExpr, data *cli.Command
 		{Path: "unicode/utf8"},
 		codegen.GoaImport(""),
 		codegen.GoaNamedImport("http", "goahttp"),
-		{Path: genpkg + "/" + codegen.SnakeCase(sd.Service.VarName), Name: sd.Service.PkgName},
+		{Path: genpkg + "/" + sd.Service.PathName, Name: sd.Service.PkgName},
 	}
 	sections := []*codegen.SectionTemplate{
 		codegen.Header(title, "client", specs),

--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -45,7 +45,7 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 	var (
 		path    string
 		data    = HTTPServices.Get(svc.Name())
-		svcName = codegen.SnakeCase(data.Service.VarName)
+		svcName = data.Service.PathName
 	)
 	path = filepath.Join(codegen.Gendir, "http", svcName, "client", "types.go")
 	header := codegen.Header(svc.Name()+" HTTP client types", "client",

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -48,7 +48,7 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 	scope := codegen.NewNameScope()
 	for _, svc := range root.API.HTTP.Services {
 		sd := HTTPServices.Get(svc.Name())
-		svcName := codegen.SnakeCase(sd.Service.VarName)
+		svcName := sd.Service.PathName
 		specs = append(specs, &codegen.ImportSpec{
 			Path: path.Join(genpkg, "http", svcName, "server"),
 			Name: scope.Unique(sd.Service.PkgName + "svr"),
@@ -146,7 +146,7 @@ func dummyMultipartFile(genpkg string, root *expr.RootExpr, svc *expr.HTTPServic
 		}
 		data := HTTPServices.Get(svc.Name())
 		specs = append(specs, &codegen.ImportSpec{
-			Path: path.Join(genpkg, codegen.SnakeCase(data.Service.VarName)),
+			Path: path.Join(genpkg, data.Service.PathName),
 			Name: scope.Unique(data.Service.PkgName, "svc"),
 		})
 

--- a/http/codegen/paths.go
+++ b/http/codegen/paths.go
@@ -22,7 +22,7 @@ func PathFiles(root *expr.RootExpr) []*codegen.File {
 // for the given service.
 func serverPath(svc *expr.HTTPServiceExpr) *codegen.File {
 	sd := HTTPServices.Get(svc.Name())
-	path := filepath.Join(codegen.Gendir, "http", codegen.SnakeCase(sd.Service.VarName), "server", "paths.go")
+	path := filepath.Join(codegen.Gendir, "http", sd.Service.PathName, "server", "paths.go")
 	return &codegen.File{Path: path, SectionTemplates: pathSections(svc, "server")}
 }
 
@@ -30,7 +30,7 @@ func serverPath(svc *expr.HTTPServiceExpr) *codegen.File {
 // for the given service.
 func clientPath(svc *expr.HTTPServiceExpr) *codegen.File {
 	sd := HTTPServices.Get(svc.Name())
-	path := filepath.Join(codegen.Gendir, "http", codegen.SnakeCase(sd.Service.VarName), "client", "paths.go")
+	path := filepath.Join(codegen.Gendir, "http", sd.Service.PathName, "client", "paths.go")
 	return &codegen.File{Path: path, SectionTemplates: pathSections(svc, "client")}
 }
 

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -31,7 +31,7 @@ func ServerFiles(genpkg string, root *expr.RootExpr) []*codegen.File {
 // server returns the file implementing the HTTP server.
 func serverFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File {
 	data := HTTPServices.Get(svc.Name())
-	svcName := codegen.SnakeCase(data.Service.VarName)
+	svcName := data.Service.PathName
 	path := filepath.Join(codegen.Gendir, "http", svcName, "server", "server.go")
 	title := fmt.Sprintf("%s HTTP server", svc.Name())
 	funcs := map[string]interface{}{
@@ -93,7 +93,7 @@ func serverFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File {
 // decoding logic.
 func serverEncodeDecodeFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File {
 	data := HTTPServices.Get(svc.Name())
-	svcName := codegen.SnakeCase(data.Service.VarName)
+	svcName := data.Service.PathName
 	path := filepath.Join(codegen.Gendir, "http", svcName, "server", "encode_decode.go")
 	title := fmt.Sprintf("%s HTTP server encoders and decoders", svc.Name())
 	sections := []*codegen.SectionTemplate{

--- a/http/codegen/server_types.go
+++ b/http/codegen/server_types.go
@@ -46,7 +46,7 @@ func serverType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 	var (
 		path    string
 		data    = HTTPServices.Get(svc.Name())
-		svcName = codegen.SnakeCase(data.Service.VarName)
+		svcName = data.Service.PathName
 	)
 	path = filepath.Join(codegen.Gendir, "http", svcName, "server", "types.go")
 	header := codegen.Header(svc.Name()+" HTTP server types", "server",

--- a/http/codegen/websocket.go
+++ b/http/codegen/websocket.go
@@ -228,7 +228,7 @@ func websocketServerFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File
 	if !hasWebSocket(data) {
 		return nil
 	}
-	svcName := codegen.SnakeCase(data.Service.VarName)
+	svcName := data.Service.PathName
 	title := fmt.Sprintf("%s WebSocket server streaming", svc.Name())
 	sections := []*codegen.SectionTemplate{
 		codegen.Header(title, "server", []*codegen.ImportSpec{
@@ -259,7 +259,7 @@ func websocketClientFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File
 	if !hasWebSocket(data) {
 		return nil
 	}
-	svcName := codegen.SnakeCase(data.Service.VarName)
+	svcName := data.Service.PathName
 	title := fmt.Sprintf("%s WebSocket client streaming", svc.Name())
 	sections := []*codegen.SectionTemplate{
 		codegen.Header(title, "client", []*codegen.ImportSpec{


### PR DESCRIPTION
Add new `PathName` field to the `service.Data` struct, and replace all uses of the `VarName` field in path context with that.

Out of the 37 references to the `VarName` field, 31 were as an argument for `codegen.SnakeCase()` to be used in a file or import path. There are **only 4** instances where the `VarName` field value is actually used to name a service type variable.

This would also come in handy for resolving goadesign/plugins#116.

*Since `PathName` might not be the best name for this field, I'm open to suggestions.*