### PR TITLE
Implement Unwrap interface to AdaptErrorNamer

### DIFF
--- a/pkg/error.go
+++ b/pkg/error.go
@@ -272,6 +272,7 @@ func (e *ServiceError) ErrorName() string { return e.Name }
 // GoaErrorName returns the error name.
 func (e *ServiceError) GoaErrorName() string { return e.ErrorName() }
 
+// Unwrap implements Wrapper interface.
 func (e *ServiceError) Unwrap() error { return e.err }
 
 // GoaErrorName returns the error name as defined in the design.
@@ -282,6 +283,11 @@ func (err AdaptErrorNamer) GoaErrorName() string {
 // Error is the error message.
 func (err AdaptErrorNamer) Error() string {
 	return err.ErrorNamer.(error).Error()
+}
+
+// Unwrap implements Wrapper interface.
+func (err AdaptErrorNamer) Unwrap() error {
+	return err.ErrorNamer.(error)
 }
 
 func withField(field string, err *ServiceError) *ServiceError {


### PR DESCRIPTION
**This is a fix to HEAD, not v3.9.0.** (v3.9.0 has same problem)

AdptErrorNamer wraps goa.ServiceError but does not implement the Unwrap interface. Therefore, errors cannot be retrieved with errors.As() and panic occurs in formatter.


### Example generated code:
```
func EncodeDivError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
	encodeError := goahttp.ErrorEncoder(encoder, formatter)
	return func(ctx context.Context, w http.ResponseWriter, v error) error {
		var deprecated goa.ErrorNamer
		if errors.As(v, &deprecated) {
			v = goa.AdaptErrorNamer{deprecated} //★ ←  wrap *goa.ServiceError
		}
		var en goa.GoaErrorNamer
		if !errors.As(v, &en) {
			return encodeError(ctx, w, v)
		}
		switch en.GoaErrorName() {
		case "zero_division":
			var res *goa.ServiceError
			errors.As(v, &res) //★ ← cannot unwrap *goa.ServiceError from AdaptError
			enc := encoder(ctx, w)
			var body interface{}
			if formatter != nil {
				body = formatter(ctx, res)
			} else {
				body = NewDivZeroDivisionResponseBody(res)
			}
			w.Header().Set("goa-error", res.GoaErrorName())
			w.WriteHeader(http.StatusBadRequest)
			return enc.Encode(body)
		default:
			return encodeError(ctx, w, v)
		}
	}
}
```