### PR TITLE
Failing test for struct:pkg:path bug

### DIFF
--- a/codegen/scope.go
+++ b/codegen/scope.go
@@ -149,7 +149,16 @@ func (s *NameScope) GoTypeDef(att *expr.AttributeExpr, ptr, useDefault bool) str
 		ss = append(ss, "}")
 		return strings.Join(ss, "\n")
 	case expr.UserType:
-		return s.GoTypeName(att)
+		pkg := ""
+
+		// For user types, it is possible to override the package those types are generated
+		// into. We must respect that override here, or risk dropping the package from the
+		// type (ie, foo.Bar => Bar).
+		if pkgOverride, ok := actual.Attribute().Meta.Last("struct:pkg:path"); ok {
+			pkg = pkgOverride
+		}
+
+		return s.GoFullTypeName(att, pkg)
 	default:
 		panic(fmt.Sprintf("unknown data type %T", actual)) // bug
 	}

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -2399,6 +2399,8 @@ type Service interface {
 	A(context.Context, *bar.Bar) (res *bar.Bar, err error)
 	// B implements B.
 	B(context.Context, *baz.Baz) (res *baz.Baz, err error)
+	// EnvelopedB implements EnvelopedB.
+	EnvelopedB(context.Context, *EnvelopedBPayload) (res *EnvelopedBResult, err error)
 }
 
 // ServiceName is the name of the service as defined in the design. This is the
@@ -2409,7 +2411,19 @@ const ServiceName = "MultiplePkgPathMethod"
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
 // MethodKey key.
-var MethodNames = [2]string{"A", "B"}
+var MethodNames = [3]string{"A", "B", "EnvelopedB"}
+
+// EnvelopedBPayload is the payload type of the MultiplePkgPathMethod service
+// EnvelopedB method.
+type EnvelopedBPayload struct {
+	Baz *baz.Baz
+}
+
+// EnvelopedBResult is the result type of the MultiplePkgPathMethod service
+// EnvelopedB method.
+type EnvelopedBResult struct {
+	Baz *baz.Baz
+}
 `
 
 const PkgPathFoo = `// Foo is the payload type of the PkgPathMethod service A method.

--- a/codegen/service/testdata/service_dsls.go
+++ b/codegen/service/testdata/service_dsls.go
@@ -612,6 +612,10 @@ var Foo = Type("Foo", func() {
 	Meta("struct:pkg:path", "foo")
 })
 
+var ContainedFoo = Type("ContainedFoo", func() {
+	Attribute("Foo", Foo)
+})
+
 var Bar = Type("Bar", func() {
 	Attribute("IntField", Int)
 	Meta("struct:pkg:path", "bar")
@@ -646,6 +650,15 @@ var PkgPathMultipleDSL = func() {
 		Method("B", func() {
 			Payload(Baz)
 			Result(Baz)
+		})
+
+		Method("EnvelopedB", func() {
+			Payload(func() {
+				Attribute("Baz", Baz)
+			})
+			Result(func() {
+				Attribute("Baz", Baz)
+			})
 		})
 	})
 }

--- a/http/codegen/server_encode_test.go
+++ b/http/codegen/server_encode_test.go
@@ -80,6 +80,9 @@ func TestEncode(t *testing.T) {
 
 		{"empty-server-response", testdata.EmptyServerResponseDSL, testdata.EmptyServerResponseEncodeCode},
 		{"empty-server-response-with-tags", testdata.EmptyServerResponseWithTagsDSL, testdata.EmptyServerResponseWithTagsEncodeCode},
+
+		{"result-with-custom-pkg-type", testdata.ResultWithCustomPkgTypeDSL, testdata.ResultWithCustomPkgTypeEncodeCode},
+		{"result-with-embedded-custom-pkg-type", testdata.ResultWithEmbeddedCustomPkgTypeDSL, testdata.ResultWithEmbeddedCustomPkgTypeEncodeCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -744,6 +744,46 @@ var ResultWithResultCollectionDSL = func() {
 	})
 }
 
+var ResultWithCustomPkgTypeDSL = func() {
+	var Foo = Type("Foo", func() {
+		Meta("struct:pkg:path", "foo")
+		Attribute("bar", String)
+	})
+
+	Service("ServiceResultWithCustomPkgTypeDSL", func() {
+		Method("MethodResultWithCustomPkgTypeDSL", func() {
+			Payload(Foo)
+			Result(Foo)
+
+			HTTP(func() {
+				GET("/")
+			})
+		})
+	})
+}
+
+var ResultWithEmbeddedCustomPkgTypeDSL = func() {
+	var Foo = Type("Foo", func() {
+		Meta("struct:pkg:path", "foo")
+		Attribute("bar", String)
+	})
+
+	var ContainedFoo = Type("ContainedFoo", func() {
+		Attribute("Foo", Foo)
+	})
+
+	Service("ServiceResultWithEmbeddedCustomPkgTypeDSL", func() {
+		Method("MethodResultWithEmbeddedCustomPkgTypeDSL", func() {
+			Payload(ContainedFoo)
+			Result(ContainedFoo)
+
+			HTTP(func() {
+				GET("/")
+			})
+		})
+	})
+}
+
 var EmptyErrorResponseBodyDSL = func() {
 	Service("ServiceEmptyErrorResponseBody", func() {
 		Method("MethodEmptyErrorResponseBody", func() {

--- a/http/codegen/testdata/result_encode_functions.go
+++ b/http/codegen/testdata/result_encode_functions.go
@@ -1022,3 +1022,31 @@ func EncodeMethodEmptyServerResponseWithTagsResponse(encoder func(context.Contex
 	}
 }
 `
+
+var ResultWithCustomPkgTypeEncodeCode = `// EncodeMethodResultWithCustomPkgTypeDSLResponse returns an encoder for
+// responses returned by the ServiceResultWithCustomPkgTypeDSL
+// MethodResultWithCustomPkgTypeDSL endpoint.
+func EncodeMethodResultWithCustomPkgTypeDSLResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
+	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+		res, _ := v.(*foo.Foo)
+		enc := encoder(ctx, w)
+		body := NewMethodResultWithCustomPkgTypeDSLResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+`
+
+var ResultWithEmbeddedCustomPkgTypeEncodeCode = `// EncodeMethodResultWithEmbeddedCustomPkgTypeDSLResponse returns an encoder
+// for responses returned by the ServiceResultWithEmbeddedCustomPkgTypeDSL
+// MethodResultWithEmbeddedCustomPkgTypeDSL endpoint.
+func EncodeMethodResultWithEmbeddedCustomPkgTypeDSLResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
+	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+		res, _ := v.(*serviceresultwithembeddedcustompkgtypedsl.ContainedFoo)
+		enc := encoder(ctx, w)
+		body := NewMethodResultWithEmbeddedCustomPkgTypeDSLResponseBody(res)
+		w.WriteHeader(http.StatusOK)
+		return enc.Encode(body)
+	}
+}
+`


### PR DESCRIPTION
Where generated code fails to reference user defined types correctly,
assuming they exist in the current package instead of their overriden
import path.

```
go test goa.design/goa/v3/codegen/service
--- FAIL: TestStructPkgPath (0.01s)
    --- FAIL: TestStructPkgPath/multiple (0.00s)
        service_test.go:132: got
            
            // Service is the MultiplePkgPathMethod service interface.
            type Service interface {
                // A implements A.
                A(context.Context, *bar.Bar) (res *bar.Bar, err error)
                // B implements B.
                B(context.Context, *baz.Baz) (res *baz.Baz, err error)
                // EnvelopedB implements EnvelopedB.
                EnvelopedB(context.Context, *EnvelopedBPayload) (res *EnvelopedBResult, err error)
            }
            
            // ServiceName is the name of the service as defined in the design. This is the
            // same value that is set in the endpoint request contexts under the ServiceKey
            // key.
            const ServiceName = "MultiplePkgPathMethod"
            
            // MethodNames lists the service method names as defined in the design. These
            // are the same values that are set in the endpoint request contexts under the
            // MethodKey key.
            var MethodNames = [3]string{"A", "B", "EnvelopedB"}
            
            // EnvelopedBPayload is the payload type of the MultiplePkgPathMethod service
            // EnvelopedB method.
            type EnvelopedBPayload struct {
                Baz *Baz
            }
            
            // EnvelopedBResult is the result type of the MultiplePkgPathMethod service
            // EnvelopedB method.
            type EnvelopedBResult struct {
                Baz *Baz
            }
            
            got vs. expected:
            25c25
            <  ␉ Baz *Baz
            ---
            >     Baz *baz.Baz
            31c31
            <  ␉ Baz *Baz
            ---
            >     Baz *baz.Baz
FAIL
FAIL    goa.design/goa/v3/codegen/service       0.244s
FAIL
```