### PR TITLE
Do not generate validation code for alias types

### DIFF
--- a/grpc/codegen/client_types_test.go
+++ b/grpc/codegen/client_types_test.go
@@ -19,6 +19,7 @@ func TestClientTypeFiles(t *testing.T) {
 		{"payload-with-duplicate-use", testdata.PayloadWithMultipleUseTypesDSL, testdata.PayloadWithMultipleUseTypesClientTypeCode},
 		{"payload-with-alias-type", testdata.PayloadWithAliasTypeDSL, testdata.PayloadWithAliasTypeClientTypeCode},
 		{"result-collection", testdata.ResultWithCollectionDSL, testdata.ResultWithCollectionClientTypeCode},
+		{"alias-validation", testdata.ResultWithAliasValidation, testdata.ResultWithAliasValidationClientTypeCode},
 		{"with-errors", testdata.UnaryRPCWithErrorsDSL, testdata.WithErrorsClientTypeCode},
 		{"bidirectional-streaming-same-type", testdata.BidirectionalStreamingRPCSameTypeDSL, testdata.BidirectionalStreamingRPCSameTypeClientTypeCode},
 	}

--- a/grpc/codegen/server_types_test.go
+++ b/grpc/codegen/server_types_test.go
@@ -22,6 +22,7 @@ func TestServerTypeFiles(t *testing.T) {
 		{"result-collection", testdata.ResultWithCollectionDSL, testdata.ResultWithCollectionServerTypeCode},
 		{"with-errors", testdata.UnaryRPCWithErrorsDSL, testdata.WithErrorsServerTypeCode},
 		{"elem-validation", testdata.ElemValidationDSL, testdata.ElemValidationServerTypesFile},
+		{"alias-validation", testdata.AliasValidationDSL, testdata.AliasValidationServerTypesFile},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -780,6 +780,10 @@ func addValidation(att *expr.AttributeExpr, sd *ServiceData, req bool) *Validati
 func collectValidations(att *expr.AttributeExpr, ctx *codegen.AttributeContext, req bool, sd *ServiceData) {
 	switch dt := att.Type.(type) {
 	case expr.UserType:
+		if expr.IsPrimitive(dt) {
+			// Alias type - validation is generatd inline in parent type validation code.
+			return
+		}
 		name := protoBufMessageName(att, sd.Scope)
 		kind := validateClient
 		if req {
@@ -796,10 +800,10 @@ func collectValidations(att *expr.AttributeExpr, ctx *codegen.AttributeContext, 
 		}
 		sd.validations = append(sd.validations, &ValidationData{
 			Name:    "Validate" + name,
-			Def:     codegen.RecursiveValidationCode(unAlias(att), ctx, true, false, "message"),
+			Def:     codegen.RecursiveValidationCode(att, ctx, true, false, "message"),
 			ArgName: "message",
 			SrcName: name,
-			SrcRef:  protoBufGoFullTypeRef(unAlias(att), sd.PkgName, sd.Scope),
+			SrcRef:  protoBufGoFullTypeRef(att, sd.PkgName, sd.Scope),
 			Kind:    kind,
 		})
 	collect:

--- a/grpc/codegen/testdata/client_type_code.go
+++ b/grpc/codegen/testdata/client_type_code.go
@@ -140,6 +140,30 @@ func NewMethodMessageUserTypeWithAliasResult(message *service_message_user_type_
 }
 `
 
+const ResultWithAliasValidationClientTypeCode = `// NewProtoMethodResultWithAliasValidationRequest builds the gRPC request type
+// from the payload of the "MethodResultWithAliasValidation" endpoint of the
+// "ServiceResultWithAliasValidation" service.
+func NewProtoMethodResultWithAliasValidationRequest() *service_result_with_alias_validationpb.MethodResultWithAliasValidationRequest {
+	message := &service_result_with_alias_validationpb.MethodResultWithAliasValidationRequest{}
+	return message
+}
+
+// NewMethodResultWithAliasValidationResult builds the result type of the
+// "MethodResultWithAliasValidation" endpoint of the
+// "ServiceResultWithAliasValidation" service from the gRPC response type.
+func NewMethodResultWithAliasValidationResult(message *service_result_with_alias_validationpb.UUID) serviceresultwithaliasvalidation.UUID {
+	result := serviceresultwithaliasvalidation.UUID(message.Field)
+	return result
+}
+
+// ValidateUUID runs the validations defined on UUID.
+func ValidateUUID(message *service_result_with_alias_validationpb.UUID) (err error) {
+	err = goa.MergeErrors(err, goa.ValidateFormat("message.field", message.Field, goa.FormatUUID))
+
+	return
+}
+`
+
 const ResultWithCollectionClientTypeCode = `// NewProtoMethodResultWithCollectionRequest builds the gRPC request type from
 // the payload of the "MethodResultWithCollection" endpoint of the
 // "ServiceResultWithCollection" service.

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -98,6 +98,18 @@ var ElemValidationDSL = func() {
 	})
 }
 
+var AliasValidationDSL = func() {
+	var UUID = Type("UUID", String, func() {
+		Format(FormatUUID)
+	})
+	Service("ServiceElemValidation", func() {
+		Method("MethodElemValidation", func() {
+			Payload(UUID)
+			GRPC(func() {})
+		})
+	})
+}
+
 var UnaryRPCAcronymDSL = func() {
 	Service("ServiceUnaryRPCAcronym", func() {
 		Method("MethodUnaryRPCAcronym_jwt", func() {
@@ -517,6 +529,19 @@ var ResultWithCollectionDSL = func() {
 			Result(func() {
 				Field(1, "result", ResultT)
 			})
+			GRPC(func() {})
+		})
+	})
+}
+
+var ResultWithAliasValidation = func() {
+	var UUID = Type("UUID", String, func() {
+		Format(FormatUUID)
+	})
+
+	Service("ServiceResultWithAliasValidation", func() {
+		Method("MethodResultWithAliasValidation", func() {
+			Result(UUID)
 			GRPC(func() {})
 		})
 	})

--- a/grpc/codegen/testdata/server_type_code.go
+++ b/grpc/codegen/testdata/server_type_code.go
@@ -381,3 +381,27 @@ func ValidateArrayOfString(message *service_elem_validationpb.ArrayOfString) (er
 	return
 }
 `
+
+const AliasValidationServerTypesFile = `// NewMethodElemValidationPayload builds the payload of the
+// "MethodElemValidation" endpoint of the "ServiceElemValidation" service from
+// the gRPC request type.
+func NewMethodElemValidationPayload(message *service_elem_validationpb.UUID) serviceelemvalidation.UUID {
+	v := serviceelemvalidation.UUID(message.Field)
+	return v
+}
+
+// NewProtoMethodElemValidationResponse builds the gRPC response type from the
+// result of the "MethodElemValidation" endpoint of the "ServiceElemValidation"
+// service.
+func NewProtoMethodElemValidationResponse() *service_elem_validationpb.MethodElemValidationResponse {
+	message := &service_elem_validationpb.MethodElemValidationResponse{}
+	return message
+}
+
+// ValidateUUID runs the validations defined on UUID.
+func ValidateUUID(message *service_elem_validationpb.UUID) (err error) {
+	err = goa.MergeErrors(err, goa.ValidateFormat("message.field", message.Field, goa.FormatUUID))
+
+	return
+}
+`


### PR DESCRIPTION
When they are used inline as the parent object validation validates
the fields inline.