### PR TITLE
Fix potential panic when method name is empty

### DIFF
--- a/dsl/method.go
+++ b/dsl/method.go
@@ -25,6 +25,9 @@ import (
 //    })
 //
 func Method(name string, fn func()) {
+	if name == "" {
+		eval.ReportError("method name cannot be empty")
+	}
 	s, ok := eval.Current().(*expr.ServiceExpr)
 	if !ok {
 		eval.IncompatibleDSL()


### PR DESCRIPTION
If an empty string is given as an argument to the `Method` DSL, it will panic.

Sample Design
```Go
var _ = Service("calc", func() {
	Method("", func() {       // ← oops! method name is empty.
		Payload(func() {
			Attribute("a", Int, "Left operand")
			Attribute("b", Int, "Right operand")
			Required("a", "b")
		})
		Result(Int)
		HTTP(func() {
			POST("/multiply/{a}/{b}")
			Response(StatusOK)
		})

	})
})
```

**Before**
```
$ goa gen sample/design
exit status 2
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
goa.design/goa/v3/expr.concat.func2({0x0?, 0x1006c0550?})
	/Users/ikawaha/go/pkg/mod/goa.design/goa/v3@v3.10.2/expr/http_body_types.go:364 +0x65
goa.design/goa/v3/expr.concat({0xc000237738, 0x3, 0xc0002376f8?})
	/Users/ikawaha/go/pkg/mod/goa.design/goa/v3@v3.10.2/expr/http_body_types.go:369 +0x63
goa.design/goa/v3/expr.httpRequestBody(0xc000304820)
	/Users/ikawaha/go/pkg/mod/goa.design/goa/v3@v3.10.2/expr/http_body_types.go:66 +0xb3
goa.design/goa/v3/expr.(*HTTPEndpointExpr).Validate(0xc000304820)
	/Users/ikawaha/go/pkg/mod/goa.design/goa/v3@v3.10.2/expr/http_endpoint.go:639 +0x1d07
goa.design/goa/v3/eval.validateSet({0xc00006f170, 0x1, 0x1?})
	/Users/ikawaha/go/pkg/mod/goa.design/goa/v3@v3.10.2/eval/eval.go:215 +0x29f
goa.design/goa/v3/expr.(*RootExpr).WalkSets(0x1009d6d80, 0x10062eeb8)
	/Users/ikawaha/go/pkg/mod/goa.design/goa/v3@v3.10.2/expr/root.go:112 +0x5e7
goa.design/goa/v3/eval.RunDSL()
	/Users/ikawaha/go/pkg/mod/goa.design/goa/v3@v3.10.2/eval/eval.go:48 +0x246
main.main()
	/Users/ikawaha/go/src/github.com/ikawaha/goahttpcheck/sample/goa2570823194/main.go:55 +0x31f
```
**After**
```
$ goa gen sample/design
exit status 1
[design/design.go:20] method name cannot be empty in service "calc"
```
