### PR TITLE
Omit setting grpc fields to zero defaults

### DIFF
--- a/grpc/codegen/client_types_test.go
+++ b/grpc/codegen/client_types_test.go
@@ -23,6 +23,7 @@ func TestClientTypeFiles(t *testing.T) {
 		{"with-errors", testdata.UnaryRPCWithErrorsDSL, testdata.WithErrorsClientTypeCode},
 		{"bidirectional-streaming-same-type", testdata.BidirectionalStreamingRPCSameTypeDSL, testdata.BidirectionalStreamingRPCSameTypeClientTypeCode},
 		{"struct-meta-type", testdata.StructMetaTypeDSL, testdata.StructMetaTypeTypeCode},
+		{"default-fields", testdata.DefaultFieldsDSL, testdata.DefaultFieldsTypeCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/grpc/codegen/proto_test.go
+++ b/grpc/codegen/proto_test.go
@@ -26,6 +26,7 @@ func TestProtoFiles(t *testing.T) {
 		{"method-with-acronym", testdata.MethodWithAcronymDSL, testdata.MethodWithAcronymProtoCode},
 		{"custom-package-name", testdata.ServiceWithPackageDSL, testdata.ServiceWithPackageCode},
 		{"struct-meta-type", testdata.StructMetaTypeDSL, testdata.StructMetaTypePackageCode},
+		{"default-fields", testdata.DefaultFieldsDSL, testdata.DefaultFieldsPackageCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/grpc/codegen/server_types_test.go
+++ b/grpc/codegen/server_types_test.go
@@ -24,6 +24,7 @@ func TestServerTypeFiles(t *testing.T) {
 		{"elem-validation", testdata.ElemValidationDSL, testdata.ElemValidationServerTypesFile},
 		{"alias-validation", testdata.AliasValidationDSL, testdata.AliasValidationServerTypesFile},
 		{"struct-meta-type", testdata.StructMetaTypeDSL, testdata.StructMetaTypeServerTypeCode},
+		{"default-fields", testdata.DefaultFieldsDSL, testdata.DefaultFieldsServerTypeCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/grpc/codegen/testdata/client_type_code.go
+++ b/grpc/codegen/testdata/client_type_code.go
@@ -357,11 +357,11 @@ func NewMethodResult(message *using_meta_typespb.MethodResponse) *usingmetatypes
 	}
 	var zeroMessageA int64
 	if message.A == zeroMessageA {
-		result.A = 0
+		result.A = 1
 	}
 	var zeroMessageB int64
 	if message.B == zeroMessageB {
-		result.B = 0
+		result.B = 2
 	}
 	if message.C != nil {
 		result.C = make([]time.Duration, len(message.C))
@@ -370,5 +370,33 @@ func NewMethodResult(message *using_meta_typespb.MethodResponse) *usingmetatypes
 		}
 	}
 	return result
+}
+`
+
+const DefaultFieldsTypeCode = `// NewProtoMethodRequest builds the gRPC request type from the payload of the
+// "Method" endpoint of the "DefaultFields" service.
+func NewProtoMethodRequest(payload *defaultfields.MethodPayload) *default_fieldspb.MethodRequest {
+	message := &default_fieldspb.MethodRequest{
+		Req:  payload.Req,
+		Def0: payload.Def0,
+		Def1: payload.Def1,
+		Def2: payload.Def2,
+		Reqs: payload.Reqs,
+		Defs: payload.Defs,
+		Defe: payload.Defe,
+		Rat:  payload.Rat,
+		Flt0: payload.Flt0,
+		Flt1: payload.Flt1,
+	}
+	if payload.Opt != nil {
+		message.Opt = *payload.Opt
+	}
+	if payload.Opts != nil {
+		message.Opts = *payload.Opts
+	}
+	if payload.Flt != nil {
+		message.Flt = *payload.Flt
+	}
+	return message
 }
 `

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -870,11 +870,11 @@ var StructMetaTypeDSL = func() {
 			Payload(func() {
 				Field(1, "a", Int64, func() {
 					Meta("struct:field:type", "flag.ErrorHandling", "flag")
-					Default(0)
+					Default(1)
 				})
 				Field(2, "b", Int64, func() {
 					Meta("struct:field:type", "flag.ErrorHandling", "flag")
-					Default(0)
+					Default(2)
 				})
 				Field(3, "c", ArrayOf(Int64), func() {
 					Elem(func() {
@@ -888,11 +888,11 @@ var StructMetaTypeDSL = func() {
 			Result(func() {
 				Field(1, "a", Int64, func() {
 					Meta("struct:field:type", "flag.ErrorHandling", "flag")
-					Default(0)
+					Default(1)
 				})
 				Field(2, "b", Int64, func() {
 					Meta("struct:field:type", "flag.ErrorHandling", "flag")
-					Default(0)
+					Default(2)
 				})
 				Field(3, "c", ArrayOf(Int64), func() {
 					Elem(func() {
@@ -902,6 +902,30 @@ var StructMetaTypeDSL = func() {
 				Field(4, "d", Int64, func() {
 					Meta("struct:field:type", "flag.ErrorHandling", "flag")
 				})
+			})
+			GRPC(func() {})
+		})
+	})
+}
+
+var DefaultFieldsDSL = func() {
+	Service("DefaultFields", func() {
+		Method("Method", func() {
+			Payload(func() {
+				Field(1, "req", Int64)
+				Field(2, "opt", Int64)
+				Field(3, "def0", Int64, func() { Default(0) })
+				Field(4, "def1", Int64, func() { Default(1) })
+				Field(5, "def2", Int64, func() { Default(2) })
+				Field(6, "reqs", String)
+				Field(7, "opts", String)
+				Field(8, "defs", String, func() { Default("!") })
+				Field(9, "defe", String, func() { Default("") })
+				Field(10, "rat", Float64)
+				Field(11, "flt", Float64)
+				Field(12, "flt0", Float64, func() { Default(0.0) })
+				Field(13, "flt1", Float64, func() { Default(1.0) })
+				Required("req", "reqs", "rat")
 			})
 			GRPC(func() {})
 		})

--- a/grpc/codegen/testdata/proto_code.go
+++ b/grpc/codegen/testdata/proto_code.go
@@ -471,3 +471,36 @@ message MethodResponse {
 	sint64 d = 4;
 }
 `
+
+const DefaultFieldsPackageCode = `
+syntax = "proto3";
+
+package default_fields;
+
+option go_package = "/default_fieldspb";
+
+// Service is the DefaultFields service interface.
+service DefaultFields {
+	// Method implements Method.
+	rpc Method (MethodRequest) returns (MethodResponse);
+}
+
+message MethodRequest {
+	sint64 req = 1;
+	sint64 opt = 2;
+	sint64 def0 = 3;
+	sint64 def1 = 4;
+	sint64 def2 = 5;
+	string reqs = 6;
+	string opts = 7;
+	string defs = 8;
+	string defe = 9;
+	double rat = 10;
+	double flt = 11;
+	double flt0 = 12;
+	double flt1 = 13;
+}
+
+message MethodResponse {
+}
+`

--- a/grpc/codegen/testdata/server_type_code.go
+++ b/grpc/codegen/testdata/server_type_code.go
@@ -419,11 +419,11 @@ func NewMethodPayload(message *using_meta_typespb.MethodRequest) *usingmetatypes
 	}
 	var zeroMessageA int64
 	if message.A == zeroMessageA {
-		v.A = 0
+		v.A = 1
 	}
 	var zeroMessageB int64
 	if message.B == zeroMessageB {
-		v.B = 0
+		v.B = 2
 	}
 	if message.C != nil {
 		v.C = make([]time.Duration, len(message.C))
@@ -450,6 +450,53 @@ func NewProtoMethodResponse(result *usingmetatypes.MethodResult) *using_meta_typ
 			message.C[i] = int64(val)
 		}
 	}
+	return message
+}
+`
+
+const DefaultFieldsServerTypeCode = `// NewMethodPayload builds the payload of the "Method" endpoint of the
+// "DefaultFields" service from the gRPC request type.
+func NewMethodPayload(message *default_fieldspb.MethodRequest) *defaultfields.MethodPayload {
+	v := &defaultfields.MethodPayload{
+		Req:  message.Req,
+		Def0: message.Def0,
+		Def1: message.Def1,
+		Def2: message.Def2,
+		Reqs: message.Reqs,
+		Defs: message.Defs,
+		Defe: message.Defe,
+		Rat:  message.Rat,
+		Flt0: message.Flt0,
+		Flt1: message.Flt1,
+	}
+	if message.Opt != 0 {
+		v.Opt = &message.Opt
+	}
+	if message.Opts != "" {
+		v.Opts = &message.Opts
+	}
+	if message.Flt != 0 {
+		v.Flt = &message.Flt
+	}
+	if message.Def1 == 0 {
+		v.Def1 = 1
+	}
+	if message.Def2 == 0 {
+		v.Def2 = 2
+	}
+	if message.Defs == "" {
+		v.Defs = "!"
+	}
+	if message.Flt1 == 0 {
+		v.Flt1 = 1
+	}
+	return v
+}
+
+// NewProtoMethodResponse builds the gRPC response type from the result of the
+// "Method" endpoint of the "DefaultFields" service.
+func NewProtoMethodResponse() *default_fieldspb.MethodResponse {
+	message := &default_fieldspb.MethodResponse{}
 	return message
 }
 `


### PR DESCRIPTION
The expected behavior for zero-valued defaults bothered me; it needlessly compared the proto message fields against zeros only to set the goa fields to zeros. This PR explicitly tests a variety of built-in types and avoids the compare and set.

It's possible the isNonZero would be better written with reflect, to reduce its code. Or moved to, say, expr.AttributeType, so that we could instead write something like this in protobuf_transform:

```diff
- if tdef := tgtc.DefaultValue; tdef != nil && ta.TargetCtx.UseDefault && isNonZero(tdef) {
+ if tgtc.HasNonzeroDefault() && ta.TargetCtx.UseDefault {
+ 	tdef := tgtc.DefaultValue
```