### PR TITLE
Make it possible to split service definitions

### DIFF
--- a/dsl/error.go
+++ b/dsl/error.go
@@ -59,14 +59,23 @@ const (
 // Attribute DSL.
 //
 // Error must appear in the Service (to define error responses that apply to all
-// the service methods) or Method expressions.
+// the service methods) or Method expressions. Error may also appear under the API
+// expression to create reusable error definitions.
 //
 // See Attribute for details on the Error arguments.
 //
 // Example:
 //
+//    var _ = API("calc", func() {
+//        Error("invalid_argument") // Uses type ErrorResult
+//        HTTP(func() {
+//            Response("invalid_argument", StatusBadRequest)
+//        })
+//    })
+//
 //    var _ = Service("divider", func() {
-//        Error("invalid_arguments") // Uses type ErrorResult
+//        Error("invalid_arguments") // Refers to error defined above.
+//                                   // No need to define HTTP mapping again.
 //
 //        // Method which uses the default type for its response.
 //        Method("divide", func() {

--- a/dsl/security.go
+++ b/dsl/security.go
@@ -179,8 +179,8 @@ func JWTSecurity(name string, fn ...func()) *expr.SchemeExpr {
 	return e
 }
 
-// Security defines authentication requirements to access a service or a service
-// method.
+// Security defines authentication requirements to access an entire API, service
+// or individual service method.
 //
 // The requirement refers to one or more OAuth2Security, BasicAuthSecurity,
 // APIKeySecurity or JWTSecurity security scheme. If the schemes include a
@@ -190,7 +190,7 @@ func JWTSecurity(name string, fn ...func()) *expr.SchemeExpr {
 // in the same scope in which case the client may validate any one of the
 // requirements for the request to be authorized.
 //
-// Security must appear in a Service or Method expression.
+// Security must appear in a API, Service or Method expression.
 //
 // Security accepts an arbitrary number of security schemes as argument
 // specified by name or by reference and an optional DSL function as last

--- a/dsl/service.go
+++ b/dsl/service.go
@@ -58,8 +58,7 @@ func Service(name string, fn func()) *expr.ServiceExpr {
 		return nil
 	}
 	if s := expr.Root.Service(name); s != nil {
-		eval.ReportError("service %#v is defined twice", name)
-		return nil
+		return s
 	}
 	s := &expr.ServiceExpr{Name: name, DSLFunc: fn}
 	expr.Root.Services = append(expr.Root.Services, s)


### PR DESCRIPTION
This commit allows service definitions to span multiple files:

file1.go
```go
var _ = Service("foo", func() {
    Method("bar", func() {
        // ...
    })
})
```

file2.go
```go
var _ = Service("foo", func() {
    Method("baz", func() {
        // ...
    })
})
```