### PR TITLE
Properly handle alias types in parameters

### DIFF
--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -331,6 +331,9 @@ func paramsFromHeaders(endpoint *expr.HTTPEndpointExpr) []*Parameter {
 }
 
 func paramFor(at *expr.AttributeExpr, name, in string, required bool) *Parameter {
+	if expr.IsAlias(at.Type) {
+		at = at.Type.(expr.UserType).Attribute()
+	}
 	p := &Parameter{
 		In:          in,
 		Name:        name,

--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -331,6 +331,7 @@ func paramsFromHeaders(endpoint *expr.HTTPEndpointExpr) []*Parameter {
 }
 
 func paramFor(at *expr.AttributeExpr, name, in string, required bool) *Parameter {
+	alias := at
 	if expr.IsAlias(at.Type) {
 		at = at.Type.(expr.UserType).Attribute()
 	}
@@ -363,7 +364,7 @@ func paramFor(at *expr.AttributeExpr, name, in string, required bool) *Parameter
 		p.Format = "byte"
 	}
 	p.Extensions = openapi.ExtensionsFromExpr(at.Meta)
-	initValidations(at, p)
+	initValidations(alias, p)
 	return p
 }
 

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -141,6 +141,10 @@ func (sf *schemafier) schemafy(attr *expr.AttributeExpr, noref ...bool) *openapi
 	s := openapi.NewSchema()
 	var note string
 
+	if expr.IsAlias(attr.Type) {
+		attr = attr.Type.(expr.UserType).Attribute()
+	}
+
 	// Initialize type and format
 	switch t := attr.Type.(type) {
 	case expr.Primitive:

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -141,12 +141,13 @@ func (sf *schemafier) schemafy(attr *expr.AttributeExpr, noref ...bool) *openapi
 	s := openapi.NewSchema()
 	var note string
 
+	unaliased := attr
 	if expr.IsAlias(attr.Type) {
-		attr = attr.Type.(expr.UserType).Attribute()
+		unaliased = attr.Type.(expr.UserType).Attribute()
 	}
 
 	// Initialize type and format
-	switch t := attr.Type.(type) {
+	switch t := unaliased.Type.(type) {
 	case expr.Primitive:
 		switch t.Kind() {
 		case expr.UIntKind, expr.UInt64Kind, expr.UInt32Kind:


### PR DESCRIPTION
Fix #2980 