### PR TITLE
Replace any with interface{} - supporting older go installs

### DIFF
--- a/grpc/codegen/protobuf_transform.go
+++ b/grpc/codegen/protobuf_transform.go
@@ -369,7 +369,7 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 	return buffer.String(), nil
 }
 
-func isNonZero(v any) bool {
+func isNonZero(v interface{}) bool {
 	switch v := v.(type) {
 	case nil:
 		return false


### PR DESCRIPTION
Switching to interface{} to allow for older Go installs to still work.