### PR TITLE
Generate multiple examples in OpenAPI

### DIFF
--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -227,10 +227,8 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 		if e.MultipartRequest {
 			ct = "multipart/form-data"
 		}
-		mt := &MediaType{
-			Schema:  bodies.RequestBody,
-			Example: e.Body.Example(rand),
-		}
+		mt := &MediaType{Schema: bodies.RequestBody}
+		initExamples(mt, e.Body, rand)
 		requestBody = &RequestBodyRef{Value: &RequestBody{
 			Description: e.Body.Description,
 			Required:    e.Body.Type != expr.Empty,

--- a/http/codegen/openapi/v3/example.go
+++ b/http/codegen/openapi/v3/example.go
@@ -1,0 +1,35 @@
+package openapiv3
+
+import "goa.design/goa/v3/expr"
+
+type (
+	// exampler is the interface used to initialize the example of an
+	// OpenAPI object.
+	exampler interface {
+		setExample(interface{})
+		setExamples(map[string]*ExampleRef)
+	}
+)
+
+// initExample sets the example or examples of the given object.
+func initExamples(obj exampler, attr *expr.AttributeExpr, r *expr.Random) {
+	examples := attr.ExtractUserExamples()
+	switch {
+	case len(examples) > 1:
+		refs := make(map[string]*ExampleRef, len(examples))
+		for _, ex := range examples {
+			example := &Example{
+				Summary:     ex.Summary,
+				Description: ex.Description,
+				Value:       ex.Value,
+			}
+			refs[ex.Summary] = &ExampleRef{Value: example}
+		}
+		obj.setExamples(refs)
+		return
+	case len(examples) > 0:
+		obj.setExample(examples[0].Value)
+	default:
+		obj.setExample(attr.Example(r))
+	}
+}

--- a/http/codegen/openapi/v3/openapi.go
+++ b/http/codegen/openapi/v3/openapi.go
@@ -256,6 +256,18 @@ type (
 	_SecurityScheme SecurityScheme
 )
 
+// MediaType implements exampler
+func (m *MediaType) setExample(val interface{})             { m.Example = val }
+func (m *MediaType) setExamples(val map[string]*ExampleRef) { m.Examples = val }
+
+// Header implements exampler
+func (h *Header) setExample(val interface{})             { h.Example = val }
+func (h *Header) setExamples(val map[string]*ExampleRef) { h.Examples = val }
+
+// Parameter implements exampler
+func (p *Parameter) setExample(val interface{})             { p.Example = val }
+func (p *Parameter) setExamples(val map[string]*ExampleRef) { p.Examples = val }
+
 // MarshalJSON returns the JSON encoding of i.
 func (i Info) MarshalJSON() ([]byte, error) {
 	return openapi.MarshalJSON(_Info(i), i.Extensions)

--- a/http/codegen/openapi/v3/parameters.go
+++ b/http/codegen/openapi/v3/parameters.go
@@ -56,14 +56,15 @@ func paramsFromHeadersAndCookies(endpoint *expr.HTTPEndpointExpr, rand *expr.Ran
 
 // paramFor converts the given attribute into a OpenAPI spec parameter.
 func paramFor(att *expr.AttributeExpr, name, in string, required bool, rand *expr.Random) *Parameter {
-	return &Parameter{
+	param := &Parameter{
 		Name:            name,
 		In:              in,
 		Description:     att.Description,
 		AllowEmptyValue: in != "path",
 		Required:        required,
 		Schema:          newSchemafier(rand).schemafy(att),
-		Example:         att.Example(rand),
 		Extensions:      openapi.ExtensionsFromExpr(att.Meta),
 	}
+	initExamples(param, att, rand)
+	return param
 }

--- a/http/codegen/openapi/v3/response.go
+++ b/http/codegen/openapi/v3/response.go
@@ -23,13 +23,15 @@ func responseFromExpr(r *expr.HTTPResponseExpr, bodies map[int][]*openapi.Schema
 	if len(*o) > 0 {
 		headers = make(map[string]*HeaderRef, len(*o))
 		expr.WalkMappedAttr(r.Headers, func(name, elem string, attr *expr.AttributeExpr) error {
-			headers[elem] = &HeaderRef{Value: &Header{
+			header := &Header{
 				Description: attr.Description,
 				Required:    r.Headers.IsRequiredNoDefault(name),
 				Schema:      newSchemafier(rand).schemafy(attr),
 				Example:     attr.Example(rand),
 				Extensions:  openapi.ExtensionsFromExpr(attr.Meta),
-			}}
+			}
+			initExamples(header, attr, rand)
+			headers[elem] = &HeaderRef{Value: header}
 			return nil
 		})
 	}
@@ -40,9 +42,9 @@ func responseFromExpr(r *expr.HTTPResponseExpr, bodies map[int][]*openapi.Schema
 			content = make(map[string]*MediaType)
 			content[ct] = &MediaType{
 				Schema:     bodies[r.StatusCode][0],
-				Example:    r.Body.Example(rand),
 				Extensions: openapi.ExtensionsFromExpr(r.Body.Meta),
 			}
+			initExamples(content[ct], r.Body, rand)
 		}
 	}
 	desc := r.Description


### PR DESCRIPTION
For headers, media types and parameters when multiple examples
are defined in the design.

Fix #3090 