### PR TITLE
Add missing imports to gRPC client and server

### DIFF
--- a/grpc/codegen/client.go
+++ b/grpc/codegen/client.go
@@ -36,17 +36,19 @@ func client(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 	{
 		svcName := data.Service.PathName
 		fpath = filepath.Join(codegen.Gendir, "grpc", svcName, "client", "client.go")
+		imports := []*codegen.ImportSpec{
+			{Path: "context"},
+			{Path: "google.golang.org/grpc"},
+			codegen.GoaImport(""),
+			codegen.GoaNamedImport("grpc", "goagrpc"),
+			codegen.GoaNamedImport("grpc/pb", "goapb"),
+			{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
+			{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
+			{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: data.PkgName},
+		}
+		imports = append(imports, data.Service.UserTypeImports...)
 		sections = []*codegen.SectionTemplate{
-			codegen.Header(svc.Name()+" gRPC client", "client", []*codegen.ImportSpec{
-				{Path: "context"},
-				{Path: "google.golang.org/grpc"},
-				codegen.GoaImport(""),
-				codegen.GoaNamedImport("grpc", "goagrpc"),
-				codegen.GoaNamedImport("grpc/pb", "goapb"),
-				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
-				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: data.PkgName},
-			}),
+			codegen.Header(svc.Name()+" gRPC client", "client", imports),
 		}
 		sections = append(sections, &codegen.SectionTemplate{
 			Name:   "client-struct",

--- a/grpc/codegen/server.go
+++ b/grpc/codegen/server.go
@@ -37,17 +37,19 @@ func serverFile(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 	{
 		svcName := data.Service.PathName
 		fpath = filepath.Join(codegen.Gendir, "grpc", svcName, "server", "server.go")
+		imports := []*codegen.ImportSpec{
+			{Path: "context"},
+			{Path: "errors"},
+			codegen.GoaImport(""),
+			codegen.GoaNamedImport("grpc", "goagrpc"),
+			{Path: "google.golang.org/grpc/codes"},
+			{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
+			{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
+			{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: data.PkgName},
+		}
+		imports = append(imports, data.Service.UserTypeImports...)
 		sections = []*codegen.SectionTemplate{
-			codegen.Header(svc.Name()+" gRPC server", "server", []*codegen.ImportSpec{
-				{Path: "context"},
-				{Path: "errors"},
-				codegen.GoaImport(""),
-				codegen.GoaNamedImport("grpc", "goagrpc"),
-				{Path: "google.golang.org/grpc/codes"},
-				{Path: path.Join(genpkg, svcName), Name: data.Service.PkgName},
-				{Path: path.Join(genpkg, svcName, "views"), Name: data.Service.ViewsPkg},
-				{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: data.PkgName},
-			}),
+			codegen.Header(svc.Name()+" gRPC server", "server", imports),
 			{Name: "server-struct", Source: serverStructT, Data: data},
 		}
 		for _, e := range data.Endpoints {


### PR DESCRIPTION
when using custom package with 'struct:pkg:path' meta.