### PR TITLE
Better handling of union attributes in OpenAPI

### DIFF
--- a/http/codegen/openapi/json_schema.go
+++ b/http/codegen/openapi/json_schema.go
@@ -302,10 +302,11 @@ func TypeSchemaWithPrefix(api *expr.APIExpr, t expr.DataType, prefix string) *Sc
 	s := NewSchema()
 	switch actual := t.(type) {
 	case expr.Primitive:
-		if name := actual.Name(); name != "any" {
-			s.Type = Type(actual.Name())
-		}
+		s.Type = Type(actual.Name())
 		switch actual.Kind() {
+		case expr.AnyKind:
+			s.Type = Type("string")
+			s.Format = "binary"
 		case expr.IntKind, expr.Int64Kind,
 			expr.UIntKind, expr.UInt64Kind:
 			s.Type = Type("integer")

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -160,8 +160,16 @@ func (sf *schemafier) schemafy(attr *expr.AttributeExpr, noref ...bool) *openapi
 			s.Type = openapi.Type("number")
 			s.Format = "double"
 		case expr.BytesKind, expr.AnyKind:
-			s.Type = openapi.Type("string")
-			s.Format = "binary"
+			if bases := attr.Bases; len(bases) > 0 {
+				for _, b := range bases {
+					// Union type
+					val := sf.schemafy(&expr.AttributeExpr{Type: b}, false)
+					s.AnyOf = append(s.AnyOf, val)
+				}
+			} else {
+				s.Type = openapi.Type("string")
+				s.Format = "binary"
+			}
 		default:
 			s.Type = openapi.Type(t.Name())
 		}

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -963,9 +963,12 @@ func makeHTTPType(att *expr.AttributeExpr, seen ...map[string]struct{}) {
 		values := expr.AsUnion(dt).Values
 		names := make([]interface{}, len(values))
 		vals := make([]string, len(values))
+		bases := make([]expr.DataType, len(values))
 		for i, nat := range values {
-			names[i] = nat.Attribute.Type.Name()
-			vals[i] = fmt.Sprintf("- %q", nat.Attribute.Type.Name())
+			n := nat.Attribute.Type.Name()
+			names[i] = n
+			vals[i] = fmt.Sprintf("- %q", n)
+			bases[i] = nat.Attribute.Type
 		}
 		obj := expr.Object([]*expr.NamedAttributeExpr{
 			{Name: "Type", Attribute: &expr.AttributeExpr{
@@ -976,6 +979,7 @@ func makeHTTPType(att *expr.AttributeExpr, seen ...map[string]struct{}) {
 			{Name: "Value", Attribute: &expr.AttributeExpr{
 				Type:        expr.Any,
 				Description: "Union value, type must be one of service package types listed above",
+				Bases:       bases, // For OpenAPI generation
 			}},
 		})
 		att.Type = &obj


### PR DESCRIPTION
Leverages `AnyOf` in OpenAPI v3 specs.