### PR TITLE
pkg:path types that reference their own package types

### DIFF
--- a/codegen/service/service_test.go
+++ b/codegen/service/service_test.go
@@ -81,7 +81,7 @@ func TestStructPkgPath(t *testing.T) {
 	}{
 		{"none", testdata.SingleMethodDSL, []string{testdata.SingleMethod}, nil, nil},
 		{"single", testdata.PkgPathDSL, []string{testdata.PkgPath}, []string{fooPath}, []string{testdata.PkgPathFoo}},
-		{"recursive", testdata.PkgPathDSL, []string{testdata.PkgPath}, []string{fooPath, recursiveFooPath}, []string{testdata.PkgPathFoo, testdata.PkgPathRecursiveFoo}},
+		{"recursive", testdata.PkgPathRecursiveDSL, []string{testdata.PkgPathRecursive}, []string{fooPath, recursiveFooPath}, []string{testdata.PkgPathRecursiveFooFoo, testdata.PkgPathRecursiveFoo}},
 		{"multiple", testdata.PkgPathMultipleDSL, []string{testdata.PkgPathMultiple}, []string{barPath, bazPath}, []string{testdata.PkgPathBar, testdata.PkgPathBaz}},
 		{"nopkg", testdata.PkgPathNoDirDSL, []string{testdata.PkgPathNoDir}, nil, nil},
 		{"dupes", testdata.PkgPathDupeDSL, []string{testdata.PkgPathDupe1, testdata.PkgPathDupe2}, []string{fooPath}, []string{testdata.PkgPathFooDupe}},

--- a/codegen/service/service_test.go
+++ b/codegen/service/service_test.go
@@ -69,6 +69,7 @@ func TestService(t *testing.T) {
 
 func TestStructPkgPath(t *testing.T) {
 	fooPath := filepath.Join("gen", "foo", "foo.go")
+	recursiveFooPath := filepath.Join("gen", "foo", "recursive_foo.go")
 	barPath := filepath.Join("gen", "bar", "bar.go")
 	bazPath := filepath.Join("gen", "baz", "baz.go")
 	cases := []struct {
@@ -80,6 +81,7 @@ func TestStructPkgPath(t *testing.T) {
 	}{
 		{"none", testdata.SingleMethodDSL, []string{testdata.SingleMethod}, nil, nil},
 		{"single", testdata.PkgPathDSL, []string{testdata.PkgPath}, []string{fooPath}, []string{testdata.PkgPathFoo}},
+		{"recursive", testdata.PkgPathDSL, []string{testdata.PkgPath}, []string{fooPath, recursiveFooPath}, []string{testdata.PkgPathFoo, testdata.PkgPathRecursiveFoo}},
 		{"multiple", testdata.PkgPathMultipleDSL, []string{testdata.PkgPathMultiple}, []string{barPath, bazPath}, []string{testdata.PkgPathBar, testdata.PkgPathBaz}},
 		{"nopkg", testdata.PkgPathNoDirDSL, []string{testdata.PkgPathNoDir}, nil, nil},
 		{"dupes", testdata.PkgPathDupeDSL, []string{testdata.PkgPathDupe1, testdata.PkgPathDupe2}, []string{fooPath}, []string{testdata.PkgPathFooDupe}},
@@ -88,7 +90,7 @@ func TestStructPkgPath(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			userTypePkgs := make(map[string][]string)
 			codegen.RunDSLWithFunc(t, c.DSL, func() {
-				expr.Root.Types = []expr.UserType{testdata.APayload, testdata.AResult, testdata.Foo, testdata.Bar, testdata.Baz, testdata.NoDir}
+				expr.Root.Types = []expr.UserType{testdata.APayload, testdata.AResult, testdata.RecursiveFoo, testdata.Foo, testdata.Bar, testdata.Baz, testdata.NoDir}
 			})
 			if len(expr.Root.Services) != len(c.SvcCodes) {
 				t.Fatalf("got %d services, expected %d", len(expr.Root.Services), len(c.SvcCodes))

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -2378,13 +2378,31 @@ const PkgPath = `
 // Service is the PkgPathMethod service interface.
 type Service interface {
 	// A implements A.
-	A(context.Context, *foo.Foo) (res *foo.RecursiveFoo, err error)
+	A(context.Context, *foo.Foo) (res *foo.Foo, err error)
 }
 
 // ServiceName is the name of the service as defined in the design. This is the
 // same value that is set in the endpoint request contexts under the ServiceKey
 // key.
 const ServiceName = "PkgPathMethod"
+
+// MethodNames lists the service method names as defined in the design. These
+// are the same values that are set in the endpoint request contexts under the
+// MethodKey key.
+var MethodNames = [1]string{"A"}
+`
+
+const PkgPathRecursive = `
+// Service is the PkgPathRecursiveMethod service interface.
+type Service interface {
+	// A implements A.
+	A(context.Context, *foo.RecursiveFoo) (res *foo.RecursiveFoo, err error)
+}
+
+// ServiceName is the name of the service as defined in the design. This is the
+// same value that is set in the endpoint request contexts under the ServiceKey
+// key.
+const ServiceName = "PkgPathRecursiveMethod"
 
 // MethodNames lists the service method names as defined in the design. These
 // are the same values that are set in the endpoint request contexts under the
@@ -2416,13 +2434,13 @@ var MethodNames = [3]string{"A", "B", "EnvelopedB"}
 // EnvelopedBPayload is the payload type of the MultiplePkgPathMethod service
 // EnvelopedB method.
 type EnvelopedBPayload struct {
-	Baz *baz.Baz
+	Baz *Baz
 }
 
 // EnvelopedBResult is the result type of the MultiplePkgPathMethod service
 // EnvelopedB method.
 type EnvelopedBResult struct {
-	Baz *baz.Baz
+	Baz *Baz
 }
 `
 
@@ -2432,7 +2450,14 @@ type Foo struct {
 }
 `
 
-const PkgPathRecursiveFoo = `// RecursiveFoo is the result type of the PkgPathMethod service A method.
+const PkgPathRecursiveFooFoo = `
+type Foo struct {
+	IntField *int
+}
+`
+
+const PkgPathRecursiveFoo = `// RecursiveFoo is the payload type of the PkgPathRecursiveMethod service A
+// method.
 type RecursiveFoo struct {
 	Foo *Foo
 }

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -2378,7 +2378,7 @@ const PkgPath = `
 // Service is the PkgPathMethod service interface.
 type Service interface {
 	// A implements A.
-	A(context.Context, *foo.Foo) (res *foo.Foo, err error)
+	A(context.Context, *foo.Foo) (res *foo.RecursiveFoo, err error)
 }
 
 // ServiceName is the name of the service as defined in the design. This is the
@@ -2429,6 +2429,12 @@ type EnvelopedBResult struct {
 const PkgPathFoo = `// Foo is the payload type of the PkgPathMethod service A method.
 type Foo struct {
 	IntField *int
+}
+`
+
+const PkgPathRecursiveFoo = `// RecursiveFoo is the result type of the PkgPathMethod service A method.
+type RecursiveFoo struct {
+	Foo *Foo
 }
 `
 

--- a/codegen/service/testdata/service_dsls.go
+++ b/codegen/service/testdata/service_dsls.go
@@ -636,6 +636,15 @@ var PkgPathDSL = func() {
 	Service("PkgPathMethod", func() {
 		Method("A", func() {
 			Payload(Foo)
+			Result(Foo)
+		})
+	})
+}
+
+var PkgPathRecursiveDSL = func() {
+	Service("PkgPathRecursiveMethod", func() {
+		Method("A", func() {
+			Payload(RecursiveFoo)
 			Result(RecursiveFoo)
 		})
 	})

--- a/codegen/service/testdata/service_dsls.go
+++ b/codegen/service/testdata/service_dsls.go
@@ -612,6 +612,11 @@ var Foo = Type("Foo", func() {
 	Meta("struct:pkg:path", "foo")
 })
 
+var RecursiveFoo = Type("RecursiveFoo", func() {
+	Attribute("Foo", Foo)
+	Meta("struct:pkg:path", "foo")
+})
+
 var Bar = Type("Bar", func() {
 	Attribute("IntField", Int)
 	Meta("struct:pkg:path", "bar")
@@ -631,7 +636,7 @@ var PkgPathDSL = func() {
 	Service("PkgPathMethod", func() {
 		Method("A", func() {
 			Payload(Foo)
-			Result(Foo)
+			Result(RecursiveFoo)
 		})
 	})
 }


### PR DESCRIPTION
If you have a user type placed in a package, ie. common, and it has a
field of another type in package common, we codegen a type reference of
common.Thing which will fail, as that code is already in the common
package.