### PR TITLE
Fix use of required on parent user type

### DIFF
--- a/dsl/validation.go
+++ b/dsl/validation.go
@@ -458,6 +458,12 @@ func Required(names ...string) {
 			at.Validation = &expr.ValidationExpr{}
 		}
 		at.Validation.AddRequired(names...)
+		if ut, ok := at.Type.(expr.UserType); ok {
+			if ut.Attribute().Validation == nil {
+				ut.Attribute().Validation = &expr.ValidationExpr{}
+			}
+			ut.Attribute().Validation.AddRequired(names...)
+		}
 	}
 }
 

--- a/dsl/validation_test.go
+++ b/dsl/validation_test.go
@@ -44,3 +44,40 @@ func TestFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestRequired(t *testing.T) {
+	att := &expr.AttributeExpr{
+		Type: &expr.UserTypeExpr{
+			AttributeExpr: &expr.AttributeExpr{
+				Type: &expr.Object{
+					{"foo", &expr.AttributeExpr{Type: String}},
+					{"bar", &expr.AttributeExpr{Type: String}},
+				},
+			},
+			TypeName: "Foo",
+		},
+	}
+	eval.Context = &eval.DSLContext{}
+	eval.Execute(func() { Required("foo") }, att)
+	if eval.Context.Errors != nil {
+		t.Errorf("Required failed unexpectedly with %s", eval.Context.Errors)
+		return
+	}
+	if len(att.Validation.Required) == 0 {
+		t.Errorf("Required not set on %+v", att)
+		return
+	}
+	if att.Validation.Required[0] != "foo" {
+		t.Errorf("Required invalid on %+v, expected foo, got %+v", att, att.Validation.Required)
+	}
+	uattr := att.Type.(*expr.UserTypeExpr).AttributeExpr
+	if uattr.Validation == nil {
+		t.Fatalf("Required not set on %+v", uattr)
+	}
+	if len(uattr.Validation.Required) == 0 {
+		t.Errorf("Required not set on %+v, got %+v", uattr, uattr.Validation.Required)
+	}
+	if uattr.Validation.Required[0] != "foo" {
+		t.Errorf("Required invalid on %+v, expected foo, got %+v", uattr, uattr.Validation.Required)
+	}
+}


### PR DESCRIPTION
For example:
```go
Payload(ParentType, func() { Required("attr") })
```
Make sure to copy required validation to user type's attribute as it is
used to generate the request payload type definition.

Fix #3026