### PR TITLE
Fix issues with struct:tag:pkg

### DIFF
--- a/expr/dup.go
+++ b/expr/dup.go
@@ -9,7 +9,14 @@ func Dup(d DataType) DataType {
 
 // DupAtt creates a copy of the given attribute.
 func DupAtt(att *AttributeExpr) *AttributeExpr {
-	return newDupper().DupAttribute(att)
+	dupper := newDupper()
+	duppedBases := make([]DataType, len(att.Bases))
+	for i, b := range att.Bases {
+		duppedBases[i] = dupper.DupType(b)
+	}
+	res := dupper.DupAttribute(att)
+	res.Bases = duppedBases
+	return res
 }
 
 // dupper implements recursive and cycle safe copy of data types.

--- a/expr/mapped_attribute.go
+++ b/expr/mapped_attribute.go
@@ -48,20 +48,12 @@ func NewMappedAttributeExpr(att *AttributeExpr) *MappedAttributeExpr {
 			validation = val.Dup()
 		}
 	}
+	attr := DupAtt(att)
+	attr.Validation = validation
 	ma := &MappedAttributeExpr{
-		AttributeExpr: &AttributeExpr{
-			Type:         Dup(att.Type),
-			References:   att.References,
-			Bases:        att.Bases,
-			Description:  att.Description,
-			Docs:         att.Docs,
-			Meta:         att.Meta,
-			DefaultValue: att.DefaultValue,
-			UserExamples: att.UserExamples,
-			Validation:   validation,
-		},
-		nameMap:    nameMap,
-		reverseMap: reverseMap,
+		AttributeExpr: attr,
+		nameMap:       nameMap,
+		reverseMap:    reverseMap,
 	}
 	ma.Remap()
 	return ma


### PR DESCRIPTION
The previous code would remove the tag from bases when building body
types without dupping them first which meant that the tag in base types
would get ignored.