### PR TITLE
Fix transform bug with result type oneof attribute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go 1.19
       uses: actions/setup-go@v3.2.1
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory
@@ -34,10 +34,10 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go 1.19
       uses: actions/setup-go@v3.2.1
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory

--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -6,7 +6,6 @@ import (
 	"go/build"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,7 +66,7 @@ func NewGenerator(cmd string, path, output string) *Generator {
 				}
 			}
 			for _, gof := range pkg.GoFiles {
-				if bs, err := ioutil.ReadFile(gof); err == nil {
+				if bs, err := os.ReadFile(gof); err == nil {
 					if f, err := parser.ParseFile(fset, "", string(bs), parser.ImportsOnly); err == nil {
 						for _, s := range f.Imports {
 							matches := p.FindStringSubmatch(s.Path.Value)
@@ -106,7 +105,7 @@ func (g *Generator) Write(debug bool) error {
 		if cwd, err := os.Getwd(); err != nil {
 			wd = cwd
 		}
-		tmp, err := ioutil.TempDir(wd, "goa")
+		tmp, err := os.MkdirTemp(wd, "goa")
 		if err != nil {
 			return err
 		}

--- a/codegen/file.go
+++ b/codegen/file.go
@@ -9,7 +9,6 @@ import (
 	"go/scanner"
 	"go/token"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,7 +137,7 @@ func finalizeGoSource(path string) error {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 	if err != nil {
-		content, _ := ioutil.ReadFile(path)
+		content, _ := os.ReadFile(path)
 		var buf bytes.Buffer
 		scanner.PrintError(&buf, err)
 		return fmt.Errorf("%s\n========\nContent:\n%s", buf.String(), content)
@@ -169,7 +168,7 @@ func finalizeGoSource(path string) error {
 	w.Close()
 
 	// Format code using goimport standard
-	bs, err := ioutil.ReadFile(path)
+	bs, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -181,5 +180,5 @@ func finalizeGoSource(path string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, bs, os.ModePerm)
+	return os.WriteFile(path, bs, os.ModePerm)
 }

--- a/codegen/generator/generate.go
+++ b/codegen/generator/generate.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -36,7 +35,7 @@ func Generate(dir, cmd string) (outputs []string, err1 error) {
 		}
 
 		// We create a temporary Go file to make sure the directory is a valid Go package
-		dummy, err := ioutil.TempFile(path, "temp.*.go")
+		dummy, err := os.CreateTemp(path, "temp.*.go")
 		if err != nil {
 			return nil, err
 		}

--- a/codegen/go_transform_union_test.go
+++ b/codegen/go_transform_union_test.go
@@ -13,12 +13,13 @@ func TestGoTransformUnion(t *testing.T) {
 		scope = NewNameScope()
 
 		// types to test
-		unionString    = root.UserType("Container").Attribute().Find("UnionString").Find("UnionString")
-		unionString2   = root.UserType("Container").Attribute().Find("UnionString2").Find("UnionString2")
-		unionStringInt = root.UserType("Container").Attribute().Find("UnionStringInt").Find("UnionStringInt")
-		unionSomeType  = root.UserType("Container").Attribute().Find("UnionSomeType").Find("UnionSomeType")
-		userType       = &expr.AttributeExpr{Type: root.UserType("UnionUserType")}
-		defaultCtx     = NewAttributeContext(false, false, true, "", scope)
+		unionString     = root.UserType("Container").Attribute().Find("UnionString").Find("UnionString")
+		unionString2    = root.UserType("Container").Attribute().Find("UnionString2").Find("UnionString2")
+		unionStringInt  = root.UserType("Container").Attribute().Find("UnionStringInt").Find("UnionStringInt")
+		unionStringInt2 = root.UserType("Container").Attribute().Find("UnionStringInt2").Find("UnionStringInt2")
+		unionSomeType   = root.UserType("Container").Attribute().Find("UnionSomeType").Find("UnionSomeType")
+		userType        = &expr.AttributeExpr{Type: root.UserType("UnionUserType")}
+		defaultCtx      = NewAttributeContext(false, false, true, "", scope)
 	)
 	tc := []struct {
 		Name     string
@@ -27,6 +28,7 @@ func TestGoTransformUnion(t *testing.T) {
 		Expected string
 	}{
 		{"UnionString to UnionString2", unionString, unionString2, unionToUnionCode},
+		{"UnionStringInt to UnionStringInt2", unionStringInt, unionStringInt2, unionMultiToUnionMultiCode},
 
 		{"UnionString to User Type", unionString, userType, unionStringToUserTypeCode},
 		{"UnionStringInt to User Type", unionStringInt, userType, unionStringIntToUserTypeCode},
@@ -89,8 +91,21 @@ const unionToUnionCode = `func transform() {
 	var target *UnionString2
 	switch actual := source.(type) {
 	case UnionStringString:
-		val := UnionString2String(actual)
-		target = UnionString2{Value: val}
+		target = UnionString2String(actual)
+
+	}
+}
+`
+
+const unionMultiToUnionMultiCode = `func transform() {
+	var target *UnionStringInt2
+	switch actual := source.(type) {
+	case UnionStringIntString:
+		target = UnionStringInt2String(actual)
+
+	case UnionStringIntInt:
+		target = UnionStringInt2Int(actual)
+
 	}
 }
 `

--- a/codegen/service/views.go
+++ b/codegen/service/views.go
@@ -49,6 +49,16 @@ func ViewsFile(genpkg string, service *expr.ServiceExpr) *codegen.File {
 			})
 		}
 
+		// Union methods
+		for _, m := range svc.viewedUnionMethods {
+			sections = append(sections, &codegen.SectionTemplate{
+				// addTypeDefSection(pathWithDefault(m.Loc, svcPath), "~"+m.TypeRef+"."+m.Name, &codegen.SectionTemplate{
+				Name:   "viewed-union-value-method",
+				Source: unionValueMethodT,
+				Data:   m,
+			})
+		}
+
 		// generate a map for result types with view name as key and the fields
 		// rendered in the view as value.
 		var (

--- a/codegen/testdata/union_dsls.go
+++ b/codegen/testdata/union_dsls.go
@@ -26,6 +26,12 @@ var TestUnionDSL = func() {
 				Attribute("Int", Int)
 			})
 		})
+		UnionStringInt2 = Type("UnionStringInt2", func() {
+			OneOf("UnionStringInt2", func() {
+				Attribute("String", String)
+				Attribute("Int", Int)
+			})
+		})
 		UnionSomeType = Type("UnionSomeType", func() {
 			OneOf("UnionSomeType", func() {
 				Attribute("SomeType", SomeType)
@@ -36,6 +42,7 @@ var TestUnionDSL = func() {
 			Attribute("UnionString", UnionString)
 			Attribute("UnionString2", UnionString2)
 			Attribute("UnionStringInt", UnionStringInt)
+			Attribute("UnionStringInt2", UnionStringInt2)
 			Attribute("UnionSomeType", UnionSomeType)
 		})
 

--- a/codegen/testing.go
+++ b/codegen/testing.go
@@ -3,7 +3,6 @@ package codegen
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -83,7 +82,7 @@ func FormatTestCode(t *testing.T, code string) string {
 	if err := finalizeGoSource(tmp); err != nil {
 		t.Fatal(err)
 	}
-	content, err := ioutil.ReadFile(tmp)
+	content, err := os.ReadFile(tmp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +112,7 @@ func Diff(t *testing.T, s1, s2 string) string {
 // It is used only for testing.
 func CreateTempFile(t *testing.T, content string) string {
 	t.Helper()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/expr/hasher.go
+++ b/expr/hasher.go
@@ -69,11 +69,13 @@ func hashMap(m *Map, ignoreFields, ignoreNames, ignoreTags bool, seen map[*Objec
 }
 
 func hashUnion(u *Union, ignoreFields, ignoreNames, ignoreTags bool, seen map[*Object]*string) *string {
-	sort.Slice(u.Values, func(i, j int) bool {
+	sorted := make([]*NamedAttributeExpr, len(u.Values))
+	copy(sorted, u.Values)
+	sort.Slice(sorted, func(i, j int) bool {
 		return u.Values[i].Name < u.Values[j].Name
 	})
 	h := unionTypePrefix + u.TypeName
-	for _, nat := range u.Values {
+	for _, nat := range sorted {
 		h += unionAttributePrefix + nat.Name + unionAttributeTypePrefix + *hash(nat.Attribute.Type, ignoreFields, ignoreNames, ignoreTags, seen)
 	}
 	return &h

--- a/expr/testing.go
+++ b/expr/testing.go
@@ -1,7 +1,6 @@
 package expr
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -76,7 +75,7 @@ func Diff(t *testing.T, s1, s2 string) string {
 // It is used only for testing.
 func CreateTempFile(t *testing.T, content string) string {
 	t.Helper()
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module goa.design/goa/v3
 
-go 1.18
+go 1.19
 
 require (
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598
@@ -32,9 +32,9 @@ require (
 	github.com/manveru/gobdd v0.0.0-20131210092515-f1a17fdd710b // indirect
 	github.com/smartystreets/goconvey v1.7.2 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b // indirect
+	golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704 // indirect
 	golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df // indirect
-	google.golang.org/genproto v0.0.0-20220715211116-798f69b842b9 // indirect
+	google.golang.org/genproto v0.0.0-20220803205849-8f55acc8769f // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b h1:3ogNYyK4oIQdIKzTu68hQrr4iuVxF3AxKl9Aj/eDrw0=
+golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -148,6 +150,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704 h1:Y7NOhdqIOU8kYI7BxsgL38d0ot0raxvcW+EMQU2QrT4=
+golang.org/x/sys v0.0.0-20220803195053-6e608f9ce704/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
@@ -172,6 +176,8 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20220715211116-798f69b842b9 h1:1aEQRgZ4Gks2SRAkLzIPpIszRazwVfjSFe1cKc+e0Jg=
 google.golang.org/genproto v0.0.0-20220715211116-798f69b842b9/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
+google.golang.org/genproto v0.0.0-20220803205849-8f55acc8769f h1:ywoA0TLvF/4n7P2lr/+bNRueYxWYUJZbRwV3hyYt8gY=
+google.golang.org/genproto v0.0.0-20220803205849-8f55acc8769f/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=

--- a/http/client.go
+++ b/http/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -63,8 +62,8 @@ func NewDebugDoer(d Doer) DebugDoer {
 func (dd *debugDoer) Do(req *http.Request) (*http.Response, error) {
 	var reqb []byte
 	if req.Body != nil {
-		reqb, _ = ioutil.ReadAll(req.Body)
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqb))
+		reqb, _ = io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewBuffer(reqb))
 	}
 
 	resp, err := dd.Doer.Do(req)
@@ -73,15 +72,15 @@ func (dd *debugDoer) Do(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	respb, err := ioutil.ReadAll(resp.Body)
+	respb, err := io.ReadAll(resp.Body)
 	if err != nil {
 		respb = []byte(fmt.Sprintf("!!failed to read response: %s", err))
 	}
-	resp.Body = ioutil.NopCloser(bytes.NewBuffer(respb))
+	resp.Body = io.NopCloser(bytes.NewBuffer(respb))
 
 	dd.Response = resp
 
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(reqb))
+	req.Body = io.NopCloser(bytes.NewBuffer(reqb))
 	dd.Request = req
 
 	dd.Fprint(os.Stderr)
@@ -108,9 +107,9 @@ func (dd *debugDoer) Fprint(w io.Writer) {
 		buf.WriteString(fmt.Sprintf("\n> %s: %s", k, strings.Join(dd.Request.Header[k], ", ")))
 	}
 
-	b, _ := ioutil.ReadAll(dd.Request.Body)
+	b, _ := io.ReadAll(dd.Request.Body)
 	if len(b) > 0 {
-		dd.Request.Body = ioutil.NopCloser(bytes.NewBuffer(b)) // reset the request body
+		dd.Request.Body = io.NopCloser(bytes.NewBuffer(b)) // reset the request body
 		buf.WriteByte('\n')
 		buf.Write(b)
 	}
@@ -132,9 +131,9 @@ func (dd *debugDoer) Fprint(w io.Writer) {
 		buf.WriteString(fmt.Sprintf("\n< %s: %s", k, strings.Join(dd.Response.Header[k], ", ")))
 	}
 
-	rb, _ := ioutil.ReadAll(dd.Response.Body) // this is reading from a memory buffer so safe to ignore errors
+	rb, _ := io.ReadAll(dd.Response.Body) // this is reading from a memory buffer so safe to ignore errors
 	if len(rb) > 0 {
-		dd.Response.Body = ioutil.NopCloser(bytes.NewBuffer(rb)) // reset the response body
+		dd.Response.Body = io.NopCloser(bytes.NewBuffer(rb)) // reset the response body
 		buf.WriteByte('\n')
 		buf.Write(rb)
 	}

--- a/http/codegen/openapi/v2/files_test.go
+++ b/http/codegen/openapi/v2/files_test.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"text/template"
@@ -76,12 +76,12 @@ func TestSections(t *testing.T) {
 
 					golden := filepath.Join(goldenPath, fmt.Sprintf("%s_%s.golden", c.Name, tname))
 					if *update {
-						if err := ioutil.WriteFile(golden, buf.Bytes(), 0644); err != nil {
+						if err := os.WriteFile(golden, buf.Bytes(), 0644); err != nil {
 							t.Fatalf("failed to update golden file: %s", err)
 						}
 					}
 
-					want, err := ioutil.ReadFile(golden)
+					want, err := os.ReadFile(golden)
 					want = bytes.Replace(want, []byte{'\r', '\n'}, []byte{'\n'}, -1)
 					if err != nil {
 						t.Fatalf("failed to read golden file: %s", err)
@@ -166,12 +166,12 @@ func TestValidations(t *testing.T) {
 
 					golden := filepath.Join(goldenPath, fmt.Sprintf("%s_%s.golden", c.Name, tname))
 					if *update {
-						if err := ioutil.WriteFile(golden, buf.Bytes(), 0644); err != nil {
+						if err := os.WriteFile(golden, buf.Bytes(), 0644); err != nil {
 							t.Fatalf("failed to update golden file: %s", err)
 						}
 					}
 
-					want, err := ioutil.ReadFile(golden)
+					want, err := os.ReadFile(golden)
 					want = bytes.Replace(want, []byte{'\r', '\n'}, []byte{'\n'}, -1)
 					if err != nil {
 						t.Fatalf("failed to read golden file: %s", err)
@@ -233,12 +233,12 @@ func TestExtensions(t *testing.T) {
 
 					golden := filepath.Join(goldenPath, fmt.Sprintf("%s_%s.golden", c.Name, tname))
 					if *update {
-						if err := ioutil.WriteFile(golden, buf.Bytes(), 0644); err != nil {
+						if err := os.WriteFile(golden, buf.Bytes(), 0644); err != nil {
 							t.Fatalf("failed to update golden file: %s", err)
 						}
 					}
 
-					want, err := ioutil.ReadFile(golden)
+					want, err := os.ReadFile(golden)
 					want = bytes.Replace(want, []byte{'\r', '\n'}, []byte{'\n'}, -1)
 					if err != nil {
 						t.Fatalf("failed to read golden file: %s", err)

--- a/http/codegen/openapi/v3/files_test.go
+++ b/http/codegen/openapi/v3/files_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -83,12 +83,12 @@ func TestFiles(t *testing.T) {
 
 					golden := filepath.Join(goldenPath, fmt.Sprintf("%s_%s.golden", strings.TrimSuffix(c.Name, "-swagger"), tname))
 					if *update {
-						if err := ioutil.WriteFile(golden, buf.Bytes(), 0644); err != nil {
+						if err := os.WriteFile(golden, buf.Bytes(), 0644); err != nil {
 							t.Fatalf("failed to update golden file: %s", err)
 						}
 					}
 
-					want, err := ioutil.ReadFile(golden)
+					want, err := os.ReadFile(golden)
 					want = bytes.Replace(want, []byte{'\r', '\n'}, []byte{'\n'}, -1)
 					if err != nil {
 						t.Fatalf("failed to read golden file: %s", err)

--- a/http/codegen/testdata/result_decode_functions.go
+++ b/http/codegen/testdata/result_decode_functions.go
@@ -746,8 +746,8 @@ var ValidateErrorResponseTypeDecodeCode = `// DecodeMethodAResponse returns a de
 // ValidateErrorResponseType MethodA endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
 // DecodeMethodAResponse may return the following errors:
-//	- "some_error" (type *validateerrorresponsetype.AError): http.StatusBadRequest
-//	- error: internal error
+//   - "some_error" (type *validateerrorresponsetype.AError): http.StatusBadRequest
+//   - error: internal error
 func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -831,9 +831,9 @@ var EmptyErrorResponseBodyDecodeCode = `// DecodeMethodEmptyErrorResponseBodyRes
 // endpoint. restoreBody controls whether the response body should be restored
 // after having been read.
 // DecodeMethodEmptyErrorResponseBodyResponse may return the following errors:
-//	- "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
-//	- "not_found" (type serviceemptyerrorresponsebody.NotFound): http.StatusNotFound
-//	- error: internal error
+//   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
+//   - "not_found" (type serviceemptyerrorresponsebody.NotFound): http.StatusNotFound
+//   - error: internal error
 func DecodeMethodEmptyErrorResponseBodyResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/http/encoding.go
+++ b/http/encoding.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"strings"
@@ -175,7 +174,7 @@ func RequestEncoder(r *http.Request) Encoder {
 		r.Header.Set(k, "application/json")
 	}
 	var buf bytes.Buffer
-	r.Body = ioutil.NopCloser(&buf)
+	r.Body = io.NopCloser(&buf)
 	return json.NewEncoder(&buf)
 }
 
@@ -294,7 +293,7 @@ type textDecoder struct {
 }
 
 func (e *textDecoder) Decode(v interface{}) error {
-	b, err := ioutil.ReadAll(e.r)
+	b, err := io.ReadAll(e.r)
 	if err != nil {
 		return err
 	}

--- a/http/middleware/debug.go
+++ b/http/middleware/debug.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"sort"
@@ -66,7 +65,7 @@ func Debug(mux goahttp.Muxer, w io.Writer) func(http.Handler) http.Handler {
 			}
 
 			// Request body
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			if err != nil {
 				b = []byte("failed to read body: " + err.Error())
 			}
@@ -77,7 +76,7 @@ func Debug(mux goahttp.Muxer, w io.Writer) func(http.Handler) http.Handler {
 					buf.WriteString(fmt.Sprintf("[%s] %s\n", reqID, line))
 				}
 			}
-			r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+			r.Body = io.NopCloser(bytes.NewBuffer(b))
 
 			dupper := &responseDupper{ResponseWriter: rw, Buffer: &bytes.Buffer{}}
 			h.ServeHTTP(dupper, r)


### PR DESCRIPTION
Upgrade to Go 1.19
Remove use of deprecated io/ioutil package

Fix #3113 