### PR TITLE
Make it possible to split service definitions

### DIFF
--- a/dsl/service.go
+++ b/dsl/service.go
@@ -58,6 +58,11 @@ func Service(name string, fn func()) *expr.ServiceExpr {
 		return nil
 	}
 	if s := expr.Root.Service(name); s != nil {
+		oldDSL := s.DSL()
+		s.DSLFunc = func() {
+			oldDSL()
+			fn()
+		}
 		return s
 	}
 	s := &expr.ServiceExpr{Name: name, DSLFunc: fn}


### PR DESCRIPTION
This commit allows service definitions to span multiple files:

file1.go
```go
var _ = Service("foo", func() {
    Method("bar", func() {
        // ...
    })
})
```

file2.go
```go
var _ = Service("foo", func() {
    Method("baz", func() {
        // ...
    })
})
```