### PR TITLE
Fix use of `struct:pkg:path` with result types.

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -1251,6 +1251,7 @@ func buildProjectedType(projected, att *expr.AttributeExpr, viewspkg string, sco
 		}
 		validations = buildValidations(projected, viewScope)
 	}
+	removeMeta(projected)
 	return &ProjectedTypeData{
 		UserTypeData: &UserTypeData{
 			Name:        varname,
@@ -1794,6 +1795,16 @@ func walkViewAttrs(obj *expr.Object, view *expr.ViewExpr, walker func(name strin
 			walker(nat.Name, attr, nat.Attribute)
 		}
 	}
+}
+
+// removeMeta removes the meta attributes from the given attribute. This is
+// needed to make sure that any field name overridding is removed when
+// generating protobuf types (as protogen itself won't honor these overrides).
+func removeMeta(att *expr.AttributeExpr) {
+	_ = codegen.Walk(att, func(a *expr.AttributeExpr) error {
+		delete(a.Meta, "struct:pkg:path")
+		return nil
+	})
 }
 
 const (

--- a/codegen/service/testdata/views_code.go
+++ b/codegen/service/testdata/views_code.go
@@ -808,3 +808,55 @@ func ValidateUserTypeView(result UserTypeView) (err error) {
 	return
 }
 `
+
+const ResultWithPkgPathCode = `// RT is the viewed result type that is projected based on a view.
+type RT struct {
+	// Type to project
+	Projected *RTView
+	// View to render
+	View string
+}
+
+// RTView is a type that runs validations on a projected type.
+type RTView struct {
+	A *UserTypeView
+}
+
+// UserTypeView is a type that runs validations on a projected type.
+type UserTypeView struct {
+	A *string
+}
+
+var (
+	// RTMap is a map indexing the attribute names of RT by view name.
+	RTMap = map[string][]string{
+		"default": {
+			"a",
+		},
+	}
+)
+
+// ValidateRT runs the validations defined on the viewed result type RT.
+func ValidateRT(result *RT) (err error) {
+	switch result.View {
+	case "default", "":
+		err = ValidateRTView(result.Projected)
+	default:
+		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default"})
+	}
+	return
+}
+
+// ValidateRTView runs the validations defined on RTView using the "default"
+// view.
+func ValidateRTView(result *RTView) (err error) {
+
+	return
+}
+
+// ValidateUserTypeView runs the validations defined on UserTypeView.
+func ValidateUserTypeView(result *UserTypeView) (err error) {
+
+	return
+}
+`

--- a/codegen/service/testdata/views_dsls.go
+++ b/codegen/service/testdata/views_dsls.go
@@ -219,7 +219,7 @@ var ResultWithMultipleMethodsDSL = func() {
 }
 
 var ResultWithEnumTypeDSL = func() {
-	var T = Type("UserType", String, func()  {
+	var T = Type("UserType", String, func() {
 		Enum("a", "b")
 	})
 	var RT = ResultType("application/vnd.result", func() {
@@ -228,6 +228,24 @@ var ResultWithEnumTypeDSL = func() {
 		})
 	})
 	Service("ResultWithEnumType", func() {
+		Method("A", func() {
+			Result(RT)
+		})
+	})
+}
+
+var ResultWithPkgPathDSL = func() {
+	var T = Type("UserType", func() {
+		Attribute("a", String)
+		Meta("struct:pkg:path", "types")
+	})
+	var RT = ResultType("application/vnd.result", func() {
+		TypeName("RT")
+		Attributes(func() {
+			Attribute("a", T)
+		})
+	})
+	Service("ResultWithPkgPath", func() {
 		Method("A", func() {
 			Result(RT)
 		})

--- a/codegen/service/views_test.go
+++ b/codegen/service/views_test.go
@@ -26,6 +26,7 @@ func TestViews(t *testing.T) {
 		{"result-with-recursive-collection-of-result-type", testdata.ResultWithRecursiveCollectionOfResultTypeDSL, testdata.ResultWithRecursiveCollectionOfResultTypeCode},
 		{"result-with-multiple-methods", testdata.ResultWithMultipleMethodsDSL, testdata.ResultWithMultipleMethodsCode},
 		{"result-with-enum-type", testdata.ResultWithEnumTypeDSL, testdata.ResultWithEnumType},
+		{"result-with-pkg-path", testdata.ResultWithPkgPathDSL, testdata.ResultWithPkgPathCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/goadesign/goa/issues/3240