### PR TITLE
Improve OpenAPI spec for error responses

### DIFF
--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -267,7 +267,18 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 			responses[strconv.Itoa(r.StatusCode)] = &ResponseRef{Value: resp}
 		}
 		for _, er := range e.HTTPErrors {
+			if er.Description != "" && er.Response.Description == "" {
+				er.Response.Description = er.Description
+			}
 			resp := responseFromExpr(er.Response, bodies.ResponseBodies, rand)
+			desc := er.Name
+			if resp.Description != nil {
+				desc += ": " + *resp.Description
+			}
+			resp.Description = &desc
+			for _, content := range resp.Content {
+				content.Example = nil
+			}
 			responses[strconv.Itoa(er.Response.StatusCode)] = &ResponseRef{Value: resp}
 		}
 	}


### PR DESCRIPTION
* Add error name to response description
* Use error description if any as response description if none provided
* Remove generated example from each error response

Fix #3037 