### PR TITLE
Properly check for nil in validation

### DIFF
--- a/codegen/testdata/validation_code.go
+++ b/codegen/testdata/validation_code.go
@@ -234,18 +234,12 @@ const (
 `
 
 	AliasTypeValidationCode = `func Validate() (err error) {
-	if target.RequiredAlias != nil {
-		err = goa.MergeErrors(err, goa.ValidatePattern("target.required_alias", string(*target.RequiredAlias), "^[A-z].*[a-z]$"))
+	err = goa.MergeErrors(err, goa.ValidatePattern("target.required_alias", string(target.RequiredAlias), "^[A-z].*[a-z]$"))
+	if utf8.RuneCountInString(string(target.RequiredAlias)) < 1 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_alias", string(target.RequiredAlias), utf8.RuneCountInString(string(target.RequiredAlias)), 1, true))
 	}
-	if target.RequiredAlias != nil {
-		if utf8.RuneCountInString(string(*target.RequiredAlias)) < 1 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_alias", string(*target.RequiredAlias), utf8.RuneCountInString(string(*target.RequiredAlias)), 1, true))
-		}
-	}
-	if target.RequiredAlias != nil {
-		if utf8.RuneCountInString(string(*target.RequiredAlias)) > 10 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_alias", string(*target.RequiredAlias), utf8.RuneCountInString(string(*target.RequiredAlias)), 10, false))
-		}
+	if utf8.RuneCountInString(string(target.RequiredAlias)) > 10 {
+		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_alias", string(target.RequiredAlias), utf8.RuneCountInString(string(target.RequiredAlias)), 10, false))
 	}
 	if target.Alias != nil {
 		err = goa.MergeErrors(err, goa.ValidatePattern("target.alias", string(*target.Alias), "^[A-z].*[a-z]$"))
@@ -524,6 +518,17 @@ const (
 	if target.Collection != nil {
 		if err2 := ValidateResultCollection(target.Collection); err2 != nil {
 			err = goa.MergeErrors(err, err2)
+		}
+	}
+}
+`
+
+	TypeWithEmbeddedTypeValidationCode = `func Validate() (err error) {
+	if target.Deep != nil {
+		if target.Deep.Integer != nil {
+			if err2 := ValidateInteger(target.Deep.Integer); err2 != nil {
+				err = goa.MergeErrors(err, err2)
+			}
 		}
 	}
 }

--- a/codegen/testdata/validation_types_dsl.go
+++ b/codegen/testdata/validation_types_dsl.go
@@ -65,7 +65,7 @@ var ValidationTypesDSL = func() {
 		_ = Type("AliasType", func() {
 			Attribute("required_alias", Alias)
 			Attribute("alias", Alias)
-			Required("required_string")
+			Required("required_alias")
 		})
 
 		_ = Type("UserType", func() {
@@ -145,6 +145,12 @@ var ValidationTypesDSL = func() {
 			TypeName("TypeWithCollection")
 			Attributes(func() {
 				Attribute("collection", CollectionOf(Result))
+			})
+		})
+
+		_ = Type("Deep", func() {
+			Attribute("deep", func() {
+				Attribute("integer", IntegerT)
 			})
 		})
 	)

--- a/codegen/validation_test.go
+++ b/codegen/validation_test.go
@@ -24,6 +24,7 @@ func TestRecursiveValidationCode(t *testing.T) {
 		rtT      = root.UserType("Result")
 		rtcolT   = root.UserType("Collection")
 		colT     = root.UserType("TypeWithCollection")
+		deepT    = root.UserType("Deep")
 	)
 	cases := []struct {
 		Name       string
@@ -58,6 +59,7 @@ func TestRecursiveValidationCode(t *testing.T) {
 		{"collection-required", rtcolT, true, false, false, testdata.ResultCollectionPointerValidationCode},
 		{"collection-pointer", rtcolT, false, true, false, testdata.ResultCollectionPointerValidationCode},
 		{"type-with-collection-pointer", colT, false, true, false, testdata.TypeWithCollectionPointerValidationCode},
+		{"type-with-embedded-type", deepT, false, true, false, testdata.TypeWithEmbeddedTypeValidationCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {


### PR DESCRIPTION
of deep data structures.

Fix #3221 