### PR TITLE
Remove error namer adapter

### DIFF
--- a/grpc/codegen/server.go
+++ b/grpc/codegen/server.go
@@ -260,10 +260,6 @@ func (s *{{ .ServerStruct }}) {{ .Method.VarName }}(
 {{- define "handle_error" }}
 	if err != nil {
 	{{- if .Errors }}
-		var deprecated goa.ErrorNamer
-		if errors.As(err, &deprecated) {
-			err = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if errors.As(err, &en) {
 			switch en.GoaErrorName() {

--- a/grpc/codegen/testdata/server_interface_code.go
+++ b/grpc/codegen/testdata/server_interface_code.go
@@ -58,10 +58,6 @@ func (s *Server) MethodUnaryRPCWithErrors(ctx context.Context, message *service_
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceUnaryRPCWithErrors")
 	resp, err := s.MethodUnaryRPCWithErrorsH.Handle(ctx, message)
 	if err != nil {
-		var deprecated goa.ErrorNamer
-		if errors.As(err, &deprecated) {
-			err = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if errors.As(err, &en) {
 			switch en.GoaErrorName() {
@@ -96,10 +92,6 @@ func (s *Server) MethodUnaryRPCWithOverridingErrors(ctx context.Context, message
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceUnaryRPCWithOverridingErrors")
 	resp, err := s.MethodUnaryRPCWithOverridingErrorsH.Handle(ctx, message)
 	if err != nil {
-		var deprecated goa.ErrorNamer
-		if errors.As(err, &deprecated) {
-			err = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if errors.As(err, &en) {
 			switch en.GoaErrorName() {
@@ -239,10 +231,6 @@ func (s *Server) MethodBidirectionalStreamingRPCWithErrors(stream service_bidire
 	ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceBidirectionalStreamingRPCWithErrors")
 	_, err := s.MethodBidirectionalStreamingRPCWithErrorsH.Decode(ctx, nil)
 	if err != nil {
-		var deprecated goa.ErrorNamer
-		if errors.As(err, &deprecated) {
-			err = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if errors.As(err, &en) {
 			switch en.GoaErrorName() {
@@ -261,10 +249,6 @@ func (s *Server) MethodBidirectionalStreamingRPCWithErrors(stream service_bidire
 	}
 	err = s.MethodBidirectionalStreamingRPCWithErrorsH.Handle(ctx, ep)
 	if err != nil {
-		var deprecated goa.ErrorNamer
-		if errors.As(err, &deprecated) {
-			err = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if errors.As(err, &en) {
 			switch en.GoaErrorName() {

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1203,10 +1203,6 @@ const errorEncoderT = `{{ printf "%s returns an encoder for errors returned by t
 func {{ .ErrorEncoder }}(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)

--- a/http/codegen/testdata/error_encoder_code.go
+++ b/http/codegen/testdata/error_encoder_code.go
@@ -6,10 +6,6 @@ var PrimitiveErrorResponseEncoderCode = `// EncodeMethodPrimitiveErrorResponseEr
 func EncodeMethodPrimitiveErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -44,10 +40,6 @@ var PrimitiveErrorInResponseHeaderEncoderCode = `// EncodeMethodPrimitiveErrorIn
 func EncodeMethodPrimitiveErrorInResponseHeaderError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -88,10 +80,6 @@ var APIPrimitiveErrorResponseEncoderCode = `// EncodeMethodAPIPrimitiveErrorResp
 func EncodeMethodAPIPrimitiveErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -130,10 +118,6 @@ var DefaultErrorResponseEncoderCode = `// EncodeMethodDefaultErrorResponseError 
 func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -164,10 +148,6 @@ var DefaultErrorResponseWithContentTypeEncoderCode = `// EncodeMethodDefaultErro
 func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -199,10 +179,6 @@ var ServiceErrorResponseEncoderCode = `// EncodeMethodServiceErrorResponseError 
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -246,10 +222,6 @@ var ServiceErrorResponseWithContentTypeEncoderCode = `// EncodeMethodServiceErro
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -294,10 +266,6 @@ var NoBodyErrorResponseEncoderCode = `// EncodeMethodServiceErrorResponseError r
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -324,10 +292,6 @@ var NoBodyErrorResponseWithContentTypeEncoderCode = `// EncodeMethodServiceError
 func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -356,10 +320,6 @@ var EmptyErrorResponseBodyEncoderCode = `// EncodeMethodEmptyErrorResponseBodyEr
 func EncodeMethodEmptyErrorResponseBodyError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)
@@ -413,10 +373,6 @@ var EmptyCustomErrorResponseBodyEncoderCode = `// EncodeMethodEmptyCustomErrorRe
 func EncodeMethodEmptyCustomErrorResponseBodyError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder, formatter func(ctx context.Context, err error) goahttp.Statuser) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder, formatter)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		var deprecated goa.ErrorNamer
-		if errors.As(v, &deprecated) {
-			v = goa.AdaptErrorNamer{deprecated}
-		}
 		var en goa.GoaErrorNamer
 		if !errors.As(v, &en) {
 			return encodeError(ctx, w, v)

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -35,24 +35,10 @@ type (
 		err error
 	}
 
-	// ErrorNamer is an interface implemented by generated error structs that
-	// exposes the name of the error as defined in the expr.
-	//
-	// Deprecated: Use GoaErrorName - https://github.com/goadesign/goa/issues/3105
-	ErrorNamer interface {
-		ErrorName() string
-	}
-
 	// GoaErrorNamer is an interface implemented by generated error structs that
 	// exposes the name of the error as defined in the design.
 	GoaErrorNamer interface {
 		GoaErrorName() string
-	}
-
-	// AdaptErrorNamer makes deprecated ErrorNamer interface compatible with
-	// GoaErrorNamer.
-	AdaptErrorNamer struct {
-		ErrorNamer
 	}
 )
 
@@ -273,16 +259,6 @@ func (e *ServiceError) ErrorName() string { return e.Name }
 func (e *ServiceError) GoaErrorName() string { return e.ErrorName() }
 
 func (e *ServiceError) Unwrap() error { return e.err }
-
-// GoaErrorName returns the error name as defined in the design.
-func (err AdaptErrorNamer) GoaErrorName() string {
-	return err.ErrorName()
-}
-
-// Error is the error message.
-func (err AdaptErrorNamer) Error() string {
-	return err.ErrorNamer.(error).Error()
-}
 
 func withField(field string, err *ServiceError) *ServiceError {
 	err.Field = &field


### PR DESCRIPTION
The code generated by Goa in a given `gen` folder will always make use of the new `GoaErrorName()` method. Generated error structs will also always expose a `GoaErrorName()` function - there is no need to adapt.