### PR TITLE
Make it possible to specify proto type Go import

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -64,6 +64,9 @@ type (
 		// UserTypeImports lists the import specifications for the user
 		// types used by the service.
 		UserTypeImports []*codegen.ImportSpec
+		// ProtoImports lists the import specifications for the custom
+		// proto types used by the service.
+		ProtoImports []*codegen.ImportSpec
 
 		// userTypes lists the type definitions that the service depends on.
 		userTypes []*UserTypeData

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -76,9 +76,9 @@ import (
 //         })
 //    })
 //
-// - "struct:field:proto" overrides the generated protobuf field type. The second
-// argument is optional and if present indicates an import path for the proto file
-// defining the type.
+// - "struct:field:proto" overrides the generated protobuf field type. If the
+// type is defined in a separate proto file, the last three elements define the
+// proto file import path, Go type name and Go import path respectively.
 //
 //    var Timestamp = Type("Timestamp", func() {
 //        Description("Google timestamp compatible design")
@@ -92,7 +92,7 @@ import (
 //
 //    var MyType = Type("MyType", func() {
 //        Field(1, "created_at", Timestamp, func() {
-//            Meta("struct:field:proto", "google.protobuf.Timestamp", "google/protobuf/timestamp.proto")
+//            Meta("struct:field:proto", "google.protobuf.Timestamp", "google/protobuf/timestamp.proto", "Timestamp", "google.golang.org/protobuf/types/known/timestamppb")
 //        })
 //    })
 //

--- a/grpc/codegen/client_types.go
+++ b/grpc/codegen/client_types.go
@@ -85,6 +85,7 @@ func clientType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 			{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: sd.PkgName},
 		}
 		imports = append(imports, sd.Service.UserTypeImports...)
+		imports = append(imports, sd.Service.ProtoImports...)
 		sections = []*codegen.SectionTemplate{codegen.Header(svc.Name()+" gRPC client types", "client", imports)}
 		for _, init := range initData {
 			sections = append(sections, &codegen.SectionTemplate{

--- a/grpc/codegen/proto.go
+++ b/grpc/codegen/proto.go
@@ -47,7 +47,7 @@ func protoFile(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 			Data: map[string]interface{}{
 				"ProtoVersion": ProtoVersion,
 				"Pkg":          pkgName(svc, svcName),
-				"Imports":      data.Imports,
+				"Imports":      data.ProtoImports,
 			},
 		},
 		// service definition

--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -213,6 +213,14 @@ func protoBufGoTypeName(att *expr.AttributeExpr, s *codegen.NameScope) string {
 // the given package name for the given attribute generated after compiling
 // the proto file (in *.pb.go).
 func protoBufGoFullTypeName(att *expr.AttributeExpr, pkg string, s *codegen.NameScope) string {
+	if proto := att.Meta["struct:field:proto"]; len(proto) > 2 {
+		typ := proto[2]
+		if len(att.Meta["struct:field:proto"]) > 3 {
+			elems := strings.Split(att.Meta["struct:field:proto"][3], "/")
+			typ = elems[len(elems)-1] + "." + typ
+		}
+		return typ
+	}
 	switch actual := att.Type.(type) {
 	case expr.UserType, expr.CompositeExpr, *expr.Union:
 		return protoBufFullMessageName(att, pkg, s)

--- a/grpc/codegen/server_types.go
+++ b/grpc/codegen/server_types.go
@@ -80,6 +80,7 @@ func serverType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 			{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: sd.PkgName},
 		}
 		imports = append(imports, sd.Service.UserTypeImports...)
+		imports = append(imports, sd.Service.ProtoImports...)
 		sections = []*codegen.SectionTemplate{codegen.Header(svc.Name()+" gRPC server types", "server", imports)}
 		for _, init := range initData {
 			if _, ok := foundInits[init.Name]; ok {


### PR DESCRIPTION
When using `struct:field:proto`