### PR TITLE
Fixed UUID generation in openapi examples

### DIFF
--- a/expr/example.go
+++ b/expr/example.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"time"
 
+	googleuuid "github.com/google/uuid"
 	regen "github.com/zach-klippenstein/goregen"
 )
 
@@ -206,11 +207,11 @@ func byFormat(a *AttributeExpr, r *ExampleGenerator) interface{} {
 		FormatRegexp:  r.Characters(3) + ".*",
 		FormatRFC1123: time.Unix(int64(r.Int())%1454957045, 0).UTC().Format(time.RFC1123), // to obtain a "fixed" rand
 		FormatUUID: func() string {
-			res, err := regen.Generate(`[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}`)
+			uuid, err := googleuuid.NewUUID()
 			if err != nil {
-				return "12345678-1234-1234-12324-123456789ABC"
+				return "12345678-1234-1234-9232-123456789ABC"
 			}
-			return res
+			return uuid.String()
 		}(),
 		FormatJSON: `{"name":"example","email":"mail@example.com"}`,
 	}[format]; ok {

--- a/expr/example_test.go
+++ b/expr/example_test.go
@@ -44,7 +44,7 @@ func TestByFormatUUID(t *testing.T) {
 	att := expr.AttributeExpr{Validation: val}
 	r := expr.NewRandom("test")
 	example := att.Example(r).(string)
-	if !regexp.MustCompile(`[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}`).MatchString(example) {
+	if !regexp.MustCompile(`[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`).MatchString(example) {
 		t.Errorf("got %s, expected a match with `[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}`", example)
 	}
 }


### PR DESCRIPTION
The OpenAPI generation currently produces invalid UUIDs in the examples. This is problematic for any tool that pulls those in for testing (ex. Postman). 

Using the regular expression to generate the UUIDs was only acceptable on occasion because it failed to take into account the different UUID variants (reserved, backwards compatible, etc).

This change makes us use the same library dependency that we were _already_ using for checking/inspecting an incoming UUID in order to generate one.

Also the generic fallback was invalid because it had one character too many.