### PR TITLE
PoC 2: ServiceError wraps error

### DIFF
--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -414,6 +414,24 @@ func {{ .Name }}(err error) {{ .TypeRef }} {
 	{{- end }}
 	}
 }
+
+{{ printf "%sWrapped builds an %s that wrapped err." .Name .TypeName |  comment }}
+func {{ .Name }}Wrapped(err error) error {
+	return goa.Append(&{{ .TypeName }}{
+		Name: {{ printf "%q" .ErrName }},
+		ID: goa.NewErrorID(),
+		Message: err.Error(),
+	{{- if .Temporary }}
+		Temporary: true,
+	{{- end }}
+	{{- if .Timeout }}
+		Timeout: true,
+	{{- end }}
+	{{- if .Fault }}
+		Fault: true,
+	{{- end }}
+	}, err)
+}
 `
 
 // input: InitData

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -370,6 +370,15 @@ func MakeError(err error) *goa.ServiceError {
 		Message: err.Error(),
 	}
 }
+
+// MakeErrorWrapped builds an goa.ServiceError that wrapped err.
+func MakeErrorWrapped(err error) error {
+	return goa.Append(&goa.ServiceError{
+		Name:    "error",
+		ID:      goa.NewErrorID(),
+		Message: err.Error(),
+	}, err)
+}
 `
 
 const CustomErrors = `

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -3,6 +3,7 @@ package goa
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -256,4 +257,53 @@ func asError(err error) *ServiceError {
 		}
 	}
 	return e
+}
+
+type errChain struct {
+	err  error
+	next error
+}
+
+func newErrChain(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.As(err, &errChain{}) {
+		return err
+	}
+	return &errChain{err: err}
+}
+
+// Error implements error interface.
+func (e errChain) Error() string {
+	return e.err.Error()
+}
+
+// Is reports whether any error in err's chain matches target.
+func (e errChain) Is(err error) bool {
+	return errors.Is(e.err, err)
+}
+
+// As reports whether any error in err's chain matches target type.
+func (e errChain) As(target interface{}) bool {
+	return errors.As(e.err, target)
+}
+
+// Unwrap implements Wrapper interface.
+func (e errChain) Unwrap() error {
+	return e.next
+}
+
+// Append appends errors and obtains chained errors.
+func Append(lhs error, rhs ...error) error {
+	if len(rhs) == 0 || rhs[0] == nil {
+		return newErrChain(lhs)
+	}
+	if lhs == nil {
+		return Append(rhs[0], rhs[1:]...)
+	}
+	if len(rhs) == 1 {
+		return &errChain{err: lhs, next: newErrChain(rhs[0])}
+	}
+	return Append(lhs, Append(rhs[0], rhs[1:]...))
 }


### PR DESCRIPTION
This is a PoC for issue https://github.com/goadesign/goa/issues/3058

* The structure of ServiceError is not modified.
* Keep the existing MakeXXXXX but create a new MakeXXXXWrapped that can wrap the original error
* MakeXXXX returns ServiceError while MakeXXXXWrapped returns error.
    * MakeXXXXWrapped returns an error that is a chained of the original error and ServiceError. 
* Errors returned by MakeXXXXWrapped satisfy the following:
    * errors.Is/As(err, original_err) == true
    * errors.Is/As(err, &ServiceError{}) == true

### sample generated code (gen/calc/service.go)
```go
// MakeDivByZero builds a goa.ServiceError from an error.
func MakeDivByZero(err error) *goa.ServiceError {
        return &goa.ServiceError{
                Name:    "DivByZero",
                ID:      goa.NewErrorID(),
                Message: err.Error(),
        }
}

// MakeDivByZeroWrapped builds an goa.ServiceError that wrapped err.
func MakeDivByZeroWrapped(err error) error {
        return goa.Append(&goa.ServiceError{
                Name:    "DivByZero",
                ID:      goa.NewErrorID(),
                Message: err.Error(),
        }, err)
}
```