### PR TITLE
Remove duplicate err declaration

### DIFF
--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -868,7 +868,9 @@ const singleResponseT = ` {{- if .ClientBody }}
 				cookies = resp.Cookies()
 		{{- if not .ClientBody }}
 			{{- if .MustValidate }}
-				err error
+				{{- if not .Headers}}
+					err error
+				{{- end }}
 			{{- end }}
 		{{- end }}
 			)

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -2247,7 +2247,7 @@ func buildResponseBodyType(body, att *expr.AttributeExpr, loc *codegen.Location,
 				}
 				code, helpers, err = marshal(srcAtt, body, src, "body", svcctx, httpctx)
 				if err != nil {
-					fmt.Println(err.Error()) // TBD validate DSL so errors are not possible
+					panic(err) // bug
 				}
 				sd.ServerTransformHelpers = codegen.AppendHelpers(sd.ServerTransformHelpers, helpers)
 			}


### PR DESCRIPTION
When response contains both headers and cookies fields.

Fixes #3217 