### PR TITLE
Add `operationId` templating

### DIFF
--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -194,9 +194,7 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 
 	// OpenAPI summary
 	var summary string
-	var operationIDFormat string
-
-	setTemplates := func(meta expr.MetaExpr) {
+	setSummary := func(meta expr.MetaExpr) {
 		for n, mdata := range meta {
 			if (n == "openapi:summary" || n == "swagger:summary") && len(mdata) > 0 {
 				if mdata[0] == "{path}" {
@@ -205,7 +203,20 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 					summary = mdata[0]
 				}
 			}
+		}
+	}
 
+	{
+		summary = fmt.Sprintf("%s %s", e.Name(), svc.Name())
+		setSummary(expr.Root.API.Meta)
+		setSummary(r.Endpoint.Meta)
+		setSummary(m.Meta)
+	}
+
+	// OpenAPI operationIdn
+	var operationIDFormat string
+	setOperationID := func(meta expr.MetaExpr) {
+		for n, mdata := range meta {
 			if (n == "openapi:operationId") && len(mdata) > 0 {
 				operationIDFormat = mdata[0]
 			}
@@ -213,11 +224,11 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 	}
 
 	{
-		summary = fmt.Sprintf("%s %s", e.Name(), svc.Name())
 		operationIDFormat = defaultOperationIDFormat
-		setTemplates(expr.Root.API.Meta)
-		setTemplates(r.Endpoint.Meta)
-		setTemplates(m.Meta)
+		setOperationID(expr.Root.API.Meta)
+		setOperationID(m.Service.Meta)
+		setOperationID(r.Endpoint.Meta)
+		setOperationID(m.Meta)
 	}
 
 	// request body

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -215,7 +215,7 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 
 	// OpenAPI operationId
 	var operationIDFormat string
-	setOperationID := func(meta expr.MetaExpr) {
+	setOperationIDFormat := func(meta expr.MetaExpr) {
 		for n, mdata := range meta {
 			if (n == "openapi:operationId") && len(mdata) > 0 {
 				operationIDFormat = mdata[0]
@@ -225,10 +225,10 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 
 	{
 		operationIDFormat = defaultOperationIDFormat
-		setOperationID(expr.Root.API.Meta)
-		setOperationID(m.Service.Meta)
-		setOperationID(r.Endpoint.Meta)
-		setOperationID(m.Meta)
+		setOperationIDFormat(expr.Root.API.Meta)
+		setOperationIDFormat(m.Service.Meta)
+		setOperationIDFormat(r.Endpoint.Meta)
+		setOperationIDFormat(m.Meta)
 	}
 
 	// request body

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -438,19 +438,19 @@ func parseOperationIDTemplate(template, service, method string, routeIndex int) 
 		"{method}", method,
 	)
 
-	operationId := repl.Replace(template)
+	operationID := repl.Replace(template)
 
 	if routeIndex == 0 {
-		return routeIndexReplacementRegExp.ReplaceAllString(operationId, "")
+		return routeIndexReplacementRegExp.ReplaceAllString(operationID, "")
 	}
 
 	// If the routeIndex is greater than 0, we need to add the routeIndex to the operationId.
 	if sep := routeIndexReplacementRegExp.FindStringSubmatch(template); sep != nil {
-		return routeIndexReplacementRegExp.ReplaceAllString(operationId, fmt.Sprintf("%s%d", sep[1], routeIndex))
+		return routeIndexReplacementRegExp.ReplaceAllString(operationID, fmt.Sprintf("%s%d", sep[1], routeIndex))
 	}
 
 	// Fallback in the event that the operationId doesn't contain the routeIndex placeholder.
-	return fmt.Sprintf("%s#%d", operationId, routeIndex)
+	return fmt.Sprintf("%s#%d", operationID, routeIndex)
 }
 
 // buildServers builds the OpenAPI Server objects from the given server

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -213,7 +213,7 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 		setSummary(m.Meta)
 	}
 
-	// OpenAPI operationIdn
+	// OpenAPI operationId
 	var operationIDFormat string
 	setOperationID := func(meta expr.MetaExpr) {
 		for n, mdata := range meta {

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -416,6 +416,11 @@ func buildFileServerOperation(key string, fs *expr.HTTPFileServerExpr, api *expr
 }
 
 func parseOperationIDTemplate(template, service, method string, routeIndex int) string {
+	// Early return if no replacement is needed for the template.
+	if !strings.Contains(template, "{") && routeIndex == 0 {
+		return template
+	}
+
 	// The template replacer
 	repl := strings.NewReplacer(
 		"{service}", service,

--- a/http/codegen/openapi/v3/builder_test.go
+++ b/http/codegen/openapi/v3/builder_test.go
@@ -159,6 +159,11 @@ func TestBuildOperation(t *testing.T) {
 		DSL:  dsls.ResponseRecursiveUserType(svcName, "response_recursive_user_type"),
 
 		ExpectedResponses: responses{"200": {"OK response.", tobj("recursive", tobj()), nil}},
+	}, {
+		Name: "response_recursive_array_user_type",
+		DSL:  dsls.ResponseRecursiveArrayUserType(svcName, "response_recursive_array_user_type"),
+
+		ExpectedResponses: responses{"200": {"OK response.", tobj("result", tobj("children", tarray)), nil}},
 	}}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/openapi/v3/builder_test.go
+++ b/http/codegen/openapi/v3/builder_test.go
@@ -260,6 +260,14 @@ func TestBuildOperationID(t *testing.T) {
 			DSL:                  dsls.OperationIDMultipleRoutes(svcName, "multiple_routes_custom_separator_without_routeIndex", "{service}.{method}"),
 			ExpectedOperationIDs: []string{"test service.multiple_routes_custom_separator_without_routeIndex", "test service.multiple_routes_custom_separator_without_routeIndex#1"},
 		}, {
+			Name:                 "multiple_routes_no_routeIndex_separator",
+			DSL:                  dsls.OperationIDMultipleRoutes(svcName, "multiple_routes_no_routeIndex_separator", "{service}.{method}({routeIndex})"),
+			ExpectedOperationIDs: []string{"test service.multiple_routes_no_routeIndex_separator", "test service.multiple_routes_no_routeIndex_separator1"},
+		}, {
+			Name:                 "multiple_routes_long_separator",
+			DSL:                  dsls.OperationIDMultipleRoutes(svcName, "multiple_routes_long_separator", "{service}.{method}(someWordsHere and maybe some spaces{routeIndex})"),
+			ExpectedOperationIDs: []string{"test service.multiple_routes_long_separator", "test service.multiple_routes_long_separatorsomeWordsHere and maybe some spaces1"},
+		}, {
 			Name:                 "custom_static_operation_id",
 			DSL:                  dsls.OperationIDMethod(svcName, "custom_static_operation_id", "listThings"),
 			ExpectedOperationIDs: []string{"listThings"},

--- a/http/codegen/openapi/v3/builder_test.go
+++ b/http/codegen/openapi/v3/builder_test.go
@@ -237,12 +237,12 @@ func TestBuildOperationID(t *testing.T) {
 	}{
 		{
 			Name:                 "template_in_method",
-			DSL:                  dsls.OperationIDMethod(svcName, "template_in_method", defaultOperationIDFormat),
-			ExpectedOperationIDs: []string{"test service#template_in_method"},
+			DSL:                  dsls.OperationIDMethod(svcName, "template_in_method", "{method}"),
+			ExpectedOperationIDs: []string{"template_in_method"},
 		}, {
 			Name:                 "template_in_service",
-			DSL:                  dsls.OperationIDService(svcName, "template_in_service", defaultOperationIDFormat),
-			ExpectedOperationIDs: []string{"test service#template_in_service"},
+			DSL:                  dsls.OperationIDService(svcName, "template_in_service", "{service}"),
+			ExpectedOperationIDs: []string{"test service"},
 		}, {
 			Name:                 "template_in_api",
 			DSL:                  dsls.OperationIDAPI(svcName, "template_in_api", defaultOperationIDFormat),

--- a/http/codegen/openapi/v3/testdata/dsls/operations.go
+++ b/http/codegen/openapi/v3/testdata/dsls/operations.go
@@ -158,3 +158,76 @@ var ResponseRecursiveArrayUserType = func(svc, met string) func() {
 		})
 	}
 }
+
+var OperationIDStatic = func(svc, met string) func() {
+	return func() {
+		var _ = Service(svc, func() {
+			Method(met, func() {
+				Meta("openapi:operationId", "staticOperationId")
+
+				HTTP(func() {
+					GET("/")
+				})
+			})
+		})
+	}
+}
+
+var OperationIDMethod = func(svc, met, tmpl string) func() {
+	return func() {
+		var _ = Service(svc, func() {
+			Method(met, func() {
+				Meta("openapi:operationId", tmpl)
+
+				HTTP(func() {
+					GET("/")
+				})
+			})
+		})
+	}
+}
+
+var OperationIDService = func(svc, met, tmpl string) func() {
+	return func() {
+		var _ = Service(svc, func() {
+			Meta("openapi:operationId", tmpl)
+
+			Method(met, func() {
+				HTTP(func() {
+					GET("/")
+				})
+			})
+		})
+	}
+}
+
+var OperationIDAPI = func(svc, met, tmpl string) func() {
+	return func() {
+		var _ = API("test api", func() {
+			Meta("openapi:operationId", tmpl)
+		})
+
+		var _ = Service(svc, func() {
+			Method(met, func() {
+				HTTP(func() {
+					GET("/")
+				})
+			})
+		})
+	}
+}
+
+var OperationIDMultipleRoutes = func(svc, met, tmpl string) func() {
+	return func() {
+		var _ = Service(svc, func() {
+			Method(met, func() {
+				Meta("openapi:operationId", tmpl)
+
+				HTTP(func() {
+					GET("/")
+					POST("/another")
+				})
+			})
+		})
+	}
+}


### PR DESCRIPTION
This PR adds template support for the `operationId` generated from the Goa DSL.

## Usage

The `operationId` may be modified at three levels, the `API()`, `Service()`, or `Method()`. The closest template to the operation will be used. For example, a custom template in `API()` will be used globally except in cases where an operation's `Service()` or `Method()` defines a template.

To specify a template in any of the supported blocks, use `Meta`.

```go
// This is the default template
Meta("openapi:operationId", "{service}#{method}(#{routeIndex})")
```

## Variables

The following replacement variables are available:

### `{service}`

This variable is replaced with the name of the Service that the operation belongs to.

### `{method}`

This variable is replaced with the name of the Method documented by the operation.

### `(#{routeIndex})`

This variable looks a bit gnarly but can be broken down into two distinct parts:

The `{routeIndex}` component is replaced with the index of the route in cases where more than one path matches the same method.

The outer component, `(# )`, indicates that the `{routeIndex}` should only be replaced with the actual *index* if its greater than 0. The `#` character, which is the default, may be replaced with any content that you wish to render as a spacer between preceding tokens and the `{routeIndex}` replacement.

The following are all valid:

- `(#{routeIndex})` - The default behavior (eg. `#1`, `#2`, etc)
- `(.{routeIndex})` - Places a `.` before the index
- `(someWords{routeIndex})` - Places `someWords` before the index
- `({routeIndex})` - No separating content between preceding tokens and the index.
- `(spaces are also supported{routeIndex})` - Places `spaces are also supported` before the index.

**Important note!** If the `routeIndex` variable is not provided and multiple paths are defined on a single operation, the template will act as if `(#{routeIndex})` were appended to the end of the `operationId` template.

## Static Content

In addition the the above replacement variables, you may also specify static content which will be rendered literally if no replacement variables are found. For example, the following would be acceptable:

```go
// operationId will be: listPosts
Meta("openapi:operationId", "listPosts")
```
