### PR TITLE
Don't append codegen files

### DIFF
--- a/codegen/file.go
+++ b/codegen/file.go
@@ -89,7 +89,7 @@ func (f *File) Render(dir string) (string, error) {
 
 	file, err := os.OpenFile(
 		path,
-		os.O_CREATE|os.O_APPEND|os.O_WRONLY,
+		os.O_CREATE|os.O_WRONLY,
 		0644,
 	)
 	if err != nil {


### PR DESCRIPTION
When we run codegen, we do so at a service level. Now services can
create files that get rendered outside of their package, there is a risk
that those files might collide.

I expect this will only happen when defining a user type, like so:

```go
var User = Type("User", func() {
	Meta("struct:pkg:path", "common")
	Attribute("id", String, "Unique identifier of the user", func() {
		Example("01FCNDV6P870EA6S7TK1DSYDG0")
	})
	// ...
})
```

And then referencing it from two or more services, as both those
services will want to generate a `common/user.go` file.

This wouldn't be an issue, except that we open codegen files in append
mode currently. Appending means we write the contents twice, resulting
in a file like this:

```go
// Code generated by goa v3.5.5, DO NOT EDIT.
//
// User types
//
// Command:
// $ goa gen github.com/incident-io/core/server/api/design -o api

package common

type User struct {
        // Unique identifier of the user
        ID string
}
// Code generated by goa v3.5.5, DO NOT EDIT.
//
// User types
//
// Command:
// $ goa gen github.com/incident-io/core/server/api/design -o api

package common

type User struct {
        // Unique identifier of the user
        ID string
}
```

This commit removes the append flag in favour of rewriting any files we
open twice, which solves the issue.