### PR TITLE
Closes #3105 - Add GoaErrorName and deprecate ErrorName

### DIFF
--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -390,7 +390,14 @@ func (e {{ .Ref }}) Error() string {
 }
 
 // ErrorName returns {{ printf "%q" .Name }}.
+//
+// Deprecated: Use GoaErrorName - https://github.com/goadesign/goa/issues/3105
 func (e {{ .Ref }}) ErrorName() string {
+	return e.GoaErrorName()
+}
+
+// GoaErrorName returns {{ printf "%q" .Name }}.
+func (e {{ .Ref }}) GoaErrorName() string {
 	return {{ errorName . }}
 }
 `

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -407,7 +407,14 @@ func (e *APayload) Error() string {
 }
 
 // ErrorName returns "APayload".
+//
+// Deprecated: Use GoaErrorName - https://github.com/goadesign/goa/issues/3105
 func (e *APayload) ErrorName() string {
+	return e.GoaErrorName()
+}
+
+// GoaErrorName returns "APayload".
+func (e *APayload) GoaErrorName() string {
 	return "user_type"
 }
 
@@ -417,7 +424,14 @@ func (e *Result) Error() string {
 }
 
 // ErrorName returns "Result".
+//
+// Deprecated: Use GoaErrorName - https://github.com/goadesign/goa/issues/3105
 func (e *Result) ErrorName() string {
+	return e.GoaErrorName()
+}
+
+// GoaErrorName returns "Result".
+func (e *Result) GoaErrorName() string {
 	return e.B
 }
 
@@ -427,7 +441,14 @@ func (e Primitive) Error() string {
 }
 
 // ErrorName returns "primitive".
+//
+// Deprecated: Use GoaErrorName - https://github.com/goadesign/goa/issues/3105
 func (e Primitive) ErrorName() string {
+	return e.GoaErrorName()
+}
+
+// GoaErrorName returns "primitive".
+func (e Primitive) GoaErrorName() string {
 	return "primitive"
 }
 `
@@ -459,7 +480,14 @@ func (e *GoaError) Error() string {
 }
 
 // ErrorName returns "GoaError".
+//
+// Deprecated: Use GoaErrorName - https://github.com/goadesign/goa/issues/3105
 func (e *GoaError) ErrorName() string {
+	return e.GoaErrorName()
+}
+
+// GoaErrorName returns "GoaError".
+func (e *GoaError) GoaErrorName() string {
 	return e.ErrorCode
 }
 `

--- a/grpc/codegen/testdata/server_interface_code.go
+++ b/grpc/codegen/testdata/server_interface_code.go
@@ -58,9 +58,13 @@ func (s *Server) MethodUnaryRPCWithErrors(ctx context.Context, message *service_
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceUnaryRPCWithErrors")
 	resp, err := s.MethodUnaryRPCWithErrorsH.Handle(ctx, message)
 	if err != nil {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if errors.As(err, &en) {
-			switch en.ErrorName() {
+			switch en.GoaErrorName() {
 			case "timeout":
 				return nil, goagrpc.NewStatusError(codes.Canceled, err, goagrpc.NewErrorResponse(err))
 			case "internal":
@@ -92,9 +96,13 @@ func (s *Server) MethodUnaryRPCWithOverridingErrors(ctx context.Context, message
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceUnaryRPCWithOverridingErrors")
 	resp, err := s.MethodUnaryRPCWithOverridingErrorsH.Handle(ctx, message)
 	if err != nil {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if errors.As(err, &en) {
-			switch en.ErrorName() {
+			switch en.GoaErrorName() {
 			case "overridden":
 				return nil, goagrpc.NewStatusError(codes.Unknown, err, goagrpc.NewErrorResponse(err))
 			case "internal":
@@ -231,9 +239,13 @@ func (s *Server) MethodBidirectionalStreamingRPCWithErrors(stream service_bidire
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceBidirectionalStreamingRPCWithErrors")
 	_, err := s.MethodBidirectionalStreamingRPCWithErrorsH.Decode(ctx, nil)
 	if err != nil {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if errors.As(err, &en) {
-			switch en.ErrorName() {
+			switch en.GoaErrorName() {
 			case "timeout":
 				return goagrpc.NewStatusError(codes.Canceled, err, goagrpc.NewErrorResponse(err))
 			case "internal":
@@ -249,9 +261,13 @@ func (s *Server) MethodBidirectionalStreamingRPCWithErrors(stream service_bidire
 	}
 	err = s.MethodBidirectionalStreamingRPCWithErrorsH.Handle(ctx, ep)
 	if err != nil {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if errors.As(err, &en) {
-			switch en.ErrorName() {
+			switch en.GoaErrorName() {
 			case "timeout":
 				return goagrpc.NewStatusError(codes.Canceled, err, goagrpc.NewErrorResponse(err))
 			case "internal":

--- a/http/codegen/testdata/error_encoder_code.go
+++ b/http/codegen/testdata/error_encoder_code.go
@@ -6,17 +6,21 @@ var PrimitiveErrorResponseEncoderCode = `// EncodeMethodPrimitiveErrorResponseEr
 func EncodeMethodPrimitiveErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "bad_request":
 			var res serviceprimitiveerrorresponse.BadRequest
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
 			body := res
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
 		case "internal_error":
@@ -24,7 +28,7 @@ func EncodeMethodPrimitiveErrorResponseError(encoder func(context.Context, http.
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
 			body := res
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		default:
@@ -40,11 +44,15 @@ var PrimitiveErrorInResponseHeaderEncoderCode = `// EncodeMethodPrimitiveErrorIn
 func EncodeMethodPrimitiveErrorInResponseHeaderError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "bad_request":
 			var res serviceprimitiveerrorinresponseheader.BadRequest
 			errors.As(v, &res)
@@ -53,7 +61,7 @@ func EncodeMethodPrimitiveErrorInResponseHeaderError(encoder func(context.Contex
 				string_s := val
 				w.Header().Set("String", string_s)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return nil
 		case "internal_error":
@@ -64,7 +72,7 @@ func EncodeMethodPrimitiveErrorInResponseHeaderError(encoder func(context.Contex
 				int_s := strconv.Itoa(val)
 				w.Header().Set("Int", int_s)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusInternalServerError)
 			return nil
 		default:
@@ -80,11 +88,15 @@ var APIPrimitiveErrorResponseEncoderCode = `// EncodeMethodAPIPrimitiveErrorResp
 func EncodeMethodAPIPrimitiveErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "internal_error":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -95,7 +107,7 @@ func EncodeMethodAPIPrimitiveErrorResponseError(encoder func(context.Context, ht
 			} else {
 				body = NewMethodAPIPrimitiveErrorResponseInternalErrorResponseBody(res)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "bad_request":
@@ -103,7 +115,7 @@ func EncodeMethodAPIPrimitiveErrorResponseError(encoder func(context.Context, ht
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
 			body := res
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
 		default:
@@ -118,11 +130,15 @@ var DefaultErrorResponseEncoderCode = `// EncodeMethodDefaultErrorResponseError 
 func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "bad_request":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -133,7 +149,7 @@ func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.Re
 			} else {
 				body = NewMethodDefaultErrorResponseBadRequestResponseBody(res)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
 		default:
@@ -148,11 +164,15 @@ var DefaultErrorResponseWithContentTypeEncoderCode = `// EncodeMethodDefaultErro
 func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "bad_request":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -164,7 +184,7 @@ func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.Re
 			} else {
 				body = NewMethodDefaultErrorResponseBadRequestResponseBody(res)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
 		default:
@@ -179,11 +199,15 @@ var ServiceErrorResponseEncoderCode = `// EncodeMethodServiceErrorResponseError 
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "internal_error":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -194,7 +218,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			} else {
 				body = NewMethodServiceErrorResponseInternalErrorResponseBody(res)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "bad_request":
@@ -207,7 +231,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			} else {
 				body = NewMethodServiceErrorResponseBadRequestResponseBody(res)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
 		default:
@@ -222,11 +246,15 @@ var ServiceErrorResponseWithContentTypeEncoderCode = `// EncodeMethodServiceErro
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "internal_error":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -237,7 +265,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			} else {
 				body = NewMethodServiceErrorResponseInternalErrorResponseBody(res)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusInternalServerError)
 			return enc.Encode(body)
 		case "bad_request":
@@ -251,7 +279,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			} else {
 				body = NewMethodServiceErrorResponseBadRequestResponseBody(res)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return enc.Encode(body)
 		default:
@@ -266,18 +294,22 @@ var NoBodyErrorResponseEncoderCode = `// EncodeMethodServiceErrorResponseError r
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "bad_request":
 			var res *servicenobodyerrorresponse.StringError
 			errors.As(v, &res)
 			if res.Header != nil {
 				w.Header().Set("Header", *res.Header)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return nil
 		default:
@@ -292,11 +324,15 @@ var NoBodyErrorResponseWithContentTypeEncoderCode = `// EncodeMethodServiceError
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "bad_request":
 			var res *servicenobodyerrorresponse.StringError
 			errors.As(v, &res)
@@ -304,7 +340,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			if res.Header != nil {
 				w.Header().Set("Header", *res.Header)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusBadRequest)
 			return nil
 		default:
@@ -320,11 +356,15 @@ var EmptyErrorResponseBodyEncoderCode = `// EncodeMethodEmptyErrorResponseBodyEr
 func EncodeMethodEmptyErrorResponseBodyError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "internal_error":
 			var res *goa.ServiceError
 			errors.As(v, &res)
@@ -346,7 +386,7 @@ func EncodeMethodEmptyErrorResponseBodyError(encoder func(context.Context, http.
 				faults := strconv.FormatBool(val)
 				w.Header().Set("Goa-Attribute-Fault", faults)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusInternalServerError)
 			return nil
 		case "not_found":
@@ -357,7 +397,7 @@ func EncodeMethodEmptyErrorResponseBodyError(encoder func(context.Context, http.
 				inHeaders := val
 				w.Header().Set("In-Header", inHeaders)
 			}
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusNotFound)
 			return nil
 		default:
@@ -373,15 +413,19 @@ var EmptyCustomErrorResponseBodyEncoderCode = `// EncodeMethodEmptyCustomErrorRe
 func EncodeMethodEmptyCustomErrorResponseBodyError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var en ErrorNamer
+		var deprecatedErrorNamer ErrorNamer
+		if errors.As(v, &deprecatedErrorNamer) {
+			v = adaptErrorNamer(deprecatedErrorNamer)
+		}
+		var en GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
 		}
-		switch en.ErrorName() {
+		switch en.GoaErrorName() {
 		case "internal_error":
 			var res *serviceemptycustomerrorresponsebody.Error
 			errors.As(v, &res)
-			w.Header().Set("goa-error", res.ErrorName())
+			w.Header().Set("goa-error", res.GoaErrorName())
 			w.WriteHeader(http.StatusInternalServerError)
 			return nil
 		default:

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -245,7 +245,12 @@ func (e ServiceError) History() []ServiceError {
 func (e *ServiceError) Error() string { return e.Message }
 
 // ErrorName returns the error name.
+//
+// Deprecated: Use GoaErrorName - https://github.com/goadesign/goa/issues/3105
 func (e *ServiceError) ErrorName() string { return e.Name }
+
+// GoaErrorName returns the error name.
+func (e *ServiceError) GoaErrorName() string { return e.ErrorName() }
 
 func (e *ServiceError) Unwrap() error { return e.err }
 


### PR DESCRIPTION
Implemented what we discussed in #3105

1. Add `GoaErrorName` methods and `GoaErrorNamer` interface alongside `ErrorName` and `ErrorNamer`.
2. Deprecate `ErrorName` and `ErrorNamer`.
3. Add adapters to support both `ErrorNamer` and `GoaErrorNamer`.