### PR TITLE
Fix conversion of a 64-bit integer to a lower bit size type int without an upper bound check.

### DIFF
--- a/codegen/cli/cli.go
+++ b/codegen/cli/cli.go
@@ -475,7 +475,7 @@ func conversionCode(from, to, typeName string, pointer bool) (string, bool, bool
 		}
 		parse += fmt.Sprintf("%s, err = strconv.ParseBool(%s)", target, from)
 	case intN:
-		parse = fmt.Sprintf("var v int64\nv, err = strconv.ParseInt(%s, 10, 64)", from)
+		parse = fmt.Sprintf("var v int64\nv, err = strconv.ParseInt(%s, 10, strconv.IntSize)", from)
 		cast = fmt.Sprintf("%s %s= int(v)", target, decl)
 	case int32N:
 		parse = fmt.Sprintf("var v int64\nv, err = strconv.ParseInt(%s, 10, 32)", from)
@@ -484,7 +484,7 @@ func conversionCode(from, to, typeName string, pointer bool) (string, bool, bool
 		parse = fmt.Sprintf("%s, err %s= strconv.ParseInt(%s, 10, 64)", target, decl, from)
 		declErr = decl == ""
 	case uintN:
-		parse = fmt.Sprintf("var v uint64\nv, err = strconv.ParseUint(%s, 10, 64)", from)
+		parse = fmt.Sprintf("var v uint64\nv, err = strconv.ParseUint(%s, 10, strconv.IntSize)", from)
 		cast = fmt.Sprintf("%s %s= uint(v)", target, decl)
 	case uint32N:
 		parse = fmt.Sprintf("var v uint64\nv, err = strconv.ParseUint(%s, 10, 32)", from)

--- a/grpc/codegen/testdata/client_cli_code.go
+++ b/grpc/codegen/testdata/client_cli_code.go
@@ -24,7 +24,7 @@ func BuildMethodAPayload(payloadWithValidationMethodAMetadataInt string, payload
 	{
 		if payloadWithValidationMethodAMetadataInt != "" {
 			var v int64
-			v, err = strconv.ParseInt(payloadWithValidationMethodAMetadataInt, 10, 64)
+			v, err = strconv.ParseInt(payloadWithValidationMethodAMetadataInt, 10, strconv.IntSize)
 			val := int(v)
 			metadataInt = &val
 			if err != nil {

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -740,7 +740,7 @@ func BuildMethodParamValidatePayload(serviceParamValidateMethodParamValidateA st
 	{
 		if serviceParamValidateMethodParamValidateA != "" {
 			var v int64
-			v, err = strconv.ParseInt(serviceParamValidateMethodParamValidateA, 10, 64)
+			v, err = strconv.ParseInt(serviceParamValidateMethodParamValidateA, 10, strconv.IntSize)
 			val := int(v)
 			a = &val
 			if err != nil {
@@ -1221,7 +1221,7 @@ func BuildMethodQueryUIntPayload(serviceQueryUIntMethodQueryUIntQ string) (*serv
 	{
 		if serviceQueryUIntMethodQueryUIntQ != "" {
 			var v uint64
-			v, err = strconv.ParseUint(serviceQueryUIntMethodQueryUIntQ, 10, 64)
+			v, err = strconv.ParseUint(serviceQueryUIntMethodQueryUIntQ, 10, strconv.IntSize)
 			val := uint(v)
 			q = &val
 			if err != nil {
@@ -1324,7 +1324,7 @@ func BuildMethodAPayload(serviceWithParamsAndHeadersBlockMethodABody string, ser
 	var path uint
 	{
 		var v uint64
-		v, err = strconv.ParseUint(serviceWithParamsAndHeadersBlockMethodAPath, 10, 64)
+		v, err = strconv.ParseUint(serviceWithParamsAndHeadersBlockMethodAPath, 10, strconv.IntSize)
 		path = uint(v)
 		if err != nil {
 			return nil, fmt.Errorf("invalid value for path, must be UINT")
@@ -1334,7 +1334,7 @@ func BuildMethodAPayload(serviceWithParamsAndHeadersBlockMethodABody string, ser
 	{
 		if serviceWithParamsAndHeadersBlockMethodAOptional != "" {
 			var v int64
-			v, err = strconv.ParseInt(serviceWithParamsAndHeadersBlockMethodAOptional, 10, 64)
+			v, err = strconv.ParseInt(serviceWithParamsAndHeadersBlockMethodAOptional, 10, strconv.IntSize)
 			val := int(v)
 			optional = &val
 			if err != nil {


### PR DESCRIPTION
Reference: https://codeql.github.com/codeql-query-help/go/go-incorrect-integer-conversion/