### PR TITLE
X-Ray segment Namespace omitempty

### DIFF
--- a/middleware/xray/segment.go
+++ b/middleware/xray/segment.go
@@ -20,7 +20,7 @@ type (
 		// Name is the name of the service reported to X-Ray.
 		Name string `json:"name"`
 		// Namespace identifies the source that created the segment.
-		Namespace string `json:"namespace"`
+		Namespace string `json:"namespace,omitempty"`
 		// Type is either the empty string or "subsegment".
 		Type string `json:"type,omitempty"`
 		// ID is a unique ID for the segment.


### PR DESCRIPTION
Per AWS spec, the `namespace` field of a Segment doc can be "aws", "remote" or absent. Empty string "" is not valid. 
More than that, the field is only allowed in Subsegment, not in Segment, but Goa uses the same class for both.

AWS X-Ray daemon is not strict about the namespace value, but other consumers are.
Open Telemetry Collector supports collecting traces in X-Ray format, but it's strict about this namespace value. This PR omits the `Namespace` field if it's empty, to enable OTC compatibility.

Another benefit of this change is reducing the total trace json document size that goes against a tight hard limit in X-Ray.

Ref: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-subsegments

See also: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/dfcd435c1955df3fe1c0ee9a39d7be86de1e990a/receiver/awsxrayreceiver/internal/translator/name.go#L57