### PR TITLE
Ensure Goa generated types have proper names

### DIFF
--- a/expr/user_type.go
+++ b/expr/user_type.go
@@ -43,6 +43,7 @@ func (u *UserTypeExpr) Name() string {
 func (u *UserTypeExpr) Rename(n string) {
 	// Remember original name for example to generate friendly docs.
 	u.AttributeExpr.AddMeta("name:original", u.TypeName)
+	delete(u.AttributeExpr.Meta, "struct:type:name")
 	u.TypeName = n
 }
 


### PR DESCRIPTION
Do not inherit meta tag that overrides type name.

Fix #3051 