### PR TITLE
Properly generate format

### DIFF
--- a/http/codegen/openapi/v3/testdata/dsls/types.go
+++ b/http/codegen/openapi/v3/testdata/dsls/types.go
@@ -15,6 +15,22 @@ func StringBodyDSL(svcName, metName string) func() {
 	}
 }
 
+func AliasStringBodyDSL(svcName, metName string) func() {
+	return func() {
+		var UUID = Type("UUID", String, func() {
+			Format(FormatUUID)
+		})
+		var _ = Service(svcName, func() {
+			Method(metName, func() {
+				Payload(UUID)
+				HTTP(func() {
+					POST("/")
+				})
+			})
+		})
+	}
+}
+
 func ObjectBodyDSL(svcName, metName string) func() {
 	return func() {
 		var _ = Service(svcName, func() {

--- a/http/codegen/openapi/v3/types_test.go
+++ b/http/codegen/openapi/v3/types_test.go
@@ -14,6 +14,7 @@ import (
 // describes a type for comparison in tests.
 type typ struct {
 	Type      string
+	Format    string
 	Props     []attr
 	SkipProps bool
 }
@@ -30,6 +31,7 @@ type rt map[int]typ
 var (
 	tempty  typ
 	tstring = typ{Type: "string"}
+	tuuid   = typ{Type: "string", Format: "uuid"}
 	tint    = typ{Type: "integer"}
 	tarray  = typ{Type: "array"}
 )
@@ -62,12 +64,19 @@ func TestBuildBodyTypes(t *testing.T) {
 		DSL  func()
 
 		ExpectedType          typ
+		ExpectedFormat        string
 		ExpectedResponseTypes rt
 	}{{
 		Name: "string_body",
 		DSL:  dsls.StringBodyDSL(svcName, "string_body"),
 
 		ExpectedType:          tstring,
+		ExpectedResponseTypes: rt{204: tempty},
+	}, {
+		Name: "alias_string_body",
+		DSL:  dsls.AliasStringBodyDSL(svcName, "alias_string_body"),
+
+		ExpectedType:          tuuid,
 		ExpectedResponseTypes: rt{204: tempty},
 	}, {
 		Name: "object_body",
@@ -185,6 +194,11 @@ func matchesSchemaWithPrefix(t *testing.T, ctx string, s *openapi.Schema, types 
 	}
 	if tt.Type != string(s.Type) {
 		t.Errorf("%s: %sgot type %q, expected %q", ctx, prefix, s.Type, tt.Type)
+	}
+	if tt.Format != "" {
+		if s.Format != tt.Format {
+			t.Errorf("%s: %sgot format %q, expected %q", ctx, prefix, s.Format, tt.Format)
+		}
 	}
 	if tt.Type == "object" {
 		if tt.SkipProps {


### PR DESCRIPTION
for primitive alias types in OpenAPI spec v3

Fixes #2995