### PR TITLE
Add ability to specify security scheme at the API level

### DIFF
--- a/expr/method.go
+++ b/expr/method.go
@@ -106,6 +106,8 @@ func (m *MethodExpr) Validate() error {
 		requirements = m.Requirements
 	} else if len(m.Service.Requirements) > 0 {
 		requirements = m.Service.Requirements
+	} else if len(Root.API.Requirements) > 0 {
+		requirements = Root.API.Requirements
 	}
 	var (
 		hasBasicAuth bool
@@ -288,22 +290,26 @@ func (m *MethodExpr) Finalize() {
 
 	// Inherit security requirements
 	noreq := false
+loop:
 	for _, r := range m.Requirements {
 		// Handle special case of no security
 		for _, s := range r.Schemes {
 			if s.Kind == NoKind {
 				noreq = true
-				break
+				break loop
 			}
-		}
-		if noreq {
-			break
 		}
 	}
 	if noreq {
 		m.Requirements = nil
-	} else if len(m.Requirements) == 0 && len(m.Service.Requirements) > 0 {
-		m.Requirements = copyReqs(m.Service.Requirements)
+		return
+	}
+	if len(m.Requirements) == 0 {
+		if len(m.Service.Requirements) > 0 {
+			m.Requirements = copyReqs(m.Service.Requirements)
+		} else if len(Root.API.Requirements) > 0 {
+			m.Requirements = copyReqs(Root.API.Requirements)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds the ability to use `Security` in a `API` function to define the default security schemes for all the API endpoints. Service and methods can override the default using by calling `Security` again in the specific scope. Method can also disable security entirely using `NoSecurity`. See the [security hierarchy](https://github.com/goadesign/examples/tree/master/security/hierarchy) example.