### PR TITLE
Generate OpenAPI spec for forced result types

### DIFF
--- a/http/codegen/openapi/v3/testdata/dsls/types.go
+++ b/http/codegen/openapi/v3/testdata/dsls/types.go
@@ -166,3 +166,21 @@ func ForcedTypeDSL(svcName, metName string) func() {
 		})
 	}
 }
+
+func ForcedResultTypeDSL(svcName, metName string) func() {
+	return func() {
+		var _ = ResultType("Forced", func() {
+			Attributes(func() {
+				Attribute("foo")
+			})
+			Meta("type:generate:force")
+		})
+		var _ = Service(svcName, func() {
+			Method(metName, func() {
+				HTTP(func() {
+					POST("/")
+				})
+			})
+		})
+	}
+}

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -137,6 +137,13 @@ func buildBodyTypes(api *expr.APIExpr) (map[string]map[string]*EndpointBodies, m
 		}
 		sf.schemafy(&expr.AttributeExpr{Type: t})
 	}
+	for _, t := range expr.Root.ResultTypes {
+		_, ok := t.Attribute().Meta["type:generate:force"]
+		if !ok {
+			continue
+		}
+		sf.schemafy(&expr.AttributeExpr{Type: t})
+	}
 	return bodies, sf.schemas
 }
 

--- a/http/codegen/openapi/v3/types_test.go
+++ b/http/codegen/openapi/v3/types_test.go
@@ -150,6 +150,13 @@ func TestBuildBodyTypes(t *testing.T) {
 		ExpectedType:          tempty,
 		ExpectedResponseTypes: rt{204: tempty},
 		ExpectedExtraTypes:    map[string]typ{"Forced": tobj("foo", tstring)},
+	}, {
+		Name: "forced_result_type",
+		DSL:  dsls.ForcedResultTypeDSL(svcName, "forced_result_type"),
+
+		ExpectedType:          tempty,
+		ExpectedResponseTypes: rt{204: tempty},
+		ExpectedExtraTypes:    map[string]typ{"Forced": tobj("foo", tstring)},
 	}}
 
 	for _, c := range cases {


### PR DESCRIPTION
Similar to https://github.com/goadesign/goa/pull/3142 but focused on forced result types.

Relates to #3129.