### PR TITLE
PoC 1: ServiceError wraps error

### DIFF
--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -399,7 +399,11 @@ const unionValueMethodT = `func ({{ .TypeRef }}) {{ .Name }}() {}
 // input: map[string]{"Type": TypeData, "Error": ErrorData}
 const errorInitT = `{{ printf "%s builds a %s from an error." .Name .TypeName |  comment }}
 func {{ .Name }}(err error) {{ .TypeRef }} {
-	return &{{ .TypeName }}{
+	return {{if (eq "goa.ServiceError" .TypeName) -}}
+               goa.NewServiceErrorWrapped(err, &goa.ServiceErrorElement{ 
+           {{- else -}}
+               &{{ .TypeName }}{
+           {{- end }}
 		Name: {{ printf "%q" .ErrName }},
 		ID: goa.NewErrorID(),
 		Message: err.Error(),
@@ -412,7 +416,7 @@ func {{ .Name }}(err error) {{ .TypeRef }} {
 	{{- if .Fault }}
 		Fault: true,
 	{{- end }}
-	}
+	}{{ if (eq "goa.ServiceError" .TypeName) -}} ) {{- end }}
 }
 `
 

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -364,11 +364,11 @@ var MethodNames = [1]string{"A"}
 
 // MakeError builds a goa.ServiceError from an error.
 func MakeError(err error) *goa.ServiceError {
-	return &goa.ServiceError{
+	return goa.NewServiceErrorWrapped(err, &goa.ServiceErrorElement{
 		Name:    "error",
 		ID:      goa.NewErrorID(),
 		Message: err.Error(),
-	}
+	})
 }
 `
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/ikawaha/errors v0.0.1
 	github.com/manveru/faker v0.0.0-20171103152722-9fbc68a78c4d
 	github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/ikawaha/errors v0.0.1 h1:xIxRduGYfj6MUR6ljIy0RMK9gqkvOvQXg0qZqO645H8=
+github.com/ikawaha/errors v0.0.1/go.mod h1:JA+XqJUzmvvJaVym/S5SJhIXqvmyoSRX/YplocAh72Q=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -225,6 +225,39 @@ func (e ServiceError) History() []ServiceError {
 	return []ServiceError{e}
 }
 
+// ServiceErrorElement is an argument type of NewServiceErrorWrapped
+// and has the same fields as the public fields of ServiceError.
+type ServiceErrorElement struct {
+	// Name is a name for that class of errors.
+	Name string
+	// ID is a unique value for each occurrence of the error.
+	ID string
+	// Pointer to the field that caused this error, if appropriate
+	Field *string
+	// Message contains the specific error details.
+	Message string
+	// Is the error a timeout?
+	Timeout bool
+	// Is the error temporary?
+	Temporary bool
+	// Is the error a server-side fault?
+	Fault bool
+}
+
+// NewServiceErrorWrapped returns a service error that wrapped the error.
+func NewServiceErrorWrapped(err error, elem ServiceErrorElement) *ServiceError {
+	return &ServiceError{
+		Name:      elem.Name,
+		ID:        elem.ID,
+		Field:     elem.Field,
+		Message:   elem.Message,
+		Timeout:   elem.Timeout,
+		Temporary: elem.Temporary,
+		Fault:     elem.Fault,
+		err:       err,
+	}
+}
+
 // Error returns the error message.
 func (e *ServiceError) Error() string { return e.Message }
 

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -29,6 +29,8 @@ type (
 		// History tracks all the individual errors that were built into this error, should
 		// this error have been merged.
 		history []ServiceError
+		// Err is a wrapped error, if exists.
+		err error
 	}
 )
 
@@ -225,6 +227,9 @@ func (e ServiceError) History() []ServiceError {
 
 // Error returns the error message.
 func (e *ServiceError) Error() string { return e.Message }
+
+// Unwrap returns the error, if ServiceError contains a wrapped error.
+func (e ServiceError) Unwrap() error { return e.err }
 
 // ErrorName returns the error name.
 func (e *ServiceError) ErrorName() string { return e.Name }

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/ikawaha/errors/chainer"
 )
 
 type (
@@ -207,6 +209,7 @@ func MergeErrors(err, other error) error {
 	//
 	// Do this before we modify ourselves, as History() may include us!
 	e.history = append(e.History(), o.History()...)
+	e.err = chainer.Append(e.err, o.err)
 
 	e.Message = e.Message + "; " + o.Message
 	e.Timeout = e.Timeout && o.Timeout

--- a/pkg/error_test.go
+++ b/pkg/error_test.go
@@ -1,0 +1,65 @@
+package goa
+
+import (
+	"errors"
+	"testing"
+)
+
+type MyError struct {
+	name string
+}
+
+func (e MyError) Error() string {
+	return e.name
+}
+
+func TestServiceError_Unwrap(t *testing.T) {
+
+	t.Run("unwrap service error", func(t *testing.T) {
+		err := &MyError{name: "wrapped error"}
+		se := &ServiceError{
+			Name: "service error",
+			err:  err,
+		}
+		if !errors.Is(se, err) {
+			t.Errorf("expected errors.Is(ServiceError, err) = true, but false")
+		}
+		var target *MyError
+		if !errors.As(se, &target) {
+			t.Fatalf("expected errors.As(ServiceError, MyError) = true, but false")
+		}
+		if got, want := target.Error(), err.Error(); got != want {
+			t.Errorf("expected %v, got %v", want, got)
+		}
+	})
+
+	t.Run("unwrap merged service error", func(t *testing.T) {
+		err1 := &MyError{name: "wrapped error #1"}
+		se1 := &ServiceError{
+			Name: "service error #1",
+			err:  err1,
+		}
+		err2 := &MyError{name: "wrapped error #2"}
+		se2 := &ServiceError{
+			Name: "service error #2",
+			err:  err2,
+		}
+
+		se := MergeErrors(se1, se2)
+
+		if !errors.Is(se, err1) {
+			t.Errorf("expected errors.Is(ServiceError, err1) = true, but false")
+		}
+		if !errors.Is(se, err2) {
+			t.Errorf("expected errors.Is(ServiceError, err2) = true, but false")
+		}
+
+		var target *MyError
+		if !errors.As(se, &target) {
+			t.Fatalf("expected errors.As(ServiceError, MyError) = true, but false")
+		}
+		if got, want := target.Error(), err1.Error(); got != want {
+			t.Errorf("expected %v, got %v", want, got)
+		}
+	})
+}


### PR DESCRIPTION
This is a PoC for issue https://github.com/goadesign/goa/issues/3058

When using the default error type, Goa generates a corresponding helper function such as MakeXXXX. This helper function takes an error its argument, but uses only the message of the error.

```
// MakeDivByZero builds a goa.ServiceError from an error.
func MakeDivByZero(err error) *goa.ServiceError {
    return &goa.ServiceError{
        Name:    "DivByZero",
        ID:      goa.NewErrorID(),
        Message: err.Error(),             // ← using only message of the error.
     }
}
```

The suggestion is to wrap this error in ServiceError.

```
	ServiceError struct {
		// Name is a name for that class of errors.
		Name string
		// ID is a unique value for each occurrence of the error.
		ID string
		// Pointer to the field that caused this error, if appropriate
		Field *string
		// Message contains the specific error details.
		Message string
		// Is the error a timeout?
		Timeout bool
		// Is the error temporary?
		Temporary bool
		// Is the error a server-side fault?
		Fault bool
		// History tracks all the individual errors that were built into this error, should
		// this error have been merged.
		history []ServiceError
		// Err is a wrapped error, if exists.
		err error                                                // ← ★ embed original error.
	}
```

Wrapping the original error makes it easier to handle errors without having to create custom errors. The error is embedded as a private field in ServiceError, so this change should not confuse users.

```
// MakeDivByZero builds a goa.ServiceError from an error.
func MakeDivByZero(err error) *goa.ServiceError {
        return goa.NewServiceErrorWrapped(err, &goa.ServiceErrorElement{  // ← ★ returns a service error that wraps the error.

                Name:    "DivByZero",
                ID:      goa.NewErrorID(),
                Message: err.Error(),
        })
}
```
