### PR TITLE
Rewrite `interface{}` to `any`

### DIFF
--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -115,7 +115,7 @@ func (g *Generator) Write(debug bool) error {
 
 	var sections []*codegen.SectionTemplate
 	{
-		data := map[string]interface{}{
+		data := map[string]any{
 			"Command":       g.Command,
 			"CleanupDirs":   cleanupDirs(g.Command, g.Output),
 			"DesignVersion": g.DesignVersion,
@@ -330,7 +330,7 @@ const mainT = `func main() {
 	fmt.Println(strings.Join(outputs, "\n"))
 }
 
-func fail(msg string, vals ...interface{}) {
+func fail(msg string, vals ...any) {
 	fmt.Fprintf(os.Stderr, msg, vals...)
 	os.Exit(1)
 }

--- a/codegen/cli/cli.go
+++ b/codegen/cli/cli.go
@@ -75,7 +75,7 @@ type (
 		// Example returns a JSON serialized example value.
 		Example string
 		// Default returns the default value if any.
-		Default interface{}
+		Default any
 	}
 
 	// BuildFunctionData contains the data needed to generate a constructor
@@ -264,7 +264,7 @@ func FlagsCode(data []*CommandData) string {
 		Name:    "parse-endpoint-flags",
 		Source:  parseFlagsT,
 		Data:    data,
-		FuncMap: map[string]interface{}{"printDescription": printDescription},
+		FuncMap: map[string]any{"printDescription": printDescription},
 	}
 	var flagsCode bytes.Buffer
 	err := section.Write(&flagsCode)
@@ -282,7 +282,7 @@ func CommandUsage(data *CommandData) *codegen.SectionTemplate {
 		Name:    "cli-command-usage",
 		Source:  commandUsageT,
 		Data:    data,
-		FuncMap: map[string]interface{}{"printDescription": printDescription},
+		FuncMap: map[string]any{"printDescription": printDescription},
 	}
 }
 
@@ -293,7 +293,7 @@ func PayloadBuilderSection(buildFunction *BuildFunctionData) *codegen.SectionTem
 		Name:   "cli-build-payload",
 		Source: buildPayloadT,
 		Data:   buildFunction,
-		FuncMap: map[string]interface{}{
+		FuncMap: map[string]any{
 			"fieldCode": fieldCode,
 		},
 	}
@@ -308,7 +308,7 @@ func PayloadBuilderSection(buildFunction *BuildFunctionData) *codegen.SectionTem
 // description is the flag description
 // required determines if the flag is required
 // example is an example value for the flag
-func NewFlagData(svcn, en, name, typeName, description string, required bool, example, def interface{}) *FlagData {
+func NewFlagData(svcn, en, name, typeName, description string, required bool, example, def any) *FlagData {
 	ex := jsonExample(example)
 	fn := goifyTerms(svcn, en, name)
 	return &FlagData{
@@ -326,7 +326,7 @@ func NewFlagData(svcn, en, name, typeName, description string, required bool, ex
 // FieldLoadCode returns the code used in the build payload function that
 // initializes one of the payload object fields. It returns the initialization
 // code and a boolean indicating whether the code requires an "err" variable.
-func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultValue interface{}, payload expr.DataType, payloadRef string) (string, bool) {
+func FieldLoadCode(f *FlagData, argName, argTypeName, validate string, defaultValue any, payload expr.DataType, payloadRef string) (string, bool) {
 	var (
 		code    string
 		declErr bool
@@ -410,13 +410,13 @@ func flagType(tname string) string {
 }
 
 // jsonExample generates a json example
-func jsonExample(v interface{}) string {
+func jsonExample(v any) string {
 	// In JSON, keys must be a string. But goa allows map keys to be anything.
 	r := reflect.ValueOf(v)
 	if r.Kind() == reflect.Map {
 		keys := r.MapKeys()
 		if keys[0].Kind() != reflect.String {
-			a := make(map[string]interface{}, len(keys))
+			a := make(map[string]any, len(keys))
 			var kstr string
 			for _, k := range keys {
 				switch t := k.Interface().(type) {

--- a/codegen/example/example_cli.go
+++ b/codegen/example/example_cli.go
@@ -45,30 +45,30 @@ func exampleCLIMain(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *c
 		&codegen.SectionTemplate{
 			Name:   "cli-main-start",
 			Source: cliMainStartT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Server": svrdata,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"join": strings.Join,
 			},
 		},
 		&codegen.SectionTemplate{
 			Name:   "cli-main-var-init",
 			Source: cliMainVarInitT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Server": svrdata,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"join": strings.Join,
 			},
 		},
 		&codegen.SectionTemplate{
 			Name:   "cli-main-endpoint-init",
 			Source: cliMainEndpointInitT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Server": svrdata,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"join":    strings.Join,
 				"toUpper": strings.ToUpper,
 			},
@@ -77,11 +77,11 @@ func exampleCLIMain(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *c
 		&codegen.SectionTemplate{
 			Name:   "cli-main-usage",
 			Source: cliMainUsageT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"APIName": root.API.Name,
 				"Server":  svrdata,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"toUpper": strings.ToUpper,
 				"join":    strings.Join,
 			},
@@ -91,7 +91,7 @@ func exampleCLIMain(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *c
 }
 
 const (
-	// input: map[string]interface{}{"Server": *Data}
+	// input: map[string]any{"Server": *Data}
 	cliMainStartT = `func main() {
 	var (
 		hostF = flag.String("host", {{ printf "%q" .Server.DefaultHost.Name }}, "Server host (valid values: {{ (join .Server.AvailableHosts ", ") }})")
@@ -107,7 +107,7 @@ const (
 	flag.Parse()
 `
 
-	// input: map[string]interface{}{"Server": *Data}
+	// input: map[string]any{"Server": *Data}
 	cliMainVarInitT = `var (
 		addr string
 		timeout int
@@ -163,10 +163,10 @@ const (
 	}
 `
 
-	// input: map[string]interface{}{"Server": *Data}
+	// input: map[string]any{"Server": *Data}
 	cliMainEndpointInitT = `var(
 		endpoint goa.Endpoint
-		payload interface{}
+		payload any
 		err error
 	)
 	{
@@ -204,7 +204,7 @@ const (
 }
 `
 
-	// input: map[string]interface{}{"APIName": string, "Server": *Data}
+	// input: map[string]any{"APIName": string, "Server": *Data}
 	cliMainUsageT = `
 func usage() {
   fmt.Fprintf(os.Stderr, ` + "`" + `%s is a command line client for the {{ .APIName }} API.

--- a/codegen/example/example_server.go
+++ b/codegen/example/example_server.go
@@ -79,35 +79,35 @@ func exampleSvrMain(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *c
 		{
 			Name:   "server-main-start",
 			Source: mainStartT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Server": svrdata,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"join": strings.Join,
 			},
 		}, {
 			Name:   "server-main-logger",
 			Source: mainLoggerT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"APIPkg": apiPkg,
 			},
 		}, {
 			Name:   "server-main-services",
 			Source: mainSvcsT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"APIPkg":   apiPkg,
 				"Services": svcData,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"mustInitServices": mustInitServices,
 			},
 		}, {
 			Name:   "server-main-endpoints",
 			Source: mainEndpointsT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Services": svcData,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"mustInitServices": mustInitServices,
 			},
 		}, {
@@ -116,11 +116,11 @@ func exampleSvrMain(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *c
 		}, {
 			Name:   "server-main-handler",
 			Source: mainServerHndlrT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Server":   svrdata,
 				"Services": svcData,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"goify":   codegen.Goify,
 				"join":    strings.Join,
 				"toUpper": strings.ToUpper,

--- a/codegen/example/server_data.go
+++ b/codegen/example/server_data.go
@@ -333,7 +333,7 @@ func buildHostData(host *expr.HostExpr) *HostData {
 }
 
 // convertToString converts primitive type to a string.
-func convertToString(vals ...interface{}) []string {
+func convertToString(vals ...any) []string {
 	str := make([]string, len(vals))
 	for i, v := range vals {
 		switch t := v.(type) {

--- a/codegen/example/testdata/example_cli_code.go
+++ b/codegen/example/testdata/example_cli_code.go
@@ -47,7 +47,7 @@ const (
 	}
 	var (
 		endpoint goa.Endpoint
-		payload  interface{}
+		payload  any
 		err      error
 	)
 	{
@@ -157,7 +157,7 @@ func indent(s string) string {
 	}
 	var (
 		endpoint goa.Endpoint
-		payload  interface{}
+		payload  any
 		err      error
 	)
 	{
@@ -285,7 +285,7 @@ func indent(s string) string {
 	}
 	var (
 		endpoint goa.Endpoint
-		payload  interface{}
+		payload  any
 		err      error
 	)
 	{
@@ -404,7 +404,7 @@ func indent(s string) string {
 	}
 	var (
 		endpoint goa.Endpoint
-		payload  interface{}
+		payload  any
 		err      error
 	)
 	{
@@ -533,7 +533,7 @@ func indent(s string) string {
 	}
 	var (
 		endpoint goa.Endpoint
-		payload  interface{}
+		payload  any
 		err      error
 	)
 	{

--- a/codegen/file.go
+++ b/codegen/file.go
@@ -48,9 +48,9 @@ type (
 		// renders the section text.
 		Source string
 		// FuncMap lists the functions used to render the templates.
-		FuncMap map[string]interface{}
+		FuncMap map[string]any
 		// Data used as input of template.
-		Data interface{}
+		Data any
 	}
 )
 

--- a/codegen/funcs.go
+++ b/codegen/funcs.go
@@ -32,8 +32,8 @@ type (
 )
 
 // TemplateFuncs lists common template helper functions.
-func TemplateFuncs() map[string]interface{} {
-	return map[string]interface{}{
+func TemplateFuncs() map[string]any {
+	return map[string]any{
 		"commandLine": CommandLine,
 		"comment":     Comment,
 	}

--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -299,7 +299,7 @@ func transformArray(source, target *expr.Array, sourceVar, targetVar string, new
 	if err := IsCompatible(source.ElemType.Type, target.ElemType.Type, sourceVar+"[0]", targetVar+"[0]"); err != nil {
 		return "", err
 	}
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ElemTypeRef":    ta.TargetCtx.Scope.Ref(target.ElemType, ta.TargetCtx.Pkg(target.ElemType)),
 		"SourceElem":     source.ElemType,
 		"TargetElem":     target.ElemType,
@@ -325,7 +325,7 @@ func transformMap(source, target *expr.Map, sourceVar, targetVar string, newVar 
 	if err := IsCompatible(source.ElemType.Type, target.ElemType.Type, sourceVar+"[*]", targetVar+"[*]"); err != nil {
 		return "", err
 	}
-	data := map[string]interface{}{
+	data := map[string]any{
 		"KeyTypeRef":     ta.TargetCtx.Scope.Ref(target.KeyType, ta.TargetCtx.Pkg(target.KeyType)),
 		"ElemTypeRef":    ta.TargetCtx.Scope.Ref(target.ElemType, ta.TargetCtx.Pkg(target.ElemType)),
 		"SourceKey":      source.KeyType,
@@ -382,7 +382,7 @@ func transformUnion(source, target *expr.AttributeExpr, sourceVar, targetVar str
 	// Need to type assert targetVar before assigning field values.
 	ta.TargetCtx.IsInterface = true
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"SourceTypeRefs": sourceTypeRefs,
 		"SourceTypes":    srcUnion.Values,
 		"TargetTypes":    tgtUnion.Values,
@@ -415,7 +415,7 @@ func transformUnionToObject(source, target *expr.AttributeExpr, sourceVar, targe
 		sourceTypeRefs[i] = ta.SourceCtx.Scope.Ref(st.Attribute, ta.SourceCtx.Pkg(st.Attribute))
 		sourceTypeNames[i] = st.Name
 	}
-	data := map[string]interface{}{
+	data := map[string]any{
 		"NewVar":          newVar,
 		"TargetVar":       targetVar,
 		"TypeRef":         ta.TargetCtx.Scope.Ref(target, ta.TargetCtx.Pkg(target)),
@@ -451,7 +451,7 @@ func transformObjectToUnion(source, target *expr.AttributeExpr, sourceVar, targe
 		unionTypes[i] = tt.Name
 		targetTypeRefs[i] = ta.TargetCtx.Scope.Ref(tt.Attribute, ta.TargetCtx.Pkg(tt.Attribute))
 	}
-	data := map[string]interface{}{
+	data := map[string]any{
 		"NewVar":         newVar,
 		"TargetVar":      targetVar,
 		"TypeRef":        ta.TargetCtx.Scope.Ref(target, ta.TargetCtx.Pkg(target)),

--- a/codegen/go_transform_test.go
+++ b/codegen/go_transform_test.go
@@ -765,7 +765,7 @@ const (
 		}
 	}
 	{
-		var zero interface{}
+		var zero any
 		if target.Any == zero {
 			target.Any = "something"
 		}

--- a/codegen/header.go
+++ b/codegen/header.go
@@ -9,7 +9,7 @@ func Header(title, pack string, imports []*ImportSpec) *SectionTemplate {
 	return &SectionTemplate{
 		Name:   "source-header",
 		Source: headerT,
-		Data: map[string]interface{}{
+		Data: map[string]any{
 			"Title":       title,
 			"ToolVersion": goa.Version(),
 			"Pkg":         pack,
@@ -25,7 +25,7 @@ func AddImport(section *SectionTemplate, imprts ...*ImportSpec) {
 		return
 	}
 	var specs []*ImportSpec
-	if data, ok := section.Data.(map[string]interface{}); ok {
+	if data, ok := section.Data.(map[string]any); ok {
 		if imports, ok := data["Imports"]; ok {
 			specs = imports.([]*ImportSpec)
 		}

--- a/codegen/service/client.go
+++ b/codegen/service/client.go
@@ -87,7 +87,7 @@ const serviceClientMethodT = `
 {{- end }}
 func (c *{{ .ClientVarName }}) {{ .VarName }}(ctx context.Context, {{ if .PayloadRef }}p {{ .PayloadRef }}{{ end }}{{ if .MethodData.SkipRequestBodyEncodeDecode}}, req io.ReadCloser{{ end }}) ({{ if $resultType }}res {{ $resultType }}, {{ end }}{{ if .MethodData.SkipResponseBodyEncodeDecode }}resp io.ReadCloser, {{ end }}err error) {
 	{{- if or $resultType .MethodData.SkipResponseBodyEncodeDecode }}
-	var ires interface{}
+	var ires any
 	{{- end }}
 	{{ if or $resultType .MethodData.SkipResponseBodyEncodeDecode }}ires{{ else }}_{{ end }}, err = c.{{ .VarName}}Endpoint(ctx, {{ if .MethodData.SkipRequestBodyEncodeDecode }}&{{ .RequestStruct }}{ {{ if .PayloadRef }}Payload: p, {{ end }}Body: req }{{ else if .PayloadRef }}p{{ else }}nil{{ end }})
 	{{- if not (or $resultType .MethodData.SkipResponseBodyEncodeDecode) }}

--- a/codegen/service/convert.go
+++ b/codegen/service/convert.go
@@ -119,7 +119,7 @@ func getPkgImport(pkg, cwd string) string {
 	return pkg
 }
 
-func getExternalTypeInfo(external interface{}) (string, string, error) {
+func getExternalTypeInfo(external any) (string, string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", "", err

--- a/codegen/service/convert_test.go
+++ b/codegen/service/convert_test.go
@@ -92,7 +92,7 @@ func TestDesignType(t *testing.T) {
 	var f bool
 	cases := []struct {
 		Name         string
-		From         interface{}
+		From         any
 		ExpectedType expr.DataType
 		ExpectedErr  string
 	}{
@@ -151,7 +151,7 @@ func TestCompatible(t *testing.T) {
 	cases := []struct {
 		Name        string
 		From        expr.DataType
-		To          interface{}
+		To          any
 		ExpectedErr string
 	}{
 		{"bool", expr.Boolean, false, ""},
@@ -167,7 +167,7 @@ func TestCompatible(t *testing.T) {
 		{"bytes", expr.Bytes, []byte{}, ""},
 		{"array", dsl.ArrayOf(expr.String), []string{}, ""},
 		{"map", dsl.MapOf(expr.String, expr.String), map[string]string{}, ""},
-		{"map-interface", dsl.MapOf(expr.String, expr.Any), map[string]interface{}{}, ""},
+		{"map-interface", dsl.MapOf(expr.String, expr.Any), map[string]any{}, ""},
 		{"object", obj, objT{}, ""},
 		{"object-mapped", objMapped, objT{}, ""},
 		{"object-ignored", objIgnored, objT{}, ""},

--- a/codegen/service/endpoint.go
+++ b/codegen/service/endpoint.go
@@ -120,7 +120,7 @@ func EndpointFile(genpkg string, service *expr.ServiceExpr) *codegen.File {
 				Name:    "endpoint-method",
 				Source:  serviceEndpointMethodT,
 				Data:    m,
-				FuncMap: map[string]interface{}{"payloadVar": payloadVar},
+				FuncMap: map[string]any{"payloadVar": payloadVar},
 			})
 		}
 	}
@@ -225,7 +225,7 @@ type {{ .ResponseStruct }} struct {
 // input: endpointMethodData
 const serviceEndpointMethodT = `{{ printf "New%sEndpoint returns an endpoint function that calls the method %q of service %q." .VarName .Name .ServiceName | comment }}
 func New{{ .VarName }}Endpoint(s {{ .ServiceVarName }}{{ range .Schemes }}, auth{{ .Type }}Fn security.Auth{{ .Type }}Func{{ end }}) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 {{- if or .ServerStream }}
 		ep := req.(*{{ .ServerStream.EndpointStruct }})
 {{- else if .SkipRequestBodyEncodeDecode }}

--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -108,7 +108,7 @@ func Files(genpkg string, service *expr.ServiceExpr, userTypePkgs map[string][]s
 		addTypeDefSection(pathWithDefault(et.Loc, svcPath), key, &codegen.SectionTemplate{
 			Name:    "service-error",
 			Source:  errorT,
-			FuncMap: map[string]interface{}{"errorName": errorName},
+			FuncMap: map[string]any{"errorName": errorName},
 			Data:    et,
 		})
 	}
@@ -174,7 +174,7 @@ func Files(genpkg string, service *expr.ServiceExpr, userTypePkgs map[string][]s
 		Name:    "service",
 		Source:  serviceT,
 		Data:    svc,
-		FuncMap: map[string]interface{}{"streamInterfaceFor": streamInterfaceFor},
+		FuncMap: map[string]any{"streamInterfaceFor": streamInterfaceFor},
 	}
 
 	// service.go
@@ -274,8 +274,8 @@ func errorName(et *UserTypeData) string {
 
 // streamInterfaceFor builds the data to generate the client and server stream
 // interfaces for the given endpoint.
-func streamInterfaceFor(typ string, m *MethodData, stream *StreamData) map[string]interface{} {
-	return map[string]interface{}{
+func streamInterfaceFor(typ string, m *MethodData, stream *StreamData) map[string]any {
+	return map[string]any{
 		"Type":     typ,
 		"Endpoint": m.Name,
 		"Stream":   stream,

--- a/codegen/service/testdata/client_code.go
+++ b/codegen/service/testdata/client_code.go
@@ -99,7 +99,7 @@ func NewClient(a goa.Endpoint) *Client {
 
 // A calls the "A" endpoint of the "WithResult" service.
 func (c *Client) A(ctx context.Context) (res *Rtype, err error) {
-	var ires interface{}
+	var ires any
 	ires, err = c.AEndpoint(ctx, nil)
 	if err != nil {
 		return
@@ -124,7 +124,7 @@ func NewClient(streamingResultMethod goa.Endpoint) *Client {
 // StreamingResultMethod calls the "StreamingResultMethod" endpoint of the
 // "StreamingResultService" service.
 func (c *Client) StreamingResultMethod(ctx context.Context, p *APayload) (res StreamingResultMethodClientStream, err error) {
-	var ires interface{}
+	var ires any
 	ires, err = c.StreamingResultMethodEndpoint(ctx, p)
 	if err != nil {
 		return
@@ -149,7 +149,7 @@ func NewClient(streamingResultNoPayloadMethod goa.Endpoint) *Client {
 // StreamingResultNoPayloadMethod calls the "StreamingResultNoPayloadMethod"
 // endpoint of the "StreamingResultNoPayloadService" service.
 func (c *Client) StreamingResultNoPayloadMethod(ctx context.Context) (res StreamingResultNoPayloadMethodClientStream, err error) {
-	var ires interface{}
+	var ires any
 	ires, err = c.StreamingResultNoPayloadMethodEndpoint(ctx, nil)
 	if err != nil {
 		return
@@ -174,7 +174,7 @@ func NewClient(streamingPayloadMethod goa.Endpoint) *Client {
 // StreamingPayloadMethod calls the "StreamingPayloadMethod" endpoint of the
 // "StreamingPayloadService" service.
 func (c *Client) StreamingPayloadMethod(ctx context.Context, p *BPayload) (res StreamingPayloadMethodClientStream, err error) {
-	var ires interface{}
+	var ires any
 	ires, err = c.StreamingPayloadMethodEndpoint(ctx, p)
 	if err != nil {
 		return
@@ -199,7 +199,7 @@ func NewClient(streamingPayloadNoPayloadMethod goa.Endpoint) *Client {
 // StreamingPayloadNoPayloadMethod calls the "StreamingPayloadNoPayloadMethod"
 // endpoint of the "StreamingPayloadNoPayloadService" service.
 func (c *Client) StreamingPayloadNoPayloadMethod(ctx context.Context) (res StreamingPayloadNoPayloadMethodClientStream, err error) {
-	var ires interface{}
+	var ires any
 	ires, err = c.StreamingPayloadNoPayloadMethodEndpoint(ctx, nil)
 	if err != nil {
 		return
@@ -224,7 +224,7 @@ func NewClient(streamingPayloadNoResultMethod goa.Endpoint) *Client {
 // StreamingPayloadNoResultMethod calls the "StreamingPayloadNoResultMethod"
 // endpoint of the "StreamingPayloadNoResultService" service.
 func (c *Client) StreamingPayloadNoResultMethod(ctx context.Context) (res StreamingPayloadNoResultMethodClientStream, err error) {
-	var ires interface{}
+	var ires any
 	ires, err = c.StreamingPayloadNoResultMethodEndpoint(ctx, nil)
 	if err != nil {
 		return
@@ -249,7 +249,7 @@ func NewClient(bidirectionalStreamingMethod goa.Endpoint) *Client {
 // BidirectionalStreamingMethod calls the "BidirectionalStreamingMethod"
 // endpoint of the "BidirectionalStreamingService" service.
 func (c *Client) BidirectionalStreamingMethod(ctx context.Context, p *BPayload) (res BidirectionalStreamingMethodClientStream, err error) {
-	var ires interface{}
+	var ires any
 	ires, err = c.BidirectionalStreamingMethodEndpoint(ctx, p)
 	if err != nil {
 		return
@@ -275,7 +275,7 @@ func NewClient(bidirectionalStreamingNoPayloadMethod goa.Endpoint) *Client {
 // "BidirectionalStreamingNoPayloadMethod" endpoint of the
 // "BidirectionalStreamingNoPayloadService" service.
 func (c *Client) BidirectionalStreamingNoPayloadMethod(ctx context.Context) (res BidirectionalStreamingNoPayloadMethodClientStream, err error) {
-	var ires interface{}
+	var ires any
 	ires, err = c.BidirectionalStreamingNoPayloadMethodEndpoint(ctx, nil)
 	if err != nil {
 		return

--- a/codegen/service/testdata/endpoint_code.go
+++ b/codegen/service/testdata/endpoint_code.go
@@ -22,7 +22,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // NewAEndpoint returns an endpoint function that calls the method "A" of
 // service "SingleEndpoint".
 func NewAEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		p := req.(*AType)
 		return nil, s.A(ctx, p)
 	}
@@ -49,7 +49,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // NewUseEndpointEndpoint returns an endpoint function that calls the method
 // "Use" of service "UseEndpoint".
 func NewUseEndpointEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		p := req.(string)
 		return nil, s.UseEndpoint(ctx, p)
 	}
@@ -81,7 +81,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // NewBEndpoint returns an endpoint function that calls the method "B" of
 // service "MultipleEndpoints".
 func NewBEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		p := req.(*BType)
 		return nil, s.B(ctx, p)
 	}
@@ -90,7 +90,7 @@ func NewBEndpoint(s Service) goa.Endpoint {
 // NewCEndpoint returns an endpoint function that calls the method "C" of
 // service "MultipleEndpoints".
 func NewCEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		p := req.(*CType)
 		return nil, s.C(ctx, p)
 	}
@@ -117,7 +117,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // NewNoPayloadEndpoint returns an endpoint function that calls the method
 // "NoPayload" of service "NoPayload".
 func NewNoPayloadEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		return nil, s.NoPayload(ctx)
 	}
 }
@@ -143,7 +143,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // NewAEndpoint returns an endpoint function that calls the method "A" of
 // service "WithResult".
 func NewAEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		res, err := s.A(ctx)
 		if err != nil {
 			return nil, err
@@ -179,7 +179,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // NewAEndpoint returns an endpoint function that calls the method "A" of
 // service "WithResultMultipleViews".
 func NewAEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		res, err := s.A(ctx)
 		if err != nil {
 			return nil, err
@@ -192,7 +192,7 @@ func NewAEndpoint(s Service) goa.Endpoint {
 // NewBEndpoint returns an endpoint function that calls the method "B" of
 // service "WithResultMultipleViews".
 func NewBEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		res, err := s.B(ctx)
 		if err != nil {
 			return nil, err
@@ -235,7 +235,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // NewStreamingResultMethodEndpoint returns an endpoint function that calls the
 // method "StreamingResultMethod" of service "StreamingResultEndpoint".
 func NewStreamingResultMethodEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*StreamingResultMethodEndpointInput)
 		return nil, s.StreamingResultMethod(ctx, ep.Payload, ep.Stream)
 	}
@@ -273,7 +273,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // calls the method "StreamingResultNoPayloadMethod" of service
 // "StreamingResultNoPayloadEndpoint".
 func NewStreamingResultNoPayloadMethodEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*StreamingResultNoPayloadMethodEndpointInput)
 		return nil, s.StreamingResultNoPayloadMethod(ctx, ep.Stream)
 	}
@@ -313,7 +313,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // calls the method "StreamingResultWithViewsMethod" of service
 // "StreamingResultWithViewsService".
 func NewStreamingResultWithViewsMethodEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*StreamingResultWithViewsMethodEndpointInput)
 		return nil, s.StreamingResultWithViewsMethod(ctx, ep.Payload, ep.Stream)
 	}
@@ -352,7 +352,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // NewStreamingPayloadMethodEndpoint returns an endpoint function that calls
 // the method "StreamingPayloadMethod" of service "StreamingPayloadEndpoint".
 func NewStreamingPayloadMethodEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*StreamingPayloadMethodEndpointInput)
 		return nil, s.StreamingPayloadMethod(ctx, ep.Payload, ep.Stream)
 	}
@@ -390,7 +390,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // calls the method "StreamingPayloadNoPayloadMethod" of service
 // "StreamingPayloadNoPayloadService".
 func NewStreamingPayloadNoPayloadMethodEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*StreamingPayloadNoPayloadMethodEndpointInput)
 		return nil, s.StreamingPayloadNoPayloadMethod(ctx, ep.Stream)
 	}
@@ -428,7 +428,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // calls the method "StreamingPayloadNoResultMethod" of service
 // "StreamingPayloadNoResultService".
 func NewStreamingPayloadNoResultMethodEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*StreamingPayloadNoResultMethodEndpointInput)
 		return nil, s.StreamingPayloadNoResultMethod(ctx, ep.Stream)
 	}
@@ -468,7 +468,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // calls the method "BidirectionalStreamingMethod" of service
 // "BidirectionalStreamingEndpoint".
 func NewBidirectionalStreamingMethodEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*BidirectionalStreamingMethodEndpointInput)
 		return nil, s.BidirectionalStreamingMethod(ctx, ep.Payload, ep.Stream)
 	}
@@ -507,7 +507,7 @@ func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
 // function that calls the method "BidirectionalStreamingNoPayloadMethod" of
 // service "BidirectionalStreamingNoPayloadService".
 func NewBidirectionalStreamingNoPayloadMethodEndpoint(s Service) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*BidirectionalStreamingNoPayloadMethodEndpointInput)
 		return nil, s.BidirectionalStreamingNoPayloadMethod(ctx, ep.Stream)
 	}

--- a/codegen/service/testdata/security_functions.go
+++ b/codegen/service/testdata/security_functions.go
@@ -46,7 +46,7 @@ var EndpointWithRequiredScopesCode = `// NewSecureWithRequiredScopesEndpoint ret
 // the method "SecureWithRequiredScopes" of service
 // "EndpointWithRequiredScopes".
 func NewSecureWithRequiredScopesEndpoint(s Service, authJWTFn security.AuthJWTFunc) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		p := req.(*SecureWithRequiredScopesPayload)
 		var err error
 		sc := security.JWTScheme{
@@ -71,7 +71,7 @@ var EndpointWithOptionalRequiredScopesCode = `// NewSecureWithOptionalRequiredSc
 // that calls the method "SecureWithOptionalRequiredScopes" of service
 // "EndpointWithOptionalRequiredScopes".
 func NewSecureWithOptionalRequiredScopesEndpoint(s Service, authBasicFn security.AuthBasicFunc) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		p := req.(*SecureWithOptionalRequiredScopesPayload)
 		var err error
 		sc := security.BasicScheme{
@@ -100,7 +100,7 @@ var EndpointWithAPIKeyOverrideCode = `// NewSecureWithAPIKeyOverrideEndpoint ret
 // the method "SecureWithAPIKeyOverride" of service
 // "EndpointWithAPIKeyOverride".
 func NewSecureWithAPIKeyOverrideEndpoint(s Service, authAPIKeyFn security.AuthAPIKeyFunc) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		p := req.(*SecureWithAPIKeyOverridePayload)
 		var err error
 		sc := security.APIKeyScheme{
@@ -124,7 +124,7 @@ func NewSecureWithAPIKeyOverrideEndpoint(s Service, authAPIKeyFn security.AuthAP
 var EndpointWithOAuth2Code = `// NewSecureWithOAuth2Endpoint returns an endpoint function that calls the
 // method "SecureWithOAuth2" of service "EndpointWithOAuth2".
 func NewSecureWithOAuth2Endpoint(s Service, authOAuth2Fn security.AuthOAuth2Func) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		p := req.(*SecureWithOAuth2Payload)
 		var err error
 		sc := security.OAuth2Scheme{
@@ -157,7 +157,7 @@ var EndpointWithBasicAuthAndSkipRequestBodyEncodeDecodeCode = `// NewEndpointWit
 // function that calls the method "EndpointWithSkipRequestBodyEncodeDecode" of
 // service "EndpointWithSkipRequestBodyEncodeDecode".
 func NewEndpointWithSkipRequestBodyEncodeDecodeEndpoint(s Service, authBasicFn security.AuthBasicFunc) goa.Endpoint {
-	return func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any) (any, error) {
 		ep := req.(*EndpointWithSkipRequestBodyEncodeDecodeRequestData)
 		var err error
 		sc := security.BasicScheme{

--- a/codegen/service/testdata/service_code.go
+++ b/codegen/service/testdata/service_code.go
@@ -2050,15 +2050,15 @@ var MethodNames = [1]string{"StreamingPayloadNoPayloadMethod"}
 type StreamingPayloadNoPayloadMethodServerStream interface {
 	// SendAndClose streams instances of "string" and closes the stream.
 	SendAndClose(string) error
-	// Recv reads instances of "interface{}" from the stream.
-	Recv() (interface{}, error)
+	// Recv reads instances of "any" from the stream.
+	Recv() (any, error)
 }
 
 // StreamingPayloadNoPayloadMethodClientStream is the interface a
 // "StreamingPayloadNoPayloadMethod" endpoint client stream must satisfy.
 type StreamingPayloadNoPayloadMethodClientStream interface {
-	// Send streams instances of "interface{}".
-	Send(interface{}) error
+	// Send streams instances of "any".
+	Send(any) error
 	// CloseAndRecv stops sending messages to the stream and reads instances of
 	// "string" from the stream.
 	CloseAndRecv() (string, error)

--- a/codegen/service/testdata/views_code.go
+++ b/codegen/service/testdata/views_code.go
@@ -37,7 +37,7 @@ func ValidateResultType(result *ResultType) (err error) {
 	case "tiny":
 		err = ValidateResultTypeViewTiny(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default", "tiny"})
 	}
 	return
 }
@@ -116,7 +116,7 @@ func ValidateResultTypeCollection(result ResultTypeCollection) (err error) {
 	case "tiny":
 		err = ValidateResultTypeCollectionViewTiny(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default", "tiny"})
 	}
 	return
 }
@@ -207,7 +207,7 @@ func ValidateResultType(result *ResultType) (err error) {
 	case "tiny":
 		err = ValidateResultTypeViewTiny(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default", "tiny"})
 	}
 	return
 }
@@ -319,7 +319,7 @@ func ValidateRT(result *RT) (err error) {
 	case "tiny":
 		err = ValidateRTViewTiny(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default", "tiny"})
 	}
 	return
 }
@@ -452,7 +452,7 @@ func ValidateRT(result *RT) (err error) {
 	case "tiny":
 		err = ValidateRTViewTiny(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default", "tiny"})
 	}
 	return
 }
@@ -521,7 +521,7 @@ func ValidateRT(result *RT) (err error) {
 	case "tiny":
 		err = ValidateRTViewTiny(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default", "tiny"})
 	}
 	return
 }
@@ -625,7 +625,7 @@ func ValidateSomeRT(result *SomeRT) (err error) {
 	case "tiny":
 		err = ValidateSomeRTViewTiny(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default", "tiny"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default", "tiny"})
 	}
 	return
 }
@@ -637,7 +637,7 @@ func ValidateAnotherResult(result *AnotherResult) (err error) {
 	case "default", "":
 		err = ValidateAnotherResultView(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default"})
 	}
 	return
 }
@@ -740,7 +740,7 @@ func ValidateRT(result *RT) (err error) {
 	case "default", "":
 		err = ValidateRTView(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default"})
 	}
 	return
 }
@@ -784,7 +784,7 @@ func ValidateResult(result *Result) (err error) {
 	case "default", "":
 		err = ValidateResultView(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default"})
 	}
 	return
 }
@@ -794,7 +794,7 @@ func ValidateResult(result *Result) (err error) {
 func ValidateResultView(result *ResultView) (err error) {
 	for _, e := range result.T {
 		if !(string(e) == "a" || string(e) == "b") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.t[*]", string(e), []interface{}{"a", "b"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("result.t[*]", string(e), []any{"a", "b"}))
 		}
 	}
 	return
@@ -803,7 +803,7 @@ func ValidateResultView(result *ResultView) (err error) {
 // ValidateUserTypeView runs the validations defined on UserTypeView.
 func ValidateUserTypeView(result UserTypeView) (err error) {
 	if !(string(result) == "a" || string(result) == "b") {
-		err = goa.MergeErrors(err, goa.InvalidEnumValueError("result", string(result), []interface{}{"a", "b"}))
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("result", string(result), []any{"a", "b"}))
 	}
 	return
 }
@@ -842,7 +842,7 @@ func ValidateRT(result *RT) (err error) {
 	case "default", "":
 		err = ValidateRTView(result.Projected)
 	default:
-		err = goa.InvalidEnumValueError("view", result.View, []interface{}{"default"})
+		err = goa.InvalidEnumValueError("view", result.View, []any{"default"})
 	}
 	return
 }

--- a/codegen/service/views.go
+++ b/codegen/service/views.go
@@ -86,7 +86,7 @@ func ViewsFile(genpkg string, service *expr.ServiceExpr) *codegen.File {
 		sections = append(sections, &codegen.SectionTemplate{
 			Name:   "viewed-type-map",
 			Source: viewedMapT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"ViewedTypes": rtdata,
 			},
 		})
@@ -121,7 +121,7 @@ func {{ .Name }}(result {{ .Ref }}) (err error) {
 }
 `
 
-// input: map[string]interface{}{"ViewedTypes": []*viewedType}
+// input: map[string]any{"ViewedTypes": []*viewedType}
 const viewedMapT = `var (
 {{- range .ViewedTypes }}
 	{{ printf "%sMap is a map indexing the attribute names of %s by view name." .Name .Name | comment }}

--- a/codegen/testdata/validation_code.go
+++ b/codegen/testdata/validation_code.go
@@ -7,7 +7,7 @@ const (
 	}
 	if target.DefaultInteger != nil {
 		if !(*target.DefaultInteger == 1 || *target.DefaultInteger == 5 || *target.DefaultInteger == 10 || *target.DefaultInteger == 100) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []interface{}{1, 5, 10, 100}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []any{1, 5, 10, 100}))
 		}
 	}
 	if target.Integer != nil {
@@ -39,7 +39,7 @@ const (
 	}
 	if target.DefaultInteger != nil {
 		if !(*target.DefaultInteger == 1 || *target.DefaultInteger == 5 || *target.DefaultInteger == 10 || *target.DefaultInteger == 100) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []interface{}{1, 5, 10, 100}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []any{1, 5, 10, 100}))
 		}
 	}
 	if target.Integer != nil {
@@ -65,7 +65,7 @@ const (
 		err = goa.MergeErrors(err, goa.InvalidRangeError("target.required_integer", target.RequiredInteger, 1, true))
 	}
 	if !(target.DefaultInteger == 1 || target.DefaultInteger == 5 || target.DefaultInteger == 10 || target.DefaultInteger == 100) {
-		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", target.DefaultInteger, []interface{}{1, 5, 10, 100}))
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", target.DefaultInteger, []any{1, 5, 10, 100}))
 	}
 	if target.Integer != nil {
 		if *target.Integer > 100 {
@@ -91,7 +91,7 @@ const (
 	}
 	if target.DefaultInteger != nil {
 		if !(*target.DefaultInteger == 1.2 || *target.DefaultInteger == 5 || *target.DefaultInteger == 10 || *target.DefaultInteger == 100.8) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []interface{}{1.2, 5, 10, 100.8}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []any{1.2, 5, 10, 100.8}))
 		}
 	}
 	if target.Float64 != nil {
@@ -123,7 +123,7 @@ const (
 	}
 	if target.DefaultInteger != nil {
 		if !(*target.DefaultInteger == 1.2 || *target.DefaultInteger == 5 || *target.DefaultInteger == 10 || *target.DefaultInteger == 100.8) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []interface{}{1.2, 5, 10, 100.8}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", *target.DefaultInteger, []any{1.2, 5, 10, 100.8}))
 		}
 	}
 	if target.Float64 != nil {
@@ -149,7 +149,7 @@ const (
 		err = goa.MergeErrors(err, goa.InvalidRangeError("target.required_float", target.RequiredFloat, 1, true))
 	}
 	if !(target.DefaultInteger == 1.2 || target.DefaultInteger == 5 || target.DefaultInteger == 10 || target.DefaultInteger == 100.8) {
-		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", target.DefaultInteger, []interface{}{1.2, 5, 10, 100.8}))
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_integer", target.DefaultInteger, []any{1.2, 5, 10, 100.8}))
 	}
 	if target.Float64 != nil {
 		if *target.Float64 > 100.1 {
@@ -179,7 +179,7 @@ const (
 	}
 	if target.DefaultString != nil {
 		if !(*target.DefaultString == "foo" || *target.DefaultString == "bar") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", *target.DefaultString, []interface{}{"foo", "bar"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", *target.DefaultString, []any{"foo", "bar"}))
 		}
 	}
 	if target.String != nil {
@@ -207,7 +207,7 @@ const (
 	}
 	if target.DefaultString != nil {
 		if !(*target.DefaultString == "foo" || *target.DefaultString == "bar") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", *target.DefaultString, []interface{}{"foo", "bar"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", *target.DefaultString, []any{"foo", "bar"}))
 		}
 	}
 	if target.String != nil {
@@ -225,7 +225,7 @@ const (
 		err = goa.MergeErrors(err, goa.InvalidLengthError("target.required_string", target.RequiredString, utf8.RuneCountInString(target.RequiredString), 10, false))
 	}
 	if !(target.DefaultString == "foo" || target.DefaultString == "bar") {
-		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", target.DefaultString, []interface{}{"foo", "bar"}))
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.default_string", target.DefaultString, []any{"foo", "bar"}))
 	}
 	if target.String != nil {
 		err = goa.MergeErrors(err, goa.ValidateFormat("target.string", *target.String, goa.FormatDateTime))
@@ -345,7 +345,7 @@ const (
 	}
 	for _, e := range target.Array {
 		if !(e == 0 || e == 1 || e == 1 || e == 2 || e == 3 || e == 5) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []interface{}{0, 1, 1, 2, 3, 5}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []any{0, 1, 1, 2, 3, 5}))
 		}
 	}
 }
@@ -363,7 +363,7 @@ const (
 	}
 	for _, e := range target.Array {
 		if !(e == 0 || e == 1 || e == 1 || e == 2 || e == 3 || e == 5) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []interface{}{0, 1, 1, 2, 3, 5}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []any{0, 1, 1, 2, 3, 5}))
 		}
 	}
 }
@@ -381,7 +381,7 @@ const (
 	}
 	for _, e := range target.Array {
 		if !(e == 0 || e == 1 || e == 1 || e == 2 || e == 3 || e == 5) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []interface{}{0, 1, 1, 2, 3, 5}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("target.array[*]", e, []any{0, 1, 1, 2, 3, 5}))
 		}
 	}
 }

--- a/codegen/types.go
+++ b/codegen/types.go
@@ -35,7 +35,7 @@ func GoNativeTypeName(t expr.DataType) string {
 	case expr.BytesKind:
 		return "[]byte"
 	case expr.AnyKind:
-		return "interface{}"
+		return "any"
 	default:
 		panic(fmt.Sprintf("cannot compute native Go type for %T", t)) // bug
 	}

--- a/codegen/types_test.go
+++ b/codegen/types_test.go
@@ -65,7 +65,7 @@ func TestGoTypeDef(t *testing.T) {
 		"Float64Kind": {&expr.AttributeExpr{Type: expr.Float64}, false, true, "float64"},
 		"StringKind":  {&expr.AttributeExpr{Type: expr.String}, false, true, "string"},
 		"BytesKind":   {&expr.AttributeExpr{Type: expr.Bytes}, false, true, "[]byte"},
-		"AnyKind":     {&expr.AttributeExpr{Type: expr.Any}, false, true, "interface{}"},
+		"AnyKind":     {&expr.AttributeExpr{Type: expr.Any}, false, true, "any"},
 
 		"Array":          {simpleArray, false, true, "[]bool"},
 		"Map":            {simpleMap, false, true, "map[int]string"},
@@ -108,7 +108,7 @@ func TestGoNativeTypeName(t *testing.T) {
 		"Float64Kind": {expr.Float64, "float64"},
 		"StringKind":  {expr.String, "string"},
 		"BytesKind":   {expr.Bytes, "[]byte"},
-		"AnyKind":     {expr.Any, "interface{}"},
+		"AnyKind":     {expr.Any, "any"},
 	}
 
 	for k, tc := range cases {

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -123,7 +123,7 @@ func recurseValidationCode(att *expr.AttributeExpr, put expr.UserType, attCtx *A
 		val := validateAttribute(ctx, elem, put, "e", context+"[*]", true)
 		if val != "" {
 			newline()
-			data := map[string]interface{}{"target": target, "validation": val}
+			data := map[string]any{"target": target, "validation": val}
 			if err := arrayValT.Execute(buf, data); err != nil {
 				panic(err) // bug
 			}
@@ -142,7 +142,7 @@ func recurseValidationCode(att *expr.AttributeExpr, put expr.UserType, attCtx *A
 		}
 		if keyVal != "" || valueVal != "" {
 			newline()
-			data := map[string]interface{}{"target": target, "keyValidation": keyVal, "valueValidation": valueVal}
+			data := map[string]any{"target": target, "keyValidation": keyVal, "valueValidation": valueVal}
 			if err := mapValT.Execute(buf, data); err != nil {
 				panic(err) // bug
 			}
@@ -166,7 +166,7 @@ func recurseValidationCode(att *expr.AttributeExpr, put expr.UserType, attCtx *A
 		}
 		if len(vals) > 0 {
 			newline()
-			data := map[string]interface{}{
+			data := map[string]any{
 				"target": target,
 				"types":  types,
 				"values": vals,
@@ -207,7 +207,7 @@ func validateAttribute(ctx *AttributeContext, att *expr.AttributeExpr, put expr.
 	}
 	var buf bytes.Buffer
 	name := ctx.Scope.Name(att, "", ctx.Pointer, ctx.UseDefault)
-	data := map[string]interface{}{"name": Goify(name, true), "target": target}
+	data := map[string]any{"name": Goify(name, true), "target": target}
 	if err := userValT.Execute(&buf, data); err != nil {
 		panic(err) // bug
 	}
@@ -257,7 +257,7 @@ func validationCode(att *expr.AttributeExpr, attCtx *AttributeContext, req, alia
 	if alias {
 		tval = fmt.Sprintf("%s(%s)", att.Type.Name(), tval)
 	}
-	data := map[string]interface{}{
+	data := map[string]any{
 		"attribute": att,
 		"attCtx":    attCtx,
 		"isPointer": isPointer,
@@ -268,7 +268,7 @@ func validationCode(att *expr.AttributeExpr, attCtx *AttributeContext, req, alia
 		"array":     expr.IsArray(att.Type),
 		"map":       expr.IsMap(att.Type),
 	}
-	runTemplate := func(tmpl *template.Template, data interface{}) string {
+	runTemplate := func(tmpl *template.Template, data any) string {
 		var buf bytes.Buffer
 		if err := tmpl.Execute(&buf, data); err != nil {
 			panic(err) // bug
@@ -437,17 +437,17 @@ func flattenValidations(att *expr.AttributeExpr, seen map[string]struct{}) {
 }
 
 // toSlice returns Go code that represents the given slice.
-func toSlice(val []interface{}) string {
+func toSlice(val []any) string {
 	elems := make([]string, len(val))
 	for i, v := range val {
 		elems[i] = fmt.Sprintf("%#v", v)
 	}
-	return fmt.Sprintf("[]interface{}{%s}", strings.Join(elems, ", "))
+	return fmt.Sprintf("[]any{%s}", strings.Join(elems, ", "))
 }
 
 // oneof produces code that compares target with each element of vals and ORs
 // the result, e.g. "target == 1 || target == 2".
-func oneof(target string, vals []interface{}) string {
+func oneof(target string, vals []any) string {
 	elems := make([]string, len(vals))
 	for i, v := range vals {
 		elems[i] = fmt.Sprintf("%s == %#v", target, v)

--- a/dsl/attribute.go
+++ b/dsl/attribute.go
@@ -111,7 +111,7 @@ import (
 //        Required("name", "age")            // List required attributes
 //    })
 //
-func Attribute(name string, args ...interface{}) {
+func Attribute(name string, args ...any) {
 	var parent *expr.AttributeExpr
 	{
 		switch def := eval.Current().(type) {
@@ -194,7 +194,7 @@ func Attribute(name string, args ...interface{}) {
 //         Pattern("[0-9]+")
 //     })
 //
-func Field(tag interface{}, name string, args ...interface{}) {
+func Field(tag any, name string, args ...any) {
 	fn := func() { Meta("rpc:tag", fmt.Sprintf("%v", tag)) }
 	if len(args) > 0 {
 		if d, ok := args[len(args)-1].(func()); ok {
@@ -223,7 +223,7 @@ func Field(tag interface{}, name string, args ...interface{}) {
 //        })
 //    })
 //
-func OneOf(name string, args ...interface{}) {
+func OneOf(name string, args ...any) {
 	if len(args) > 2 {
 		eval.ReportError("OneOf: wrong number of arguments")
 	}
@@ -246,7 +246,7 @@ func OneOf(name string, args ...interface{}) {
 // Default must appear in an Attribute DSL.
 //
 // Default takes one parameter: the default value.
-func Default(def interface{}) {
+func Default(def any) {
 	a, ok := eval.Current().(*expr.AttributeExpr)
 	if !ok {
 		eval.IncompatibleDSL()
@@ -299,7 +299,7 @@ func Default(def interface{}) {
 //        })
 //    })
 //
-func Example(args ...interface{}) {
+func Example(args ...any) {
 	if len(args) == 0 {
 		eval.ReportError("not enough arguments")
 		return
@@ -310,7 +310,7 @@ func Example(args ...interface{}) {
 	}
 	var (
 		summary string
-		arg     interface{}
+		arg     any
 	)
 	if len(args) == 1 {
 		summary = "default"
@@ -347,7 +347,7 @@ func Example(args ...interface{}) {
 	a.UserExamples = append(a.UserExamples, ex)
 }
 
-func parseAttributeArgs(baseAttr *expr.AttributeExpr, args ...interface{}) (expr.DataType, string, func()) {
+func parseAttributeArgs(baseAttr *expr.AttributeExpr, args ...any) (expr.DataType, string, func()) {
 	var (
 		dataType    expr.DataType
 		description string

--- a/dsl/convert.go
+++ b/dsl/convert.go
@@ -66,7 +66,7 @@ import (
 //	    // Additional fields are OK
 //	    Description string
 //	}
-func ConvertTo(obj interface{}) {
+func ConvertTo(obj any) {
 	var ut expr.UserType
 	switch actual := eval.Current().(type) {
 	case *expr.AttributeExpr:
@@ -146,7 +146,7 @@ func ConvertTo(obj interface{}) {
 //	    // Additional fields are OK
 //	    Description string
 //	}
-func CreateFrom(obj interface{}) {
+func CreateFrom(obj any) {
 	var ut expr.UserType
 	switch actual := eval.Current().(type) {
 	case *expr.AttributeExpr:

--- a/dsl/error.go
+++ b/dsl/error.go
@@ -84,9 +84,9 @@ const (
 //        })
 //    })
 //
-func Error(name string, args ...interface{}) {
+func Error(name string, args ...any) {
 	if len(args) == 0 {
-		args = []interface{}{expr.ErrorResult}
+		args = []any{expr.ErrorResult}
 	}
 	dt, desc, fn := parseAttributeArgs(nil, args...)
 	att := &expr.AttributeExpr{
@@ -173,7 +173,7 @@ func Error(name string, args ...interface{}) {
 //        return nil
 //    }
 //
-func ErrorName(args ...interface{}) {
+func ErrorName(args ...any) {
 	if len(args) == 0 {
 		eval.IncompatibleDSL()
 		return

--- a/dsl/headers.go
+++ b/dsl/headers.go
@@ -58,7 +58,7 @@ import (
 //         })
 //     })
 //
-func Headers(args interface{}) {
+func Headers(args any) {
 	fn, ok := args.(func())
 	if !ok {
 		eval.InvalidArgError("function", args)

--- a/dsl/http.go
+++ b/dsl/http.go
@@ -376,7 +376,7 @@ func route(method, path string) *expr.RouteExpr {
 //        })
 //    })
 //
-func Header(name string, args ...interface{}) {
+func Header(name string, args ...any) {
 	h := headers(eval.Current())
 	if h == nil {
 		eval.IncompatibleDSL()
@@ -435,7 +435,7 @@ func Header(name string, args ...interface{}) {
 //        })
 //    })
 //
-func Cookie(name string, args ...interface{}) {
+func Cookie(name string, args ...any) {
 	h := cookies(eval.Current())
 	if h == nil {
 		eval.IncompatibleDSL()
@@ -614,7 +614,7 @@ func CookieHTTPOnly() {
 //         })
 //     })
 //
-func Params(args interface{}) {
+func Params(args any) {
 	p := params(eval.Current())
 	if p == nil {
 		eval.IncompatibleDSL()
@@ -671,7 +671,7 @@ func Params(args interface{}) {
 //        })
 //    })
 //
-func Param(name string, args ...interface{}) {
+func Param(name string, args ...any) {
 	p := params(eval.Current())
 	if p == nil {
 		eval.IncompatibleDSL()
@@ -719,7 +719,7 @@ func Param(name string, args ...interface{}) {
 //        })
 //    })
 //
-func MapParams(args ...interface{}) {
+func MapParams(args ...any) {
 	if len(args) > 1 {
 		eval.ReportError("too many arguments")
 	}
@@ -874,7 +874,7 @@ func SkipResponseBodyEncodeDecode() {
 //         })
 //     })
 //
-func Body(args ...interface{}) {
+func Body(args ...any) {
 	if len(args) == 0 {
 		eval.ReportError("not enough arguments, use Body(name), Body(type), Body(func()) or Body(type, func())")
 		return

--- a/dsl/payload.go
+++ b/dsl/payload.go
@@ -68,7 +68,7 @@ import (
 //	        Required("left", "right")
 //	    })
 //	})
-func Payload(val interface{}, args ...interface{}) {
+func Payload(val any, args ...any) {
 	if len(args) > 2 {
 		eval.ReportError("too many arguments")
 	}
@@ -122,7 +122,7 @@ func Payload(val interface{}, args ...interface{}) {
 //	Method("add", func() {
 //	    StreamingPayload(Operands)
 //	})
-func StreamingPayload(val interface{}, args ...interface{}) {
+func StreamingPayload(val any, args ...any) {
 	if len(args) > 2 {
 		eval.ReportError("too many arguments")
 	}
@@ -139,7 +139,7 @@ func StreamingPayload(val interface{}, args ...interface{}) {
 	}
 }
 
-func methodDSL(m *expr.MethodExpr, suffix string, p interface{}, args ...interface{}) *expr.AttributeExpr {
+func methodDSL(m *expr.MethodExpr, suffix string, p any, args ...any) *expr.AttributeExpr {
 	var (
 		att *expr.AttributeExpr
 		fn  func()

--- a/dsl/response.go
+++ b/dsl/response.go
@@ -93,13 +93,13 @@ import (
 //        })
 //    })
 //
-func Response(val interface{}, args ...interface{}) {
+func Response(val any, args ...any) {
 	name, ok := val.(string)
 	if !ok && len(args) > 0 {
 		name, ok = args[0].(string)
 		if ok {
 			arg := args[0]
-			args = append([]interface{}{val}, args[1:]...)
+			args = append([]any{val}, args[1:]...)
 			val = arg
 		}
 	}
@@ -201,7 +201,7 @@ func Code(code int) {
 	}
 }
 
-func grpcError(n string, p eval.Expression, args ...interface{}) *expr.GRPCErrorExpr {
+func grpcError(n string, p eval.Expression, args ...any) *expr.GRPCErrorExpr {
 	if len(args) == 0 {
 		eval.ReportError("not enough arguments, use Response(name, status), Response(name, status, func()) or Response(name, func())")
 		return nil
@@ -209,7 +209,7 @@ func grpcError(n string, p eval.Expression, args ...interface{}) *expr.GRPCError
 	var (
 		code int
 		fn   func()
-		val  interface{}
+		val  any
 	)
 	val = args[0]
 	args = args[1:]
@@ -230,7 +230,7 @@ func grpcError(n string, p eval.Expression, args ...interface{}) *expr.GRPCError
 	}
 }
 
-func parseResponseArgs(val interface{}, args ...interface{}) (code int, fn func()) {
+func parseResponseArgs(val any, args ...any) (code int, fn func()) {
 	switch t := val.(type) {
 	case int:
 		code = t
@@ -259,7 +259,7 @@ func parseResponseArgs(val interface{}, args ...interface{}) (code int, fn func(
 	return
 }
 
-func httpError(n string, p eval.Expression, args ...interface{}) *expr.HTTPErrorExpr {
+func httpError(n string, p eval.Expression, args ...any) *expr.HTTPErrorExpr {
 	if len(args) == 0 {
 		eval.ReportError("not enough arguments, use Response(name, status), Response(name, status, func()) or Response(name, func())")
 		return nil
@@ -267,7 +267,7 @@ func httpError(n string, p eval.Expression, args ...interface{}) *expr.HTTPError
 	var (
 		code int
 		fn   func()
-		val  interface{}
+		val  any
 	)
 	val = args[0]
 	args = args[1:]

--- a/dsl/result.go
+++ b/dsl/result.go
@@ -70,7 +70,7 @@ import (
 //	        Required("value")
 //	    })
 //	})
-func Result(val interface{}, args ...interface{}) {
+func Result(val any, args ...any) {
 	if len(args) > 2 {
 		eval.ReportError("too many arguments")
 		return
@@ -128,7 +128,7 @@ func Result(val interface{}, args ...interface{}) {
 //	        Required("value")
 //	    })
 //	})
-func StreamingResult(val interface{}, args ...interface{}) {
+func StreamingResult(val any, args ...any) {
 	if len(args) > 2 {
 		eval.ReportError("too many arguments")
 		return

--- a/dsl/result_type.go
+++ b/dsl/result_type.go
@@ -62,7 +62,7 @@ var resultTypeCount int
 //	        Attribute("origin")
 //	    })
 //	 })
-func ResultType(identifier string, args ...interface{}) *expr.ResultTypeExpr {
+func ResultType(identifier string, args ...any) *expr.ResultTypeExpr {
 	if _, ok := eval.Current().(eval.TopExpr); !ok {
 		eval.IncompatibleDSL()
 		return nil
@@ -292,7 +292,7 @@ func View(name string, adsl ...func()) {
 //	        })
 //	    })
 //	})
-func CollectionOf(v interface{}, adsl ...func()) *expr.ResultTypeExpr {
+func CollectionOf(v any, adsl ...func()) *expr.ResultTypeExpr {
 	var m *expr.ResultTypeExpr
 	var ok bool
 	m, ok = v.(*expr.ResultTypeExpr)

--- a/dsl/security.go
+++ b/dsl/security.go
@@ -231,7 +231,7 @@ func JWTSecurity(name string, fn ...func()) *expr.SchemeExpr {
 //        })
 //    })
 //
-func Security(args ...interface{}) {
+func Security(args ...any) {
 	var dsl func()
 	{
 		if d, ok := args[len(args)-1].(func()); ok {
@@ -327,7 +327,7 @@ func NoSecurity() {
 //        })
 //    })
 //
-func Username(name string, args ...interface{}) {
+func Username(name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:username") })
 	Attribute(name, args...)
 }
@@ -338,7 +338,7 @@ func Username(name string, args ...interface{}) {
 // UsernameField takes the same arguments as Username with the addition of the
 // tag value as the first argument.
 //
-func UsernameField(tag interface{}, name string, args ...interface{}) {
+func UsernameField(tag any, name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:username") })
 	Field(tag, name, args...)
 }
@@ -366,7 +366,7 @@ func UsernameField(tag interface{}, name string, args ...interface{}) {
 //        })
 //    })
 //
-func Password(name string, args ...interface{}) {
+func Password(name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:password") })
 	Attribute(name, args...)
 }
@@ -377,7 +377,7 @@ func Password(name string, args ...interface{}) {
 // PasswordField takes the same arguments as Password with the addition of the
 // tag value as the first argument.
 //
-func PasswordField(tag interface{}, name string, args ...interface{}) {
+func PasswordField(tag any, name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:password") })
 	Field(tag, name, args...)
 }
@@ -420,7 +420,7 @@ func PasswordField(tag interface{}, name string, args ...interface{}) {
 //        })
 //    })
 //
-func APIKey(scheme, name string, args ...interface{}) {
+func APIKey(scheme, name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:apikey:"+scheme, scheme) })
 	Attribute(name, args...)
 }
@@ -431,7 +431,7 @@ func APIKey(scheme, name string, args ...interface{}) {
 // APIKeyField takes the same arguments as APIKey with the addition of the
 // tag value as the first argument.
 //
-func APIKeyField(tag interface{}, scheme, name string, args ...interface{}) {
+func APIKeyField(tag any, scheme, name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:apikey:"+scheme, scheme) })
 	Field(tag, name, args...)
 }
@@ -460,7 +460,7 @@ func APIKeyField(tag interface{}, scheme, name string, args ...interface{}) {
 //        })
 //    })
 //
-func AccessToken(name string, args ...interface{}) {
+func AccessToken(name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:accesstoken") })
 	Attribute(name, args...)
 }
@@ -471,7 +471,7 @@ func AccessToken(name string, args ...interface{}) {
 // AccessTokenField takes the same arguments as AccessToken with the addition of the
 // tag value as the first argument.
 //
-func AccessTokenField(tag interface{}, name string, args ...interface{}) {
+func AccessTokenField(tag any, name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:accesstoken") })
 	Field(tag, name, args...)
 }
@@ -498,7 +498,7 @@ func AccessTokenField(tag interface{}, name string, args ...interface{}) {
 //        })
 //    })
 //
-func Token(name string, args ...interface{}) {
+func Token(name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:token") })
 	Attribute(name, args...)
 }
@@ -509,7 +509,7 @@ func Token(name string, args ...interface{}) {
 // TokenField takes the same arguments as Token with the addition of the
 // tag value as the first argument.
 //
-func TokenField(tag interface{}, name string, args ...interface{}) {
+func TokenField(tag any, name string, args ...any) {
 	args = useDSL(args, func() { Meta("security:token") })
 	Field(tag, name, args...)
 }
@@ -666,9 +666,9 @@ func securitySchemeRedefined(name string) bool {
 
 // useDSL modifies the Attribute function to use the given function as DSL,
 // merging it with any pre-existing DSL.
-func useDSL(args []interface{}, d func()) []interface{} {
+func useDSL(args []any, d func()) []any {
 	if len(args) == 0 {
-		return []interface{}{d}
+		return []any{d}
 	}
 	ds, ok := args[len(args)-1].(func())
 	if ok {

--- a/dsl/server.go
+++ b/dsl/server.go
@@ -192,7 +192,7 @@ func URI(uri string) {
 //        })
 //    })
 //
-func Variable(name string, args ...interface{}) {
+func Variable(name string, args ...any) {
 	if _, ok := eval.Current().(*expr.HostExpr); !ok {
 		eval.IncompatibleDSL()
 		return

--- a/dsl/types.go
+++ b/dsl/types.go
@@ -36,7 +36,7 @@ const (
 	// Bytes is the type for binary data.
 	Bytes = expr.Bytes
 
-	// Any is the type for an arbitrary JSON value (interface{} in Go).
+	// Any is the type for an arbitrary JSON value (any in Go).
 	Any = expr.Any
 )
 

--- a/dsl/user_type.go
+++ b/dsl/user_type.go
@@ -57,7 +57,7 @@ var (
 //         Required("b", "c")
 //     })
 //
-func Type(name string, args ...interface{}) expr.UserType {
+func Type(name string, args ...any) expr.UserType {
 	if len(args) > 2 {
 		eval.ReportError("too many arguments")
 		return nil
@@ -78,7 +78,7 @@ func Type(name string, args ...interface{}) expr.UserType {
 	)
 	if len(args) == 0 {
 		// Make Type behave like Attribute
-		args = []interface{}{expr.String}
+		args = []any{expr.String}
 	}
 	switch a := args[0].(type) {
 	case expr.DataType:
@@ -135,7 +135,7 @@ func Type(name string, args ...interface{}) expr.UserType {
 // a result type where ArrayOf returns a user type. In general you want to use
 // CollectionOf if the argument is a result type and ArrayOf if it is a user
 // type.
-func ArrayOf(v interface{}, fn ...func()) *expr.Array {
+func ArrayOf(v any, fn ...func()) *expr.Array {
 	var t expr.DataType
 	var ok bool
 	t, ok = v.(expr.DataType)
@@ -176,7 +176,7 @@ func ArrayOf(v interface{}, fn ...func()) *expr.Array {
 //        })
 //    })
 //
-func MapOf(k, v interface{}, fn ...func()) *expr.Map {
+func MapOf(k, v any, fn ...func()) *expr.Map {
 	var tk, tv expr.DataType
 	var ok bool
 	tk, ok = k.(expr.DataType)

--- a/dsl/validation.go
+++ b/dsl/validation.go
@@ -68,7 +68,7 @@ const (
 //        })
 //    })
 //
-func Enum(vals ...interface{}) {
+func Enum(vals ...any) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		for i, v := range vals {
 			// When can a.Type be nil? glad you asked
@@ -99,7 +99,7 @@ func Enum(vals ...interface{}) {
 			if a.Validation == nil {
 				a.Validation = &expr.ValidationExpr{}
 			}
-			a.Validation.Values = make([]interface{}, len(vals))
+			a.Validation.Values = make([]any, len(vals))
 			for i, v := range vals {
 				switch actual := v.(type) {
 				case expr.MapVal:
@@ -199,7 +199,7 @@ func Pattern(p string) {
 //        ExclusiveMinimum(100)
 //    })
 //
-func ExclusiveMinimum(val interface{}) {
+func ExclusiveMinimum(val any) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil &&
 			a.Type.Kind() != expr.IntKind && a.Type.Kind() != expr.UIntKind &&
@@ -241,7 +241,7 @@ func ExclusiveMinimum(val interface{}) {
 //        Minimum(100)
 //    })
 //
-func Minimum(val interface{}) {
+func Minimum(val any) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil &&
 			a.Type.Kind() != expr.IntKind && a.Type.Kind() != expr.UIntKind &&
@@ -283,7 +283,7 @@ func Minimum(val interface{}) {
 //        ExclusiveMaximum(100)
 //    })
 //
-func ExclusiveMaximum(val interface{}) {
+func ExclusiveMaximum(val any) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil &&
 			a.Type.Kind() != expr.IntKind && a.Type.Kind() != expr.UIntKind &&
@@ -325,7 +325,7 @@ func ExclusiveMaximum(val interface{}) {
 //        Maximum(100)
 //    })
 //
-func Maximum(val interface{}) {
+func Maximum(val any) {
 	if a, ok := eval.Current().(*expr.AttributeExpr); ok {
 		if a.Type != nil &&
 			a.Type.Kind() != expr.IntKind && a.Type.Kind() != expr.UIntKind &&

--- a/dsl/value.go
+++ b/dsl/value.go
@@ -21,11 +21,11 @@ type Val expr.Val
 //        Value(Val{"ID": 1})
 //    })
 //
-func Value(val interface{}) {
+func Value(val any) {
 	switch e := eval.Current().(type) {
 	case *expr.ExampleExpr:
 		if v, ok := val.(expr.Val); ok {
-			val = map[string]interface{}(v)
+			val = map[string]any(v)
 		}
 		e.Value = val
 	default:

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -95,7 +95,7 @@ func Current() Expression {
 
 // ReportError records a DSL error for reporting post DSL execution. It accepts
 // a format and values a la fmt.Printf.
-func ReportError(fm string, vals ...interface{}) {
+func ReportError(fm string, vals ...any) {
 	var suffix string
 	if cur := Context.Stack.Current(); cur != nil {
 		if name := cur.EvalName(); name != "" {
@@ -122,7 +122,7 @@ func IncompatibleDSL() {
 
 // InvalidArgError records an invalid argument error. It is used by DSL
 // functions that take dynamic arguments.
-func InvalidArgError(expected string, actual interface{}) {
+func InvalidArgError(expected string, actual any) {
 	ReportError("cannot use %#v (type %s) as type %s", actual, reflect.TypeOf(actual), expected)
 }
 
@@ -151,7 +151,7 @@ func (verr *ValidationErrors) Merge(err *ValidationErrors) {
 }
 
 // Add adds a validation error to the target.
-func (verr *ValidationErrors) Add(def Expression, format string, vals ...interface{}) {
+func (verr *ValidationErrors) Add(def Expression, format string, vals ...any) {
 	verr.AddError(def, fmt.Errorf(format, vals...))
 }
 

--- a/eval/expression.go
+++ b/eval/expression.go
@@ -100,7 +100,7 @@ func (t TopExpr) EvalName() string { return string(t) }
 
 // ToExpressionSet is a convenience function that accepts a slice of expressions
 // and builds the corresponding ExpressionSet.
-func ToExpressionSet(slice interface{}) ExpressionSet {
+func ToExpressionSet(slice any) ExpressionSet {
 	if slice == nil {
 		return nil
 	}

--- a/eval/expression_test.go
+++ b/eval/expression_test.go
@@ -11,12 +11,12 @@ func (e Expr) EvalName() string { return "test expression" }
 func TestToExpressionSet(t *testing.T) {
 	cases := []struct {
 		Name        string
-		Slice       []interface{}
+		Slice       []any
 		ExpectPanic bool
 	}{
-		{"simple", []interface{}{Expr(42)}, false},
+		{"simple", []any{Expr(42)}, false},
 		{"nil", nil, false},
-		{"invalid", []interface{}{42}, true},
+		{"invalid", []any{42}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -28,7 +28,7 @@ type (
 		// Meta is a list of key/value pairs
 		Meta MetaExpr
 		// Optional member default value
-		DefaultValue interface{}
+		DefaultValue any
 		// UserExample set in DSL or computed in Finalize
 		UserExamples []*ExampleExpr
 		// finalized is true if the attribute has been finalized - only
@@ -43,12 +43,12 @@ type (
 		// Description is an optional long description.
 		Description string
 		// Value is the example value.
-		Value interface{}
+		Value any
 	}
 
 	// Val is the type used to provide the value of examples for attributes that are
 	// objects.
-	Val map[string]interface{}
+	Val map[string]any
 
 	// CompositeExpr defines a generic composite expression that contains an
 	// attribute.  This makes it possible for plugins to use attributes in
@@ -62,7 +62,7 @@ type (
 	ValidationExpr struct {
 		// Values represents an enum validation as described at
 		// http://json-schema.org/latest/json-schema-validation.html#anchor76.
-		Values []interface{}
+		Values []any
 		// Format represents a format validation as described at
 		// http://json-schema.org/latest/json-schema-validation.html#anchor104.
 		Format ValidationFormat
@@ -493,7 +493,7 @@ func (a *AttributeExpr) HasDefaultValue(attName string) bool {
 // GetDefault gets the default value for the child attribute with the given
 // name. It returns nil if the child attribute with the given name does not
 // exist or if the child attribute does not have a default value.
-func (a *AttributeExpr) GetDefault(attName string) interface{} {
+func (a *AttributeExpr) GetDefault(attName string) any {
 	if o := AsObject(a.Type); o != nil {
 		att := o.Attribute(attName)
 		if att.DefaultValue != nil {
@@ -508,7 +508,7 @@ func (a *AttributeExpr) GetDefault(attName string) interface{} {
 
 // SetDefault sets the default for the attribute. It also converts HashVal
 // and ArrayVal to map and slice respectively.
-func (a *AttributeExpr) SetDefault(def interface{}) {
+func (a *AttributeExpr) SetDefault(def any) {
 	switch actual := def.(type) {
 	case MapVal:
 		a.DefaultValue = actual.ToMap()
@@ -563,7 +563,7 @@ func (a *AttributeExpr) Delete(name string) {
 			a.Validation.RemoveRequired(name)
 		}
 		for _, ex := range a.UserExamples {
-			if m, ok := ex.Value.(map[string]interface{}); ok {
+			if m, ok := ex.Value.(map[string]any); ok {
 				delete(m, name)
 			}
 		}

--- a/expr/attribute_test.go
+++ b/expr/attribute_test.go
@@ -838,7 +838,7 @@ func TestAttributeExprHasDefaultValue(t *testing.T) {
 
 func TestValidationExprHasRequiredOnly(t *testing.T) {
 	var (
-		values           = []interface{}{"foo"}
+		values           = []any{"foo"}
 		pattern          = "^foo$"
 		exclusiveMinimum = 1.1
 		minimum          = 1.1
@@ -848,7 +848,7 @@ func TestValidationExprHasRequiredOnly(t *testing.T) {
 		maxLength        = 3
 	)
 	cases := map[string]struct {
-		values           []interface{}
+		values           []any
 		format           ValidationFormat
 		pattern          string
 		exclusiveMinimum *float64

--- a/expr/example.go
+++ b/expr/example.go
@@ -18,7 +18,7 @@ const (
 // Example returns the example set on the attribute at design time. If there
 // isn't such a value then Example computes a random value for the attribute
 // using the given random value producer.
-func (a *AttributeExpr) Example(r *ExampleGenerator) interface{} {
+func (a *AttributeExpr) Example(r *ExampleGenerator) any {
 	if ex := a.ExtractUserExamples(); len(ex) > 0 {
 		// Return the last item in the slice so that examples can be overridden
 		// in the DSL. Overridden examples are always appended to the UserExamples
@@ -51,7 +51,7 @@ func (a *AttributeExpr) Example(r *ExampleGenerator) interface{} {
 	)
 	for attempts < maxAttempts {
 		attempts++
-		var example interface{}
+		var example any
 		// Format comes first, since it initiates the example
 		if hasFormat {
 			example = byFormat(a, r)
@@ -144,7 +144,7 @@ func hasMinMaxValidation(a *AttributeExpr) bool {
 }
 
 // byLength generates a random size array of examples based on what's given.
-func byLength(a *AttributeExpr, r *ExampleGenerator) interface{} {
+func byLength(a *AttributeExpr, r *ExampleGenerator) any {
 	count := NewLength(a, r)
 	switch a.Type.Kind() {
 	case StringKind:
@@ -152,14 +152,14 @@ func byLength(a *AttributeExpr, r *ExampleGenerator) interface{} {
 	case BytesKind:
 		return []byte(r.Characters(count))
 	case MapKind:
-		raw := make(map[interface{}]interface{})
+		raw := make(map[any]any)
 		m := a.Type.(*Map)
 		for i := 0; i < count; i++ {
 			raw[m.KeyType.Example(r)] = m.ElemType.Example(r)
 		}
 		return m.MakeMap(raw)
 	case ArrayKind:
-		raw := make([]interface{}, count)
+		raw := make([]any, count)
 		ar := a.Type.(*Array)
 		for i := 0; i < count; i++ {
 			raw[i] = ar.ElemType.Example(r)
@@ -171,7 +171,7 @@ func byLength(a *AttributeExpr, r *ExampleGenerator) interface{} {
 }
 
 // byEnum returns a random selected enum value.
-func byEnum(a *AttributeExpr, r *ExampleGenerator) interface{} {
+func byEnum(a *AttributeExpr, r *ExampleGenerator) any {
 	if !hasEnumValidation(a) {
 		return nil
 	}
@@ -182,12 +182,12 @@ func byEnum(a *AttributeExpr, r *ExampleGenerator) interface{} {
 }
 
 // byFormat returns a random example based on the format the user asks.
-func byFormat(a *AttributeExpr, r *ExampleGenerator) interface{} {
+func byFormat(a *AttributeExpr, r *ExampleGenerator) any {
 	if !hasFormatValidation(a) {
 		return nil
 	}
 	format := a.Validation.Format
-	if res, ok := map[ValidationFormat]interface{}{
+	if res, ok := map[ValidationFormat]any{
 		FormatEmail:    r.Email(),
 		FormatHostname: r.Hostname(),
 		FormatDate:     time.Unix(int64(r.Int())%1454957045, 0).UTC().Format(time.DateOnly), // to obtain a "fixed" rand
@@ -223,7 +223,7 @@ func byFormat(a *AttributeExpr, r *ExampleGenerator) interface{} {
 // byPattern generates a random value that satisfies the pattern.
 //
 // Note: if multiple patterns are given, only one of them is used.
-func byPattern(a *AttributeExpr, r *ExampleGenerator) interface{} {
+func byPattern(a *AttributeExpr, r *ExampleGenerator) any {
 	if !hasPatternValidation(a) {
 		return false
 	}
@@ -235,7 +235,7 @@ func byPattern(a *AttributeExpr, r *ExampleGenerator) interface{} {
 	return gen.Generate()
 }
 
-func byMinMax(a *AttributeExpr, r *ExampleGenerator) interface{} {
+func byMinMax(a *AttributeExpr, r *ExampleGenerator) any {
 	if !hasMinMaxValidation(a) {
 		return nil
 	}
@@ -320,7 +320,7 @@ func byMinMax(a *AttributeExpr, r *ExampleGenerator) interface{} {
 	}
 }
 
-func checkPattern(a *AttributeExpr, example interface{}) bool {
+func checkPattern(a *AttributeExpr, example any) bool {
 	if !hasPatternValidation(a) {
 		return true
 	}
@@ -335,7 +335,7 @@ func checkPattern(a *AttributeExpr, example interface{}) bool {
 	return true
 }
 
-func checkMinMaxValue(a *AttributeExpr, example interface{}) bool {
+func checkMinMaxValue(a *AttributeExpr, example any) bool {
 	if !hasMinMaxValidation(a) {
 		return true
 	}

--- a/expr/example_test.go
+++ b/expr/example_test.go
@@ -53,15 +53,15 @@ func TestExample(t *testing.T) {
 	cases := []struct {
 		Name     string
 		DSL      func()
-		Expected interface{}
+		Expected any
 		Error    string
 	}{
 		{"with-example", testdata.WithExampleDSL, "example", ""},
 		{"with-array-example", testdata.WithArrayExampleDSL, []int{1, 2}, ""},
 		{"with-map-example", testdata.WithMapExampleDSL, map[string]int{"name": 1, "value": 2}, ""},
 		{"with-multiple-examples", testdata.WithMultipleExamplesDSL, 100, ""},
-		{"overriding-example", testdata.OverridingExampleDSL, map[string]interface{}{"name": "overridden"}, ""},
-		{"with-extend", testdata.WithExtendExampleDSL, map[string]interface{}{"name": "example"}, ""},
+		{"overriding-example", testdata.OverridingExampleDSL, map[string]any{"name": "overridden"}, ""},
+		{"with-extend", testdata.WithExtendExampleDSL, map[string]any{"name": "example"}, ""},
 		{"invalid-example-type", testdata.InvalidExampleTypeDSL, nil, "example value map[int]int{1:1} is incompatible with attribute of type map in attribute"},
 		{"empty-example", testdata.EmptyExampleDSL, nil, "not enough arguments in attribute"},
 		{"hiding-example", testdata.HidingExampleDSL, nil, ""},

--- a/expr/http_body_types.go
+++ b/expr/http_body_types.go
@@ -295,7 +295,7 @@ func buildHTTPResponseBody(name string, attr *AttributeExpr, resp *HTTPResponseE
 // unionToObject returns an object adequate to serialize the given union type.
 func unionToObject(att *AttributeExpr, name, suffix, svcName string) *AttributeExpr {
 	values := AsUnion(att.Type).Values
-	names := make([]interface{}, len(values))
+	names := make([]any, len(values))
 	vals := make([]string, len(values))
 	for i, nat := range values {
 		names[i] = nat.Attribute.Type.Name()
@@ -432,7 +432,7 @@ func removeAttribute(attr *MappedAttributeExpr, name string) {
 		attr.Validation.RemoveRequired(name)
 	}
 	for _, ex := range attr.UserExamples {
-		if m, ok := ex.Value.(map[string]interface{}); ok {
+		if m, ok := ex.Value.(map[string]any); ok {
 			delete(m, name)
 		}
 	}

--- a/expr/http_cookie_test.go
+++ b/expr/http_cookie_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHTTPResponseCookie(t *testing.T) {
-	type Props map[string]interface{}
+	type Props map[string]any
 
 	cases := []struct {
 		Name  string

--- a/expr/project_test.go
+++ b/expr/project_test.go
@@ -83,7 +83,7 @@ func TestProject(t *testing.T) {
 // by the view. name may use the format "name:view" in which case view is the
 // name of the view used to render the attribute (when its type is a result
 // type).
-func view(name string, params ...interface{}) *ViewExpr {
+func view(name string, params ...any) *ViewExpr {
 	var obj Object = make([]*NamedAttributeExpr, len(params)/2)
 	for i := 0; i < len(params); i += 2 {
 		var (
@@ -114,7 +114,7 @@ func view(name string, params ...interface{}) *ViewExpr {
 //
 //    resultType("attr1", String, "attr2", Int, view1, view2)
 //
-func resultType(params ...interface{}) *ResultTypeExpr {
+func resultType(params ...any) *ResultTypeExpr {
 	var (
 		views []*ViewExpr
 		obj   Object
@@ -157,7 +157,7 @@ func collection(elemType *ResultTypeExpr) *ResultTypeExpr {
 	}
 }
 
-func resultRecursive(params ...interface{}) *ResultTypeExpr {
+func resultRecursive(params ...any) *ResultTypeExpr {
 	rt := resultType(params...)
 	recAtt := &NamedAttributeExpr{Name: "rec", Attribute: &AttributeExpr{Type: rt, Description: "desc rec"}}
 	obj := AsObject(rt)

--- a/expr/random.go
+++ b/expr/random.go
@@ -63,11 +63,11 @@ func NewRandom(seed string) *ExampleGenerator {
 
 type ExampleGenerator struct {
 	Randomizer
-	seen map[string]*interface{}
+	seen map[string]*any
 }
 
 // PreviouslySeen returns the previously seen value for a given ID
-func (r *ExampleGenerator) PreviouslySeen(typeID string) (*interface{}, bool) {
+func (r *ExampleGenerator) PreviouslySeen(typeID string) (*any, bool) {
 	if r.seen == nil {
 		return nil, false
 	}
@@ -76,9 +76,9 @@ func (r *ExampleGenerator) PreviouslySeen(typeID string) (*interface{}, bool) {
 }
 
 // HaveSeen stores the seen value in the randomizer, for reuse later
-func (r *ExampleGenerator) HaveSeen(typeID string, val *interface{}) {
+func (r *ExampleGenerator) HaveSeen(typeID string, val *any) {
 	if r.seen == nil {
-		r.seen = make(map[string]*interface{})
+		r.seen = make(map[string]*any)
 	}
 
 	r.seen[typeID] = val

--- a/expr/root.go
+++ b/expr/root.go
@@ -45,7 +45,7 @@ type (
 		User UserType
 
 		// External is an instance of the type being converted from or to.
-		External interface{}
+		External any
 	}
 )
 

--- a/expr/server_test.go
+++ b/expr/server_test.go
@@ -145,7 +145,7 @@ func TestHostExprValidate(t *testing.T) {
 		invalidSchemeURIs = []URIExpr{
 			invalidSchemeURI,
 		}
-		objectPrimitive = func(d interface{}, v *ValidationExpr) *Object {
+		objectPrimitive = func(d any, v *ValidationExpr) *Object {
 			return &Object{
 				{
 					Name: foo,
@@ -157,7 +157,7 @@ func TestHostExprValidate(t *testing.T) {
 				},
 			}
 		}
-		objectNonPrimitive = func(d interface{}) *Object {
+		objectNonPrimitive = func(d any) *Object {
 			return &Object{
 				{
 					Name: bar,
@@ -247,7 +247,7 @@ func TestHostExprValidate(t *testing.T) {
 		"uri variable has no default value and no enum varidation values": {
 			uris: validURIs,
 			variables: attribute(objectPrimitive(nil, &ValidationExpr{
-				Values: []interface{}{},
+				Values: []any{},
 			})),
 			expected: &eval.ValidationErrors{
 				Errors: []error{

--- a/expr/types.go
+++ b/expr/types.go
@@ -19,9 +19,9 @@ type (
 		Name() string
 		// IsCompatible checks whether val has a Go type that is compatible with the data
 		// type.
-		IsCompatible(interface{}) bool
+		IsCompatible(any) bool
 		// Example generates a pseudo-random value using the given random generator.
-		Example(*ExampleGenerator) interface{}
+		Example(*ExampleGenerator) any
 		// Hash returns a unique hash value for the instance of the type.
 		Hash() string
 	}
@@ -83,10 +83,10 @@ type (
 	}
 
 	// ArrayVal is the type used to set the default value for arrays.
-	ArrayVal []interface{}
+	ArrayVal []any
 
 	// MapVal is the type used to set the default value for maps.
-	MapVal map[interface{}]interface{}
+	MapVal map[any]any
 )
 
 const (
@@ -162,7 +162,7 @@ const (
 	// Bytes is the type for binary data.
 	Bytes = Primitive(BytesKind)
 
-	// Any is the type for an arbitrary JSON value (interface{} in Go).
+	// Any is the type for an arbitrary JSON value (any in Go).
 	Any = Primitive(AnyKind)
 )
 
@@ -321,7 +321,7 @@ func (p Primitive) Name() string {
 }
 
 // IsCompatible returns true if val is compatible with p.
-func (p Primitive) IsCompatible(val interface{}) bool {
+func (p Primitive) IsCompatible(val any) bool {
 	if p == Any {
 		return true
 	}
@@ -346,7 +346,7 @@ func (p Primitive) IsCompatible(val interface{}) bool {
 
 // Example generates a pseudo-random primitive value using the given random
 // generator.
-func (p Primitive) Example(r *ExampleGenerator) interface{} {
+func (p Primitive) Example(r *ExampleGenerator) any {
 	switch p {
 	case Boolean:
 		return r.Bool()
@@ -394,7 +394,7 @@ func (a *Array) Hash() string {
 }
 
 // IsCompatible returns true if val is compatible with p.
-func (a *Array) IsCompatible(val interface{}) bool {
+func (a *Array) IsCompatible(val any) bool {
 	k := reflect.TypeOf(val).Kind()
 	if k != reflect.Array && k != reflect.Slice {
 		return false
@@ -411,23 +411,23 @@ func (a *Array) IsCompatible(val interface{}) bool {
 
 // Example generates a pseudo-random array value using the given random
 // generator.
-func (a *Array) Example(r *ExampleGenerator) interface{} {
+func (a *Array) Example(r *ExampleGenerator) any {
 	count := NewLength(a.ElemType, r)
-	res := make([]interface{}, count)
+	res := make([]any, count)
 	for i := 0; i < count; i++ {
 		res[i] = a.ElemType.Example(r)
 		if res[i] == nil {
 			// Handle the case of recursive data structures
-			res[i] = make(map[string]interface{})
+			res[i] = make(map[string]any)
 		}
 	}
 	return a.MakeSlice(res)
 }
 
 // MakeSlice examines the key type from the Array and create a slice with
-// builtin type if possible. The idea is to avoid generating []interface{} and
+// builtin type if possible. The idea is to avoid generating []any and
 // produce more precise types.
-func (a *Array) MakeSlice(s []interface{}) interface{} {
+func (a *Array) MakeSlice(s []any) any {
 	slice := reflect.MakeSlice(toReflectType(a), 0, len(s))
 	for _, item := range s {
 		slice = reflect.Append(slice, reflect.ValueOf(item))
@@ -436,8 +436,8 @@ func (a *Array) MakeSlice(s []interface{}) interface{} {
 }
 
 // ToSlice converts an ArrayVal into a slice.
-func (a ArrayVal) ToSlice() []interface{} {
-	arr := make([]interface{}, len(a))
+func (a ArrayVal) ToSlice() []any {
+	arr := make([]any, len(a))
 	for i, elem := range a {
 		switch actual := elem.(type) {
 		case ArrayVal:
@@ -524,14 +524,14 @@ func (o *Object) Merge(other *Object) *Object {
 }
 
 // IsCompatible returns true if o describes the (Go) type of val.
-func (o *Object) IsCompatible(val interface{}) bool {
+func (o *Object) IsCompatible(val any) bool {
 	k := reflect.TypeOf(val).Kind()
 	return k == reflect.Map || k == reflect.Struct
 }
 
 // Example returns a random value of the object.
-func (o *Object) Example(r *ExampleGenerator) interface{} {
-	res := make(map[string]interface{})
+func (o *Object) Example(r *ExampleGenerator) any {
+	res := make(map[string]any)
 	for _, nat := range *o {
 		if v := nat.Attribute.Example(r); v != nil {
 			res[nat.Name] = v
@@ -552,7 +552,7 @@ func (m *Map) Hash() string {
 }
 
 // IsCompatible returns true if o describes the (Go) type of val.
-func (m *Map) IsCompatible(val interface{}) bool {
+func (m *Map) IsCompatible(val any) bool {
 	k := reflect.TypeOf(val).Kind()
 	if k != reflect.Map {
 		return false
@@ -569,13 +569,13 @@ func (m *Map) IsCompatible(val interface{}) bool {
 }
 
 // Example returns a random example value.
-func (m *Map) Example(r *ExampleGenerator) interface{} {
+func (m *Map) Example(r *ExampleGenerator) any {
 	if IsObject(m.KeyType.Type) || IsArray(m.KeyType.Type) || IsMap(m.KeyType.Type) {
 		// not much we can do for non hashable Go types
 		return nil
 	}
 	count := r.Int()%3 + 1
-	pair := map[interface{}]interface{}{}
+	pair := map[any]any{}
 	for i := 0; i < count; i++ {
 		k := m.KeyType.Example(r)
 		v := m.ElemType.Example(r)
@@ -587,9 +587,9 @@ func (m *Map) Example(r *ExampleGenerator) interface{} {
 }
 
 // MakeMap examines the key type from a Map and create a map with builtin type
-// if possible. The idea is to avoid generating map[interface{}]interface{},
+// if possible. The idea is to avoid generating map[any]any,
 // which cannot be handled by json.Marshal.
-func (m *Map) MakeMap(raw map[interface{}]interface{}) interface{} {
+func (m *Map) MakeMap(raw map[any]any) any {
 	ma := reflect.MakeMap(toReflectType(m))
 	for key, value := range raw {
 		ma.SetMapIndex(reflect.ValueOf(key), reflect.ValueOf(value))
@@ -598,8 +598,8 @@ func (m *Map) MakeMap(raw map[interface{}]interface{}) interface{} {
 }
 
 // ToMap converts a MapVal to a map.
-func (m MapVal) ToMap() map[interface{}]interface{} {
-	mp := make(map[interface{}]interface{}, len(m))
+func (m MapVal) ToMap() map[any]any {
+	mp := make(map[any]any, len(m))
 	for k, v := range m {
 		switch actual := v.(type) {
 		case ArrayVal:
@@ -625,7 +625,7 @@ func (u *Union) Hash() string {
 }
 
 // IsCompatible returns true if u describes the (Go) type of val.
-func (u *Union) IsCompatible(val interface{}) bool {
+func (u *Union) IsCompatible(val any) bool {
 	for _, nat := range u.Values {
 		if nat.Attribute.Type.IsCompatible(val) {
 			return true
@@ -635,7 +635,7 @@ func (u *Union) IsCompatible(val interface{}) bool {
 }
 
 // Example returns a random example value.
-func (u *Union) Example(r *ExampleGenerator) interface{} {
+func (u *Union) Example(r *ExampleGenerator) any {
 	if len(u.Values) == 0 {
 		return nil
 	}
@@ -696,7 +696,7 @@ func toReflectType(dtype DataType) reflect.Type {
 	case BytesKind:
 		return reflect.TypeOf([]byte{})
 	case ObjectKind:
-		return reflect.TypeOf(map[string]interface{}{})
+		return reflect.TypeOf(map[string]any{})
 	case UserTypeKind:
 		return toReflectType(dtype.(*UserTypeExpr).Attribute().Type)
 	case ResultTypeKind:
@@ -710,10 +710,10 @@ func toReflectType(dtype DataType) reflect.Type {
 		if m.KeyType.Type.Kind() != ObjectKind {
 			ktype = toReflectType(m.KeyType.Type)
 		} else {
-			ktype = reflect.TypeOf([]interface{}{}).Elem()
+			ktype = reflect.TypeOf([]any{}).Elem()
 		}
 		return reflect.MapOf(ktype, toReflectType(m.ElemType.Type))
 	default:
-		return reflect.TypeOf([]interface{}{}).Elem()
+		return reflect.TypeOf([]any{}).Elem()
 	}
 }

--- a/expr/types_test.go
+++ b/expr/types_test.go
@@ -569,127 +569,127 @@ func TestPrimitiveIsCompatible(t *testing.T) {
 	)
 	cases := map[string]struct {
 		p        Primitive
-		values   []interface{}
+		values   []any
 		expected bool
 	}{
 		"any": {
 			p:        Any,
-			values:   []interface{}{b},
+			values:   []any{b},
 			expected: true,
 		},
 		"boolean compatible": {
 			p:        Boolean,
-			values:   []interface{}{b},
+			values:   []any{b},
 			expected: true,
 		},
 		"boolean not compatible": {
 			p:        Boolean,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64, s, bs},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64, s, bs},
 			expected: false,
 		},
 		"int compatible": {
 			p:        Int,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32},
 			expected: true,
 		},
 		"int not compatible": {
 			p:        Int,
-			values:   []interface{}{b, i64, ui64, f32, f64, s, bs},
+			values:   []any{b, i64, ui64, f32, f64, s, bs},
 			expected: false,
 		},
 		"int32 compatible": {
 			p:        Int32,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32},
 			expected: true,
 		},
 		"int32 not compatible": {
 			p:        Int32,
-			values:   []interface{}{b, i64, ui64, f32, f64, s, bs},
+			values:   []any{b, i64, ui64, f32, f64, s, bs},
 			expected: false,
 		},
 		"int64 compatible": {
 			p:        Int64,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64},
 			expected: true,
 		},
 		"int64 not compatible": {
 			p:        Int64,
-			values:   []interface{}{b, f32, f64, s, bs},
+			values:   []any{b, f32, f64, s, bs},
 			expected: false,
 		},
 		"uint compatible": {
 			p:        UInt,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32},
 			expected: true,
 		},
 		"uint not compatible": {
 			p:        UInt,
-			values:   []interface{}{b, i64, ui64, f32, f64, s, bs},
+			values:   []any{b, i64, ui64, f32, f64, s, bs},
 			expected: false,
 		},
 		"uint32 compatible": {
 			p:        UInt32,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32},
 			expected: true,
 		},
 		"uint32 not compatible": {
 			p:        UInt32,
-			values:   []interface{}{b, i64, ui64, f32, f64, s, bs},
+			values:   []any{b, i64, ui64, f32, f64, s, bs},
 			expected: false,
 		},
 		"uint64 compatible": {
 			p:        UInt64,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64},
 			expected: true,
 		},
 		"uint64 not compatible": {
 			p:        UInt64,
-			values:   []interface{}{b, f32, f64, s, bs},
+			values:   []any{b, f32, f64, s, bs},
 			expected: false,
 		},
 		"float32 compatible": {
 			p:        Float32,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64},
 			expected: true,
 		},
 		"float32 not compatible": {
 			p:        Float32,
-			values:   []interface{}{b, s, bs},
+			values:   []any{b, s, bs},
 			expected: false,
 		},
 		"float64 compatible": {
 			p:        Float64,
-			values:   []interface{}{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64},
+			values:   []any{i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64},
 			expected: true,
 		},
 		"float64 not compatible": {
 			p:        Float64,
-			values:   []interface{}{b, s, bs},
+			values:   []any{b, s, bs},
 			expected: false,
 		},
 		"string compatible": {
 			p:        String,
-			values:   []interface{}{s},
+			values:   []any{s},
 			expected: true,
 		},
 		"string not compatible": {
 			p:        String,
-			values:   []interface{}{b, i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64, bs},
+			values:   []any{b, i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64, bs},
 			expected: false,
 		},
 		"bytes compatible": {
 			p:        Bytes,
-			values:   []interface{}{s, bs},
+			values:   []any{s, bs},
 			expected: true,
 		},
 		"bytes not compatible": {
 			p:        Bytes,
-			values:   []interface{}{b, i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64},
+			values:   []any{b, i, i8, i16, i32, ui, ui8, ui16, ui32, i64, ui64, f32, f64},
 			expected: false,
 		},
 		"not supported types": {
 			p:        Boolean,
-			values:   []interface{}{ss, is},
+			values:   []any{ss, is},
 			expected: false,
 		},
 	}
@@ -712,27 +712,27 @@ func TestArrayIsCompatible(t *testing.T) {
 	)
 	cases := map[string]struct {
 		typ      DataType
-		values   []interface{}
+		values   []any
 		expected bool
 	}{
 		"compatible": {
 			typ:      Int,
-			values:   []interface{}{ia, is},
+			values:   []any{ia, is},
 			expected: true,
 		},
 		"not array and slice": {
 			typ:      String,
-			values:   []interface{}{b, i},
+			values:   []any{b, i},
 			expected: false,
 		},
 		"array but not compatible": {
 			typ:      String,
-			values:   []interface{}{ia},
+			values:   []any{ia},
 			expected: false,
 		},
 		"slice but not compatible": {
 			typ:      String,
-			values:   []interface{}{is},
+			values:   []any{is},
 			expected: false,
 		},
 	}
@@ -804,15 +804,15 @@ func TestObjectIsCompatible(t *testing.T) {
 		m = map[int]string{}
 	)
 	cases := map[string]struct {
-		values   []interface{}
+		values   []any
 		expected bool
 	}{
 		"compatible": {
-			values:   []interface{}{s, m},
+			values:   []any{s, m},
 			expected: true,
 		},
 		"not comatible": {
-			values:   []interface{}{b, i},
+			values:   []any{b, i},
 			expected: false,
 		},
 	}
@@ -842,19 +842,19 @@ func TestMapIsCompatible(t *testing.T) {
 		}
 	)
 	cases := map[string]struct {
-		values   []interface{}
+		values   []any
 		expected bool
 	}{
 		"compatible": {
-			values:   []interface{}{ism},
+			values:   []any{ism},
 			expected: true,
 		},
 		"not comatible": {
-			values:   []interface{}{b, i},
+			values:   []any{b, i},
 			expected: false,
 		},
 		"map but not comatible": {
-			values:   []interface{}{ssm, iim},
+			values:   []any{ssm, iim},
 			expected: false,
 		},
 	}

--- a/expr/user_type.go
+++ b/expr/user_type.go
@@ -48,7 +48,7 @@ func (u *UserTypeExpr) Rename(n string) {
 }
 
 // IsCompatible returns true if u describes the (Go) type of val.
-func (u *UserTypeExpr) IsCompatible(val interface{}) bool {
+func (u *UserTypeExpr) IsCompatible(val any) bool {
 	return u.Type == nil || u.Type.IsCompatible(val)
 }
 
@@ -82,18 +82,18 @@ func (u *UserTypeExpr) Hash() string {
 
 // Example produces an example for the user type which is JSON serialization
 // compatible.
-func (u *UserTypeExpr) Example(r *ExampleGenerator) interface{} {
+func (u *UserTypeExpr) Example(r *ExampleGenerator) any {
 	if ex := u.recExample(r); ex != nil {
 		return *ex
 	}
 	return nil
 }
 
-func (u *UserTypeExpr) recExample(r *ExampleGenerator) *interface{} {
+func (u *UserTypeExpr) recExample(r *ExampleGenerator) *any {
 	if ex, ok := r.PreviouslySeen(u.ID()); ok {
 		return ex
 	}
-	var ex interface{}
+	var ex any
 	pex := &ex
 	r.HaveSeen(u.ID(), pex)
 	actual := u.Type.Example(r)

--- a/expr/user_type_test.go
+++ b/expr/user_type_test.go
@@ -58,22 +58,22 @@ func TestUserTypeExprIsCompatible(t *testing.T) {
 	)
 	cases := map[string]struct {
 		typ      DataType
-		values   []interface{}
+		values   []any
 		expected bool
 	}{
 		"compatible": {
 			typ:      Int,
-			values:   []interface{}{i},
+			values:   []any{i},
 			expected: true,
 		},
 		"not compatible": {
 			typ:      Int,
-			values:   []interface{}{b},
+			values:   []any{b},
 			expected: false,
 		},
 		"type is nil": {
 			typ:      nil,
-			values:   []interface{}{b, i},
+			values:   []any{b, i},
 			expected: true,
 		},
 	}

--- a/grpc/client.go
+++ b/grpc/client.go
@@ -11,11 +11,11 @@ type (
 	// Invoker invokes a gRPC method. The request and response types
 	// are goa types.
 	Invoker interface {
-		Invoke(ctx context.Context, req interface{}) (res interface{}, err error)
+		Invoke(ctx context.Context, req any) (res any, err error)
 	}
 
 	// RemoteFunc invokes a RPC method.
-	RemoteFunc func(ctx context.Context, reqpb interface{}, opts ...grpc.CallOption) (respb interface{}, err error)
+	RemoteFunc func(ctx context.Context, reqpb any, opts ...grpc.CallOption) (respb any, err error)
 
 	cliInvoker struct {
 		encoder RequestEncoder
@@ -34,14 +34,14 @@ func NewInvoker(fn RemoteFunc, enc RequestEncoder, dec ResponseDecoder) Invoker 
 }
 
 // Invoke invokes the given remote gRPC client method.
-func (d *cliInvoker) Invoke(ctx context.Context, req interface{}) (interface{}, error) {
+func (d *cliInvoker) Invoke(ctx context.Context, req any) (any, error) {
 	md, ok := metadata.FromOutgoingContext(ctx)
 	if !ok {
 		md = metadata.MD{}
 	}
 
 	var (
-		reqpb interface{}
+		reqpb any
 		err   error
 	)
 	{
@@ -56,7 +56,7 @@ func (d *cliInvoker) Invoke(ctx context.Context, req interface{}) (interface{}, 
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	var (
-		respb interface{}
+		respb any
 
 		hdr  = metadata.MD{}
 		trlr = metadata.MD{}
@@ -69,7 +69,7 @@ func (d *cliInvoker) Invoke(ctx context.Context, req interface{}) (interface{}, 
 	}
 
 	var (
-		res interface{}
+		res any
 	)
 	{
 		if d.decoder != nil {

--- a/grpc/codegen/client.go
+++ b/grpc/codegen/client.go
@@ -202,7 +202,7 @@ func New{{ .ClientStruct }}(cc *grpc.ClientConn, opts ...grpc.CallOption) *{{ .C
 // input: EndpointData
 const clientEndpointInitT = `{{ printf "%s calls the %q function in %s.%s interface." .Method.VarName .Method.VarName .PkgName .ClientInterface | comment }}
 func (c *{{ .ClientStruct }}) {{ .Method.VarName }}() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			Build{{ .Method.VarName }}Func(c.grpccli, c.opts...),
 			{{ if .PayloadRef }}Encode{{ .Method.VarName }}Request{{ else }}nil{{ end }},
@@ -240,7 +240,7 @@ func (c *{{ .ClientStruct }}) {{ .Method.VarName }}() goa.Endpoint {
 // input: EndpointData
 const remoteMethodBuilderT = `{{ printf "Build%sFunc builds the remote method to invoke for %q service %q endpoint." .Method.VarName .ServiceName .Method.Name | comment }}
 func Build{{ .Method.VarName }}Func(grpccli {{ .PkgName }}.{{ .ClientInterface }}, cliopts ...grpc.CallOption) goagrpc.RemoteFunc {
-	return func(ctx context.Context, reqpb interface{}, opts ...grpc.CallOption) (interface{}, error) {
+	return func(ctx context.Context, reqpb any, opts ...grpc.CallOption) (any, error) {
 		for _, opt := range cliopts {
 			opts = append(opts, opt)
 		}
@@ -254,7 +254,7 @@ func Build{{ .Method.VarName }}Func(grpccli {{ .PkgName }}.{{ .ClientInterface }
 
 // input: EndpointData
 const responseDecoderT = `{{ printf "Decode%sResponse decodes responses from the %s %s endpoint." .Method.VarName .ServiceName .Method.Name | comment }}
-func Decode{{ .Method.VarName }}Response(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func Decode{{ .Method.VarName }}Response(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 {{- if or .Response.Headers .Response.Trailers }}
 	var (
 	{{- range .Response.Headers }}
@@ -376,7 +376,7 @@ func Decode{{ .Method.VarName }}Response(ctx context.Context, v interface{}, hdr
 
 // input: EndpointData
 const requestEncoderT = `{{ printf "Encode%sRequest encodes requests sent to %s %s endpoint." .Method.VarName .ServiceName .Method.Name | comment }}
-func Encode{{ .Method.VarName }}Request(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func Encode{{ .Method.VarName }}Request(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.({{ .PayloadRef }})
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("{{ .ServiceName }}", "{{ .Method.Name }}", "{{ .PayloadRef }}", v)

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -202,10 +202,10 @@ func makeFlags(e *EndpointData, args []*InitArgData) ([]*cli.FlagData, *cli.Buil
 
 const parseEndpointT = `// ParseEndpoint returns the endpoint and payload as specified on the command
 // line.
-func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, interface{}, error) {
+func ParseEndpoint(cc *grpc.ClientConn, opts ...grpc.CallOption) (goa.Endpoint, any, error) {
 	{{ .FlagsCode }}
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)

--- a/grpc/codegen/client_types.go
+++ b/grpc/codegen/client_types.go
@@ -92,7 +92,7 @@ func clientType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 				Name:   "client-type-init",
 				Source: typeInitT,
 				Data:   init,
-				FuncMap: map[string]interface{}{
+				FuncMap: map[string]any{
 					"isAlias": expr.IsAlias,
 					"fullName": func(dt expr.DataType) string {
 						if loc := codegen.UserTypeLocation(dt); loc != nil {

--- a/grpc/codegen/example_cli.go
+++ b/grpc/codegen/example_cli.go
@@ -87,7 +87,7 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 }
 
 const (
-	grpcCLIDoT = `func doGRPC(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
+	grpcCLIDoT = `func doGRPC(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, error) {
 	conn, err := grpc.Dial(host, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
     fmt.Fprintf(os.Stderr, "could not connect to gRPC server at %s: %v\n", host, err)

--- a/grpc/codegen/example_server.go
+++ b/grpc/codegen/example_server.go
@@ -104,7 +104,7 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 			{
 				Name:   "server-grpc-start",
 				Source: grpcSvrStartT,
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"Services": svcdata,
 				},
 			}, {
@@ -113,23 +113,23 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 			}, {
 				Name:   "server-grpc-init",
 				Source: grpcSvrInitT,
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"Services": svcdata,
 				},
 			}, {
 				Name:   "server-grpc-register",
 				Source: grpcRegisterSvrT,
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"Services": svcdata,
 				},
-				FuncMap: map[string]interface{}{
+				FuncMap: map[string]any{
 					"goify":      codegen.Goify,
 					"needStream": needStream,
 				},
 			}, {
 				Name:   "server-grpc-end",
 				Source: grpcSvrEndT,
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"Services": svcdata,
 				},
 			},
@@ -152,7 +152,7 @@ func needStream(data []*ServiceData) bool {
 }
 
 const (
-	// input: map[string]interface{}{"Services":[]*ServiceData}
+	// input: map[string]any{"Services":[]*ServiceData}
 	grpcSvrStartT = `{{ comment "handleGRPCServer starts configures and starts a gRPC server on the given URL. It shuts down the server if any error is received in the error channel." }}
 func handleGRPCServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if .Service.Methods }}, {{ .Service.VarName }}Endpoints *{{ .Service.PkgName }}.Endpoints{{ end }}{{ end }}, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {
 `
@@ -167,7 +167,7 @@ func handleGRPCServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
   }
 	`
 
-	// input: map[string]interface{}{"Services":[]*ServiceData}
+	// input: map[string]any{"Services":[]*ServiceData}
 	grpcSvrInitT = `
 	// Wrap the endpoints with the transport specific layers. The generated
 	// server packages contains code generated from the design which maps
@@ -189,7 +189,7 @@ func handleGRPCServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	}
 `
 
-	// input: map[string]interface{}{"Services":[]*ServiceData}
+	// input: map[string]any{"Services":[]*ServiceData}
 	grpcRegisterSvrT = `
 	// Initialize gRPC server with the middleware.
 	srv := grpc.NewServer(
@@ -221,7 +221,7 @@ func handleGRPCServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	reflection.Register(srv)
 `
 
-	// input: map[string]interface{}{"Services":[]*ServiceData}
+	// input: map[string]any{"Services":[]*ServiceData}
 	grpcSvrEndT = `
 	(*wg).Add(1)
 	go func() {

--- a/grpc/codegen/proto.go
+++ b/grpc/codegen/proto.go
@@ -35,7 +35,7 @@ func protoFile(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 		{
 			Name:   "proto-header",
 			Source: protoHeaderT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Title":       fmt.Sprintf("%s protocol buffer definition", svc.Name()),
 				"ToolVersion": goa.Version(),
 			},
@@ -44,7 +44,7 @@ func protoFile(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File {
 		{
 			Name:   "proto-start",
 			Source: protoStartT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"ProtoVersion": ProtoVersion,
 				"Pkg":          pkgName(svc, svcName),
 				"Imports":      data.ProtoImports,

--- a/grpc/codegen/protobuf_transform.go
+++ b/grpc/codegen/protobuf_transform.go
@@ -439,7 +439,7 @@ func transformArray(source, target *expr.Array, sourceVar, targetVar string, new
 		}
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"ElemTypeRef":    targetRef,
 		"SourceElem":     src,
 		"TargetElem":     tgt,
@@ -516,7 +516,7 @@ func transformMap(source, target *expr.Map, sourceVar, targetVar string, newVar 
 			return "", err
 		}
 	}
-	data := map[string]interface{}{
+	data := map[string]any{
 		"KeyTypeRef":     targetKeyRef,
 		"ElemTypeRef":    targetElemRef,
 		"SourceKey":      source.KeyType,
@@ -555,7 +555,7 @@ func transformUnionToProto(source, target *expr.AttributeExpr, sourceVar, target
 		targetValueTypeNames[i] = ta.message + "_" + fieldName
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"SourceVar":            sourceVar,
 		"TargetVar":            targetVar,
 		"SourceValueTypeRefs":  tdata.SourceValueTypeRefs,
@@ -586,7 +586,7 @@ func transformUnionFromProto(source, target *expr.AttributeExpr, sourceVar, targ
 		sourceFieldNames[i] = fieldName
 	}
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"SourceVar":           sourceVar,
 		"TargetVar":           targetVar,
 		"SourceValueTypeRefs": tdata.SourceValueTypeRefs,

--- a/grpc/codegen/server.go
+++ b/grpc/codegen/server.go
@@ -149,7 +149,7 @@ func serverEncodeDecode(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File 
 					Name:   "response-encoder",
 					Source: responseEncoderT,
 					Data:   e,
-					FuncMap: map[string]interface{}{
+					FuncMap: map[string]any{
 						"typeConversionData":       typeConversionData,
 						"metadataEncodeDecodeData": metadataEncodeDecodeData,
 					},
@@ -170,8 +170,8 @@ func serverEncodeDecode(genpkg string, svc *expr.GRPCServiceExpr) *codegen.File 
 	return &codegen.File{Path: fpath, SectionTemplates: sections}
 }
 
-func transTmplFuncs(s *expr.GRPCServiceExpr) map[string]interface{} {
-	return map[string]interface{}{
+func transTmplFuncs(s *expr.GRPCServiceExpr) map[string]any {
+	return map[string]any{
 		"goTypeRef": func(dt expr.DataType) string {
 			return service.Services.Get(s.Name()).Scope.GoTypeRef(&expr.AttributeExpr{Type: dt})
 		},
@@ -180,8 +180,8 @@ func transTmplFuncs(s *expr.GRPCServiceExpr) map[string]interface{} {
 
 // typeConversionData produces the template data suitable for executing the
 // "type_conversion" template.
-func typeConversionData(dt expr.DataType, varName string, target string) map[string]interface{} {
-	return map[string]interface{}{
+func typeConversionData(dt expr.DataType, varName string, target string) map[string]any {
+	return map[string]any{
 		"Type":    dt,
 		"VarName": varName,
 		"Target":  target,
@@ -190,8 +190,8 @@ func typeConversionData(dt expr.DataType, varName string, target string) map[str
 
 // metadataEncodeDecodeData produces the template data suitable for executing the
 // "metadata_decoder" and "metadata_encoder" template.
-func metadataEncodeDecodeData(md *MetadataData, vname string) map[string]interface{} {
-	return map[string]interface{}{
+func metadataEncodeDecodeData(md *MetadataData, vname string) map[string]any {
+	return map[string]any{
 		"Metadata": md,
 		"VarName":  vname,
 	}
@@ -281,7 +281,7 @@ func (s *{{ .ServerStruct }}) {{ .Method.VarName }}(
 
 // input: EndpointData
 const requestDecoderT = `{{ printf "Decode%sRequest decodes requests sent to %q service %q endpoint." .Method.VarName .ServiceName .Method.Name | comment }}
-func Decode{{ .Method.VarName }}Request(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func Decode{{ .Method.VarName }}Request(ctx context.Context, v any, md metadata.MD) (any, error) {
 {{- if .Request.Metadata }}
 	var (
 	{{- range .Request.Metadata }}
@@ -394,7 +394,7 @@ func Decode{{ .Method.VarName }}Request(ctx context.Context, v interface{}, md m
 
 // input: EndpointData
 const responseEncoderT = `{{ printf "Encode%sResponse encodes responses from the %q service %q endpoint." .Method.VarName .ServiceName .Method.Name | comment }}
-func Encode{{ .Method.VarName }}Response(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func Encode{{ .Method.VarName }}Response(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 {{- if .ViewedResultRef }}
 	vres, ok := v.({{ .ViewedResultRef }})
 	if !ok {

--- a/grpc/codegen/server_types.go
+++ b/grpc/codegen/server_types.go
@@ -90,7 +90,7 @@ func serverType(genpkg string, svc *expr.GRPCServiceExpr, seen map[string]struct
 				Name:   "server-type-init",
 				Source: typeInitT,
 				Data:   init,
-				FuncMap: map[string]interface{}{
+				FuncMap: map[string]any{
 					"isAlias": expr.IsAlias,
 					"fullName": func(dt expr.DataType) string {
 						if loc := codegen.UserTypeLocation(dt); loc != nil {

--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -157,9 +157,9 @@ type (
 		// Validate contains the validation code if any.
 		Validate string
 		// DefaultValue contains the default value if any.
-		DefaultValue interface{}
+		DefaultValue any
 		// Example is an example value.
-		Example interface{}
+		Example any
 	}
 
 	// ErrorData contains the error information required to generate the
@@ -307,12 +307,12 @@ type (
 		// Required is true if the arg is required to build the payload.
 		Required bool
 		// DefaultValue is the default value of the arg.
-		DefaultValue interface{}
+		DefaultValue any
 		// Validate contains the validation code for the argument
 		// value if any.
 		Validate string
 		// Example is a example value
-		Example interface{}
+		Example any
 	}
 
 	// StreamData contains data to render the stream struct type that implements

--- a/grpc/codegen/testdata/client_endpoint_init_code.go
+++ b/grpc/codegen/testdata/client_endpoint_init_code.go
@@ -3,7 +3,7 @@ package testdata
 const UnaryRPCsClientEndpointInitCode = `// MethodUnaryRPCA calls the "MethodUnaryRPCA" function in
 // service_unary_rp_cspb.ServiceUnaryRPCsClient interface.
 func (c *Client) MethodUnaryRPCA() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodUnaryRPCAFunc(c.grpccli, c.opts...),
 			EncodeMethodUnaryRPCARequest,
@@ -19,7 +19,7 @@ func (c *Client) MethodUnaryRPCA() goa.Endpoint {
 // MethodUnaryRPCB calls the "MethodUnaryRPCB" function in
 // service_unary_rp_cspb.ServiceUnaryRPCsClient interface.
 func (c *Client) MethodUnaryRPCB() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodUnaryRPCBFunc(c.grpccli, c.opts...),
 			EncodeMethodUnaryRPCBRequest,
@@ -36,7 +36,7 @@ func (c *Client) MethodUnaryRPCB() goa.Endpoint {
 const UnaryRPCNoPayloadClientEndpointInitCode = `// MethodUnaryRPCNoPayload calls the "MethodUnaryRPCNoPayload" function in
 // service_unary_rpc_no_payloadpb.ServiceUnaryRPCNoPayloadClient interface.
 func (c *Client) MethodUnaryRPCNoPayload() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodUnaryRPCNoPayloadFunc(c.grpccli, c.opts...),
 			nil,
@@ -53,7 +53,7 @@ func (c *Client) MethodUnaryRPCNoPayload() goa.Endpoint {
 const UnaryRPCNoResultClientEndpointInitCode = `// MethodUnaryRPCNoResult calls the "MethodUnaryRPCNoResult" function in
 // service_unary_rpc_no_resultpb.ServiceUnaryRPCNoResultClient interface.
 func (c *Client) MethodUnaryRPCNoResult() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodUnaryRPCNoResultFunc(c.grpccli, c.opts...),
 			EncodeMethodUnaryRPCNoResultRequest,
@@ -70,7 +70,7 @@ func (c *Client) MethodUnaryRPCNoResult() goa.Endpoint {
 const UnaryRPCWithErrorsClientEndpointInitCode = `// MethodUnaryRPCWithErrors calls the "MethodUnaryRPCWithErrors" function in
 // service_unary_rpc_with_errorspb.ServiceUnaryRPCWithErrorsClient interface.
 func (c *Client) MethodUnaryRPCWithErrors() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodUnaryRPCWithErrorsFunc(c.grpccli, c.opts...),
 			EncodeMethodUnaryRPCWithErrorsRequest,
@@ -105,7 +105,7 @@ func (c *Client) MethodUnaryRPCWithErrors() goa.Endpoint {
 const UnaryRPCAcronymClientEndpointInitCode = `// MethodUnaryRPCAcronymJWT calls the "MethodUnaryRPCAcronymJWT" function in
 // service_unary_rpc_acronympb.ServiceUnaryRPCAcronymClient interface.
 func (c *Client) MethodUnaryRPCAcronymJWT() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodUnaryRPCAcronymJWTFunc(c.grpccli, c.opts...),
 			nil,
@@ -122,7 +122,7 @@ func (c *Client) MethodUnaryRPCAcronymJWT() goa.Endpoint {
 const ServerStreamingRPCClientEndpointInitCode = `// MethodServerStreamingRPC calls the "MethodServerStreamingRPC" function in
 // service_server_streaming_rpcpb.ServiceServerStreamingRPCClient interface.
 func (c *Client) MethodServerStreamingRPC() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodServerStreamingRPCFunc(c.grpccli, c.opts...),
 			EncodeMethodServerStreamingRPCRequest,
@@ -139,7 +139,7 @@ func (c *Client) MethodServerStreamingRPC() goa.Endpoint {
 const ClientStreamingRPCClientEndpointInitCode = `// MethodClientStreamingRPC calls the "MethodClientStreamingRPC" function in
 // service_client_streaming_rpcpb.ServiceClientStreamingRPCClient interface.
 func (c *Client) MethodClientStreamingRPC() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodClientStreamingRPCFunc(c.grpccli, c.opts...),
 			nil,
@@ -158,7 +158,7 @@ const ClientStreamingNoResultClientEndpointInitCode = `// MethodClientStreamingN
 // service_client_streaming_no_resultpb.ServiceClientStreamingNoResultClient
 // interface.
 func (c *Client) MethodClientStreamingNoResult() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodClientStreamingNoResultFunc(c.grpccli, c.opts...),
 			nil,
@@ -177,7 +177,7 @@ const ClientStreamingRPCWithPayloadClientEndpointInitCode = `// MethodClientStre
 // service_client_streaming_rpc_with_payloadpb.ServiceClientStreamingRPCWithPayloadClient
 // interface.
 func (c *Client) MethodClientStreamingRPCWithPayload() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodClientStreamingRPCWithPayloadFunc(c.grpccli, c.opts...),
 			EncodeMethodClientStreamingRPCWithPayloadRequest,
@@ -196,7 +196,7 @@ const BidirectionalStreamingRPCClientEndpointInitCode = `// MethodBidirectionalS
 // service_bidirectional_streaming_rpcpb.ServiceBidirectionalStreamingRPCClient
 // interface.
 func (c *Client) MethodBidirectionalStreamingRPC() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodBidirectionalStreamingRPCFunc(c.grpccli, c.opts...),
 			nil,
@@ -215,7 +215,7 @@ const BidirectionalStreamingRPCWithPayloadClientEndpointInitCode = `// MethodBid
 // service_bidirectional_streaming_rpc_with_payloadpb.ServiceBidirectionalStreamingRPCWithPayloadClient
 // interface.
 func (c *Client) MethodBidirectionalStreamingRPCWithPayload() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodBidirectionalStreamingRPCWithPayloadFunc(c.grpccli, c.opts...),
 			EncodeMethodBidirectionalStreamingRPCWithPayloadRequest,
@@ -234,7 +234,7 @@ const BidirectionalStreamingRPCWithErrorsClientEndpointInitCode = `// MethodBidi
 // service_bidirectional_streaming_rpc_with_errorspb.ServiceBidirectionalStreamingRPCWithErrorsClient
 // interface.
 func (c *Client) MethodBidirectionalStreamingRPCWithErrors() goa.Endpoint {
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		inv := goagrpc.NewInvoker(
 			BuildMethodBidirectionalStreamingRPCWithErrorsFunc(c.grpccli, c.opts...),
 			nil,

--- a/grpc/codegen/testdata/client_type_code.go
+++ b/grpc/codegen/testdata/client_type_code.go
@@ -282,7 +282,7 @@ func NewMethodUnaryRPCWithErrorsCustomErrorError(message *service_unary_rpc_with
 // on MethodUnaryRPCWithErrorsInternalError.
 func ValidateMethodUnaryRPCWithErrorsInternalError(errmsg *service_unary_rpc_with_errorspb.MethodUnaryRPCWithErrorsInternalError) (err error) {
 	if !(errmsg.Name == "this" || errmsg.Name == "that") {
-		err = goa.MergeErrors(err, goa.InvalidEnumValueError("errmsg.name", errmsg.Name, []interface{}{"this", "that"}))
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("errmsg.name", errmsg.Name, []any{"this", "that"}))
 	}
 	return
 }
@@ -291,7 +291,7 @@ func ValidateMethodUnaryRPCWithErrorsInternalError(errmsg *service_unary_rpc_wit
 // on MethodUnaryRPCWithErrorsBadRequestError.
 func ValidateMethodUnaryRPCWithErrorsBadRequestError(errmsg *service_unary_rpc_with_errorspb.MethodUnaryRPCWithErrorsBadRequestError) (err error) {
 	if !(errmsg.Name == "this" || errmsg.Name == "that") {
-		err = goa.MergeErrors(err, goa.InvalidEnumValueError("errmsg.name", errmsg.Name, []interface{}{"this", "that"}))
+		err = goa.MergeErrors(err, goa.InvalidEnumValueError("errmsg.name", errmsg.Name, []any{"this", "that"}))
 	}
 	return
 }

--- a/grpc/codegen/testdata/example_code.go
+++ b/grpc/codegen/testdata/example_code.go
@@ -242,7 +242,7 @@ const ExampleSingleHostPkgPathCLIImport = `import (
 )
 `
 
-const ExampleCLICode = `func doGRPC(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
+const ExampleCLICode = `func doGRPC(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, error) {
 	conn, err := grpc.Dial(host, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not connect to gRPC server at %s: %v\n", host, err)

--- a/grpc/codegen/testdata/request_decoder_code.go
+++ b/grpc/codegen/testdata/request_decoder_code.go
@@ -3,7 +3,7 @@ package testdata
 const PayloadUserTypeRequestDecoderCode = `// DecodeMethodMessageUserTypeWithNestedUserTypesRequest decodes requests sent
 // to "ServiceMessageUserTypeWithNestedUserTypes" service
 // "MethodMessageUserTypeWithNestedUserTypes" endpoint.
-func DecodeMethodMessageUserTypeWithNestedUserTypesRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodMessageUserTypeWithNestedUserTypesRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		message *service_message_user_type_with_nested_user_typespb.MethodMessageUserTypeWithNestedUserTypesRequest
 		ok      bool
@@ -23,7 +23,7 @@ func DecodeMethodMessageUserTypeWithNestedUserTypesRequest(ctx context.Context, 
 
 const PayloadArrayRequestDecoderCode = `// DecodeMethodUnaryRPCNoResultRequest decodes requests sent to
 // "ServiceUnaryRPCNoResult" service "MethodUnaryRPCNoResult" endpoint.
-func DecodeMethodUnaryRPCNoResultRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodUnaryRPCNoResultRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		message *service_unary_rpc_no_resultpb.MethodUnaryRPCNoResultRequest
 		ok      bool
@@ -43,7 +43,7 @@ func DecodeMethodUnaryRPCNoResultRequest(ctx context.Context, v interface{}, md 
 
 const PayloadMapRequestDecoderCode = `// DecodeMethodMessageMapRequest decodes requests sent to "ServiceMessageMap"
 // service "MethodMessageMap" endpoint.
-func DecodeMethodMessageMapRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodMessageMapRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		message *service_message_mappb.MethodMessageMapRequest
 		ok      bool
@@ -66,7 +66,7 @@ func DecodeMethodMessageMapRequest(ctx context.Context, v interface{}, md metada
 
 const PayloadPrimitiveRequestDecoderCode = `// DecodeMethodServerStreamingRPCRequest decodes requests sent to
 // "ServiceServerStreamingRPC" service "MethodServerStreamingRPC" endpoint.
-func DecodeMethodServerStreamingRPCRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodServerStreamingRPCRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		message *service_server_streaming_rpcpb.MethodServerStreamingRPCRequest
 		ok      bool
@@ -87,7 +87,7 @@ func DecodeMethodServerStreamingRPCRequest(ctx context.Context, v interface{}, m
 const PayloadPrimitiveWithStreamingPayloadRequestDecoderCode = `// DecodeMethodClientStreamingRPCWithPayloadRequest decodes requests sent to
 // "ServiceClientStreamingRPCWithPayload" service
 // "MethodClientStreamingRPCWithPayload" endpoint.
-func DecodeMethodClientStreamingRPCWithPayloadRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodClientStreamingRPCWithPayloadRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		goaPayload int
 		err        error
@@ -119,7 +119,7 @@ func DecodeMethodClientStreamingRPCWithPayloadRequest(ctx context.Context, v int
 const PayloadUserTypeWithStreamingPayloadRequestDecoderCode = `// DecodeMethodBidirectionalStreamingRPCWithPayloadRequest decodes requests
 // sent to "ServiceBidirectionalStreamingRPCWithPayload" service
 // "MethodBidirectionalStreamingRPCWithPayload" endpoint.
-func DecodeMethodBidirectionalStreamingRPCWithPayloadRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodBidirectionalStreamingRPCWithPayloadRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		a   *int
 		b   *string
@@ -153,7 +153,7 @@ func DecodeMethodBidirectionalStreamingRPCWithPayloadRequest(ctx context.Context
 
 const PayloadWithMetadataRequestDecoderCode = `// DecodeMethodMessageWithMetadataRequest decodes requests sent to
 // "ServiceMessageWithMetadata" service "MethodMessageWithMetadata" endpoint.
-func DecodeMethodMessageWithMetadataRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodMessageWithMetadataRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		inMetadata *int
 		err        error
@@ -192,7 +192,7 @@ func DecodeMethodMessageWithMetadataRequest(ctx context.Context, v interface{}, 
 
 const PayloadWithValidateRequestDecoderCode = `// DecodeMethodMessageWithValidateRequest decodes requests sent to
 // "ServiceMessageWithValidate" service "MethodMessageWithValidate" endpoint.
-func DecodeMethodMessageWithValidateRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodMessageWithValidateRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		inMetadata *int
 		err        error
@@ -239,7 +239,7 @@ func DecodeMethodMessageWithValidateRequest(ctx context.Context, v interface{}, 
 
 const PayloadWithSecurityAttrsRequestDecoderCode = `// DecodeMethodMessageWithSecurityRequest decodes requests sent to
 // "ServiceMessageWithSecurity" service "MethodMessageWithSecurity" endpoint.
-func DecodeMethodMessageWithSecurityRequest(ctx context.Context, v interface{}, md metadata.MD) (interface{}, error) {
+func DecodeMethodMessageWithSecurityRequest(ctx context.Context, v any, md metadata.MD) (any, error) {
 	var (
 		token    *string
 		key      *string

--- a/grpc/codegen/testdata/request_encoder_code.go
+++ b/grpc/codegen/testdata/request_encoder_code.go
@@ -3,7 +3,7 @@ package testdata
 const PayloadUserTypeRequestEncoderCode = `// EncodeMethodMessageUserTypeWithNestedUserTypesRequest encodes requests sent
 // to ServiceMessageUserTypeWithNestedUserTypes
 // MethodMessageUserTypeWithNestedUserTypes endpoint.
-func EncodeMethodMessageUserTypeWithNestedUserTypesRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageUserTypeWithNestedUserTypesRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.(*servicemessageusertypewithnestedusertypes.UT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageUserTypeWithNestedUserTypes", "MethodMessageUserTypeWithNestedUserTypes", "*servicemessageusertypewithnestedusertypes.UT", v)
@@ -14,7 +14,7 @@ func EncodeMethodMessageUserTypeWithNestedUserTypesRequest(ctx context.Context, 
 
 const PayloadArrayRequestEncoderCode = `// EncodeMethodUnaryRPCNoResultRequest encodes requests sent to
 // ServiceUnaryRPCNoResult MethodUnaryRPCNoResult endpoint.
-func EncodeMethodUnaryRPCNoResultRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodUnaryRPCNoResultRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.([]string)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceUnaryRPCNoResult", "MethodUnaryRPCNoResult", "[]string", v)
@@ -25,7 +25,7 @@ func EncodeMethodUnaryRPCNoResultRequest(ctx context.Context, v interface{}, md 
 
 const PayloadMapRequestEncoderCode = `// EncodeMethodMessageMapRequest encodes requests sent to ServiceMessageMap
 // MethodMessageMap endpoint.
-func EncodeMethodMessageMapRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageMapRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.(map[int]*servicemessagemap.UT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageMap", "MethodMessageMap", "map[int]*servicemessagemap.UT", v)
@@ -36,7 +36,7 @@ func EncodeMethodMessageMapRequest(ctx context.Context, v interface{}, md *metad
 
 const PayloadPrimitiveRequestEncoderCode = `// EncodeMethodServerStreamingRPCRequest encodes requests sent to
 // ServiceServerStreamingRPC MethodServerStreamingRPC endpoint.
-func EncodeMethodServerStreamingRPCRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodServerStreamingRPCRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.(int)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceServerStreamingRPC", "MethodServerStreamingRPC", "int", v)
@@ -48,7 +48,7 @@ func EncodeMethodServerStreamingRPCRequest(ctx context.Context, v interface{}, m
 const PayloadPrimitiveWithStreamingPayloadRequestEncoderCode = `// EncodeMethodClientStreamingRPCWithPayloadRequest encodes requests sent to
 // ServiceClientStreamingRPCWithPayload MethodClientStreamingRPCWithPayload
 // endpoint.
-func EncodeMethodClientStreamingRPCWithPayloadRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodClientStreamingRPCWithPayloadRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.(int)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceClientStreamingRPCWithPayload", "MethodClientStreamingRPCWithPayload", "int", v)
@@ -61,7 +61,7 @@ func EncodeMethodClientStreamingRPCWithPayloadRequest(ctx context.Context, v int
 const PayloadUserTypeWithStreamingPayloadRequestEncoderCode = `// EncodeMethodBidirectionalStreamingRPCWithPayloadRequest encodes requests
 // sent to ServiceBidirectionalStreamingRPCWithPayload
 // MethodBidirectionalStreamingRPCWithPayload endpoint.
-func EncodeMethodBidirectionalStreamingRPCWithPayloadRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodBidirectionalStreamingRPCWithPayloadRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.(*servicebidirectionalstreamingrpcwithpayload.Payload)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceBidirectionalStreamingRPCWithPayload", "MethodBidirectionalStreamingRPCWithPayload", "*servicebidirectionalstreamingrpcwithpayload.Payload", v)
@@ -78,7 +78,7 @@ func EncodeMethodBidirectionalStreamingRPCWithPayloadRequest(ctx context.Context
 
 const PayloadWithMetadataRequestEncoderCode = `// EncodeMethodMessageWithMetadataRequest encodes requests sent to
 // ServiceMessageWithMetadata MethodMessageWithMetadata endpoint.
-func EncodeMethodMessageWithMetadataRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageWithMetadataRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.(*servicemessagewithmetadata.RequestUT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageWithMetadata", "MethodMessageWithMetadata", "*servicemessagewithmetadata.RequestUT", v)
@@ -92,7 +92,7 @@ func EncodeMethodMessageWithMetadataRequest(ctx context.Context, v interface{}, 
 
 const PayloadWithValidateRequestEncoderCode = `// EncodeMethodMessageWithValidateRequest encodes requests sent to
 // ServiceMessageWithValidate MethodMessageWithValidate endpoint.
-func EncodeMethodMessageWithValidateRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageWithValidateRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.(*servicemessagewithvalidate.RequestUT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageWithValidate", "MethodMessageWithValidate", "*servicemessagewithvalidate.RequestUT", v)
@@ -106,7 +106,7 @@ func EncodeMethodMessageWithValidateRequest(ctx context.Context, v interface{}, 
 
 const PayloadWithSecurityAttrsRequestEncoderCode = `// EncodeMethodMessageWithSecurityRequest encodes requests sent to
 // ServiceMessageWithSecurity MethodMessageWithSecurity endpoint.
-func EncodeMethodMessageWithSecurityRequest(ctx context.Context, v interface{}, md *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageWithSecurityRequest(ctx context.Context, v any, md *metadata.MD) (any, error) {
 	payload, ok := v.(*servicemessagewithsecurity.RequestUT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageWithSecurity", "MethodMessageWithSecurity", "*servicemessagewithsecurity.RequestUT", v)

--- a/grpc/codegen/testdata/response_decoder_code.go
+++ b/grpc/codegen/testdata/response_decoder_code.go
@@ -2,7 +2,7 @@ package testdata
 
 const ResultWithViewsResponseDecoderCode = `// DecodeMethodMessageResultTypeWithViewsResponse decodes responses from the
 // ServiceMessageResultTypeWithViews MethodMessageResultTypeWithViews endpoint.
-func DecodeMethodMessageResultTypeWithViewsResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodMessageResultTypeWithViewsResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	var view string
 	{
 		if vals := hdr.Get("goa-view"); len(vals) > 0 {
@@ -25,7 +25,7 @@ func DecodeMethodMessageResultTypeWithViewsResponse(ctx context.Context, v inter
 const ResultWithExplicitViewResponseDecoderCode = `// DecodeMethodMessageResultTypeWithExplicitViewResponse decodes responses from
 // the ServiceMessageResultTypeWithExplicitView
 // MethodMessageResultTypeWithExplicitView endpoint.
-func DecodeMethodMessageResultTypeWithExplicitViewResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodMessageResultTypeWithExplicitViewResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	var view string
 	{
 		if vals := hdr.Get("goa-view"); len(vals) > 0 {
@@ -47,7 +47,7 @@ func DecodeMethodMessageResultTypeWithExplicitViewResponse(ctx context.Context, 
 
 const ResultArrayResponseDecoderCode = `// DecodeMethodMessageArrayResponse decodes responses from the
 // ServiceMessageArray MethodMessageArray endpoint.
-func DecodeMethodMessageArrayResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodMessageArrayResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	message, ok := v.(*service_message_arraypb.MethodMessageArrayResponse)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageArray", "MethodMessageArray", "*service_message_arraypb.MethodMessageArrayResponse", v)
@@ -62,7 +62,7 @@ func DecodeMethodMessageArrayResponse(ctx context.Context, v interface{}, hdr, t
 
 const ResultPrimitiveResponseDecoderCode = `// DecodeMethodUnaryRPCNoPayloadResponse decodes responses from the
 // ServiceUnaryRPCNoPayload MethodUnaryRPCNoPayload endpoint.
-func DecodeMethodUnaryRPCNoPayloadResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodUnaryRPCNoPayloadResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	message, ok := v.(*service_unary_rpc_no_payloadpb.MethodUnaryRPCNoPayloadResponse)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceUnaryRPCNoPayload", "MethodUnaryRPCNoPayload", "*service_unary_rpc_no_payloadpb.MethodUnaryRPCNoPayloadResponse", v)
@@ -74,7 +74,7 @@ func DecodeMethodUnaryRPCNoPayloadResponse(ctx context.Context, v interface{}, h
 
 const ResultWithMetadataResponseDecoderCode = `// DecodeMethodMessageWithMetadataResponse decodes responses from the
 // ServiceMessageWithMetadata MethodMessageWithMetadata endpoint.
-func DecodeMethodMessageWithMetadataResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodMessageWithMetadataResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	var (
 		inHeader  *int
 		inTrailer *bool
@@ -117,7 +117,7 @@ func DecodeMethodMessageWithMetadataResponse(ctx context.Context, v interface{},
 
 const ResultWithValidateResponseDecoderCode = `// DecodeMethodMessageWithValidateResponse decodes responses from the
 // ServiceMessageWithValidate MethodMessageWithValidate endpoint.
-func DecodeMethodMessageWithValidateResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodMessageWithValidateResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	var (
 		inHeader  *int
 		inTrailer *bool
@@ -152,7 +152,7 @@ func DecodeMethodMessageWithValidateResponse(ctx context.Context, v interface{},
 		}
 		if inTrailer != nil {
 			if !(*inTrailer == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("inTrailer", *inTrailer, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("inTrailer", *inTrailer, []any{true}))
 			}
 		}
 	}
@@ -174,7 +174,7 @@ func DecodeMethodMessageWithValidateResponse(ctx context.Context, v interface{},
 const ResultCollectionResponseDecoderCode = `// DecodeMethodMessageUserTypeWithNestedUserTypesResponse decodes responses
 // from the ServiceMessageUserTypeWithNestedUserTypes
 // MethodMessageUserTypeWithNestedUserTypes endpoint.
-func DecodeMethodMessageUserTypeWithNestedUserTypesResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodMessageUserTypeWithNestedUserTypesResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	var view string
 	{
 		if vals := hdr.Get("goa-view"); len(vals) > 0 {
@@ -196,7 +196,7 @@ func DecodeMethodMessageUserTypeWithNestedUserTypesResponse(ctx context.Context,
 
 const ServerStreamingResponseDecoderCode = `// DecodeMethodServerStreamingUserTypeRPCResponse decodes responses from the
 // ServiceServerStreamingUserTypeRPC MethodServerStreamingUserTypeRPC endpoint.
-func DecodeMethodServerStreamingUserTypeRPCResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodServerStreamingUserTypeRPCResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	return &MethodServerStreamingUserTypeRPCClientStream{
 		stream: v.(service_server_streaming_user_type_rpcpb.ServiceServerStreamingUserTypeRPC_MethodServerStreamingUserTypeRPCClient),
 	}, nil
@@ -205,7 +205,7 @@ func DecodeMethodServerStreamingUserTypeRPCResponse(ctx context.Context, v inter
 
 const ServerStreamingResultWithViewsResponseDecoderCode = `// DecodeMethodServerStreamingUserTypeRPCResponse decodes responses from the
 // ServiceServerStreamingUserTypeRPC MethodServerStreamingUserTypeRPC endpoint.
-func DecodeMethodServerStreamingUserTypeRPCResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodServerStreamingUserTypeRPCResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	var view string
 	{
 		if vals := hdr.Get("goa-view"); len(vals) > 0 {
@@ -221,7 +221,7 @@ func DecodeMethodServerStreamingUserTypeRPCResponse(ctx context.Context, v inter
 
 const ClientStreamingResponseDecoderCode = `// DecodeMethodClientStreamingRPCResponse decodes responses from the
 // ServiceClientStreamingRPC MethodClientStreamingRPC endpoint.
-func DecodeMethodClientStreamingRPCResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodClientStreamingRPCResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	return &MethodClientStreamingRPCClientStream{
 		stream: v.(service_client_streaming_rpcpb.ServiceClientStreamingRPC_MethodClientStreamingRPCClient),
 	}, nil
@@ -230,7 +230,7 @@ func DecodeMethodClientStreamingRPCResponse(ctx context.Context, v interface{}, 
 
 const BidirectionalStreamingResponseDecoderCode = `// DecodeMethodBidirectionalStreamingRPCResponse decodes responses from the
 // ServiceBidirectionalStreamingRPC MethodBidirectionalStreamingRPC endpoint.
-func DecodeMethodBidirectionalStreamingRPCResponse(ctx context.Context, v interface{}, hdr, trlr metadata.MD) (interface{}, error) {
+func DecodeMethodBidirectionalStreamingRPCResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	var view string
 	{
 		if vals := hdr.Get("goa-view"); len(vals) > 0 {

--- a/grpc/codegen/testdata/response_encoder_code.go
+++ b/grpc/codegen/testdata/response_encoder_code.go
@@ -2,7 +2,7 @@ package testdata
 
 const EmptyResultResponseEncoderCode = `// EncodeMethodUnaryRPCNoResultResponse encodes responses from the
 // "ServiceUnaryRPCNoResult" service "MethodUnaryRPCNoResult" endpoint.
-func EncodeMethodUnaryRPCNoResultResponse(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func EncodeMethodUnaryRPCNoResultResponse(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 	resp := NewProtoMethodUnaryRPCNoResultResponse()
 	return resp, nil
 }
@@ -11,7 +11,7 @@ func EncodeMethodUnaryRPCNoResultResponse(ctx context.Context, v interface{}, hd
 const ResultWithViewsResponseEncoderCode = `// EncodeMethodMessageResultTypeWithViewsResponse encodes responses from the
 // "ServiceMessageResultTypeWithViews" service
 // "MethodMessageResultTypeWithViews" endpoint.
-func EncodeMethodMessageResultTypeWithViewsResponse(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageResultTypeWithViewsResponse(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 	vres, ok := v.(*servicemessageresulttypewithviewsviews.RT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageResultTypeWithViews", "MethodMessageResultTypeWithViews", "*servicemessageresulttypewithviewsviews.RT", v)
@@ -26,7 +26,7 @@ func EncodeMethodMessageResultTypeWithViewsResponse(ctx context.Context, v inter
 const ResultWithExplicitViewResponseEncoderCode = `// EncodeMethodMessageResultTypeWithExplicitViewResponse encodes responses from
 // the "ServiceMessageResultTypeWithExplicitView" service
 // "MethodMessageResultTypeWithExplicitView" endpoint.
-func EncodeMethodMessageResultTypeWithExplicitViewResponse(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageResultTypeWithExplicitViewResponse(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 	vres, ok := v.(*servicemessageresulttypewithexplicitviewviews.RT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageResultTypeWithExplicitView", "MethodMessageResultTypeWithExplicitView", "*servicemessageresulttypewithexplicitviewviews.RT", v)
@@ -40,7 +40,7 @@ func EncodeMethodMessageResultTypeWithExplicitViewResponse(ctx context.Context, 
 
 const ResultArrayResponseEncoderCode = `// EncodeMethodMessageArrayResponse encodes responses from the
 // "ServiceMessageArray" service "MethodMessageArray" endpoint.
-func EncodeMethodMessageArrayResponse(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageArrayResponse(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 	result, ok := v.([]*servicemessagearray.UT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageArray", "MethodMessageArray", "[]*servicemessagearray.UT", v)
@@ -52,7 +52,7 @@ func EncodeMethodMessageArrayResponse(ctx context.Context, v interface{}, hdr, t
 
 const ResultPrimitiveResponseEncoderCode = `// EncodeMethodUnaryRPCNoPayloadResponse encodes responses from the
 // "ServiceUnaryRPCNoPayload" service "MethodUnaryRPCNoPayload" endpoint.
-func EncodeMethodUnaryRPCNoPayloadResponse(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func EncodeMethodUnaryRPCNoPayloadResponse(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 	result, ok := v.(string)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceUnaryRPCNoPayload", "MethodUnaryRPCNoPayload", "string", v)
@@ -64,7 +64,7 @@ func EncodeMethodUnaryRPCNoPayloadResponse(ctx context.Context, v interface{}, h
 
 const ResultWithMetadataResponseEncoderCode = `// EncodeMethodMessageWithMetadataResponse encodes responses from the
 // "ServiceMessageWithMetadata" service "MethodMessageWithMetadata" endpoint.
-func EncodeMethodMessageWithMetadataResponse(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageWithMetadataResponse(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 	result, ok := v.(*servicemessagewithmetadata.ResponseUT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageWithMetadata", "MethodMessageWithMetadata", "*servicemessagewithmetadata.ResponseUT", v)
@@ -84,7 +84,7 @@ func EncodeMethodMessageWithMetadataResponse(ctx context.Context, v interface{},
 
 const ResultWithValidateResponseEncoderCode = `// EncodeMethodMessageWithValidateResponse encodes responses from the
 // "ServiceMessageWithValidate" service "MethodMessageWithValidate" endpoint.
-func EncodeMethodMessageWithValidateResponse(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageWithValidateResponse(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 	result, ok := v.(*servicemessagewithvalidate.ResponseUT)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageWithValidate", "MethodMessageWithValidate", "*servicemessagewithvalidate.ResponseUT", v)
@@ -105,7 +105,7 @@ func EncodeMethodMessageWithValidateResponse(ctx context.Context, v interface{},
 const ResultCollectionResponseEncoderCode = `// EncodeMethodMessageUserTypeWithNestedUserTypesResponse encodes responses
 // from the "ServiceMessageUserTypeWithNestedUserTypes" service
 // "MethodMessageUserTypeWithNestedUserTypes" endpoint.
-func EncodeMethodMessageUserTypeWithNestedUserTypesResponse(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (interface{}, error) {
+func EncodeMethodMessageUserTypeWithNestedUserTypesResponse(ctx context.Context, v any, hdr, trlr *metadata.MD) (any, error) {
 	vres, ok := v.(servicemessageusertypewithnestedusertypesviews.RTCollection)
 	if !ok {
 		return nil, goagrpc.ErrInvalidType("ServiceMessageUserTypeWithNestedUserTypes", "MethodMessageUserTypeWithNestedUserTypes", "servicemessageusertypewithnestedusertypesviews.RTCollection", v)

--- a/grpc/encoding.go
+++ b/grpc/encoding.go
@@ -9,17 +9,17 @@ import (
 type (
 	// RequestDecoder is used by the server to decode gRPC request message type
 	// and any incoming metadata to goa type.
-	RequestDecoder func(ctx context.Context, pb interface{}, md metadata.MD) (v interface{}, err error)
+	RequestDecoder func(ctx context.Context, pb any, md metadata.MD) (v any, err error)
 
 	// RequestEncoder is used by the client to encode goa type to gRPC message
 	// type and sets the outgoing metadata.
-	RequestEncoder func(ctx context.Context, v interface{}, md *metadata.MD) (pb interface{}, err error)
+	RequestEncoder func(ctx context.Context, v any, md *metadata.MD) (pb any, err error)
 
 	// ResponseDecoder is used by the client to decode gRPC response message
 	// type and any incoming metadata (headers and trailers) to goa type.
-	ResponseDecoder func(ctx context.Context, pb interface{}, hdr, trlr metadata.MD) (v interface{}, err error)
+	ResponseDecoder func(ctx context.Context, pb any, hdr, trlr metadata.MD) (v any, err error)
 
 	// ResponseEncoder is used by the server to encode goa type to gRPC response
 	// message type and sets the response headers and trailers.
-	ResponseEncoder func(ctx context.Context, v interface{}, hdr, trlr *metadata.MD) (pb interface{}, err error)
+	ResponseEncoder func(ctx context.Context, v any, hdr, trlr *metadata.MD) (pb any, err error)
 )

--- a/grpc/error.go
+++ b/grpc/error.go
@@ -126,7 +126,7 @@ func DecodeError(err error) proto.Message {
 
 // ErrInvalidType is the error returned when the wrong type is given to a
 // encoder or decoder.
-func ErrInvalidType(svc, m, expected string, actual interface{}) error {
+func ErrInvalidType(svc, m, expected string, actual any) error {
 	msg := fmt.Sprintf("invalid value expected %s, got %v", expected, actual)
 	return &ClientError{Name: "invalid_type", Message: msg, Service: svc, Method: m}
 }

--- a/grpc/handler.go
+++ b/grpc/handler.go
@@ -22,7 +22,7 @@ type (
 		// It takes a protocol buffer message type and returns a
 		// protocol buffer message type and any error when executing the
 		// RPC.
-		Handle(ctx context.Context, reqpb interface{}) (respb interface{}, err error)
+		Handle(ctx context.Context, reqpb any) (respb any, err error)
 	}
 
 	// StreamHandler handles a streaming RPC. The stream may be client-side,
@@ -32,11 +32,11 @@ type (
 		//
 		// input contains the endpoint payload (if any) and generated
 		// endpoint stream.
-		Handle(ctx context.Context, input interface{}) (err error)
+		Handle(ctx context.Context, input any) (err error)
 		// Decode decodes the protocol buffer message and metadata to
 		// the service type. For client-side and bidirectional streams,
 		// the message is nil.
-		Decode(ctx context.Context, reqpb interface{}) (req interface{}, err error)
+		Decode(ctx context.Context, reqpb any) (req any, err error)
 	}
 
 	unaryHandler struct {
@@ -69,9 +69,9 @@ func NewStreamHandler(e goa.Endpoint, dec RequestDecoder) StreamHandler {
 }
 
 // Handle serves a gRPC request.
-func (h *unaryHandler) Handle(ctx context.Context, reqpb interface{}) (interface{}, error) {
+func (h *unaryHandler) Handle(ctx context.Context, reqpb any) (any, error) {
 	var (
-		req interface{}
+		req any
 		err error
 	)
 	{
@@ -88,7 +88,7 @@ func (h *unaryHandler) Handle(ctx context.Context, reqpb interface{}) (interface
 	}
 
 	var (
-		resp interface{}
+		resp any
 	)
 	{
 		// Invoke goa endpoint
@@ -98,7 +98,7 @@ func (h *unaryHandler) Handle(ctx context.Context, reqpb interface{}) (interface
 	}
 
 	var (
-		respb interface{}
+		respb any
 
 		hdr  = metadata.MD{}
 		trlr = metadata.MD{}
@@ -133,9 +133,9 @@ func (h *unaryHandler) Handle(ctx context.Context, reqpb interface{}) (interface
 }
 
 // Decode decodes the request message and incoming metadata into goa type.
-func (h *streamHandler) Decode(ctx context.Context, reqpb interface{}) (interface{}, error) {
+func (h *streamHandler) Decode(ctx context.Context, reqpb any) (any, error) {
 	var (
-		req interface{}
+		req any
 		err error
 	)
 	{
@@ -153,7 +153,7 @@ func (h *streamHandler) Decode(ctx context.Context, reqpb interface{}) (interfac
 }
 
 // Handle serves a gRPC request.
-func (h *streamHandler) Handle(ctx context.Context, stream interface{}) error {
+func (h *streamHandler) Handle(ctx context.Context, stream any) error {
 	_, err := h.endpoint(ctx, stream)
 	return err
 }

--- a/grpc/middleware/canceler.go
+++ b/grpc/middleware/canceler.go
@@ -54,7 +54,7 @@ func StreamCanceler(ctx context.Context) grpc.StreamServerInterceptor {
 			(*cancel)()
 		}
 	}()
-	return grpc.StreamServerInterceptor(func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return grpc.StreamServerInterceptor(func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		if atomic.LoadUint32(&canceling) == 1 {
 			return status.Error(codes.Unavailable, "server is stopping")
 		}

--- a/grpc/middleware/canceler_test.go
+++ b/grpc/middleware/canceler_test.go
@@ -28,7 +28,7 @@ func TestStreamCanceler(t *testing.T) {
 		{
 			name:   "handler canceled",
 			stream: grpcm.NewWrappedServerStream(context.Background(), &testCancelerStream{}),
-			handler: func(srv interface{}, stream grpc.ServerStream) error {
+			handler: func(srv any, stream grpc.ServerStream) error {
 				<-stream.Context().Done() // block until canceled
 				return nil
 			},
@@ -36,7 +36,7 @@ func TestStreamCanceler(t *testing.T) {
 		{
 			name:   "handler not canceled",
 			stream: grpcm.NewWrappedServerStream(context.Background(), &testCancelerStream{}),
-			handler: func(srv interface{}, stream grpc.ServerStream) error {
+			handler: func(srv any, stream grpc.ServerStream) error {
 				// don't block, finish before being canceled
 				return nil
 			},

--- a/grpc/middleware/log.go
+++ b/grpc/middleware/log.go
@@ -23,7 +23,7 @@ import (
 // The middleware logs the incoming requests gRPC method. It also logs the
 // response gRPC status code, message length (in bytes), and timing information.
 func UnaryServerLog(l middleware.Logger) grpc.UnaryServerInterceptor {
-	return grpc.UnaryServerInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return grpc.UnaryServerInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		return unaryLog(ctx, req, info, handler, l)
 	})
 }
@@ -32,7 +32,7 @@ func UnaryServerLog(l middleware.Logger) grpc.UnaryServerInterceptor {
 // and outgoing responses similar to UnaryServerLog but uses the request context
 // to extract the logger.
 func UnaryServerLogContext(logFromCtx func(context.Context) middleware.Logger) grpc.UnaryServerInterceptor {
-	return grpc.UnaryServerInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return grpc.UnaryServerInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		l := logFromCtx(ctx)
 		if l == nil {
 			return handler(ctx, req)
@@ -47,7 +47,7 @@ func UnaryServerLogContext(logFromCtx func(context.Context) middleware.Logger) g
 // each incoming request and logs it with the request and corresponding
 // response details.
 func StreamServerLog(l middleware.Logger) grpc.StreamServerInterceptor {
-	return grpc.StreamServerInterceptor(func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return grpc.StreamServerInterceptor(func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		return streamLog(srv, ss, info, handler, l)
 	})
 }
@@ -56,7 +56,7 @@ func StreamServerLog(l middleware.Logger) grpc.StreamServerInterceptor {
 // requests and responses similar to StreamServerLog but uses the stream context
 // to extract the logger.
 func StreamServerLogContext(logFromCtx func(context.Context) middleware.Logger) grpc.StreamServerInterceptor {
-	return grpc.StreamServerInterceptor(func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return grpc.StreamServerInterceptor(func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		l := logFromCtx(ss.Context())
 		if l == nil {
 			return handler(srv, ss)
@@ -66,7 +66,7 @@ func StreamServerLogContext(logFromCtx func(context.Context) middleware.Logger) 
 }
 
 // unaryLog does the actual logging given the logger for unary methods.
-func unaryLog(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, l middleware.Logger) (resp interface{}, err error) {
+func unaryLog(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler, l middleware.Logger) (resp any, err error) {
 	var reqID string
 	{
 		md, ok := metadata.FromIncomingContext(ctx)
@@ -99,7 +99,7 @@ func unaryLog(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, 
 }
 
 // streamLog does the actual logging given the logger for streaming methods.
-func streamLog(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, l middleware.Logger) error {
+func streamLog(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler, l middleware.Logger) error {
 	var reqID string
 	{
 		md, ok := metadata.FromIncomingContext(ss.Context())
@@ -139,7 +139,7 @@ func shortID() string {
 	return base64.RawURLEncoding.EncodeToString(b)
 }
 
-func messageLength(msg interface{}) int64 {
+func messageLength(msg any) int64 {
 	var length int64
 	{
 		if m, ok := msg.(proto.Message); ok {

--- a/grpc/middleware/requestid.go
+++ b/grpc/middleware/requestid.go
@@ -29,7 +29,7 @@ const (
 //    middleware.XRequestMetadataLimitOption(128))))
 func UnaryRequestID(options ...middleware.RequestIDOption) grpc.UnaryServerInterceptor {
 	o := middleware.NewRequestIDOptions(options...)
-	return grpc.UnaryServerInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return grpc.UnaryServerInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		ctx = generateRequestID(ctx, o)
 		return handler(ctx, req)
 	})
@@ -50,7 +50,7 @@ func UnaryRequestID(options ...middleware.RequestIDOption) grpc.UnaryServerInter
 //    middleware.XRequestMetadataLimitOption(128))))
 func StreamRequestID(options ...middleware.RequestIDOption) grpc.StreamServerInterceptor {
 	o := middleware.NewRequestIDOptions(options...)
-	return grpc.StreamServerInterceptor(func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return grpc.StreamServerInterceptor(func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := generateRequestID(ss.Context(), o)
 		wss := NewWrappedServerStream(ctx, ss)
 		return handler(srv, wss)

--- a/grpc/middleware/requestid_test.go
+++ b/grpc/middleware/requestid_test.go
@@ -33,7 +33,7 @@ func TestUnaryRequestID(t *testing.T) {
 		{
 			name: "default",
 			ctx:  context.Background(),
-			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler: func(ctx context.Context, req any) (any, error) {
 				md, ok := metadata.FromIncomingContext(ctx)
 				if !ok {
 					return nil, fmt.Errorf("incoming request metadata not found")
@@ -47,7 +47,7 @@ func TestUnaryRequestID(t *testing.T) {
 		{
 			name: "ignore-request-id-metadata",
 			ctx:  populateRequestID(id),
-			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler: func(ctx context.Context, req any) (any, error) {
 				md, ok := metadata.FromIncomingContext(ctx)
 				if !ok {
 					return nil, fmt.Errorf("incoming request metadata not found")
@@ -64,7 +64,7 @@ func TestUnaryRequestID(t *testing.T) {
 				grpcm.UseXRequestIDMetadataOption(true),
 			},
 			ctx: populateRequestID(id),
-			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler: func(ctx context.Context, req any) (any, error) {
 				md, ok := metadata.FromIncomingContext(ctx)
 				if !ok {
 					return nil, fmt.Errorf("incoming request metadata not found")
@@ -82,7 +82,7 @@ func TestUnaryRequestID(t *testing.T) {
 				grpcm.XRequestMetadataLimitOption(2),
 			},
 			ctx: populateRequestID(id),
-			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler: func(ctx context.Context, req any) (any, error) {
 				md, ok := metadata.FromIncomingContext(ctx)
 				if !ok {
 					return nil, fmt.Errorf("incoming request metadata not found")
@@ -121,7 +121,7 @@ func TestStreamRequestID(t *testing.T) {
 		{
 			name:   "default",
 			stream: grpcm.NewWrappedServerStream(context.Background(), &testServerStream{}),
-			handler: func(srv interface{}, stream grpc.ServerStream) error {
+			handler: func(srv any, stream grpc.ServerStream) error {
 				md, ok := metadata.FromIncomingContext(stream.Context())
 				if !ok {
 					return fmt.Errorf("incoming request metadata not found")
@@ -135,7 +135,7 @@ func TestStreamRequestID(t *testing.T) {
 		{
 			name:   "ignore-request-id-metadata",
 			stream: grpcm.NewWrappedServerStream(populateRequestID(id), &testServerStream{}),
-			handler: func(srv interface{}, stream grpc.ServerStream) error {
+			handler: func(srv any, stream grpc.ServerStream) error {
 				md, ok := metadata.FromIncomingContext(stream.Context())
 				if !ok {
 					return fmt.Errorf("incoming request metadata not found")
@@ -152,7 +152,7 @@ func TestStreamRequestID(t *testing.T) {
 				grpcm.UseXRequestIDMetadataOption(true),
 			},
 			stream: grpcm.NewWrappedServerStream(populateRequestID(id), &testServerStream{}),
-			handler: func(srv interface{}, stream grpc.ServerStream) error {
+			handler: func(srv any, stream grpc.ServerStream) error {
 				md, ok := metadata.FromIncomingContext(stream.Context())
 				if !ok {
 					return fmt.Errorf("incoming request metadata not found")
@@ -170,7 +170,7 @@ func TestStreamRequestID(t *testing.T) {
 				grpcm.XRequestMetadataLimitOption(2),
 			},
 			stream: grpcm.NewWrappedServerStream(populateRequestID(id), &testServerStream{}),
-			handler: func(srv interface{}, stream grpc.ServerStream) error {
+			handler: func(srv any, stream grpc.ServerStream) error {
 				md, ok := metadata.FromIncomingContext(stream.Context())
 				if !ok {
 					return fmt.Errorf("incoming request metadata not found")

--- a/grpc/middleware/trace.go
+++ b/grpc/middleware/trace.go
@@ -36,7 +36,7 @@ const (
 //    middleware.SamplingPercent(100)))
 func UnaryServerTrace(opts ...middleware.TraceOption) grpc.UnaryServerInterceptor {
 	o := middleware.NewTraceOptions(opts...)
-	return grpc.UnaryServerInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return grpc.UnaryServerInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		ctx = withTrace(ctx, info.FullMethod, o)
 		return handler(ctx, req)
 	})
@@ -55,7 +55,7 @@ func UnaryServerTrace(opts ...middleware.TraceOption) grpc.UnaryServerIntercepto
 //    middleware.MaxSamplingRate(50)))
 func StreamServerTrace(opts ...middleware.TraceOption) grpc.StreamServerInterceptor {
 	o := middleware.NewTraceOptions(opts...)
-	return grpc.StreamServerInterceptor(func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return grpc.StreamServerInterceptor(func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := withTrace(ss.Context(), info.FullMethod, o)
 		wss := NewWrappedServerStream(ctx, ss)
 		return handler(srv, wss)
@@ -69,7 +69,7 @@ func StreamServerTrace(opts ...middleware.TraceOption) grpc.StreamServerIntercep
 // Example:
 //  conn, err := grpc.Dial(url, grpc.WithUnaryInterceptor(UnaryClientTrace()))
 func UnaryClientTrace() grpc.UnaryClientInterceptor {
-	return grpc.UnaryClientInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return grpc.UnaryClientInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		ctx = setTrace(ctx)
 		return invoker(ctx, method, req, reply, cc, opts...)
 	})

--- a/grpc/middleware/trace_test.go
+++ b/grpc/middleware/trace_test.go
@@ -47,7 +47,7 @@ func TestUnaryServerTrace(t *testing.T) {
 	}
 	for k, c := range cases {
 		t.Run(k, func(t *testing.T) {
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler := func(ctx context.Context, req any) (any, error) {
 				var ctxTraceID, ctxSpanID, ctxParentID string
 				{
 					if traceID := ctx.Value(middleware.TraceIDKey); traceID != nil {
@@ -123,7 +123,7 @@ func TestStreamServerTrace(t *testing.T) {
 	}
 	for k, c := range cases {
 		t.Run(k, func(t *testing.T) {
-			handler := func(srv interface{}, stream grpc.ServerStream) error {
+			handler := func(srv any, stream grpc.ServerStream) error {
 				ctx := stream.Context()
 				var ctxTraceID, ctxSpanID, ctxParentID string
 				{
@@ -179,7 +179,7 @@ func TestUnaryClientTrace(t *testing.T) {
 		TraceID, SpanID string
 		Invoker         grpc.UnaryInvoker
 	}{
-		"no-trace": {"", "", func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		"no-trace": {"", "", func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			md, ok := metadata.FromOutgoingContext(ctx)
 			if !ok {
 				md = metadata.MD{}
@@ -192,7 +192,7 @@ func TestUnaryClientTrace(t *testing.T) {
 			}
 			return nil
 		}},
-		"with-trace": {traceID, spanID, func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		"with-trace": {traceID, spanID, func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			md, ok := metadata.FromOutgoingContext(ctx)
 			if !ok {
 				md = metadata.MD{}

--- a/grpc/middleware/xray/middleware.go
+++ b/grpc/middleware/xray/middleware.go
@@ -73,7 +73,7 @@ func NewUnaryServer(service, daemon string) (grpc.UnaryServerInterceptor, error)
 	if err != nil {
 		return nil, fmt.Errorf("xray: failed to connect to daemon - %s", err)
 	}
-	return grpc.UnaryServerInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	return grpc.UnaryServerInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		var (
 			spanID   = ctx.Value(middleware.TraceSpanIDKey)
 			traceID  = ctx.Value(middleware.TraceIDKey)
@@ -110,7 +110,7 @@ func NewStreamServer(service, daemon string) (grpc.StreamServerInterceptor, erro
 	if err != nil {
 		return nil, fmt.Errorf("xray: failed to connect to daemon - %s", err)
 	}
-	return grpc.StreamServerInterceptor(func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return grpc.StreamServerInterceptor(func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		var (
 			ctx      = ss.Context()
 			spanID   = ctx.Value(middleware.TraceSpanIDKey)
@@ -145,7 +145,7 @@ func NewStreamServer(service, daemon string) (grpc.StreamServerInterceptor, erro
 // trace information in the context which is used by the tracing middleware.
 // This middleware must be mounted before the tracing middleware.
 func UnaryClient(host string) grpc.UnaryClientInterceptor {
-	return grpc.UnaryClientInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return grpc.UnaryClientInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		seg := ctx.Value(xray.SegKey)
 		if seg == nil {
 			return invoker(ctx, method, req, reply, cc, opts...)
@@ -194,7 +194,7 @@ func StreamClient(host string) grpc.StreamClientInterceptor {
 	})
 }
 
-func (c *xrayStreamClientWrapper) SendMsg(m interface{}) error {
+func (c *xrayStreamClientWrapper) SendMsg(m any) error {
 	if err := c.ClientStream.SendMsg(m); err != nil {
 		c.recordErrorAndClose(err)
 		return err
@@ -202,7 +202,7 @@ func (c *xrayStreamClientWrapper) SendMsg(m interface{}) error {
 	return nil
 }
 
-func (c *xrayStreamClientWrapper) RecvMsg(m interface{}) error {
+func (c *xrayStreamClientWrapper) RecvMsg(m any) error {
 	if err := c.ClientStream.RecvMsg(m); err != nil {
 		c.recordErrorAndClose(err)
 		return err

--- a/grpc/middleware/xray/middleware_test.go
+++ b/grpc/middleware/xray/middleware_test.go
@@ -153,7 +153,7 @@ func TestUnaryServerMiddleware(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create middleware: %s", err)
 			}
-			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler := func(ctx context.Context, req any) (any, error) {
 				if c.Segment.Error {
 					return nil, c.Segment.Exception
 				}
@@ -298,7 +298,7 @@ func TestStreamServerMiddleware(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create middleware: %s", err)
 			}
-			handler := func(srv interface{}, stream grpc.ServerStream) error {
+			handler := func(srv any, stream grpc.ServerStream) error {
 				if c.Segment.Error {
 					return c.Segment.Exception
 				}
@@ -418,7 +418,7 @@ func TestUnaryClient(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			invoker := func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 				if tc.Error {
 					return status.Error(tc.StatusCode, "error")
 				}
@@ -493,7 +493,7 @@ func (cs *mockClientStream) Header() (metadata.MD, error) {
 	return nil, cs.err
 }
 
-func (cs *mockClientStream) SendMsg(m interface{}) error {
+func (cs *mockClientStream) SendMsg(m any) error {
 	return cs.err
 }
 
@@ -501,7 +501,7 @@ func (cs *mockClientStream) CloseSend() error {
 	return cs.err
 }
 
-func (cs *mockClientStream) RecvMsg(m interface{}) error {
+func (cs *mockClientStream) RecvMsg(m any) error {
 	return cs.err
 }
 
@@ -564,7 +564,7 @@ func TestStreamClient(t *testing.T) {
 					t.Errorf("expected request error to be %v, got %v", tc.RequestError, errored)
 				}
 				if err == nil {
-					var msg interface{}
+					var msg any
 					err2 := cs.RecvMsg(msg)
 					closed := err2 == io.EOF
 					if tc.StreamClosed != closed {

--- a/grpc/middleware/xray/segment.go
+++ b/grpc/middleware/xray/segment.go
@@ -21,7 +21,7 @@ type GRPCSegment struct {
 // RecordRequest traces a request.
 //
 // It sets Http.Request & Namespace (ex: "remote")
-func (s *GRPCSegment) RecordRequest(ctx context.Context, method string, req interface{}, namespace string) {
+func (s *GRPCSegment) RecordRequest(ctx context.Context, method string, req any, namespace string) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -34,7 +34,7 @@ func (s *GRPCSegment) RecordRequest(ctx context.Context, method string, req inte
 }
 
 // RecordResponse traces a response.
-func (s *GRPCSegment) RecordResponse(resp interface{}) {
+func (s *GRPCSegment) RecordResponse(resp any) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -88,7 +88,7 @@ func (s *GRPCSegment) RecordError(err error) {
 }
 
 // requestData creates a Request from a http.Request.
-func requestData(ctx context.Context, method string, req interface{}) *xray.Request {
+func requestData(ctx context.Context, method string, req any) *xray.Request {
 	var agent string
 	{
 		md, ok := metadata.FromIncomingContext(ctx)
@@ -112,7 +112,7 @@ func requestData(ctx context.Context, method string, req interface{}) *xray.Requ
 	}
 }
 
-func messageLength(msg interface{}) int64 {
+func messageLength(msg any) int64 {
 	var length int64
 	{
 		if m, ok := msg.(proto.Message); ok {

--- a/http/client.go
+++ b/http/client.go
@@ -154,7 +154,7 @@ func (c *ClientError) Error() string {
 
 // ErrInvalidType is the error returned when the wrong type is given to a
 // method function.
-func ErrInvalidType(svc, m, expected string, actual interface{}) error {
+func ErrInvalidType(svc, m, expected string, actual any) error {
 	msg := fmt.Sprintf("invalid value expected %s, got %v", expected, actual)
 	return &ClientError{Name: "invalid_type", Message: msg, Service: svc, Method: m}
 }

--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -284,9 +284,9 @@ func NewMethodExplicitBodyUserResultObjectMultipleViewResulttypemultipleviewsOK(
 const MixedPayloadInBodyClientTypesFile = `// MethodARequestBody is the type of the "ServiceMixedPayloadInBody" service
 // "MethodA" endpoint HTTP request body.
 type MethodARequestBody struct {
-	Any    any          ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
+	Any    any                  ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
 	Array  []float32            ` + "`" + `form:"array" json:"array" xml:"array"` + "`" + `
-	Map    map[uint]any ` + "`" + `form:"map,omitempty" json:"map,omitempty" xml:"map,omitempty"` + "`" + `
+	Map    map[uint]any         ` + "`" + `form:"map,omitempty" json:"map,omitempty" xml:"map,omitempty"` + "`" + `
 	Object *BPayloadRequestBody ` + "`" + `form:"object" json:"object" xml:"object"` + "`" + `
 	DupObj *BPayloadRequestBody ` + "`" + `form:"dup_obj,omitempty" json:"dup_obj,omitempty" xml:"dup_obj,omitempty"` + "`" + `
 }

--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -284,9 +284,9 @@ func NewMethodExplicitBodyUserResultObjectMultipleViewResulttypemultipleviewsOK(
 const MixedPayloadInBodyClientTypesFile = `// MethodARequestBody is the type of the "ServiceMixedPayloadInBody" service
 // "MethodA" endpoint HTTP request body.
 type MethodARequestBody struct {
-	Any    interface{}          ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
+	Any    any          ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
 	Array  []float32            ` + "`" + `form:"array" json:"array" xml:"array"` + "`" + `
-	Map    map[uint]interface{} ` + "`" + `form:"map,omitempty" json:"map,omitempty" xml:"map,omitempty"` + "`" + `
+	Map    map[uint]any ` + "`" + `form:"map,omitempty" json:"map,omitempty" xml:"map,omitempty"` + "`" + `
 	Object *BPayloadRequestBody ` + "`" + `form:"object" json:"object" xml:"object"` + "`" + `
 	DupObj *BPayloadRequestBody ` + "`" + `form:"dup_obj,omitempty" json:"dup_obj,omitempty" xml:"dup_obj,omitempty"` + "`" + `
 }
@@ -310,7 +310,7 @@ func NewMethodARequestBody(p *servicemixedpayloadinbody.APayload) *MethodAReques
 		}
 	}
 	if p.Map != nil {
-		body.Map = make(map[uint]interface{}, len(p.Map))
+		body.Map = make(map[uint]any, len(p.Map))
 		for key, val := range p.Map {
 			tk := key
 			tv := val

--- a/http/codegen/client_cli.go
+++ b/http/codegen/client_cli.go
@@ -148,7 +148,7 @@ func endpointParser(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, da
 				cli.FlagsCode(cliData),
 				data,
 			},
-			FuncMap: map[string]interface{}{"streamingCmdExists": streamingCmdExists},
+			FuncMap: map[string]any{"streamingCmdExists": streamingCmdExists},
 		},
 	}
 	for _, cmd := range cliData {
@@ -315,10 +315,10 @@ func ParseEndpoint(
 		{{- end }}
 	{{- end }}
 	{{- end }}
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	{{ .FlagsCode }}
     var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)

--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -189,7 +189,7 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 					Name:    "client-result-init",
 					Source:  clientTypeInitT,
 					Data:    init,
-					FuncMap: map[string]interface{}{"fieldCode": fieldCode},
+					FuncMap: map[string]any{"fieldCode": fieldCode},
 				})
 			}
 		}
@@ -202,7 +202,7 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 						Name:    "client-error-result-init",
 						Source:  clientTypeInitT,
 						Data:    init,
-						FuncMap: map[string]interface{}{"fieldCode": fieldCode},
+						FuncMap: map[string]any{"fieldCode": fieldCode},
 					})
 				}
 			}

--- a/http/codegen/example_cli.go
+++ b/http/codegen/example_cli.go
@@ -77,21 +77,21 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 		{
 			Name:   "cli-http-streaming",
 			Source: httpCLIStreamingT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Services": svcData,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"needStream": needStream,
 			},
 		},
 		{
 			Name:   "cli-http-end",
 			Source: httpCLIEndT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Services": svcData,
 				"APIPkg":   apiPkg,
 			},
-			FuncMap: map[string]interface{}{
+			FuncMap: map[string]any{
 				"needStream":   needStream,
 				"hasWebSocket": hasWebSocket,
 			},
@@ -109,7 +109,7 @@ func exampleCLI(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *codeg
 }
 
 const (
-	httpCLIStartT = `func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
+	httpCLIStartT = `func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, error) {
 	var (
 		doer goahttp.Doer
 	)
@@ -121,7 +121,7 @@ const (
 	}
 `
 
-	// input: map[string]interface{}{"Services": []*ServiceData}
+	// input: map[string]any{"Services": []*ServiceData}
 	httpCLIStreamingT = `{{- if needStream .Services }}
 	var (
     dialer *websocket.Dialer
@@ -132,7 +132,7 @@ const (
 	{{ end }}
 `
 
-	// input: map[string]interface{}{"Services": []*ServiceData}
+	// input: map[string]any{"Services": []*ServiceData}
 	httpCLIEndT = `return cli.ParseEndpoint(
 		scheme,
 		host,

--- a/http/codegen/example_server.go
+++ b/http/codegen/example_server.go
@@ -86,7 +86,7 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 		{
 			Name:   "server-http-start",
 			Source: httpSvrStartT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Services": svcdata,
 			},
 		},
@@ -96,17 +96,17 @@ func exampleServer(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr) *co
 		{
 			Name:   "server-http-init",
 			Source: httpSvrInitT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Services": svcdata,
 				"APIPkg":   apiPkg,
 			},
-			FuncMap: map[string]interface{}{"needStream": needStream, "hasWebSocket": hasWebSocket},
+			FuncMap: map[string]any{"needStream": needStream, "hasWebSocket": hasWebSocket},
 		},
 		{Name: "server-http-middleware", Source: httpSvrMiddlewareT},
 		{
 			Name:   "server-http-end",
 			Source: httpSvrEndT,
-			Data: map[string]interface{}{
+			Data: map[string]any{
 				"Services": svcdata,
 			},
 		},
@@ -198,7 +198,7 @@ func {{ .FuncName }}(mw *multipart.Writer, p {{ .Payload.Ref }}) error {
 }
 `
 
-	// input: map[string]interface{}{"Services":[]*ServiceData}
+	// input: map[string]any{"Services":[]*ServiceData}
 	httpSvrStartT = `{{ comment "handleHTTPServer starts configures and starts a HTTP server on the given URL. It shuts down the server if any error is received in the error channel." }}
 func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if .Service.Methods }}, {{ .Service.VarName }}Endpoints *{{ .Service.PkgName }}.Endpoints{{ end }}{{ end }}, wg *sync.WaitGroup, errc chan error, logger *log.Logger, debug bool) {
 `
@@ -233,7 +233,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	}
 `
 
-	// input: map[string]interface{}{"APIPkg":string, "Services":[]*ServiceData}
+	// input: map[string]any{"APIPkg":string, "Services":[]*ServiceData}
 	httpSvrInitT = `
 	// Wrap the endpoints with the transport specific layers. The generated
 	// server packages contains code generated from the design which maps
@@ -283,7 +283,7 @@ func handleHTTPServer(ctx context.Context, u *url.URL{{ range $.Services }}{{ if
 	}
 `
 
-	// input: map[string]interface{}{"Services":[]*ServiceData}
+	// input: map[string]any{"Services":[]*ServiceData}
 	httpSvrEndT = `
 	// Start HTTP server using default configuration, change the code to
 	// configure the server as required by your service.

--- a/http/codegen/openapi/docs.go
+++ b/http/codegen/openapi/docs.go
@@ -5,9 +5,9 @@ import "goa.design/goa/v3/expr"
 // ExternalDocs represents an OpenAPI External Documentation object as defined in
 // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#externalDocumentationObject
 type ExternalDocs struct {
-	Description string                 `json:"description,omitempty"`
-	URL         string                 `json:"url,omitempty"`
-	Extensions  map[string]interface{} `json:"-" yaml:"-"`
+	Description string         `json:"description,omitempty"`
+	URL         string         `json:"url,omitempty"`
+	Extensions  map[string]any `json:"-" yaml:"-"`
 }
 
 // DocsFromExpr builds a ExternalDocs from the Goa docs expression.

--- a/http/codegen/openapi/extensions.go
+++ b/http/codegen/openapi/extensions.go
@@ -9,7 +9,7 @@ import (
 
 // ExtensionsFromExpr generates openapi extensions from the given meta
 // expression.
-func ExtensionsFromExpr(mdata expr.MetaExpr) map[string]interface{} {
+func ExtensionsFromExpr(mdata expr.MetaExpr) map[string]any {
 	swag := extensionsFromExprWithPrefix(mdata, "swagger:extension:")
 	open := extensionsFromExprWithPrefix(mdata, "openapi:extension:")
 	if swag == nil {
@@ -26,11 +26,11 @@ func ExtensionsFromExpr(mdata expr.MetaExpr) map[string]interface{} {
 
 // extensionsFromExprWithPrefix generates openapi extensions from
 // the given meta expression with keys starting the given prefix.
-func extensionsFromExprWithPrefix(mdata expr.MetaExpr, prefix string) map[string]interface{} {
+func extensionsFromExprWithPrefix(mdata expr.MetaExpr, prefix string) map[string]any {
 	if !strings.HasSuffix(prefix, ":") {
 		prefix += ":"
 	}
-	extensions := make(map[string]interface{})
+	extensions := make(map[string]any)
 	for key, value := range mdata {
 		if !strings.HasPrefix(key, prefix) {
 			continue
@@ -43,7 +43,7 @@ func extensionsFromExprWithPrefix(mdata expr.MetaExpr, prefix string) map[string
 			continue
 		}
 		val := value[0]
-		ival := interface{}(val)
+		ival := any(val)
 		if err := json.Unmarshal([]byte(val), &ival); err != nil {
 			extensions[name] = val
 			continue

--- a/http/codegen/openapi/json_schema.go
+++ b/http/codegen/openapi/json_schema.go
@@ -22,8 +22,8 @@ type (
 		Properties   map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
 		Definitions  map[string]*Schema `json:"definitions,omitempty" yaml:"definitions,omitempty"`
 		Description  string             `json:"description,omitempty" yaml:"description,omitempty"`
-		DefaultValue interface{}        `json:"default,omitempty" yaml:"default,omitempty"`
-		Example      interface{}        `json:"example,omitempty" yaml:"example,omitempty"`
+		DefaultValue any                `json:"default,omitempty" yaml:"default,omitempty"`
+		Example      any                `json:"example,omitempty" yaml:"example,omitempty"`
 
 		// Hyper schema
 		Media     *Media  `json:"media,omitempty" yaml:"media,omitempty"`
@@ -33,25 +33,25 @@ type (
 		Ref       string  `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
 		// Validation
-		Enum                 []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
-		Format               string        `json:"format,omitempty" yaml:"format,omitempty"`
-		Pattern              string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-		ExclusiveMinimum     *float64      `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
-		Minimum              *float64      `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-		ExclusiveMaximum     *float64      `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
-		Maximum              *float64      `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-		MinLength            *int          `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-		MaxLength            *int          `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-		MinItems             *int          `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-		MaxItems             *int          `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-		Required             []string      `json:"required,omitempty" yaml:"required,omitempty"`
-		AdditionalProperties interface{}   `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
+		Enum                 []any    `json:"enum,omitempty" yaml:"enum,omitempty"`
+		Format               string   `json:"format,omitempty" yaml:"format,omitempty"`
+		Pattern              string   `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+		ExclusiveMinimum     *float64 `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+		Minimum              *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+		ExclusiveMaximum     *float64 `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+		Maximum              *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+		MinLength            *int     `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+		MaxLength            *int     `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+		MinItems             *int     `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+		MaxItems             *int     `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+		Required             []string `json:"required,omitempty" yaml:"required,omitempty"`
+		AdditionalProperties any      `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
 
 		// Union
 		AnyOf []*Schema `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
 
 		// Extensions defines the OpenAPI extensions.
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Extensions map[string]any `json:"-" yaml:"-"`
 	}
 
 	// Type is the JSON type enum.
@@ -371,7 +371,7 @@ func AttributeTypeSchemaWithPrefix(api *expr.APIExpr, at *expr.AttributeExpr, pr
 }
 
 // ToString returns the string representation of the given type.
-func ToString(val interface{}) string {
+func ToString(val any) string {
 	switch actual := val.(type) {
 	case string:
 		return actual
@@ -386,18 +386,18 @@ func ToString(val interface{}) string {
 	}
 }
 
-// ToStringMap converts map[interface{}]interface{} to a map[string]interface{}
+// ToStringMap converts map[any]any to a map[string]any
 // when possible.
-func ToStringMap(val interface{}) interface{} {
+func ToStringMap(val any) any {
 	switch actual := val.(type) {
-	case map[interface{}]interface{}:
-		m := make(map[string]interface{})
+	case map[any]any:
+		m := make(map[string]any)
 		for k, v := range actual {
 			m[ToString(k)] = ToStringMap(v)
 		}
 		return m
-	case []interface{}:
-		mapSlice := make([]interface{}, len(actual))
+	case []any:
+		mapSlice := make([]any, len(actual))
 		for i, e := range actual {
 			mapSlice[i] = ToStringMap(e)
 		}
@@ -413,7 +413,7 @@ func (s *Schema) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (s *Schema) MarshalYAML() (interface{}, error) {
+func (s *Schema) MarshalYAML() (any, error) {
 	return MarshalYAML((*_Schema)(s), s.Extensions)
 }
 
@@ -517,7 +517,7 @@ func toSchemaHrefs(r *expr.RouteExpr) []string {
 	res := make([]string, len(paths))
 	for i, path := range paths {
 		params := expr.ExtractHTTPWildcards(path)
-		args := make([]interface{}, len(params))
+		args := make([]any, len(params))
 		for j, p := range params {
 			args[j] = fmt.Sprintf("/{%s}", p)
 		}

--- a/http/codegen/openapi/marshal.go
+++ b/http/codegen/openapi/marshal.go
@@ -8,7 +8,7 @@ import (
 
 // MarshalJSON produces the JSON resulting from encoding an object composed of
 // the fields in v (which must me a struct) and the keys in extensions.
-func MarshalJSON(v interface{}, extensions map[string]interface{}) ([]byte, error) {
+func MarshalJSON(v any, extensions map[string]any) ([]byte, error) {
 	marshaled, err := json.Marshal(v)
 	if err != nil {
 		return nil, err
@@ -16,11 +16,11 @@ func MarshalJSON(v interface{}, extensions map[string]interface{}) ([]byte, erro
 	if len(extensions) == 0 {
 		return marshaled, nil
 	}
-	var unmarshaled interface{}
+	var unmarshaled any
 	if err := json.Unmarshal(marshaled, &unmarshaled); err != nil {
 		return nil, err
 	}
-	asserted := unmarshaled.(map[string]interface{})
+	asserted := unmarshaled.(map[string]any)
 	for k, v := range extensions {
 		asserted[k] = v
 	}
@@ -33,7 +33,7 @@ func MarshalJSON(v interface{}, extensions map[string]interface{}) ([]byte, erro
 
 // MarshalYAML produces the JSON resulting from encoding an object composed of
 // the fields in v (which must me a struct) and the keys in extensions.
-func MarshalYAML(v interface{}, extensions map[string]interface{}) (interface{}, error) {
+func MarshalYAML(v any, extensions map[string]any) (any, error) {
 	if len(extensions) == 0 {
 		return v, nil
 	}
@@ -41,7 +41,7 @@ func MarshalYAML(v interface{}, extensions map[string]interface{}) (interface{},
 	if err != nil {
 		return nil, err
 	}
-	var unmarshaled map[string]interface{}
+	var unmarshaled map[string]any
 	if err := yaml.Unmarshal(marshaled, &unmarshaled); err != nil {
 		return nil, err
 	}

--- a/http/codegen/openapi/merge.go
+++ b/http/codegen/openapi/merge.go
@@ -4,7 +4,7 @@ import "reflect"
 
 // mergeItems is an internal datatype used to merge two schemas.
 type mergeItems []struct {
-	a, b   interface{}
+	a, b   any
 	needed bool
 }
 

--- a/http/codegen/openapi/tags.go
+++ b/http/codegen/openapi/tags.go
@@ -18,7 +18,7 @@ type Tag struct {
 	// ExternalDocs is additional external documentation for this tag.
 	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 	// Extensions defines the OpenAPI extensions.
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 }
 
 // TagsFromExpr extracts the OpenAPI related metadata from the given expression.
@@ -94,6 +94,6 @@ func (t Tag) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (t Tag) MarshalYAML() (interface{}, error) {
+func (t Tag) MarshalYAML() (any, error) {
 	return MarshalYAML(_tag(t), t.Extensions)
 }

--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -51,7 +51,7 @@ func NewV2(root *expr.RootExpr, h *expr.HostExpr) (*V2, error) {
 		},
 		Host:                host,
 		BasePath:            basePath,
-		Paths:               make(map[string]interface{}),
+		Paths:               make(map[string]any),
 		Consumes:            root.API.HTTP.Consumes,
 		Produces:            root.API.HTTP.Produces,
 		Parameters:          paramMap,
@@ -495,7 +495,7 @@ func buildPathFromFileServer(s *V2, root *expr.RootExpr, fs *expr.HTTPFileServer
 		if key == "" {
 			key = "/"
 		}
-		var path interface{}
+		var path any
 		var ok bool
 		if path, ok = s.Paths[key]; !ok {
 			path = new(Path)
@@ -663,7 +663,7 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 		if bp != "/" {
 			key = strings.TrimPrefix(key, bp)
 		}
-		var path interface{}
+		var path any
 		var ok bool
 		if path, ok = s.Paths[key]; !ok {
 			path = new(Path)
@@ -690,7 +690,7 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 	}
 }
 
-func initEnumValidation(def interface{}, values []interface{}) {
+func initEnumValidation(def any, values []any) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Enum = values
@@ -701,7 +701,7 @@ func initEnumValidation(def interface{}, values []interface{}) {
 	}
 }
 
-func initFormatValidation(def interface{}, format string) {
+func initFormatValidation(def any, format string) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Format = format
@@ -712,7 +712,7 @@ func initFormatValidation(def interface{}, format string) {
 	}
 }
 
-func initPatternValidation(def interface{}, pattern string) {
+func initPatternValidation(def any, pattern string) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Pattern = pattern
@@ -723,7 +723,7 @@ func initPatternValidation(def interface{}, pattern string) {
 	}
 }
 
-func initExclusiveMinimumValidation(def interface{}, exclMin *float64) {
+func initExclusiveMinimumValidation(def any, exclMin *float64) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Minimum = exclMin
@@ -737,7 +737,7 @@ func initExclusiveMinimumValidation(def interface{}, exclMin *float64) {
 	}
 }
 
-func initMinimumValidation(def interface{}, min *float64) {
+func initMinimumValidation(def any, min *float64) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Minimum = min
@@ -751,7 +751,7 @@ func initMinimumValidation(def interface{}, min *float64) {
 	}
 }
 
-func initExclusiveMaximumValidation(def interface{}, exclMax *float64) {
+func initExclusiveMaximumValidation(def any, exclMax *float64) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Maximum = exclMax
@@ -765,7 +765,7 @@ func initExclusiveMaximumValidation(def interface{}, exclMax *float64) {
 	}
 }
 
-func initMaximumValidation(def interface{}, max *float64) {
+func initMaximumValidation(def any, max *float64) {
 	switch actual := def.(type) {
 	case *Parameter:
 		actual.Maximum = max
@@ -779,7 +779,7 @@ func initMaximumValidation(def interface{}, max *float64) {
 	}
 }
 
-func initMinLengthValidation(def interface{}, isArray bool, min *int) {
+func initMinLengthValidation(def any, isArray bool, min *int) {
 	switch actual := def.(type) {
 	case *Parameter:
 		if isArray {
@@ -794,7 +794,7 @@ func initMinLengthValidation(def interface{}, isArray bool, min *int) {
 	}
 }
 
-func initMaxLengthValidation(def interface{}, isArray bool, max *int) {
+func initMaxLengthValidation(def any, isArray bool, max *int) {
 	switch actual := def.(type) {
 	case *Parameter:
 		if isArray {
@@ -809,7 +809,7 @@ func initMaxLengthValidation(def interface{}, isArray bool, max *int) {
 	}
 }
 
-func initValidations(attr *expr.AttributeExpr, def interface{}) {
+func initValidations(attr *expr.AttributeExpr, def any) {
 	val := attr.Validation
 	if val == nil {
 		return

--- a/http/codegen/openapi/v2/builder_test.go
+++ b/http/codegen/openapi/v2/builder_test.go
@@ -27,7 +27,7 @@ func TestBuildPathFromFileServer(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {
 			s := &V2{
-				Paths: make(map[string]interface{}),
+				Paths: make(map[string]any),
 			}
 			root := &expr.RootExpr{
 				API: &expr.APIExpr{
@@ -81,7 +81,7 @@ func TestBuildPathFromExpr(t *testing.T) {
 		t.Run(k, func(t *testing.T) {
 			s := &V2{
 				Consumes: []string{"application/json"},
-				Paths:    make(map[string]interface{}),
+				Paths:    make(map[string]any),
 			}
 			root := &expr.RootExpr{
 				API: &expr.APIExpr{},

--- a/http/codegen/openapi/v2/files.go
+++ b/http/codegen/openapi/v2/files.go
@@ -41,7 +41,7 @@ func Files(root *expr.RootExpr) ([]*codegen.File, error) {
 	}, nil
 }
 
-func toJSON(d interface{}) string {
+func toJSON(d any) string {
 	b, err := json.Marshal(d)
 	if err != nil {
 		panic("openapi: " + err.Error()) // bug
@@ -49,7 +49,7 @@ func toJSON(d interface{}) string {
 	return string(b)
 }
 
-func toYAML(d interface{}) string {
+func toYAML(d any) string {
 	b, err := yaml.Marshal(d)
 	if err != nil {
 		panic("openapi: " + err.Error()) // bug

--- a/http/codegen/openapi/v2/files_test.go
+++ b/http/codegen/openapi/v2/files_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi2"
 	"goa.design/goa/v3/codegen"
 	httpgen "goa.design/goa/v3/http/codegen"
-	openapi "goa.design/goa/v3/http/codegen/openapi"
+	"goa.design/goa/v3/http/codegen/openapi"
 	openapiv2 "goa.design/goa/v3/http/codegen/openapi/v2"
 	"goa.design/goa/v3/http/codegen/testdata"
 )
@@ -105,7 +105,7 @@ func TestSections(t *testing.T) {
 }
 
 func prettifyJSON(t *testing.T, b []byte) string {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		t.Errorf("failed to unmarshal swagger JSON: %s", err)
 	}

--- a/http/codegen/openapi/v2/openapi.go
+++ b/http/codegen/openapi/v2/openapi.go
@@ -18,7 +18,7 @@ type (
 		Schemes             []string                       `json:"schemes,omitempty" yaml:"schemes,omitempty"`
 		Consumes            []string                       `json:"consumes,omitempty" yaml:"consumes,omitempty"`
 		Produces            []string                       `json:"produces,omitempty" yaml:"produces,omitempty"`
-		Paths               map[string]interface{}         `json:"paths" yaml:"paths"`
+		Paths               map[string]any                 `json:"paths" yaml:"paths"`
 		Definitions         map[string]*openapi.Schema     `json:"definitions,omitempty" yaml:"definitions,omitempty"`
 		Parameters          map[string]*Parameter          `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 		Responses           map[string]*Response           `json:"responses,omitempty" yaml:"responses,omitempty"`
@@ -30,13 +30,13 @@ type (
 	// Info provides metadata about the API. The metadata can be used by the clients if needed,
 	// and can be presented in the OpenAPI UI for convenience.
 	Info struct {
-		Title          string                 `json:"title" yaml:"title"`
-		Description    string                 `json:"description,omitempty" yaml:"description,omitempty"`
-		TermsOfService string                 `json:"termsOfService,omitempty" yaml:"termsOfService,omitempty"`
-		Contact        *expr.ContactExpr      `json:"contact,omitempty" yaml:"contact,omitempty"`
-		License        *expr.LicenseExpr      `json:"license,omitempty" yaml:"license,omitempty"`
-		Version        string                 `json:"version" yaml:"version"`
-		Extensions     map[string]interface{} `json:"-" yaml:"-"`
+		Title          string            `json:"title" yaml:"title"`
+		Description    string            `json:"description,omitempty" yaml:"description,omitempty"`
+		TermsOfService string            `json:"termsOfService,omitempty" yaml:"termsOfService,omitempty"`
+		Contact        *expr.ContactExpr `json:"contact,omitempty" yaml:"contact,omitempty"`
+		License        *expr.LicenseExpr `json:"license,omitempty" yaml:"license,omitempty"`
+		Version        string            `json:"version" yaml:"version"`
+		Extensions     map[string]any    `json:"-" yaml:"-"`
 	}
 
 	// Path holds the relative paths to the individual endpoints.
@@ -61,7 +61,7 @@ type (
 		// described under this path.
 		Parameters []*Parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Extensions map[string]any `json:"-" yaml:"-"`
 	}
 
 	// Operation describes a single API operation on a path.
@@ -96,7 +96,7 @@ type (
 		// Security is a declaration of which security schemes are applied for this operation.
 		Security []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Extensions map[string]any `json:"-" yaml:"-"`
 	}
 
 	// Parameter describes a single operation parameter.
@@ -133,21 +133,21 @@ type (
 		// Default declares the value of the parameter that the server will use if none is
 		// provided, for example a "count" to control the number of results per page might
 		// default to 100 if not supplied by the client in the request.
-		Default          interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
-		Maximum          *float64      `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
-		Minimum          *float64      `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
-		MaxLength        *int          `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-		MinLength        *int          `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-		Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-		MaxItems         *int          `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-		MinItems         *int          `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-		UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
-		Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
-		MultipleOf       float64       `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+		Default          any      `json:"default,omitempty" yaml:"default,omitempty"`
+		Maximum          *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+		ExclusiveMaximum bool     `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+		Minimum          *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+		ExclusiveMinimum bool     `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+		MaxLength        *int     `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+		MinLength        *int     `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+		Pattern          string   `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+		MaxItems         *int     `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+		MinItems         *int     `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+		UniqueItems      bool     `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+		Enum             []any    `json:"enum,omitempty" yaml:"enum,omitempty"`
+		MultipleOf       float64  `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Extensions map[string]any `json:"-" yaml:"-"`
 	}
 
 	// Response describes an operation response.
@@ -165,7 +165,7 @@ type (
 		// This field is exclusive with the other fields of Response.
 		Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Extensions map[string]any `json:"-" yaml:"-"`
 	}
 
 	// Header represents a header parameter.
@@ -185,19 +185,19 @@ type (
 		// Default declares the value of the parameter that the server will use if none is
 		// provided, for example a "count" to control the number of results per page might
 		// default to 100 if not supplied by the client in the request.
-		Default          interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
-		Maximum          *float64      `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
-		Minimum          *float64      `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
-		MaxLength        *int          `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-		MinLength        *int          `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-		Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-		MaxItems         *int          `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-		MinItems         *int          `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-		UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
-		Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
-		MultipleOf       float64       `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+		Default          any      `json:"default,omitempty" yaml:"default,omitempty"`
+		Maximum          *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+		ExclusiveMaximum bool     `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+		Minimum          *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+		ExclusiveMinimum bool     `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+		MaxLength        *int     `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+		MinLength        *int     `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+		Pattern          string   `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+		MaxItems         *int     `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+		MinItems         *int     `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+		UniqueItems      bool     `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+		Enum             []any    `json:"enum,omitempty" yaml:"enum,omitempty"`
+		MultipleOf       float64  `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	}
 
 	// SecurityDefinition allows the definition of a security scheme that can be used by the
@@ -224,7 +224,7 @@ type (
 		// Scopes list the  available scopes for the OAuth2 security scheme.
 		Scopes map[string]string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 		// Extensions defines the swagger extensions.
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Extensions map[string]any `json:"-" yaml:"-"`
 	}
 
 	// Scope corresponds to an available scope for an OAuth2 security scheme.
@@ -248,19 +248,19 @@ type (
 		// Default declares the value of the parameter that the server will use if none is
 		// provided, for example a "count" to control the number of results per page might
 		// default to 100 if not supplied by the client in the request.
-		Default          interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
-		Maximum          *float64      `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-		ExclusiveMaximum bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
-		Minimum          *float64      `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-		ExclusiveMinimum bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
-		MaxLength        *int          `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-		MinLength        *int          `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-		Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-		MaxItems         *int          `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-		MinItems         *int          `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-		UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
-		Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
-		MultipleOf       float64       `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+		Default          any      `json:"default,omitempty" yaml:"default,omitempty"`
+		Maximum          *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+		ExclusiveMaximum bool     `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+		Minimum          *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+		ExclusiveMinimum bool     `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+		MaxLength        *int     `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+		MinLength        *int     `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+		Pattern          string   `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+		MaxItems         *int     `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+		MinItems         *int     `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+		UniqueItems      bool     `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+		Enum             []any    `json:"enum,omitempty" yaml:"enum,omitempty"`
+		MultipleOf       float64  `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	}
 
 	// These types are used in openapi.MarshalJSON() to avoid recursive call of json.Marshal().
@@ -303,31 +303,31 @@ func (s SecurityDefinition) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (i Info) MarshalYAML() (interface{}, error) {
+func (i Info) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Info(i), i.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (p Path) MarshalYAML() (interface{}, error) {
+func (p Path) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Path(p), p.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (o Operation) MarshalYAML() (interface{}, error) {
+func (o Operation) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Operation(o), o.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (p Parameter) MarshalYAML() (interface{}, error) {
+func (p Parameter) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Parameter(p), p.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (r Response) MarshalYAML() (interface{}, error) {
+func (r Response) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Response(r), r.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (s SecurityDefinition) MarshalYAML() (interface{}, error) {
+func (s SecurityDefinition) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_SecurityDefinition(s), s.Extensions)
 }

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -157,7 +157,7 @@ func buildPaths(h *expr.HTTPExpr, bodies map[string]map[string]*EndpointBodies, 
 					}
 					path.Extensions = openapi.ExtensionsFromExpr(r.Endpoint.Meta)
 					if len(exts) > 0 {
-						path.Extensions = make(map[string]interface{})
+						path.Extensions = make(map[string]any)
 						for k, v := range exts {
 							path.Extensions[k] = v
 						}
@@ -462,8 +462,8 @@ func buildServers(servers []*expr.ServerExpr) []*Server {
 		for _, host := range svr.Hosts {
 			var (
 				serverVariable   = make(map[string]*ServerVariable)
-				defaultValue     interface{}
-				validationValues []interface{}
+				defaultValue     any
+				validationValues []any
 			)
 
 			// Get the first URL expression in the host by default.

--- a/http/codegen/openapi/v3/example.go
+++ b/http/codegen/openapi/v3/example.go
@@ -6,7 +6,7 @@ type (
 	// exampler is the interface used to initialize the example of an
 	// OpenAPI object.
 	exampler interface {
-		setExample(interface{})
+		setExample(any)
 		setExamples(map[string]*ExampleRef)
 	}
 )

--- a/http/codegen/openapi/v3/files.go
+++ b/http/codegen/openapi/v3/files.go
@@ -39,7 +39,7 @@ func Files(root *expr.RootExpr) ([]*codegen.File, error) {
 	}, nil
 }
 
-func toJSON(d interface{}) string {
+func toJSON(d any) string {
 	b, err := json.Marshal(d)
 	if err != nil {
 		panic("openapi: " + err.Error()) // bug
@@ -47,7 +47,7 @@ func toJSON(d interface{}) string {
 	return string(b)
 }
 
-func toYAML(d interface{}) string {
+func toYAML(d any) string {
 	b, err := yaml.Marshal(d)
 	if err != nil {
 		panic("openapi: " + err.Error()) // bug

--- a/http/codegen/openapi/v3/files_test.go
+++ b/http/codegen/openapi/v3/files_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"goa.design/goa/v3/codegen"
 	httpgen "goa.design/goa/v3/http/codegen"
-	openapi "goa.design/goa/v3/http/codegen/openapi"
+	"goa.design/goa/v3/http/codegen/openapi"
 	openapiv3 "goa.design/goa/v3/http/codegen/openapi/v3"
 	"goa.design/goa/v3/http/codegen/testdata"
 )
@@ -113,7 +113,7 @@ func TestFiles(t *testing.T) {
 }
 
 func prettifyJSON(t *testing.T, b []byte) string {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(b, &v); err != nil {
 		t.Errorf("failed to unmarshal swagger JSON: %s", err)
 	}

--- a/http/codegen/openapi/v3/openapi.go
+++ b/http/codegen/openapi/v3/openapi.go
@@ -7,27 +7,27 @@ type (
 	// generate an OpenAPI specification as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md
 	OpenAPI struct {
-		OpenAPI      string                 `json:"openapi" yaml:"openapi"` // Required
-		Info         *Info                  `json:"info" yaml:"info"`       // Required
-		Servers      []*Server              `json:"servers,omitempty" yaml:"servers,omitempty"`
-		Paths        map[string]*PathItem   `json:"paths" yaml:"paths"` // Required
-		Components   *Components            `json:"components,omitempty" yaml:"components,omitempty"`
-		Tags         []*openapi.Tag         `json:"tags,omitempty" yaml:"tags,omitempty"`
-		Security     []map[string][]string  `json:"security,omitempty" yaml:"security,omitempty"`
-		ExternalDocs *openapi.ExternalDocs  `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
-		Extensions   map[string]interface{} `json:"-" yaml:"-"`
+		OpenAPI      string                `json:"openapi" yaml:"openapi"` // Required
+		Info         *Info                 `json:"info" yaml:"info"`       // Required
+		Servers      []*Server             `json:"servers,omitempty" yaml:"servers,omitempty"`
+		Paths        map[string]*PathItem  `json:"paths" yaml:"paths"` // Required
+		Components   *Components           `json:"components,omitempty" yaml:"components,omitempty"`
+		Tags         []*openapi.Tag        `json:"tags,omitempty" yaml:"tags,omitempty"`
+		Security     []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
+		ExternalDocs *openapi.ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+		Extensions   map[string]any        `json:"-" yaml:"-"`
 	}
 
 	// Info represents an OpenAPI Info object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#infoObject
 	Info struct {
-		Title          string                 `json:"title" yaml:"title"` // Required
-		Description    string                 `json:"description,omitempty" yaml:"description,omitempty"`
-		TermsOfService string                 `json:"termsOfService,omitempty" yaml:"termsOfService,omitempty"`
-		Contact        *Contact               `json:"contact,omitempty" yaml:"contact,omitempty"`
-		License        *License               `json:"license,omitempty" yaml:"license,omitempty"`
-		Version        string                 `json:"version" yaml:"version"` // Required
-		Extensions     map[string]interface{} `json:"-" yaml:"-"`
+		Title          string         `json:"title" yaml:"title"` // Required
+		Description    string         `json:"description,omitempty" yaml:"description,omitempty"`
+		TermsOfService string         `json:"termsOfService,omitempty" yaml:"termsOfService,omitempty"`
+		Contact        *Contact       `json:"contact,omitempty" yaml:"contact,omitempty"`
+		License        *License       `json:"license,omitempty" yaml:"license,omitempty"`
+		Version        string         `json:"version" yaml:"version"` // Required
+		Extensions     map[string]any `json:"-" yaml:"-"`
 	}
 
 	// Server represents an OpenAPI Server object as defined in
@@ -41,21 +41,21 @@ type (
 	// PathItem represents an OpenAPI Path Item object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#pathItemObject
 	PathItem struct {
-		Ref         string                 `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-		Summary     string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
-		Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
-		Connect     *Operation             `json:"connect,omitempty" yaml:"connect,omitempty"`
-		Delete      *Operation             `json:"delete,omitempty" yaml:"delete,omitempty"`
-		Get         *Operation             `json:"get,omitempty" yaml:"get,omitempty"`
-		Head        *Operation             `json:"head,omitempty" yaml:"head,omitempty"`
-		Options     *Operation             `json:"options,omitempty" yaml:"options,omitempty"`
-		Patch       *Operation             `json:"patch,omitempty" yaml:"patch,omitempty"`
-		Post        *Operation             `json:"post,omitempty" yaml:"post,omitempty"`
-		Put         *Operation             `json:"put,omitempty" yaml:"put,omitempty"`
-		Trace       *Operation             `json:"trace,omitempty" yaml:"trace,omitempty"`
-		Servers     []*Server              `json:"servers,omitempty" yaml:"servers,omitempty"`
-		Parameters  []*ParameterRef        `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-		Extensions  map[string]interface{} `json:"-" yaml:"-"`
+		Ref         string          `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+		Summary     string          `json:"summary,omitempty" yaml:"summary,omitempty"`
+		Description string          `json:"description,omitempty" yaml:"description,omitempty"`
+		Connect     *Operation      `json:"connect,omitempty" yaml:"connect,omitempty"`
+		Delete      *Operation      `json:"delete,omitempty" yaml:"delete,omitempty"`
+		Get         *Operation      `json:"get,omitempty" yaml:"get,omitempty"`
+		Head        *Operation      `json:"head,omitempty" yaml:"head,omitempty"`
+		Options     *Operation      `json:"options,omitempty" yaml:"options,omitempty"`
+		Patch       *Operation      `json:"patch,omitempty" yaml:"patch,omitempty"`
+		Post        *Operation      `json:"post,omitempty" yaml:"post,omitempty"`
+		Put         *Operation      `json:"put,omitempty" yaml:"put,omitempty"`
+		Trace       *Operation      `json:"trace,omitempty" yaml:"trace,omitempty"`
+		Servers     []*Server       `json:"servers,omitempty" yaml:"servers,omitempty"`
+		Parameters  []*ParameterRef `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+		Extensions  map[string]any  `json:"-" yaml:"-"`
 	}
 
 	// Components represents an OpenAPI Components object as defined in
@@ -70,32 +70,32 @@ type (
 		Examples        map[string]*ExampleRef        `json:"examples,omitempty" yaml:"examples,omitempty"`
 		Links           map[string]*LinkRef           `json:"links,omitempty" yaml:"links,omitempty"`
 		Callbacks       map[string]*CallbackRef       `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
-		Extensions      map[string]interface{}        `json:"-" yaml:"-"`
+		Extensions      map[string]any                `json:"-" yaml:"-"`
 	}
 
 	// Contact represents an OpenAPI Contact object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#contactObject
 	Contact struct {
-		Name       string                 `json:"name,omitempty" yaml:"name,omitempty"`
-		URL        string                 `json:"url,omitempty" yaml:"url,omitempty"`
-		Email      string                 `json:"email,omitempty" yaml:"email,omitempty"`
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Name       string         `json:"name,omitempty" yaml:"name,omitempty"`
+		URL        string         `json:"url,omitempty" yaml:"url,omitempty"`
+		Email      string         `json:"email,omitempty" yaml:"email,omitempty"`
+		Extensions map[string]any `json:"-" yaml:"-"`
 	}
 
 	// License represents an OpenAPI License object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#licenseObject
 	License struct {
-		Name       string                 `json:"name" yaml:"name"` // Required
-		URL        string                 `json:"url,omitempty" yaml:"url,omitempty"`
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Name       string         `json:"name" yaml:"name"` // Required
+		URL        string         `json:"url,omitempty" yaml:"url,omitempty"`
+		Extensions map[string]any `json:"-" yaml:"-"`
 	}
 
 	// ServerVariable represents an OpenAPI Server Variable object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#serverVariableObject
 	ServerVariable struct {
-		Enum        []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
-		Default     interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
-		Description string        `json:"description,omitempty" yaml:"description,omitempty"`
+		Enum        []any  `json:"enum,omitempty" yaml:"enum,omitempty"`
+		Default     any    `json:"default,omitempty" yaml:"default,omitempty"`
+		Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	}
 
 	// Operation represents an OpenAPI Operation object as defined in
@@ -113,7 +113,7 @@ type (
 		Security     []map[string][]string   `json:"security,omitempty" yaml:"security,omitempty"`
 		Servers      []*Server               `json:"servers,omitempty" yaml:"servers,omitempty"`
 		ExternalDocs *openapi.ExternalDocs   `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
-		Extensions   map[string]interface{}  `json:"-" yaml:"-"`
+		Extensions   map[string]any          `json:"-" yaml:"-"`
 	}
 
 	// Parameter represents an OpenAPI Parameter object as defined in
@@ -129,41 +129,41 @@ type (
 		Deprecated      bool                   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 		Required        bool                   `json:"required,omitempty" yaml:"required,omitempty"`
 		Schema          *openapi.Schema        `json:"schema,omitempty" yaml:"schema,omitempty"`
-		Example         interface{}            `json:"example,omitempty" yaml:"example,omitempty"`
+		Example         any                    `json:"example,omitempty" yaml:"example,omitempty"`
 		Examples        map[string]*ExampleRef `json:"examples,omitempty" yaml:"examples,omitempty"`
 		Content         map[string]*MediaType  `json:"content,omitempty" yaml:"content,omitempty"`
-		Extensions      map[string]interface{} `json:"-" yaml:"-"`
+		Extensions      map[string]any         `json:"-" yaml:"-"`
 	}
 
 	// Response represents an OpenAPI Response object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#responseObject
 	Response struct {
-		Description *string                `json:"description,omitempty" yaml:"description,omitempty"`
-		Headers     map[string]*HeaderRef  `json:"headers,omitempty" yaml:"headers,omitempty"`
-		Content     map[string]*MediaType  `json:"content,omitempty" yaml:"content,omitempty"`
-		Links       map[string]*LinkRef    `json:"links,omitempty" yaml:"links,omitempty"`
-		Extensions  map[string]interface{} `json:"-" yaml:"-"`
+		Description *string               `json:"description,omitempty" yaml:"description,omitempty"`
+		Headers     map[string]*HeaderRef `json:"headers,omitempty" yaml:"headers,omitempty"`
+		Content     map[string]*MediaType `json:"content,omitempty" yaml:"content,omitempty"`
+		Links       map[string]*LinkRef   `json:"links,omitempty" yaml:"links,omitempty"`
+		Extensions  map[string]any        `json:"-" yaml:"-"`
 	}
 
 	// MediaType represents an OpenAPI Media Type object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#mediaTypeObject
 	MediaType struct {
 		Schema     *openapi.Schema        `json:"schema,omitempty" yaml:"schema,omitempty"`
-		Example    interface{}            `json:"example,omitempty" yaml:"example,omitempty"`
+		Example    any                    `json:"example,omitempty" yaml:"example,omitempty"`
 		Examples   map[string]*ExampleRef `json:"examples,omitempty" yaml:"examples,omitempty"`
 		Encoding   map[string]*Encoding   `json:"encoding,omitempty" yaml:"encoding,omitempty"`
-		Extensions map[string]interface{} `json:"-" yaml:"-"`
+		Extensions map[string]any         `json:"-" yaml:"-"`
 	}
 
 	// Encoding represents an OpenAPI Encoding object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#encodingObject
 	Encoding struct {
-		ContentType   string                 `json:"contentType,omitempty" yaml:"contentType,omitempty"`
-		Headers       map[string]*HeaderRef  `json:"headers,omitempty" yaml:"headers,omitempty"`
-		Style         string                 `json:"style,omitempty" yaml:"style,omitempty"`
-		Explode       *bool                  `json:"explode,omitempty" yaml:"explode,omitempty"`
-		AllowReserved bool                   `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
-		Extensions    map[string]interface{} `json:"-" yaml:"-"`
+		ContentType   string                `json:"contentType,omitempty" yaml:"contentType,omitempty"`
+		Headers       map[string]*HeaderRef `json:"headers,omitempty" yaml:"headers,omitempty"`
+		Style         string                `json:"style,omitempty" yaml:"style,omitempty"`
+		Explode       *bool                 `json:"explode,omitempty" yaml:"explode,omitempty"`
+		AllowReserved bool                  `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
+		Extensions    map[string]any        `json:"-" yaml:"-"`
 	}
 
 	// Header represents an OpenAPI Header object as defined in
@@ -177,74 +177,74 @@ type (
 		Deprecated      bool                   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 		Required        bool                   `json:"required,omitempty" yaml:"required,omitempty"`
 		Schema          *openapi.Schema        `json:"schema,omitempty" yaml:"schema,omitempty"`
-		Example         interface{}            `json:"example,omitempty" yaml:"example,omitempty"`
+		Example         any                    `json:"example,omitempty" yaml:"example,omitempty"`
 		Examples        map[string]*ExampleRef `json:"examples,omitempty" yaml:"examples,omitempty"`
 		Content         map[string]*MediaType  `json:"content,omitempty" yaml:"content,omitempty"`
-		Extensions      map[string]interface{} `json:"-" yaml:"-"`
+		Extensions      map[string]any         `json:"-" yaml:"-"`
 	}
 
 	// Link represents an OpenAPI Link object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#linkObject
 	Link struct {
-		OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-		OperationRef string                 `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
-		Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
-		Parameters   map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-		Server       *Server                `json:"server,omitempty" yaml:"server,omitempty"`
-		RequestBody  interface{}            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-		Extensions   map[string]interface{} `json:"-" yaml:"-"`
+		OperationID  string         `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+		OperationRef string         `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
+		Description  string         `json:"description,omitempty" yaml:"description,omitempty"`
+		Parameters   map[string]any `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+		Server       *Server        `json:"server,omitempty" yaml:"server,omitempty"`
+		RequestBody  any            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+		Extensions   map[string]any `json:"-" yaml:"-"`
 	}
 
 	// Example represents an OpenAPI Example object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#exampleObject
 	Example struct {
-		Summary       string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
-		Description   string                 `json:"description,omitempty" yaml:"description,omitempty"`
-		Value         interface{}            `json:"value,omitempty" yaml:"value,omitempty"`
-		ExternalValue string                 `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
-		Extensions    map[string]interface{} `json:"-" yaml:"-"`
+		Summary       string         `json:"summary,omitempty" yaml:"summary,omitempty"`
+		Description   string         `json:"description,omitempty" yaml:"description,omitempty"`
+		Value         any            `json:"value,omitempty" yaml:"value,omitempty"`
+		ExternalValue string         `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
+		Extensions    map[string]any `json:"-" yaml:"-"`
 	}
 
 	// RequestBody represents an OpenAPI RequestBody object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#requestBodyObject
 	RequestBody struct {
-		Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
-		Required    bool                   `json:"required,omitempty" yaml:"required,omitempty"`
-		Content     map[string]*MediaType  `json:"content,omitempty" yaml:"content,omitempty"`
-		Extensions  map[string]interface{} `json:"-" yaml:"-"`
+		Description string                `json:"description,omitempty" yaml:"description,omitempty"`
+		Required    bool                  `json:"required,omitempty" yaml:"required,omitempty"`
+		Content     map[string]*MediaType `json:"content,omitempty" yaml:"content,omitempty"`
+		Extensions  map[string]any        `json:"-" yaml:"-"`
 	}
 
 	// SecurityScheme represents an OpenAPI SecurityScheme object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#securitySchemeObject
 	SecurityScheme struct {
-		Type         string                 `json:"type,omitempty" yaml:"type,omitempty"`
-		Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
-		Name         string                 `json:"name,omitempty" yaml:"name,omitempty"`
-		In           string                 `json:"in,omitempty" yaml:"in,omitempty"`
-		Scheme       string                 `json:"scheme,omitempty" yaml:"scheme,omitempty"`
-		BearerFormat string                 `json:"bearerFormat,omitempty" yaml:"bearerFormat,omitempty"`
-		Flows        *OAuthFlows            `json:"flows,omitempty" yaml:"flows,omitempty"`
-		Extensions   map[string]interface{} `json:"-" yaml:"-"`
+		Type         string         `json:"type,omitempty" yaml:"type,omitempty"`
+		Description  string         `json:"description,omitempty" yaml:"description,omitempty"`
+		Name         string         `json:"name,omitempty" yaml:"name,omitempty"`
+		In           string         `json:"in,omitempty" yaml:"in,omitempty"`
+		Scheme       string         `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+		BearerFormat string         `json:"bearerFormat,omitempty" yaml:"bearerFormat,omitempty"`
+		Flows        *OAuthFlows    `json:"flows,omitempty" yaml:"flows,omitempty"`
+		Extensions   map[string]any `json:"-" yaml:"-"`
 	}
 
 	// OAuthFlows represents an OpenAPI OAuthFlows object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#oauthFlowsObject
 	OAuthFlows struct {
-		Implicit          *OAuthFlow             `json:"implicit,omitempty" yaml:"implicit,omitempty"`
-		Password          *OAuthFlow             `json:"password,omitempty" yaml:"password,omitempty"`
-		ClientCredentials *OAuthFlow             `json:"clientCredentials,omitempty" yaml:"clientCredentials,omitempty"`
-		AuthorizationCode *OAuthFlow             `json:"authorizationCode,omitempty" yaml:"authorizationCode,omitempty"`
-		Extensions        map[string]interface{} `json:"-" yaml:"-"`
+		Implicit          *OAuthFlow     `json:"implicit,omitempty" yaml:"implicit,omitempty"`
+		Password          *OAuthFlow     `json:"password,omitempty" yaml:"password,omitempty"`
+		ClientCredentials *OAuthFlow     `json:"clientCredentials,omitempty" yaml:"clientCredentials,omitempty"`
+		AuthorizationCode *OAuthFlow     `json:"authorizationCode,omitempty" yaml:"authorizationCode,omitempty"`
+		Extensions        map[string]any `json:"-" yaml:"-"`
 	}
 
 	// OAuthFlow represents an OpenAPI OAuthFlow object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#oauthFlowObject
 	OAuthFlow struct {
-		AuthorizationURL string                 `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
-		TokenURL         string                 `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
-		RefreshURL       string                 `json:"refreshUrl,omitempty" yaml:"refreshUrl,omitempty"`
-		Scopes           map[string]string      `json:"scopes" yaml:"scopes"`
-		Extensions       map[string]interface{} `json:"-" yaml:"-"`
+		AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
+		TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
+		RefreshURL       string            `json:"refreshUrl,omitempty" yaml:"refreshUrl,omitempty"`
+		Scopes           map[string]string `json:"scopes" yaml:"scopes"`
+		Extensions       map[string]any    `json:"-" yaml:"-"`
 	}
 
 	// These types are used in openapi.MarshalJSON() to avoid recursive call of json.Marshal().
@@ -257,15 +257,15 @@ type (
 )
 
 // MediaType implements exampler
-func (m *MediaType) setExample(val interface{})             { m.Example = val }
+func (m *MediaType) setExample(val any)                     { m.Example = val }
 func (m *MediaType) setExamples(val map[string]*ExampleRef) { m.Examples = val }
 
 // Header implements exampler
-func (h *Header) setExample(val interface{})             { h.Example = val }
+func (h *Header) setExample(val any)                     { h.Example = val }
 func (h *Header) setExamples(val map[string]*ExampleRef) { h.Examples = val }
 
 // Parameter implements exampler
-func (p *Parameter) setExample(val interface{})             { p.Example = val }
+func (p *Parameter) setExample(val any)                     { p.Example = val }
 func (p *Parameter) setExamples(val map[string]*ExampleRef) { p.Examples = val }
 
 // MarshalJSON returns the JSON encoding of i.
@@ -299,31 +299,31 @@ func (s SecurityScheme) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (i Info) MarshalYAML() (interface{}, error) {
+func (i Info) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Info(i), i.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (p PathItem) MarshalYAML() (interface{}, error) {
+func (p PathItem) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_PathItem(p), p.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (o Operation) MarshalYAML() (interface{}, error) {
+func (o Operation) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Operation(o), o.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (p Parameter) MarshalYAML() (interface{}, error) {
+func (p Parameter) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Parameter(p), p.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (r Response) MarshalYAML() (interface{}, error) {
+func (r Response) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_Response(r), r.Extensions)
 }
 
 // MarshalYAML returns value which marshaled in place of the original value
-func (s SecurityScheme) MarshalYAML() (interface{}, error) {
+func (s SecurityScheme) MarshalYAML() (any, error) {
 	return openapi.MarshalYAML(_SecurityScheme(s), s.Extensions)
 }

--- a/http/codegen/openapi/v3/ref.go
+++ b/http/codegen/openapi/v3/ref.go
@@ -74,14 +74,14 @@ func (r *LinkRef) MarshalJSON() ([]byte, error)           { return marshalJSONRe
 func (r *RequestBodyRef) MarshalJSON() ([]byte, error)    { return marshalJSONRef(r.Ref, r.Value) }
 func (r *SecuritySchemeRef) MarshalJSON() ([]byte, error) { return marshalJSONRef(r.Ref, r.Value) }
 
-func (r *ParameterRef) MarshalYAML() (interface{}, error)      { return marshalYAMLRef(r.Ref, r.Value) }
-func (r *ResponseRef) MarshalYAML() (interface{}, error)       { return marshalYAMLRef(r.Ref, r.Value) }
-func (r *HeaderRef) MarshalYAML() (interface{}, error)         { return marshalYAMLRef(r.Ref, r.Value) }
-func (r *CallbackRef) MarshalYAML() (interface{}, error)       { return marshalYAMLRef(r.Ref, r.Value) }
-func (r *ExampleRef) MarshalYAML() (interface{}, error)        { return marshalYAMLRef(r.Ref, r.Value) }
-func (r *LinkRef) MarshalYAML() (interface{}, error)           { return marshalYAMLRef(r.Ref, r.Value) }
-func (r *RequestBodyRef) MarshalYAML() (interface{}, error)    { return marshalYAMLRef(r.Ref, r.Value) }
-func (r *SecuritySchemeRef) MarshalYAML() (interface{}, error) { return marshalYAMLRef(r.Ref, r.Value) }
+func (r *ParameterRef) MarshalYAML() (any, error)      { return marshalYAMLRef(r.Ref, r.Value) }
+func (r *ResponseRef) MarshalYAML() (any, error)       { return marshalYAMLRef(r.Ref, r.Value) }
+func (r *HeaderRef) MarshalYAML() (any, error)         { return marshalYAMLRef(r.Ref, r.Value) }
+func (r *CallbackRef) MarshalYAML() (any, error)       { return marshalYAMLRef(r.Ref, r.Value) }
+func (r *ExampleRef) MarshalYAML() (any, error)        { return marshalYAMLRef(r.Ref, r.Value) }
+func (r *LinkRef) MarshalYAML() (any, error)           { return marshalYAMLRef(r.Ref, r.Value) }
+func (r *RequestBodyRef) MarshalYAML() (any, error)    { return marshalYAMLRef(r.Ref, r.Value) }
+func (r *SecuritySchemeRef) MarshalYAML() (any, error) { return marshalYAMLRef(r.Ref, r.Value) }
 
 func (r *ParameterRef) UnmarshalJSON(d []byte) error   { return unmarshalJSONRef(d, &r.Ref, &r.Value) }
 func (r *ResponseRef) UnmarshalJSON(d []byte) error    { return unmarshalJSONRef(d, &r.Ref, &r.Value) }
@@ -94,28 +94,28 @@ func (r *SecuritySchemeRef) UnmarshalJSON(d []byte) error {
 	return unmarshalJSONRef(d, &r.Ref, &r.Value)
 }
 
-func (r *ParameterRef) UnmarshalYAML(u func(interface{}) error) error {
+func (r *ParameterRef) UnmarshalYAML(u func(any) error) error {
 	return unmarshalYAMLRef(u, &r.Ref, &r.Value)
 }
-func (r *ResponseRef) UnmarshalYAML(u func(interface{}) error) error {
+func (r *ResponseRef) UnmarshalYAML(u func(any) error) error {
 	return unmarshalYAMLRef(u, &r.Ref, &r.Value)
 }
-func (r *HeaderRef) UnmarshalYAML(u func(interface{}) error) error {
+func (r *HeaderRef) UnmarshalYAML(u func(any) error) error {
 	return unmarshalYAMLRef(u, &r.Ref, &r.Value)
 }
-func (r *CallbackRef) UnmarshalYAML(u func(interface{}) error) error {
+func (r *CallbackRef) UnmarshalYAML(u func(any) error) error {
 	return unmarshalYAMLRef(u, &r.Ref, &r.Value)
 }
-func (r *ExampleRef) UnmarshalYAML(u func(interface{}) error) error {
+func (r *ExampleRef) UnmarshalYAML(u func(any) error) error {
 	return unmarshalYAMLRef(u, &r.Ref, &r.Value)
 }
-func (r *LinkRef) UnmarshalYAML(u func(interface{}) error) error {
+func (r *LinkRef) UnmarshalYAML(u func(any) error) error {
 	return unmarshalYAMLRef(u, &r.Ref, &r.Value)
 }
-func (r *RequestBodyRef) UnmarshalYAML(u func(interface{}) error) error {
+func (r *RequestBodyRef) UnmarshalYAML(u func(any) error) error {
 	return unmarshalYAMLRef(u, &r.Ref, &r.Value)
 }
-func (r *SecuritySchemeRef) UnmarshalYAML(u func(interface{}) error) error {
+func (r *SecuritySchemeRef) UnmarshalYAML(u func(any) error) error {
 	return unmarshalYAMLRef(u, &r.Ref, &r.Value)
 }
 
@@ -123,14 +123,14 @@ type refs struct {
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 }
 
-func marshalJSONRef(ref string, v interface{}) ([]byte, error) {
+func marshalJSONRef(ref string, v any) ([]byte, error) {
 	if len(ref) > 0 {
 		return json.Marshal(&refs{ref})
 	}
 	return json.Marshal(v)
 }
 
-func unmarshalJSONRef(data []byte, ref *string, v interface{}) error {
+func unmarshalJSONRef(data []byte, ref *string, v any) error {
 	refs := &refs{}
 	if err := json.Unmarshal(data, refs); err == nil {
 		if len(refs.Ref) > 0 {
@@ -141,14 +141,14 @@ func unmarshalJSONRef(data []byte, ref *string, v interface{}) error {
 	return json.Unmarshal(data, v)
 }
 
-func marshalYAMLRef(ref string, v interface{}) (interface{}, error) {
+func marshalYAMLRef(ref string, v any) (any, error) {
 	if len(ref) > 0 {
 		return &refs{ref}, nil
 	}
 	return v, nil
 }
 
-func unmarshalYAMLRef(u func(interface{}) error, ref *string, v interface{}) error {
+func unmarshalYAMLRef(u func(any) error, ref *string, v any) error {
 	refs := &refs{}
 	if err := u(refs); err == nil {
 		if len(refs.Ref) > 0 {

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -330,18 +330,18 @@ func toRef(n string) string {
 	return fmt.Sprintf("#/components/schemas/%s", n)
 }
 
-// toStringMap converts map[interface{}]interface{} to a map[string]interface{}
+// toStringMap converts map[any]any to a map[string]any
 // when possible.
-func toStringMap(val interface{}) interface{} {
+func toStringMap(val any) any {
 	switch actual := val.(type) {
-	case map[interface{}]interface{}:
-		m := make(map[string]interface{})
+	case map[any]any:
+		m := make(map[string]any)
 		for k, v := range actual {
 			m[toString(k)] = toStringMap(v)
 		}
 		return m
-	case []interface{}:
-		mapSlice := make([]interface{}, len(actual))
+	case []any:
+		mapSlice := make([]any, len(actual))
 		for i, e := range actual {
 			mapSlice[i] = toStringMap(e)
 		}
@@ -352,7 +352,7 @@ func toStringMap(val interface{}) interface{} {
 }
 
 // toString returns the string representation of the given type.
-func toString(val interface{}) string {
+func toString(val any) string {
 	switch actual := val.(type) {
 	case string:
 		return actual

--- a/http/codegen/openapi/v3/types_test.go
+++ b/http/codegen/openapi/v3/types_test.go
@@ -36,7 +36,7 @@ var (
 	tarray  = typ{Type: "array"}
 )
 
-func tobj(attrs ...interface{}) typ {
+func tobj(attrs ...any) typ {
 	res := typ{Type: "object"}
 	if len(attrs) == 0 {
 		res.SkipProps = true

--- a/http/codegen/server_types.go
+++ b/http/codegen/server_types.go
@@ -177,7 +177,7 @@ func serverType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 				Name:    "server-payload-init",
 				Source:  serverTypeInitT,
 				Data:    init,
-				FuncMap: map[string]interface{}{"fieldCode": fieldCode},
+				FuncMap: map[string]any{"fieldCode": fieldCode},
 			})
 		}
 		if isWebSocketEndpoint(adata) && adata.ServerWebSocket.Payload != nil {
@@ -186,7 +186,7 @@ func serverType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 					Name:    "server-payload-init",
 					Source:  serverTypeInitT,
 					Data:    init,
-					FuncMap: map[string]interface{}{"fieldCode": fieldCode},
+					FuncMap: map[string]any{"fieldCode": fieldCode},
 				})
 			}
 		}

--- a/http/codegen/server_types_test.go
+++ b/http/codegen/server_types_test.go
@@ -46,9 +46,9 @@ func TestServerTypes(t *testing.T) {
 const MixedPayloadInBodyServerTypesFile = `// MethodARequestBody is the type of the "ServiceMixedPayloadInBody" service
 // "MethodA" endpoint HTTP request body.
 type MethodARequestBody struct {
-	Any    any          ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
+	Any    any                  ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
 	Array  []float32            ` + "`" + `form:"array,omitempty" json:"array,omitempty" xml:"array,omitempty"` + "`" + `
-	Map    map[uint]any ` + "`" + `form:"map,omitempty" json:"map,omitempty" xml:"map,omitempty"` + "`" + `
+	Map    map[uint]any         ` + "`" + `form:"map,omitempty" json:"map,omitempty" xml:"map,omitempty"` + "`" + `
 	Object *BPayloadRequestBody ` + "`" + `form:"object,omitempty" json:"object,omitempty" xml:"object,omitempty"` + "`" + `
 	DupObj *BPayloadRequestBody ` + "`" + `form:"dup_obj,omitempty" json:"dup_obj,omitempty" xml:"dup_obj,omitempty"` + "`" + `
 }

--- a/http/codegen/server_types_test.go
+++ b/http/codegen/server_types_test.go
@@ -46,9 +46,9 @@ func TestServerTypes(t *testing.T) {
 const MixedPayloadInBodyServerTypesFile = `// MethodARequestBody is the type of the "ServiceMixedPayloadInBody" service
 // "MethodA" endpoint HTTP request body.
 type MethodARequestBody struct {
-	Any    interface{}          ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
+	Any    any          ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
 	Array  []float32            ` + "`" + `form:"array,omitempty" json:"array,omitempty" xml:"array,omitempty"` + "`" + `
-	Map    map[uint]interface{} ` + "`" + `form:"map,omitempty" json:"map,omitempty" xml:"map,omitempty"` + "`" + `
+	Map    map[uint]any ` + "`" + `form:"map,omitempty" json:"map,omitempty" xml:"map,omitempty"` + "`" + `
 	Object *BPayloadRequestBody ` + "`" + `form:"object,omitempty" json:"object,omitempty" xml:"object,omitempty"` + "`" + `
 	DupObj *BPayloadRequestBody ` + "`" + `form:"dup_obj,omitempty" json:"dup_obj,omitempty" xml:"dup_obj,omitempty"` + "`" + `
 }
@@ -70,7 +70,7 @@ func NewMethodAAPayload(body *MethodARequestBody) *servicemixedpayloadinbody.APa
 		v.Array[i] = val
 	}
 	if body.Map != nil {
-		v.Map = make(map[uint]interface{}, len(body.Map))
+		v.Map = make(map[uint]any, len(body.Map))
 		for key, val := range body.Map {
 			tk := key
 			tv := val

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -429,11 +429,11 @@ type (
 		// pointer.
 		FieldPointer bool
 		// DefaultValue is the default value of the attribute if any.
-		DefaultValue interface{}
+		DefaultValue any
 		// Validate contains the validation code for the attribute value if any.
 		Validate string
 		// Example is an example attribute value
-		Example interface{}
+		Example any
 	}
 
 	// InitArgData represents a single constructor argument.
@@ -526,7 +526,7 @@ type (
 		// ValidateRef contains the call to the validation code.
 		ValidateRef string
 		// Example is an example value for the type.
-		Example interface{}
+		Example any
 		// View is the view used to render the (result) type if any.
 		View string
 	}
@@ -686,7 +686,7 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 
 					var buffer bytes.Buffer
 					pf := expr.HTTPWildcardRegex.ReplaceAllString(rpath, "/%v")
-					err := pathInitTmpl.Execute(&buffer, map[string]interface{}{
+					err := pathInitTmpl.Execute(&buffer, map[string]any{
 						"Args":       initArgs,
 						"PathParams": pathParamsObj,
 						"PathFormat": pf,
@@ -779,7 +779,7 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 					payloadRef = svc.Scope.GoFullTypeRef(a.MethodExpr.Payload, pkg)
 				}
 			}
-			data := map[string]interface{}{
+			data := map[string]any{
 				"PayloadRef":   payloadRef,
 				"HasFields":    expr.IsObject(a.MethodExpr.Payload.Type),
 				"ServiceName":  svc.Name,
@@ -796,7 +796,7 @@ func (d ServicesData) analyze(hs *expr.HTTPServiceExpr) *ServiceData {
 			if err := requestInitTmpl.Execute(&buf, data); err != nil {
 				panic(err) // bug
 			}
-			clientArgs := []*InitArgData{{Ref: "v", AttributeData: &AttributeData{VarName: "v", TypeRef: "interface{}"}}}
+			clientArgs := []*InitArgData{{Ref: "v", AttributeData: &AttributeData{VarName: "v", TypeRef: "any"}}}
 			requestInit = &InitData{
 				Name:        name,
 				Description: fmt.Sprintf("%s instantiates a HTTP request object with method and path set to call the %q service %q endpoint", name, svc.Name, ep.Name),
@@ -962,7 +962,7 @@ func makeHTTPTypeRecursive(att *expr.AttributeExpr, seen map[string]struct{}) *e
 		att.Type = &obj
 	case *expr.Union:
 		values := expr.AsUnion(dt).Values
-		names := make([]interface{}, len(values))
+		names := make([]any, len(values))
 		vals := make([]string, len(values))
 		bases := make([]expr.DataType, len(values))
 		for i, nat := range values {
@@ -2777,8 +2777,8 @@ func needInit(dt expr.DataType) bool {
 
 // upgradeParams returns the data required to render the websocket_upgrade
 // template.
-func upgradeParams(e *EndpointData, fn string) map[string]interface{} {
-	return map[string]interface{}{
+func upgradeParams(e *EndpointData, fn string) map[string]any {
+	return map[string]any{
 		"ViewedResult": e.Method.ViewedResult,
 		"Function":     fn,
 	}

--- a/http/codegen/testdata/client_request_build_functions.go
+++ b/http/codegen/testdata/client_request_build_functions.go
@@ -3,7 +3,7 @@ package testdata
 const PathStringRequestBuildCode = `// BuildMethodPathStringRequest instantiates a HTTP request object with method
 // and path set to call the "ServicePathString" service "MethodPathString"
 // endpoint
-func (c *Client) BuildMethodPathStringRequest(ctx context.Context, v interface{}) (*http.Request, error) {
+func (c *Client) BuildMethodPathStringRequest(ctx context.Context, v any) (*http.Request, error) {
 	var (
 		p string
 	)
@@ -32,7 +32,7 @@ func (c *Client) BuildMethodPathStringRequest(ctx context.Context, v interface{}
 const PathStringRequiredRequestBuildCode = `// BuildMethodPathStringValidateRequest instantiates a HTTP request object with
 // method and path set to call the "ServicePathStringValidate" service
 // "MethodPathStringValidate" endpoint
-func (c *Client) BuildMethodPathStringValidateRequest(ctx context.Context, v interface{}) (*http.Request, error) {
+func (c *Client) BuildMethodPathStringValidateRequest(ctx context.Context, v any) (*http.Request, error) {
 	var (
 		p string
 	)
@@ -59,7 +59,7 @@ func (c *Client) BuildMethodPathStringValidateRequest(ctx context.Context, v int
 const PathStringDefaultRequestBuildCode = `// BuildMethodPathStringDefaultRequest instantiates a HTTP request object with
 // method and path set to call the "ServicePathStringDefault" service
 // "MethodPathStringDefault" endpoint
-func (c *Client) BuildMethodPathStringDefaultRequest(ctx context.Context, v interface{}) (*http.Request, error) {
+func (c *Client) BuildMethodPathStringDefaultRequest(ctx context.Context, v any) (*http.Request, error) {
 	var (
 		p string
 	)
@@ -86,7 +86,7 @@ func (c *Client) BuildMethodPathStringDefaultRequest(ctx context.Context, v inte
 const PathObjectRequestBuildCode = `// BuildMethodPathObjectRequest instantiates a HTTP request object with method
 // and path set to call the "ServicePathObject" service "MethodPathObject"
 // endpoint
-func (c *Client) BuildMethodPathObjectRequest(ctx context.Context, v interface{}) (*http.Request, error) {
+func (c *Client) BuildMethodPathObjectRequest(ctx context.Context, v any) (*http.Request, error) {
 	var (
 		id string
 	)

--- a/http/codegen/testdata/error_encoder_code.go
+++ b/http/codegen/testdata/error_encoder_code.go
@@ -89,7 +89,7 @@ func EncodeMethodAPIPrimitiveErrorResponseError(encoder func(context.Context, ht
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
-			var body interface{}
+			var body any
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
@@ -127,7 +127,7 @@ func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.Re
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
-			var body interface{}
+			var body any
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
@@ -158,7 +158,7 @@ func EncodeMethodDefaultErrorResponseError(encoder func(context.Context, http.Re
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/xml")
 			enc := encoder(ctx, w)
-			var body interface{}
+			var body any
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
@@ -188,7 +188,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
-			var body interface{}
+			var body any
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
@@ -201,7 +201,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
-			var body interface{}
+			var body any
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
@@ -231,7 +231,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			var res *goa.ServiceError
 			errors.As(v, &res)
 			enc := encoder(ctx, w)
-			var body interface{}
+			var body any
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {
@@ -245,7 +245,7 @@ func EncodeMethodServiceErrorResponseError(encoder func(context.Context, http.Re
 			errors.As(v, &res)
 			ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/xml")
 			enc := encoder(ctx, w)
-			var body interface{}
+			var body any
 			if formatter != nil {
 				body = formatter(ctx, res)
 			} else {

--- a/http/codegen/testdata/example_code.go
+++ b/http/codegen/testdata/example_code.go
@@ -511,7 +511,7 @@ func errorHandler(logger *log.Logger) func(context.Context, http.ResponseWriter,
 }
 `
 
-	ExampleCLICode = `func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
+	ExampleCLICode = `func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, error) {
 	var (
 		doer goahttp.Doer
 	)
@@ -541,7 +541,7 @@ func httpUsageExamples() string {
 }
 `
 
-	StreamingExampleCLICode = `func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
+	StreamingExampleCLICode = `func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, error) {
 	var (
 		doer goahttp.Doer
 	)
@@ -580,7 +580,7 @@ func httpUsageExamples() string {
 }
 `
 
-	StreamingMultipleServicesExampleCLICode = `func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, interface{}, error) {
+	StreamingMultipleServicesExampleCLICode = `func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, error) {
 	var (
 		doer goahttp.Doer
 	)

--- a/http/codegen/testdata/multipart_code.go
+++ b/http/codegen/testdata/multipart_code.go
@@ -53,7 +53,7 @@ var MultipartPrimitiveDecoderFuncCode = `// NewServiceMultipartPrimitiveMethodMu
 // service "MethodMultipartPrimitive" endpoint.
 func NewServiceMultipartPrimitiveMethodMultipartPrimitiveDecoder(mux goahttp.Muxer, serviceMultipartPrimitiveMethodMultipartPrimitiveDecoderFn ServiceMultipartPrimitiveMethodMultipartPrimitiveDecoderFunc) func(r *http.Request) goahttp.Decoder {
 	return func(r *http.Request) goahttp.Decoder {
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			mr, merr := r.MultipartReader()
 			if merr != nil {
 				return merr
@@ -73,7 +73,7 @@ var MultipartUserTypeDecoderFuncCode = `// NewServiceMultipartUserTypeMethodMult
 // "MethodMultipartUserType" endpoint.
 func NewServiceMultipartUserTypeMethodMultipartUserTypeDecoder(mux goahttp.Muxer, serviceMultipartUserTypeMethodMultipartUserTypeDecoderFn ServiceMultipartUserTypeMethodMultipartUserTypeDecoderFunc) func(r *http.Request) goahttp.Decoder {
 	return func(r *http.Request) goahttp.Decoder {
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			mr, merr := r.MultipartReader()
 			if merr != nil {
 				return merr
@@ -93,7 +93,7 @@ var MultipartArrayTypeDecoderFuncCode = `// NewServiceMultipartArrayTypeMethodMu
 // service "MethodMultipartArrayType" endpoint.
 func NewServiceMultipartArrayTypeMethodMultipartArrayTypeDecoder(mux goahttp.Muxer, serviceMultipartArrayTypeMethodMultipartArrayTypeDecoderFn ServiceMultipartArrayTypeMethodMultipartArrayTypeDecoderFunc) func(r *http.Request) goahttp.Decoder {
 	return func(r *http.Request) goahttp.Decoder {
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			mr, merr := r.MultipartReader()
 			if merr != nil {
 				return merr
@@ -113,7 +113,7 @@ var MultipartMapTypeDecoderFuncCode = `// NewServiceMultipartMapTypeMethodMultip
 // "MethodMultipartMapType" endpoint.
 func NewServiceMultipartMapTypeMethodMultipartMapTypeDecoder(mux goahttp.Muxer, serviceMultipartMapTypeMethodMultipartMapTypeDecoderFn ServiceMultipartMapTypeMethodMultipartMapTypeDecoderFunc) func(r *http.Request) goahttp.Decoder {
 	return func(r *http.Request) goahttp.Decoder {
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			mr, merr := r.MultipartReader()
 			if merr != nil {
 				return merr
@@ -133,7 +133,7 @@ var MultipartWithParamDecoderFuncCode = `// NewServiceMultipartWithParamMethodMu
 // service "MethodMultipartWithParam" endpoint.
 func NewServiceMultipartWithParamMethodMultipartWithParamDecoder(mux goahttp.Muxer, serviceMultipartWithParamMethodMultipartWithParamDecoderFn ServiceMultipartWithParamMethodMultipartWithParamDecoderFunc) func(r *http.Request) goahttp.Decoder {
 	return func(r *http.Request) goahttp.Decoder {
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			mr, merr := r.MultipartReader()
 			if merr != nil {
 				return merr
@@ -188,7 +188,7 @@ var MultipartWithParamsAndHeadersDecoderFuncCode = `// NewServiceMultipartWithPa
 // "MethodMultipartWithParamsAndHeaders" endpoint.
 func NewServiceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersDecoder(mux goahttp.Muxer, serviceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersDecoderFn ServiceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersDecoderFunc) func(r *http.Request) goahttp.Decoder {
 	return func(r *http.Request) goahttp.Decoder {
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			mr, merr := r.MultipartReader()
 			if merr != nil {
 				return merr
@@ -258,7 +258,7 @@ func NewServiceMultipartPrimitiveMethodMultipartPrimitiveEncoder(encoderFn Servi
 	return func(r *http.Request) goahttp.Encoder {
 		body := &bytes.Buffer{}
 		mw := multipart.NewWriter(body)
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			p := v.(string)
 			if err := encoderFn(mw, p); err != nil {
 				return err
@@ -278,7 +278,7 @@ func NewServiceMultipartUserTypeMethodMultipartUserTypeEncoder(encoderFn Service
 	return func(r *http.Request) goahttp.Encoder {
 		body := &bytes.Buffer{}
 		mw := multipart.NewWriter(body)
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			p := v.(*servicemultipartusertype.MethodMultipartUserTypePayload)
 			if err := encoderFn(mw, p); err != nil {
 				return err
@@ -297,7 +297,7 @@ func NewServiceMultipartArrayTypeMethodMultipartArrayTypeEncoder(encoderFn Servi
 	return func(r *http.Request) goahttp.Encoder {
 		body := &bytes.Buffer{}
 		mw := multipart.NewWriter(body)
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			p := v.([]*servicemultipartarraytype.PayloadType)
 			if err := encoderFn(mw, p); err != nil {
 				return err
@@ -317,7 +317,7 @@ func NewServiceMultipartMapTypeMethodMultipartMapTypeEncoder(encoderFn ServiceMu
 	return func(r *http.Request) goahttp.Encoder {
 		body := &bytes.Buffer{}
 		mw := multipart.NewWriter(body)
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			p := v.(map[string]int)
 			if err := encoderFn(mw, p); err != nil {
 				return err
@@ -337,7 +337,7 @@ func NewServiceMultipartWithParamMethodMultipartWithParamEncoder(encoderFn Servi
 	return func(r *http.Request) goahttp.Encoder {
 		body := &bytes.Buffer{}
 		mw := multipart.NewWriter(body)
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			p := v.(*servicemultipartwithparam.PayloadType)
 			if err := encoderFn(mw, p); err != nil {
 				return err
@@ -358,7 +358,7 @@ func NewServiceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersE
 	return func(r *http.Request) goahttp.Encoder {
 		body := &bytes.Buffer{}
 		mw := multipart.NewWriter(body)
-		return goahttp.EncodingFunc(func(v interface{}) error {
+		return goahttp.EncodingFunc(func(v any) error {
 			p := v.(*servicemultipartwithparamsandheaders.PayloadType)
 			if err := encoderFn(mw, p); err != nil {
 				return err

--- a/http/codegen/testdata/parse_endpoint_functions.go
+++ b/http/codegen/testdata/parse_endpoint_functions.go
@@ -8,7 +8,7 @@ func ParseEndpoint(
 	enc func(*http.Request) goahttp.Encoder,
 	dec func(*http.Response) goahttp.Decoder,
 	restore bool,
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	var (
 		serviceMultiNoPayload1Flags = flag.NewFlagSet("service-multi-no-payload1", flag.ContinueOnError)
 
@@ -98,7 +98,7 @@ func ParseEndpoint(
 	}
 
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)
@@ -142,7 +142,7 @@ func ParseEndpoint(
 	enc func(*http.Request) goahttp.Encoder,
 	dec func(*http.Response) goahttp.Decoder,
 	restore bool,
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	var (
 		serviceMultiSimple1Flags = flag.NewFlagSet("service-multi-simple1", flag.ContinueOnError)
 
@@ -234,7 +234,7 @@ func ParseEndpoint(
 	}
 
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)
@@ -278,7 +278,7 @@ func ParseEndpoint(
 	enc func(*http.Request) goahttp.Encoder,
 	dec func(*http.Response) goahttp.Decoder,
 	restore bool,
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	var (
 		serviceMultiRequired1Flags = flag.NewFlagSet("service-multi-required1", flag.ContinueOnError)
 
@@ -364,7 +364,7 @@ func ParseEndpoint(
 	}
 
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)
@@ -405,7 +405,7 @@ func ParseEndpoint(
 	enc func(*http.Request) goahttp.Encoder,
 	dec func(*http.Response) goahttp.Decoder,
 	restore bool,
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	var (
 		serviceMultiFlags = flag.NewFlagSet("service-multi", flag.ContinueOnError)
 
@@ -476,7 +476,7 @@ func ParseEndpoint(
 	}
 
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)
@@ -513,7 +513,7 @@ func ParseEndpoint(
 	dialer goahttp.Dialer,
 	streamingServiceAConfigurer *streamingserviceac.ConnConfigurer,
 	streamingServiceBConfigurer *streamingservicebc.ConnConfigurer,
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	var (
 		streamingServiceAFlags = flag.NewFlagSet("streaming-service-a", flag.ContinueOnError)
 
@@ -591,7 +591,7 @@ func ParseEndpoint(
 	}
 
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)
@@ -769,7 +769,7 @@ func ParseEndpoint(
 	enc func(*http.Request) goahttp.Encoder,
 	dec func(*http.Response) goahttp.Decoder,
 	restore bool,
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	var (
 		serviceBodyPrimitiveBoolValidateFlags = flag.NewFlagSet("service-body-primitive-bool-validate", flag.ContinueOnError)
 
@@ -832,7 +832,7 @@ func ParseEndpoint(
 	}
 
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)
@@ -867,7 +867,7 @@ func ParseEndpoint(
 	enc func(*http.Request) goahttp.Encoder,
 	dec func(*http.Response) goahttp.Decoder,
 	restore bool,
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	var (
 		serviceBodyPrimitiveArrayStringValidateFlags = flag.NewFlagSet("service-body-primitive-array-string-validate", flag.ContinueOnError)
 
@@ -930,7 +930,7 @@ func ParseEndpoint(
 	}
 
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)
@@ -1054,7 +1054,7 @@ func ParseEndpoint(
 	enc func(*http.Request) goahttp.Encoder,
 	dec func(*http.Response) goahttp.Decoder,
 	restore bool,
-) (goa.Endpoint, interface{}, error) {
+) (goa.Endpoint, any, error) {
 	var (
 		serviceMapQueryPrimitiveArrayFlags = flag.NewFlagSet("service-map-query-primitive-array", flag.ContinueOnError)
 
@@ -1117,7 +1117,7 @@ func ParseEndpoint(
 	}
 
 	var (
-		data     interface{}
+		data     any
 		endpoint goa.Endpoint
 		err      error
 	)
@@ -1258,7 +1258,7 @@ func BuildMethodQueryStringValidatePayload(serviceQueryStringValidateMethodQuery
 	{
 		q = serviceQueryStringValidateMethodQueryStringValidateQ
 		if !(q == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []interface{}{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err

--- a/http/codegen/testdata/path_functions.go
+++ b/http/codegen/testdata/path_functions.go
@@ -166,7 +166,7 @@ func MethodPathBoolSliceParamServicePathBoolSliceParamPath(a []bool) string {
 `
 
 var PathInterfaceSliceParamCode = `// MethodPathInterfaceSliceParamServicePathInterfaceSliceParamPath returns the URL path to the ServicePathInterfaceSliceParam service MethodPathInterfaceSliceParam HTTP endpoint.
-func MethodPathInterfaceSliceParamServicePathInterfaceSliceParamPath(a []interface{}) string {
+func MethodPathInterfaceSliceParamServicePathInterfaceSliceParamPath(a []any) string {
 	aSlice := make([]string, len(a))
 	for i, v := range a {
 		aSlice[i] = url.QueryEscape(fmt.Sprintf("%v", v))

--- a/http/codegen/testdata/payload_constructor_functions.go
+++ b/http/codegen/testdata/payload_constructor_functions.go
@@ -222,7 +222,7 @@ func NewMethodQueryBytesValidatePayload(q []byte) *servicequerybytesvalidate.Met
 
 var PayloadQueryAnyConstructorCode = `// NewMethodQueryAnyPayload builds a ServiceQueryAny service MethodQueryAny
 // endpoint payload.
-func NewMethodQueryAnyPayload(q interface{}) *servicequeryany.MethodQueryAnyPayload {
+func NewMethodQueryAnyPayload(q any) *servicequeryany.MethodQueryAnyPayload {
 	v := &servicequeryany.MethodQueryAnyPayload{}
 	v.Q = q
 
@@ -232,7 +232,7 @@ func NewMethodQueryAnyPayload(q interface{}) *servicequeryany.MethodQueryAnyPayl
 
 var PayloadQueryAnyValidateConstructorCode = `// NewMethodQueryAnyValidatePayload builds a ServiceQueryAnyValidate service
 // MethodQueryAnyValidate endpoint payload.
-func NewMethodQueryAnyValidatePayload(q interface{}) *servicequeryanyvalidate.MethodQueryAnyValidatePayload {
+func NewMethodQueryAnyValidatePayload(q any) *servicequeryanyvalidate.MethodQueryAnyValidatePayload {
 	v := &servicequeryanyvalidate.MethodQueryAnyValidatePayload{}
 	v.Q = q
 
@@ -472,7 +472,7 @@ func NewMethodQueryArrayBytesValidatePayload(q [][]byte) *servicequeryarraybytes
 
 var PayloadQueryArrayAnyConstructorCode = `// NewMethodQueryArrayAnyPayload builds a ServiceQueryArrayAny service
 // MethodQueryArrayAny endpoint payload.
-func NewMethodQueryArrayAnyPayload(q []interface{}) *servicequeryarrayany.MethodQueryArrayAnyPayload {
+func NewMethodQueryArrayAnyPayload(q []any) *servicequeryarrayany.MethodQueryArrayAnyPayload {
 	v := &servicequeryarrayany.MethodQueryArrayAnyPayload{}
 	v.Q = q
 
@@ -482,7 +482,7 @@ func NewMethodQueryArrayAnyPayload(q []interface{}) *servicequeryarrayany.Method
 
 var PayloadQueryArrayAnyValidateConstructorCode = `// NewMethodQueryArrayAnyValidatePayload builds a ServiceQueryArrayAnyValidate
 // service MethodQueryArrayAnyValidate endpoint payload.
-func NewMethodQueryArrayAnyValidatePayload(q []interface{}) *servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload {
+func NewMethodQueryArrayAnyValidatePayload(q []any) *servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload {
 	v := &servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload{}
 	v.Q = q
 

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -2,8 +2,8 @@ package testdata
 
 var PayloadQueryBoolDecodeCode = `// DecodeMethodQueryBoolRequest returns a decoder for requests sent to the
 // ServiceQueryBool MethodQueryBool endpoint.
-func DecodeMethodQueryBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *bool
 			err error
@@ -30,8 +30,8 @@ func DecodeMethodQueryBoolRequest(mux goahttp.Muxer, decoder func(*http.Request)
 
 var PayloadQueryBoolValidateDecodeCode = `// DecodeMethodQueryBoolValidateRequest returns a decoder for requests sent to
 // the ServiceQueryBoolValidate MethodQueryBoolValidate endpoint.
-func DecodeMethodQueryBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   bool
 			err error
@@ -48,7 +48,7 @@ func DecodeMethodQueryBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.
 			q = v
 		}
 		if !(q == true) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []interface{}{true}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{true}))
 		}
 		if err != nil {
 			return nil, err
@@ -62,8 +62,8 @@ func DecodeMethodQueryBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.
 
 var PayloadQueryIntDecodeCode = `// DecodeMethodQueryIntRequest returns a decoder for requests sent to the
 // ServiceQueryInt MethodQueryInt endpoint.
-func DecodeMethodQueryIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *int
 			err error
@@ -91,8 +91,8 @@ func DecodeMethodQueryIntRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 
 var PayloadQueryIntValidateDecodeCode = `// DecodeMethodQueryIntValidateRequest returns a decoder for requests sent to
 // the ServiceQueryIntValidate MethodQueryIntValidate endpoint.
-func DecodeMethodQueryIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   int
 			err error
@@ -123,8 +123,8 @@ func DecodeMethodQueryIntValidateRequest(mux goahttp.Muxer, decoder func(*http.R
 
 var PayloadQueryInt32DecodeCode = `// DecodeMethodQueryInt32Request returns a decoder for requests sent to the
 // ServiceQueryInt32 MethodQueryInt32 endpoint.
-func DecodeMethodQueryInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *int32
 			err error
@@ -152,8 +152,8 @@ func DecodeMethodQueryInt32Request(mux goahttp.Muxer, decoder func(*http.Request
 
 var PayloadQueryInt32ValidateDecodeCode = `// DecodeMethodQueryInt32ValidateRequest returns a decoder for requests sent to
 // the ServiceQueryInt32Validate MethodQueryInt32Validate endpoint.
-func DecodeMethodQueryInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   int32
 			err error
@@ -184,8 +184,8 @@ func DecodeMethodQueryInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http
 
 var PayloadQueryInt64DecodeCode = `// DecodeMethodQueryInt64Request returns a decoder for requests sent to the
 // ServiceQueryInt64 MethodQueryInt64 endpoint.
-func DecodeMethodQueryInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *int64
 			err error
@@ -212,8 +212,8 @@ func DecodeMethodQueryInt64Request(mux goahttp.Muxer, decoder func(*http.Request
 
 var PayloadQueryInt64ValidateDecodeCode = `// DecodeMethodQueryInt64ValidateRequest returns a decoder for requests sent to
 // the ServiceQueryInt64Validate MethodQueryInt64Validate endpoint.
-func DecodeMethodQueryInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   int64
 			err error
@@ -244,8 +244,8 @@ func DecodeMethodQueryInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http
 
 var PayloadQueryUIntDecodeCode = `// DecodeMethodQueryUIntRequest returns a decoder for requests sent to the
 // ServiceQueryUInt MethodQueryUInt endpoint.
-func DecodeMethodQueryUIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryUIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *uint
 			err error
@@ -273,8 +273,8 @@ func DecodeMethodQueryUIntRequest(mux goahttp.Muxer, decoder func(*http.Request)
 
 var PayloadQueryUIntValidateDecodeCode = `// DecodeMethodQueryUIntValidateRequest returns a decoder for requests sent to
 // the ServiceQueryUIntValidate MethodQueryUIntValidate endpoint.
-func DecodeMethodQueryUIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryUIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   uint
 			err error
@@ -305,8 +305,8 @@ func DecodeMethodQueryUIntValidateRequest(mux goahttp.Muxer, decoder func(*http.
 
 var PayloadQueryUInt32DecodeCode = `// DecodeMethodQueryUInt32Request returns a decoder for requests sent to the
 // ServiceQueryUInt32 MethodQueryUInt32 endpoint.
-func DecodeMethodQueryUInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryUInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *uint32
 			err error
@@ -334,8 +334,8 @@ func DecodeMethodQueryUInt32Request(mux goahttp.Muxer, decoder func(*http.Reques
 
 var PayloadQueryUInt32ValidateDecodeCode = `// DecodeMethodQueryUInt32ValidateRequest returns a decoder for requests sent
 // to the ServiceQueryUInt32Validate MethodQueryUInt32Validate endpoint.
-func DecodeMethodQueryUInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryUInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   uint32
 			err error
@@ -366,8 +366,8 @@ func DecodeMethodQueryUInt32ValidateRequest(mux goahttp.Muxer, decoder func(*htt
 
 var PayloadQueryUInt64DecodeCode = `// DecodeMethodQueryUInt64Request returns a decoder for requests sent to the
 // ServiceQueryUInt64 MethodQueryUInt64 endpoint.
-func DecodeMethodQueryUInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryUInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *uint64
 			err error
@@ -394,8 +394,8 @@ func DecodeMethodQueryUInt64Request(mux goahttp.Muxer, decoder func(*http.Reques
 
 var PayloadQueryUInt64ValidateDecodeCode = `// DecodeMethodQueryUInt64ValidateRequest returns a decoder for requests sent
 // to the ServiceQueryUInt64Validate MethodQueryUInt64Validate endpoint.
-func DecodeMethodQueryUInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryUInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   uint64
 			err error
@@ -426,8 +426,8 @@ func DecodeMethodQueryUInt64ValidateRequest(mux goahttp.Muxer, decoder func(*htt
 
 var PayloadQueryFloat32DecodeCode = `// DecodeMethodQueryFloat32Request returns a decoder for requests sent to the
 // ServiceQueryFloat32 MethodQueryFloat32 endpoint.
-func DecodeMethodQueryFloat32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryFloat32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *float32
 			err error
@@ -455,8 +455,8 @@ func DecodeMethodQueryFloat32Request(mux goahttp.Muxer, decoder func(*http.Reque
 
 var PayloadQueryFloat32ValidateDecodeCode = `// DecodeMethodQueryFloat32ValidateRequest returns a decoder for requests sent
 // to the ServiceQueryFloat32Validate MethodQueryFloat32Validate endpoint.
-func DecodeMethodQueryFloat32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryFloat32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   float32
 			err error
@@ -487,8 +487,8 @@ func DecodeMethodQueryFloat32ValidateRequest(mux goahttp.Muxer, decoder func(*ht
 
 var PayloadQueryFloat64DecodeCode = `// DecodeMethodQueryFloat64Request returns a decoder for requests sent to the
 // ServiceQueryFloat64 MethodQueryFloat64 endpoint.
-func DecodeMethodQueryFloat64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryFloat64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *float64
 			err error
@@ -515,8 +515,8 @@ func DecodeMethodQueryFloat64Request(mux goahttp.Muxer, decoder func(*http.Reque
 
 var PayloadQueryFloat64ValidateDecodeCode = `// DecodeMethodQueryFloat64ValidateRequest returns a decoder for requests sent
 // to the ServiceQueryFloat64Validate MethodQueryFloat64Validate endpoint.
-func DecodeMethodQueryFloat64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryFloat64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   float64
 			err error
@@ -547,8 +547,8 @@ func DecodeMethodQueryFloat64ValidateRequest(mux goahttp.Muxer, decoder func(*ht
 
 var PayloadQueryStringDecodeCode = `// DecodeMethodQueryStringRequest returns a decoder for requests sent to the
 // ServiceQueryString MethodQueryString endpoint.
-func DecodeMethodQueryStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q *string
 		)
@@ -565,8 +565,8 @@ func DecodeMethodQueryStringRequest(mux goahttp.Muxer, decoder func(*http.Reques
 
 var PayloadQueryStringValidateDecodeCode = `// DecodeMethodQueryStringValidateRequest returns a decoder for requests sent
 // to the ServiceQueryStringValidate MethodQueryStringValidate endpoint.
-func DecodeMethodQueryStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   string
 			err error
@@ -576,7 +576,7 @@ func DecodeMethodQueryStringValidateRequest(mux goahttp.Muxer, decoder func(*htt
 			err = goa.MergeErrors(err, goa.MissingFieldError("q", "query string"))
 		}
 		if !(q == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []interface{}{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -591,8 +591,8 @@ func DecodeMethodQueryStringValidateRequest(mux goahttp.Muxer, decoder func(*htt
 var PayloadQueryStringNotRequiredValidateDecodeCode = `// DecodeMethodQueryStringNotRequiredValidateRequest returns a decoder for
 // requests sent to the ServiceQueryStringNotRequiredValidate
 // MethodQueryStringNotRequiredValidate endpoint.
-func DecodeMethodQueryStringNotRequiredValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryStringNotRequiredValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   *string
 			err error
@@ -603,7 +603,7 @@ func DecodeMethodQueryStringNotRequiredValidateRequest(mux goahttp.Muxer, decode
 		}
 		if q != nil {
 			if !(*q == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", *q, []interface{}{"val"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", *q, []any{"val"}))
 			}
 		}
 		if err != nil {
@@ -618,8 +618,8 @@ func DecodeMethodQueryStringNotRequiredValidateRequest(mux goahttp.Muxer, decode
 
 var PayloadQueryBytesDecodeCode = `// DecodeMethodQueryBytesRequest returns a decoder for requests sent to the
 // ServiceQueryBytes MethodQueryBytes endpoint.
-func DecodeMethodQueryBytesRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryBytesRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q []byte
 		)
@@ -638,8 +638,8 @@ func DecodeMethodQueryBytesRequest(mux goahttp.Muxer, decoder func(*http.Request
 
 var PayloadQueryBytesValidateDecodeCode = `// DecodeMethodQueryBytesValidateRequest returns a decoder for requests sent to
 // the ServiceQueryBytesValidate MethodQueryBytesValidate endpoint.
-func DecodeMethodQueryBytesValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryBytesValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []byte
 			err error
@@ -666,10 +666,10 @@ func DecodeMethodQueryBytesValidateRequest(mux goahttp.Muxer, decoder func(*http
 
 var PayloadQueryAnyDecodeCode = `// DecodeMethodQueryAnyRequest returns a decoder for requests sent to the
 // ServiceQueryAny MethodQueryAny endpoint.
-func DecodeMethodQueryAnyRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryAnyRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
-			q interface{}
+			q any
 		)
 		qRaw := r.URL.Query().Get("q")
 		if qRaw != "" {
@@ -684,10 +684,10 @@ func DecodeMethodQueryAnyRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 
 var PayloadQueryAnyValidateDecodeCode = `// DecodeMethodQueryAnyValidateRequest returns a decoder for requests sent to
 // the ServiceQueryAnyValidate MethodQueryAnyValidate endpoint.
-func DecodeMethodQueryAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
-			q   interface{}
+			q   any
 			err error
 		)
 		q = r.URL.Query().Get("q")
@@ -695,7 +695,7 @@ func DecodeMethodQueryAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.R
 			err = goa.MergeErrors(err, goa.MissingFieldError("q", "query string"))
 		}
 		if !(q == "val" || q == 1) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []interface{}{"val", 1}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"val", 1}))
 		}
 		if err != nil {
 			return nil, err
@@ -709,8 +709,8 @@ func DecodeMethodQueryAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.R
 
 var PayloadQueryArrayBoolDecodeCode = `// DecodeMethodQueryArrayBoolRequest returns a decoder for requests sent to the
 // ServiceQueryArrayBool MethodQueryArrayBool endpoint.
-func DecodeMethodQueryArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []bool
 			err error
@@ -741,8 +741,8 @@ func DecodeMethodQueryArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Req
 var PayloadQueryArrayBoolValidateDecodeCode = `// DecodeMethodQueryArrayBoolValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayBoolValidate MethodQueryArrayBoolValidate
 // endpoint.
-func DecodeMethodQueryArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []bool
 			err error
@@ -766,7 +766,7 @@ func DecodeMethodQueryArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*
 		}
 		for _, e := range q {
 			if !(e == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []any{true}))
 			}
 		}
 		if err != nil {
@@ -781,8 +781,8 @@ func DecodeMethodQueryArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*
 
 var PayloadQueryArrayIntDecodeCode = `// DecodeMethodQueryArrayIntRequest returns a decoder for requests sent to the
 // ServiceQueryArrayInt MethodQueryArrayInt endpoint.
-func DecodeMethodQueryArrayIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []int
 			err error
@@ -812,8 +812,8 @@ func DecodeMethodQueryArrayIntRequest(mux goahttp.Muxer, decoder func(*http.Requ
 
 var PayloadQueryArrayIntValidateDecodeCode = `// DecodeMethodQueryArrayIntValidateRequest returns a decoder for requests sent
 // to the ServiceQueryArrayIntValidate MethodQueryArrayIntValidate endpoint.
-func DecodeMethodQueryArrayIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []int
 			err error
@@ -852,8 +852,8 @@ func DecodeMethodQueryArrayIntValidateRequest(mux goahttp.Muxer, decoder func(*h
 
 var PayloadQueryArrayInt32DecodeCode = `// DecodeMethodQueryArrayInt32Request returns a decoder for requests sent to
 // the ServiceQueryArrayInt32 MethodQueryArrayInt32 endpoint.
-func DecodeMethodQueryArrayInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []int32
 			err error
@@ -884,8 +884,8 @@ func DecodeMethodQueryArrayInt32Request(mux goahttp.Muxer, decoder func(*http.Re
 var PayloadQueryArrayInt32ValidateDecodeCode = `// DecodeMethodQueryArrayInt32ValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayInt32Validate MethodQueryArrayInt32Validate
 // endpoint.
-func DecodeMethodQueryArrayInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []int32
 			err error
@@ -924,8 +924,8 @@ func DecodeMethodQueryArrayInt32ValidateRequest(mux goahttp.Muxer, decoder func(
 
 var PayloadQueryArrayInt64DecodeCode = `// DecodeMethodQueryArrayInt64Request returns a decoder for requests sent to
 // the ServiceQueryArrayInt64 MethodQueryArrayInt64 endpoint.
-func DecodeMethodQueryArrayInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []int64
 			err error
@@ -956,8 +956,8 @@ func DecodeMethodQueryArrayInt64Request(mux goahttp.Muxer, decoder func(*http.Re
 var PayloadQueryArrayInt64ValidateDecodeCode = `// DecodeMethodQueryArrayInt64ValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayInt64Validate MethodQueryArrayInt64Validate
 // endpoint.
-func DecodeMethodQueryArrayInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []int64
 			err error
@@ -996,8 +996,8 @@ func DecodeMethodQueryArrayInt64ValidateRequest(mux goahttp.Muxer, decoder func(
 
 var PayloadQueryArrayUIntDecodeCode = `// DecodeMethodQueryArrayUIntRequest returns a decoder for requests sent to the
 // ServiceQueryArrayUInt MethodQueryArrayUInt endpoint.
-func DecodeMethodQueryArrayUIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayUIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []uint
 			err error
@@ -1028,8 +1028,8 @@ func DecodeMethodQueryArrayUIntRequest(mux goahttp.Muxer, decoder func(*http.Req
 var PayloadQueryArrayUIntValidateDecodeCode = `// DecodeMethodQueryArrayUIntValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayUIntValidate MethodQueryArrayUIntValidate
 // endpoint.
-func DecodeMethodQueryArrayUIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayUIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []uint
 			err error
@@ -1068,8 +1068,8 @@ func DecodeMethodQueryArrayUIntValidateRequest(mux goahttp.Muxer, decoder func(*
 
 var PayloadQueryArrayUInt32DecodeCode = `// DecodeMethodQueryArrayUInt32Request returns a decoder for requests sent to
 // the ServiceQueryArrayUInt32 MethodQueryArrayUInt32 endpoint.
-func DecodeMethodQueryArrayUInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayUInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []uint32
 			err error
@@ -1100,8 +1100,8 @@ func DecodeMethodQueryArrayUInt32Request(mux goahttp.Muxer, decoder func(*http.R
 var PayloadQueryArrayUInt32ValidateDecodeCode = `// DecodeMethodQueryArrayUInt32ValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayUInt32Validate MethodQueryArrayUInt32Validate
 // endpoint.
-func DecodeMethodQueryArrayUInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayUInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []uint32
 			err error
@@ -1140,8 +1140,8 @@ func DecodeMethodQueryArrayUInt32ValidateRequest(mux goahttp.Muxer, decoder func
 
 var PayloadQueryArrayUInt64DecodeCode = `// DecodeMethodQueryArrayUInt64Request returns a decoder for requests sent to
 // the ServiceQueryArrayUInt64 MethodQueryArrayUInt64 endpoint.
-func DecodeMethodQueryArrayUInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayUInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []uint64
 			err error
@@ -1172,8 +1172,8 @@ func DecodeMethodQueryArrayUInt64Request(mux goahttp.Muxer, decoder func(*http.R
 var PayloadQueryArrayUInt64ValidateDecodeCode = `// DecodeMethodQueryArrayUInt64ValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayUInt64Validate MethodQueryArrayUInt64Validate
 // endpoint.
-func DecodeMethodQueryArrayUInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayUInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []uint64
 			err error
@@ -1212,8 +1212,8 @@ func DecodeMethodQueryArrayUInt64ValidateRequest(mux goahttp.Muxer, decoder func
 
 var PayloadQueryArrayFloat32DecodeCode = `// DecodeMethodQueryArrayFloat32Request returns a decoder for requests sent to
 // the ServiceQueryArrayFloat32 MethodQueryArrayFloat32 endpoint.
-func DecodeMethodQueryArrayFloat32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayFloat32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []float32
 			err error
@@ -1244,8 +1244,8 @@ func DecodeMethodQueryArrayFloat32Request(mux goahttp.Muxer, decoder func(*http.
 var PayloadQueryArrayFloat32ValidateDecodeCode = `// DecodeMethodQueryArrayFloat32ValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayFloat32Validate MethodQueryArrayFloat32Validate
 // endpoint.
-func DecodeMethodQueryArrayFloat32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayFloat32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []float32
 			err error
@@ -1284,8 +1284,8 @@ func DecodeMethodQueryArrayFloat32ValidateRequest(mux goahttp.Muxer, decoder fun
 
 var PayloadQueryArrayFloat64DecodeCode = `// DecodeMethodQueryArrayFloat64Request returns a decoder for requests sent to
 // the ServiceQueryArrayFloat64 MethodQueryArrayFloat64 endpoint.
-func DecodeMethodQueryArrayFloat64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayFloat64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []float64
 			err error
@@ -1316,8 +1316,8 @@ func DecodeMethodQueryArrayFloat64Request(mux goahttp.Muxer, decoder func(*http.
 var PayloadQueryArrayFloat64ValidateDecodeCode = `// DecodeMethodQueryArrayFloat64ValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayFloat64Validate MethodQueryArrayFloat64Validate
 // endpoint.
-func DecodeMethodQueryArrayFloat64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayFloat64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []float64
 			err error
@@ -1356,8 +1356,8 @@ func DecodeMethodQueryArrayFloat64ValidateRequest(mux goahttp.Muxer, decoder fun
 
 var PayloadQueryArrayStringDecodeCode = `// DecodeMethodQueryArrayStringRequest returns a decoder for requests sent to
 // the ServiceQueryArrayString MethodQueryArrayString endpoint.
-func DecodeMethodQueryArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q []string
 		)
@@ -1372,8 +1372,8 @@ func DecodeMethodQueryArrayStringRequest(mux goahttp.Muxer, decoder func(*http.R
 var PayloadQueryArrayStringValidateDecodeCode = `// DecodeMethodQueryArrayStringValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayStringValidate MethodQueryArrayStringValidate
 // endpoint.
-func DecodeMethodQueryArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []string
 			err error
@@ -1387,7 +1387,7 @@ func DecodeMethodQueryArrayStringValidateRequest(mux goahttp.Muxer, decoder func
 		}
 		for _, e := range q {
 			if !(e == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []interface{}{"val"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []any{"val"}))
 			}
 		}
 		if err != nil {
@@ -1402,8 +1402,8 @@ func DecodeMethodQueryArrayStringValidateRequest(mux goahttp.Muxer, decoder func
 
 var PayloadQueryArrayBytesDecodeCode = `// DecodeMethodQueryArrayBytesRequest returns a decoder for requests sent to
 // the ServiceQueryArrayBytes MethodQueryArrayBytes endpoint.
-func DecodeMethodQueryArrayBytesRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayBytesRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q [][]byte
 		)
@@ -1426,8 +1426,8 @@ func DecodeMethodQueryArrayBytesRequest(mux goahttp.Muxer, decoder func(*http.Re
 var PayloadQueryArrayBytesValidateDecodeCode = `// DecodeMethodQueryArrayBytesValidateRequest returns a decoder for requests
 // sent to the ServiceQueryArrayBytesValidate MethodQueryArrayBytesValidate
 // endpoint.
-func DecodeMethodQueryArrayBytesValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayBytesValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   [][]byte
 			err error
@@ -1462,15 +1462,15 @@ func DecodeMethodQueryArrayBytesValidateRequest(mux goahttp.Muxer, decoder func(
 
 var PayloadQueryArrayAnyDecodeCode = `// DecodeMethodQueryArrayAnyRequest returns a decoder for requests sent to the
 // ServiceQueryArrayAny MethodQueryArrayAny endpoint.
-func DecodeMethodQueryArrayAnyRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayAnyRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
-			q []interface{}
+			q []any
 		)
 		{
 			qRaw := r.URL.Query()["q"]
 			if qRaw != nil {
-				q = make([]interface{}, len(qRaw))
+				q = make([]any, len(qRaw))
 				for i, rv := range qRaw {
 					q[i] = rv
 				}
@@ -1485,10 +1485,10 @@ func DecodeMethodQueryArrayAnyRequest(mux goahttp.Muxer, decoder func(*http.Requ
 
 var PayloadQueryArrayAnyValidateDecodeCode = `// DecodeMethodQueryArrayAnyValidateRequest returns a decoder for requests sent
 // to the ServiceQueryArrayAnyValidate MethodQueryArrayAnyValidate endpoint.
-func DecodeMethodQueryArrayAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryArrayAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
-			q   []interface{}
+			q   []any
 			err error
 		)
 		{
@@ -1496,7 +1496,7 @@ func DecodeMethodQueryArrayAnyValidateRequest(mux goahttp.Muxer, decoder func(*h
 			if qRaw == nil {
 				return nil, goa.MergeErrors(err, goa.MissingFieldError("q", "query string"))
 			}
-			q = make([]interface{}, len(qRaw))
+			q = make([]any, len(qRaw))
 			for i, rv := range qRaw {
 				q[i] = rv
 			}
@@ -1506,7 +1506,7 @@ func DecodeMethodQueryArrayAnyValidateRequest(mux goahttp.Muxer, decoder func(*h
 		}
 		for _, e := range q {
 			if !(e == "val" || e == 1) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []interface{}{"val", 1}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []any{"val", 1}))
 			}
 		}
 		if err != nil {
@@ -1521,8 +1521,8 @@ func DecodeMethodQueryArrayAnyValidateRequest(mux goahttp.Muxer, decoder func(*h
 
 var PayloadQueryMapStringStringDecodeCode = `// DecodeMethodQueryMapStringStringRequest returns a decoder for requests sent
 // to the ServiceQueryMapStringString MethodQueryMapStringString endpoint.
-func DecodeMethodQueryMapStringStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q map[string]string
 		)
@@ -1555,8 +1555,8 @@ func DecodeMethodQueryMapStringStringRequest(mux goahttp.Muxer, decoder func(*ht
 var PayloadQueryMapStringStringValidateDecodeCode = `// DecodeMethodQueryMapStringStringValidateRequest returns a decoder for
 // requests sent to the ServiceQueryMapStringStringValidate
 // MethodQueryMapStringStringValidate endpoint.
-func DecodeMethodQueryMapStringStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string]string
 			err error
@@ -1586,10 +1586,10 @@ func DecodeMethodQueryMapStringStringValidateRequest(mux goahttp.Muxer, decoder 
 		}
 		for k, v := range q {
 			if !(k == "key") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{"key"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{"key"}))
 			}
 			if !(v == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []interface{}{"val"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []any{"val"}))
 			}
 		}
 		if err != nil {
@@ -1604,8 +1604,8 @@ func DecodeMethodQueryMapStringStringValidateRequest(mux goahttp.Muxer, decoder 
 
 var PayloadQueryMapStringBoolDecodeCode = `// DecodeMethodQueryMapStringBoolRequest returns a decoder for requests sent to
 // the ServiceQueryMapStringBool MethodQueryMapStringBool endpoint.
-func DecodeMethodQueryMapStringBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string]bool
 			err error
@@ -1651,8 +1651,8 @@ func DecodeMethodQueryMapStringBoolRequest(mux goahttp.Muxer, decoder func(*http
 var PayloadQueryMapStringBoolValidateDecodeCode = `// DecodeMethodQueryMapStringBoolValidateRequest returns a decoder for requests
 // sent to the ServiceQueryMapStringBoolValidate
 // MethodQueryMapStringBoolValidate endpoint.
-func DecodeMethodQueryMapStringBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string]bool
 			err error
@@ -1691,10 +1691,10 @@ func DecodeMethodQueryMapStringBoolValidateRequest(mux goahttp.Muxer, decoder fu
 		}
 		for k, v := range q {
 			if !(k == "key") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{"key"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{"key"}))
 			}
 			if !(v == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []any{true}))
 			}
 		}
 		if err != nil {
@@ -1709,8 +1709,8 @@ func DecodeMethodQueryMapStringBoolValidateRequest(mux goahttp.Muxer, decoder fu
 
 var PayloadQueryMapBoolStringDecodeCode = `// DecodeMethodQueryMapBoolStringRequest returns a decoder for requests sent to
 // the ServiceQueryMapBoolString MethodQueryMapBoolString endpoint.
-func DecodeMethodQueryMapBoolStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapBoolStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool]string
 			err error
@@ -1752,8 +1752,8 @@ func DecodeMethodQueryMapBoolStringRequest(mux goahttp.Muxer, decoder func(*http
 var PayloadQueryMapBoolStringValidateDecodeCode = `// DecodeMethodQueryMapBoolStringValidateRequest returns a decoder for requests
 // sent to the ServiceQueryMapBoolStringValidate
 // MethodQueryMapBoolStringValidate endpoint.
-func DecodeMethodQueryMapBoolStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapBoolStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool]string
 			err error
@@ -1788,10 +1788,10 @@ func DecodeMethodQueryMapBoolStringValidateRequest(mux goahttp.Muxer, decoder fu
 		}
 		for k, v := range q {
 			if !(k == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{true}))
 			}
 			if !(v == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []interface{}{"val"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []any{"val"}))
 			}
 		}
 		if err != nil {
@@ -1806,8 +1806,8 @@ func DecodeMethodQueryMapBoolStringValidateRequest(mux goahttp.Muxer, decoder fu
 
 var PayloadQueryMapBoolBoolDecodeCode = `// DecodeMethodQueryMapBoolBoolRequest returns a decoder for requests sent to
 // the ServiceQueryMapBoolBool MethodQueryMapBoolBool endpoint.
-func DecodeMethodQueryMapBoolBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapBoolBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool]bool
 			err error
@@ -1858,8 +1858,8 @@ func DecodeMethodQueryMapBoolBoolRequest(mux goahttp.Muxer, decoder func(*http.R
 var PayloadQueryMapBoolBoolValidateDecodeCode = `// DecodeMethodQueryMapBoolBoolValidateRequest returns a decoder for requests
 // sent to the ServiceQueryMapBoolBoolValidate MethodQueryMapBoolBoolValidate
 // endpoint.
-func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool]bool
 			err error
@@ -1903,10 +1903,10 @@ func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func
 		}
 		for k, v := range q {
 			if !(k == false) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{false}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{false}))
 			}
 			if !(v == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []any{true}))
 			}
 		}
 		if err != nil {
@@ -1922,8 +1922,8 @@ func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func
 var PayloadQueryMapStringArrayStringDecodeCode = `// DecodeMethodQueryMapStringArrayStringRequest returns a decoder for requests
 // sent to the ServiceQueryMapStringArrayString MethodQueryMapStringArrayString
 // endpoint.
-func DecodeMethodQueryMapStringArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q map[string][]string
 		)
@@ -1956,8 +1956,8 @@ func DecodeMethodQueryMapStringArrayStringRequest(mux goahttp.Muxer, decoder fun
 var PayloadQueryMapStringArrayStringValidateDecodeCode = `// DecodeMethodQueryMapStringArrayStringValidateRequest returns a decoder for
 // requests sent to the ServiceQueryMapStringArrayStringValidate
 // MethodQueryMapStringArrayStringValidate endpoint.
-func DecodeMethodQueryMapStringArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string][]string
 			err error
@@ -1987,7 +1987,7 @@ func DecodeMethodQueryMapStringArrayStringValidateRequest(mux goahttp.Muxer, dec
 		}
 		for k, v := range q {
 			if !(k == "key") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{"key"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{"key"}))
 			}
 			if len(v) < 2 {
 				err = goa.MergeErrors(err, goa.InvalidLengthError("q[key]", v, len(v), 2, true))
@@ -2006,8 +2006,8 @@ func DecodeMethodQueryMapStringArrayStringValidateRequest(mux goahttp.Muxer, dec
 var PayloadQueryMapStringArrayBoolDecodeCode = `// DecodeMethodQueryMapStringArrayBoolRequest returns a decoder for requests
 // sent to the ServiceQueryMapStringArrayBool MethodQueryMapStringArrayBool
 // endpoint.
-func DecodeMethodQueryMapStringArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string][]bool
 			err error
@@ -2055,8 +2055,8 @@ func DecodeMethodQueryMapStringArrayBoolRequest(mux goahttp.Muxer, decoder func(
 var PayloadQueryMapStringArrayBoolValidateDecodeCode = `// DecodeMethodQueryMapStringArrayBoolValidateRequest returns a decoder for
 // requests sent to the ServiceQueryMapStringArrayBoolValidate
 // MethodQueryMapStringArrayBoolValidate endpoint.
-func DecodeMethodQueryMapStringArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string][]bool
 			err error
@@ -2097,7 +2097,7 @@ func DecodeMethodQueryMapStringArrayBoolValidateRequest(mux goahttp.Muxer, decod
 		}
 		for k, v := range q {
 			if !(k == "key") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{"key"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{"key"}))
 			}
 			if len(v) < 2 {
 				err = goa.MergeErrors(err, goa.InvalidLengthError("q[key]", v, len(v), 2, true))
@@ -2116,8 +2116,8 @@ func DecodeMethodQueryMapStringArrayBoolValidateRequest(mux goahttp.Muxer, decod
 var PayloadQueryMapBoolArrayStringDecodeCode = `// DecodeMethodQueryMapBoolArrayStringRequest returns a decoder for requests
 // sent to the ServiceQueryMapBoolArrayString MethodQueryMapBoolArrayString
 // endpoint.
-func DecodeMethodQueryMapBoolArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapBoolArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool][]string
 			err error
@@ -2159,8 +2159,8 @@ func DecodeMethodQueryMapBoolArrayStringRequest(mux goahttp.Muxer, decoder func(
 var PayloadQueryMapBoolArrayStringValidateDecodeCode = `// DecodeMethodQueryMapBoolArrayStringValidateRequest returns a decoder for
 // requests sent to the ServiceQueryMapBoolArrayStringValidate
 // MethodQueryMapBoolArrayStringValidate endpoint.
-func DecodeMethodQueryMapBoolArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapBoolArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool][]string
 			err error
@@ -2194,7 +2194,7 @@ func DecodeMethodQueryMapBoolArrayStringValidateRequest(mux goahttp.Muxer, decod
 		}
 		for k, v := range q {
 			if !(k == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{true}))
 			}
 			if len(v) < 2 {
 				err = goa.MergeErrors(err, goa.InvalidLengthError("q[key]", v, len(v), 2, true))
@@ -2212,8 +2212,8 @@ func DecodeMethodQueryMapBoolArrayStringValidateRequest(mux goahttp.Muxer, decod
 
 var PayloadQueryMapBoolArrayBoolDecodeCode = `// DecodeMethodQueryMapBoolArrayBoolRequest returns a decoder for requests sent
 // to the ServiceQueryMapBoolArrayBool MethodQueryMapBoolArrayBool endpoint.
-func DecodeMethodQueryMapBoolArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapBoolArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool][]bool
 			err error
@@ -2266,8 +2266,8 @@ func DecodeMethodQueryMapBoolArrayBoolRequest(mux goahttp.Muxer, decoder func(*h
 var PayloadQueryMapBoolArrayBoolValidateDecodeCode = `// DecodeMethodQueryMapBoolArrayBoolValidateRequest returns a decoder for
 // requests sent to the ServiceQueryMapBoolArrayBoolValidate
 // MethodQueryMapBoolArrayBoolValidate endpoint.
-func DecodeMethodQueryMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool][]bool
 			err error
@@ -2313,7 +2313,7 @@ func DecodeMethodQueryMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder
 		}
 		for k, v := range q {
 			if !(k == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{true}))
 			}
 			if len(v) < 2 {
 				err = goa.MergeErrors(err, goa.InvalidLengthError("q[key]", v, len(v), 2, true))
@@ -2332,8 +2332,8 @@ func DecodeMethodQueryMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder
 var PayloadQueryPrimitiveStringValidateDecodeCode = `// DecodeMethodQueryPrimitiveStringValidateRequest returns a decoder for
 // requests sent to the ServiceQueryPrimitiveStringValidate
 // MethodQueryPrimitiveStringValidate endpoint.
-func DecodeMethodQueryPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   string
 			err error
@@ -2343,7 +2343,7 @@ func DecodeMethodQueryPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder 
 			err = goa.MergeErrors(err, goa.MissingFieldError("q", "query string"))
 		}
 		if !(q == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []interface{}{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -2358,8 +2358,8 @@ func DecodeMethodQueryPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder 
 var PayloadQueryPrimitiveBoolValidateDecodeCode = `// DecodeMethodQueryPrimitiveBoolValidateRequest returns a decoder for requests
 // sent to the ServiceQueryPrimitiveBoolValidate
 // MethodQueryPrimitiveBoolValidate endpoint.
-func DecodeMethodQueryPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   bool
 			err error
@@ -2376,7 +2376,7 @@ func DecodeMethodQueryPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fu
 			q = v
 		}
 		if !(q == true) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []interface{}{true}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{true}))
 		}
 		if err != nil {
 			return nil, err
@@ -2391,8 +2391,8 @@ func DecodeMethodQueryPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fu
 var PayloadQueryPrimitiveArrayStringValidateDecodeCode = `// DecodeMethodQueryPrimitiveArrayStringValidateRequest returns a decoder for
 // requests sent to the ServiceQueryPrimitiveArrayStringValidate
 // MethodQueryPrimitiveArrayStringValidate endpoint.
-func DecodeMethodQueryPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []string
 			err error
@@ -2406,7 +2406,7 @@ func DecodeMethodQueryPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, dec
 		}
 		for _, e := range q {
 			if !(e == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []interface{}{"val"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []any{"val"}))
 			}
 		}
 		if err != nil {
@@ -2422,8 +2422,8 @@ func DecodeMethodQueryPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, dec
 var PayloadQueryPrimitiveArrayBoolValidateDecodeCode = `// DecodeMethodQueryPrimitiveArrayBoolValidateRequest returns a decoder for
 // requests sent to the ServiceQueryPrimitiveArrayBoolValidate
 // MethodQueryPrimitiveArrayBoolValidate endpoint.
-func DecodeMethodQueryPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   []bool
 			err error
@@ -2447,7 +2447,7 @@ func DecodeMethodQueryPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decod
 		}
 		for _, e := range q {
 			if !(e == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[*]", e, []any{true}))
 			}
 		}
 		if err != nil {
@@ -2464,8 +2464,8 @@ var PayloadQueryPrimitiveMapStringArrayStringValidateDecodeCode = `// DecodeMeth
 // decoder for requests sent to the
 // ServiceQueryPrimitiveMapStringArrayStringValidate
 // MethodQueryPrimitiveMapStringArrayStringValidate endpoint.
-func DecodeMethodQueryPrimitiveMapStringArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryPrimitiveMapStringArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string][]string
 			err error
@@ -2515,8 +2515,8 @@ func DecodeMethodQueryPrimitiveMapStringArrayStringValidateRequest(mux goahttp.M
 var PayloadQueryPrimitiveMapStringBoolValidateDecodeCode = `// DecodeMethodQueryPrimitiveMapStringBoolValidateRequest returns a decoder for
 // requests sent to the ServiceQueryPrimitiveMapStringBoolValidate
 // MethodQueryPrimitiveMapStringBoolValidate endpoint.
-func DecodeMethodQueryPrimitiveMapStringBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryPrimitiveMapStringBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string]bool
 			err error
@@ -2556,7 +2556,7 @@ func DecodeMethodQueryPrimitiveMapStringBoolValidateRequest(mux goahttp.Muxer, d
 		for k, v := range q {
 			err = goa.MergeErrors(err, goa.ValidatePattern("q.key", k, "key"))
 			if !(v == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key]", v, []any{true}))
 			}
 		}
 		if err != nil {
@@ -2572,8 +2572,8 @@ func DecodeMethodQueryPrimitiveMapStringBoolValidateRequest(mux goahttp.Muxer, d
 var PayloadQueryPrimitiveMapBoolArrayBoolValidateDecodeCode = `// DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest returns a decoder
 // for requests sent to the ServiceQueryPrimitiveMapBoolArrayBoolValidate
 // MethodQueryPrimitiveMapBoolArrayBoolValidate endpoint.
-func DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[bool][]bool
 			err error
@@ -2619,14 +2619,14 @@ func DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(mux goahttp.Muxer
 		}
 		for k, v := range q {
 			if !(k == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{true}))
 			}
 			if len(v) < 2 {
 				err = goa.MergeErrors(err, goa.InvalidLengthError("q[key]", v, len(v), 2, true))
 			}
 			for _, e := range v {
 				if !(e == false) {
-					err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key][*]", e, []interface{}{false}))
+					err = goa.MergeErrors(err, goa.InvalidEnumValueError("q[key][*]", e, []any{false}))
 				}
 			}
 		}
@@ -2643,8 +2643,8 @@ func DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(mux goahttp.Muxer
 var PayloadQueryMapStringMapIntStringValidateDecodeCode = `// DecodeMethodQueryMapStringMapIntStringValidateRequest returns a decoder for
 // requests sent to the ServiceQueryMapStringMapIntStringValidate
 // MethodQueryMapStringMapIntStringValidate endpoint.
-func DecodeMethodQueryMapStringMapIntStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapStringMapIntStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[string]map[int]string
 			err error
@@ -2686,7 +2686,7 @@ func DecodeMethodQueryMapStringMapIntStringValidateRequest(mux goahttp.Muxer, de
 		}
 		for k, _ := range q {
 			if !(k == "foo") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{"foo"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{"foo"}))
 			}
 		}
 		if err != nil {
@@ -2702,8 +2702,8 @@ func DecodeMethodQueryMapStringMapIntStringValidateRequest(mux goahttp.Muxer, de
 var PayloadQueryMapIntMapStringArrayIntValidateDecodeCode = `// DecodeMethodQueryMapIntMapStringArrayIntValidateRequest returns a decoder
 // for requests sent to the ServiceQueryMapIntMapStringArrayIntValidate
 // MethodQueryMapIntMapStringArrayIntValidate endpoint.
-func DecodeMethodQueryMapIntMapStringArrayIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryMapIntMapStringArrayIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   map[int]map[string][]int
 			err error
@@ -2756,7 +2756,7 @@ func DecodeMethodQueryMapIntMapStringArrayIntValidateRequest(mux goahttp.Muxer, 
 		}
 		for k, _ := range q {
 			if !(k == 1 || k == 2 || k == 3) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []interface{}{1, 2, 3}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("q.key", k, []any{1, 2, 3}))
 			}
 		}
 		if err != nil {
@@ -2771,8 +2771,8 @@ func DecodeMethodQueryMapIntMapStringArrayIntValidateRequest(mux goahttp.Muxer, 
 
 var PayloadQueryStringMappedDecodeCode = `// DecodeMethodQueryStringMappedRequest returns a decoder for requests sent to
 // the ServiceQueryStringMapped MethodQueryStringMapped endpoint.
-func DecodeMethodQueryStringMappedRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryStringMappedRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			query *string
 		)
@@ -2789,8 +2789,8 @@ func DecodeMethodQueryStringMappedRequest(mux goahttp.Muxer, decoder func(*http.
 
 var PayloadQueryStringDefaultDecodeCode = `// DecodeMethodQueryStringDefaultRequest returns a decoder for requests sent to
 // the ServiceQueryStringDefault MethodQueryStringDefault endpoint.
-func DecodeMethodQueryStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q string
 		)
@@ -2810,8 +2810,8 @@ func DecodeMethodQueryStringDefaultRequest(mux goahttp.Muxer, decoder func(*http
 var PayloadQueryStringSliceDefaultDecodeCode = `// DecodeMethodQueryStringSliceDefaultRequest returns a decoder for requests
 // sent to the ServiceQueryStringSliceDefault MethodQueryStringSliceDefault
 // endpoint.
-func DecodeMethodQueryStringSliceDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryStringSliceDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q []string
 		)
@@ -2829,8 +2829,8 @@ func DecodeMethodQueryStringSliceDefaultRequest(mux goahttp.Muxer, decoder func(
 var PayloadQueryStringDefaultValidateDecodeCode = `// DecodeMethodQueryStringDefaultValidateRequest returns a decoder for requests
 // sent to the ServiceQueryStringDefaultValidate
 // MethodQueryStringDefaultValidate endpoint.
-func DecodeMethodQueryStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   string
 			err error
@@ -2842,7 +2842,7 @@ func DecodeMethodQueryStringDefaultValidateRequest(mux goahttp.Muxer, decoder fu
 			q = "def"
 		}
 		if !(q == "def") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []interface{}{"def"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"def"}))
 		}
 		if err != nil {
 			return nil, err
@@ -2857,8 +2857,8 @@ func DecodeMethodQueryStringDefaultValidateRequest(mux goahttp.Muxer, decoder fu
 var PayloadQueryPrimitiveStringDefaultDecodeCode = `// DecodeMethodQueryPrimitiveStringDefaultRequest returns a decoder for
 // requests sent to the ServiceQueryPrimitiveStringDefault
 // MethodQueryPrimitiveStringDefault endpoint.
-func DecodeMethodQueryPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q   string
 			err error
@@ -2880,8 +2880,8 @@ func DecodeMethodQueryPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder f
 var PayloadExtendedQueryStringDecodeCode = `// DecodeMethodQueryStringExtendedPayloadRequest returns a decoder for requests
 // sent to the ServiceQueryStringExtendedPayload
 // MethodQueryStringExtendedPayload endpoint.
-func DecodeMethodQueryStringExtendedPayloadRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodQueryStringExtendedPayloadRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			q *string
 		)
@@ -2898,8 +2898,8 @@ func DecodeMethodQueryStringExtendedPayloadRequest(mux goahttp.Muxer, decoder fu
 
 var PayloadPathStringDecodeCode = `// DecodeMethodPathStringRequest returns a decoder for requests sent to the
 // ServicePathString MethodPathString endpoint.
-func DecodeMethodPathStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodPathStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			p string
 
@@ -2915,8 +2915,8 @@ func DecodeMethodPathStringRequest(mux goahttp.Muxer, decoder func(*http.Request
 
 var PayloadPathStringValidateDecodeCode = `// DecodeMethodPathStringValidateRequest returns a decoder for requests sent to
 // the ServicePathStringValidate MethodPathStringValidate endpoint.
-func DecodeMethodPathStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodPathStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			p   string
 			err error
@@ -2925,7 +2925,7 @@ func DecodeMethodPathStringValidateRequest(mux goahttp.Muxer, decoder func(*http
 		)
 		p = params["p"]
 		if !(p == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []interface{}{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -2939,8 +2939,8 @@ func DecodeMethodPathStringValidateRequest(mux goahttp.Muxer, decoder func(*http
 
 var PayloadPathArrayStringDecodeCode = `// DecodeMethodPathArrayStringRequest returns a decoder for requests sent to
 // the ServicePathArrayString MethodPathArrayString endpoint.
-func DecodeMethodPathArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodPathArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			p []string
 
@@ -2964,8 +2964,8 @@ func DecodeMethodPathArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Re
 var PayloadPathArrayStringValidateDecodeCode = `// DecodeMethodPathArrayStringValidateRequest returns a decoder for requests
 // sent to the ServicePathArrayStringValidate MethodPathArrayStringValidate
 // endpoint.
-func DecodeMethodPathArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodPathArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			p   []string
 			err error
@@ -2981,7 +2981,7 @@ func DecodeMethodPathArrayStringValidateRequest(mux goahttp.Muxer, decoder func(
 			}
 		}
 		if !(p == []string{"val"}) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []interface{}{[]string{"val"}}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []any{[]string{"val"}}))
 		}
 		if err != nil {
 			return nil, err
@@ -2996,8 +2996,8 @@ func DecodeMethodPathArrayStringValidateRequest(mux goahttp.Muxer, decoder func(
 var PayloadPathPrimitiveStringValidateDecodeCode = `// DecodeMethodPathPrimitiveStringValidateRequest returns a decoder for
 // requests sent to the ServicePathPrimitiveStringValidate
 // MethodPathPrimitiveStringValidate endpoint.
-func DecodeMethodPathPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodPathPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			p   string
 			err error
@@ -3006,7 +3006,7 @@ func DecodeMethodPathPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder f
 		)
 		p = params["p"]
 		if !(p == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []interface{}{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -3021,8 +3021,8 @@ func DecodeMethodPathPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder f
 var PayloadPathPrimitiveBoolValidateDecodeCode = `// DecodeMethodPathPrimitiveBoolValidateRequest returns a decoder for requests
 // sent to the ServicePathPrimitiveBoolValidate MethodPathPrimitiveBoolValidate
 // endpoint.
-func DecodeMethodPathPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodPathPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			p   bool
 			err error
@@ -3038,7 +3038,7 @@ func DecodeMethodPathPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fun
 			p = v
 		}
 		if !(p == true) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []interface{}{true}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []any{true}))
 		}
 		if err != nil {
 			return nil, err
@@ -3053,8 +3053,8 @@ func DecodeMethodPathPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fun
 var PayloadPathPrimitiveArrayStringValidateDecodeCode = `// DecodeMethodPathPrimitiveArrayStringValidateRequest returns a decoder for
 // requests sent to the ServicePathPrimitiveArrayStringValidate
 // MethodPathPrimitiveArrayStringValidate endpoint.
-func DecodeMethodPathPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodPathPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			p   []string
 			err error
@@ -3074,7 +3074,7 @@ func DecodeMethodPathPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, deco
 		}
 		for _, e := range p {
 			if !(e == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("p[*]", e, []interface{}{"val"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("p[*]", e, []any{"val"}))
 			}
 		}
 		if err != nil {
@@ -3090,8 +3090,8 @@ func DecodeMethodPathPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, deco
 var PayloadPathPrimitiveArrayBoolValidateDecodeCode = `// DecodeMethodPathPrimitiveArrayBoolValidateRequest returns a decoder for
 // requests sent to the ServicePathPrimitiveArrayBoolValidate
 // MethodPathPrimitiveArrayBoolValidate endpoint.
-func DecodeMethodPathPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodPathPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			p   []bool
 			err error
@@ -3115,7 +3115,7 @@ func DecodeMethodPathPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decode
 		}
 		for _, e := range p {
 			if !(e == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("p[*]", e, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("p[*]", e, []any{true}))
 			}
 		}
 		if err != nil {
@@ -3130,8 +3130,8 @@ func DecodeMethodPathPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decode
 
 var PayloadHeaderStringDecodeCode = `// DecodeMethodHeaderStringRequest returns a decoder for requests sent to the
 // ServiceHeaderString MethodHeaderString endpoint.
-func DecodeMethodHeaderStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h *string
 		)
@@ -3148,8 +3148,8 @@ func DecodeMethodHeaderStringRequest(mux goahttp.Muxer, decoder func(*http.Reque
 
 var PayloadHeaderStringValidateDecodeCode = `// DecodeMethodHeaderStringValidateRequest returns a decoder for requests sent
 // to the ServiceHeaderStringValidate MethodHeaderStringValidate endpoint.
-func DecodeMethodHeaderStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h   *string
 			err error
@@ -3173,8 +3173,8 @@ func DecodeMethodHeaderStringValidateRequest(mux goahttp.Muxer, decoder func(*ht
 
 var PayloadHeaderArrayStringDecodeCode = `// DecodeMethodHeaderArrayStringRequest returns a decoder for requests sent to
 // the ServiceHeaderArrayString MethodHeaderArrayString endpoint.
-func DecodeMethodHeaderArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h []string
 		)
@@ -3189,8 +3189,8 @@ func DecodeMethodHeaderArrayStringRequest(mux goahttp.Muxer, decoder func(*http.
 var PayloadHeaderArrayStringValidateDecodeCode = `// DecodeMethodHeaderArrayStringValidateRequest returns a decoder for requests
 // sent to the ServiceHeaderArrayStringValidate MethodHeaderArrayStringValidate
 // endpoint.
-func DecodeMethodHeaderArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h   []string
 			err error
@@ -3198,7 +3198,7 @@ func DecodeMethodHeaderArrayStringValidateRequest(mux goahttp.Muxer, decoder fun
 		h = r.Header["H"]
 		for _, e := range h {
 			if !(e == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("h[*]", e, []interface{}{"val"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("h[*]", e, []any{"val"}))
 			}
 		}
 		if err != nil {
@@ -3214,8 +3214,8 @@ func DecodeMethodHeaderArrayStringValidateRequest(mux goahttp.Muxer, decoder fun
 var PayloadHeaderPrimitiveStringValidateDecodeCode = `// DecodeMethodHeaderPrimitiveStringValidateRequest returns a decoder for
 // requests sent to the ServiceHeaderPrimitiveStringValidate
 // MethodHeaderPrimitiveStringValidate endpoint.
-func DecodeMethodHeaderPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h   string
 			err error
@@ -3225,7 +3225,7 @@ func DecodeMethodHeaderPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder
 			err = goa.MergeErrors(err, goa.MissingFieldError("h", "header"))
 		}
 		if !(h == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []interface{}{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -3240,8 +3240,8 @@ func DecodeMethodHeaderPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder
 var PayloadHeaderPrimitiveBoolValidateDecodeCode = `// DecodeMethodHeaderPrimitiveBoolValidateRequest returns a decoder for
 // requests sent to the ServiceHeaderPrimitiveBoolValidate
 // MethodHeaderPrimitiveBoolValidate endpoint.
-func DecodeMethodHeaderPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h   bool
 			err error
@@ -3258,7 +3258,7 @@ func DecodeMethodHeaderPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder f
 			h = v
 		}
 		if !(h == true) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []interface{}{true}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []any{true}))
 		}
 		if err != nil {
 			return nil, err
@@ -3273,8 +3273,8 @@ func DecodeMethodHeaderPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder f
 var PayloadHeaderPrimitiveArrayStringValidateDecodeCode = `// DecodeMethodHeaderPrimitiveArrayStringValidateRequest returns a decoder for
 // requests sent to the ServiceHeaderPrimitiveArrayStringValidate
 // MethodHeaderPrimitiveArrayStringValidate endpoint.
-func DecodeMethodHeaderPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h   []string
 			err error
@@ -3302,8 +3302,8 @@ func DecodeMethodHeaderPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, de
 var PayloadHeaderPrimitiveArrayBoolValidateDecodeCode = `// DecodeMethodHeaderPrimitiveArrayBoolValidateRequest returns a decoder for
 // requests sent to the ServiceHeaderPrimitiveArrayBoolValidate
 // MethodHeaderPrimitiveArrayBoolValidate endpoint.
-func DecodeMethodHeaderPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h   []bool
 			err error
@@ -3327,7 +3327,7 @@ func DecodeMethodHeaderPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, deco
 		}
 		for _, e := range h {
 			if !(e == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("h[*]", e, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("h[*]", e, []any{true}))
 			}
 		}
 		if err != nil {
@@ -3342,8 +3342,8 @@ func DecodeMethodHeaderPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, deco
 
 var PayloadHeaderStringDefaultDecodeCode = `// DecodeMethodHeaderStringDefaultRequest returns a decoder for requests sent
 // to the ServiceHeaderStringDefault MethodHeaderStringDefault endpoint.
-func DecodeMethodHeaderStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h string
 		)
@@ -3363,8 +3363,8 @@ func DecodeMethodHeaderStringDefaultRequest(mux goahttp.Muxer, decoder func(*htt
 var PayloadHeaderStringDefaultValidateDecodeCode = `// DecodeMethodHeaderStringDefaultValidateRequest returns a decoder for
 // requests sent to the ServiceHeaderStringDefaultValidate
 // MethodHeaderStringDefaultValidate endpoint.
-func DecodeMethodHeaderStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h   string
 			err error
@@ -3376,7 +3376,7 @@ func DecodeMethodHeaderStringDefaultValidateRequest(mux goahttp.Muxer, decoder f
 			h = "def"
 		}
 		if !(h == "def") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []interface{}{"def"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []any{"def"}))
 		}
 		if err != nil {
 			return nil, err
@@ -3391,8 +3391,8 @@ func DecodeMethodHeaderStringDefaultValidateRequest(mux goahttp.Muxer, decoder f
 var PayloadHeaderPrimitiveStringDefaultDecodeCode = `// DecodeMethodHeaderPrimitiveStringDefaultRequest returns a decoder for
 // requests sent to the ServiceHeaderPrimitiveStringDefault
 // MethodHeaderPrimitiveStringDefault endpoint.
-func DecodeMethodHeaderPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodHeaderPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			h   string
 			err error
@@ -3413,8 +3413,8 @@ func DecodeMethodHeaderPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder 
 
 var PayloadCookieStringDecodeCode = `// DecodeMethodCookieStringRequest returns a decoder for requests sent to the
 // ServiceCookieString MethodCookieString endpoint.
-func DecodeMethodCookieStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodCookieStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			c2 *string
 			c  *http.Cookie
@@ -3436,8 +3436,8 @@ func DecodeMethodCookieStringRequest(mux goahttp.Muxer, decoder func(*http.Reque
 
 var PayloadCookieStringValidateDecodeCode = `// DecodeMethodCookieStringValidateRequest returns a decoder for requests sent
 // to the ServiceCookieStringValidate MethodCookieStringValidate endpoint.
-func DecodeMethodCookieStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodCookieStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			c2  *string
 			err error
@@ -3467,8 +3467,8 @@ func DecodeMethodCookieStringValidateRequest(mux goahttp.Muxer, decoder func(*ht
 var PayloadCookiePrimitiveStringValidateDecodeCode = `// DecodeMethodCookiePrimitiveStringValidateRequest returns a decoder for
 // requests sent to the ServiceCookiePrimitiveStringValidate
 // MethodCookiePrimitiveStringValidate endpoint.
-func DecodeMethodCookiePrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodCookiePrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			c2  string
 			err error
@@ -3481,7 +3481,7 @@ func DecodeMethodCookiePrimitiveStringValidateRequest(mux goahttp.Muxer, decoder
 			c2 = c.Value
 		}
 		if !(c2 == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []interface{}{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -3496,8 +3496,8 @@ func DecodeMethodCookiePrimitiveStringValidateRequest(mux goahttp.Muxer, decoder
 var PayloadCookiePrimitiveBoolValidateDecodeCode = `// DecodeMethodCookiePrimitiveBoolValidateRequest returns a decoder for
 // requests sent to the ServiceCookiePrimitiveBoolValidate
 // MethodCookiePrimitiveBoolValidate endpoint.
-func DecodeMethodCookiePrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodCookiePrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			c2  bool
 			err error
@@ -3519,7 +3519,7 @@ func DecodeMethodCookiePrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder f
 			c2 = v
 		}
 		if !(c2 == true) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []interface{}{true}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []any{true}))
 		}
 		if err != nil {
 			return nil, err
@@ -3533,8 +3533,8 @@ func DecodeMethodCookiePrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder f
 
 var PayloadCookieStringDefaultDecodeCode = `// DecodeMethodCookieStringDefaultRequest returns a decoder for requests sent
 // to the ServiceCookieStringDefault MethodCookieStringDefault endpoint.
-func DecodeMethodCookieStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodCookieStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			c2 string
 			c  *http.Cookie
@@ -3559,8 +3559,8 @@ func DecodeMethodCookieStringDefaultRequest(mux goahttp.Muxer, decoder func(*htt
 var PayloadCookieStringDefaultValidateDecodeCode = `// DecodeMethodCookieStringDefaultValidateRequest returns a decoder for
 // requests sent to the ServiceCookieStringDefaultValidate
 // MethodCookieStringDefaultValidate endpoint.
-func DecodeMethodCookieStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodCookieStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			c2  string
 			err error
@@ -3577,7 +3577,7 @@ func DecodeMethodCookieStringDefaultValidateRequest(mux goahttp.Muxer, decoder f
 			c2 = "def"
 		}
 		if !(c2 == "def") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []interface{}{"def"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []any{"def"}))
 		}
 		if err != nil {
 			return nil, err
@@ -3591,8 +3591,8 @@ func DecodeMethodCookieStringDefaultValidateRequest(mux goahttp.Muxer, decoder f
 var PayloadCookiePrimitiveStringDefaultDecodeCode = `// DecodeMethodCookiePrimitiveStringDefaultRequest returns a decoder for
 // requests sent to the ServiceCookiePrimitiveStringDefault
 // MethodCookiePrimitiveStringDefault endpoint.
-func DecodeMethodCookiePrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodCookiePrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			c2  string
 			err error
@@ -3616,8 +3616,8 @@ func DecodeMethodCookiePrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder 
 
 var PayloadBodyStringDecodeCode = `// DecodeMethodBodyStringRequest returns a decoder for requests sent to the
 // ServiceBodyString MethodBodyString endpoint.
-func DecodeMethodBodyStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyStringRequestBody
 			err  error
@@ -3638,8 +3638,8 @@ func DecodeMethodBodyStringRequest(mux goahttp.Muxer, decoder func(*http.Request
 
 var PayloadBodyStringValidateDecodeCode = `// DecodeMethodBodyStringValidateRequest returns a decoder for requests sent to
 // the ServiceBodyStringValidate MethodBodyStringValidate endpoint.
-func DecodeMethodBodyStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyStringValidateRequestBody
 			err  error
@@ -3664,8 +3664,8 @@ func DecodeMethodBodyStringValidateRequest(mux goahttp.Muxer, decoder func(*http
 
 var PayloadBodyUserDecodeCode = `// DecodeMethodBodyUserRequest returns a decoder for requests sent to the
 // ServiceBodyUser MethodBodyUser endpoint.
-func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyUserRequestBody
 			err  error
@@ -3686,8 +3686,8 @@ func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 
 var PayloadBodyUserRequiredDecodeCode = `// DecodeMethodBodyUserRequest returns a decoder for requests sent to the
 // ServiceBodyUser MethodBodyUser endpoint.
-func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyUserRequestBody
 			err  error
@@ -3712,8 +3712,8 @@ func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 
 var PayloadBodyNestedUserDecodeCode = `// DecodeMethodBodyUserRequest returns a decoder for requests sent to the
 // ServiceBodyUser MethodBodyUser endpoint.
-func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyUserRequestBody
 			err  error
@@ -3739,8 +3739,8 @@ func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 
 var PayloadBodyUserValidateDecodeCode = `// DecodeMethodBodyUserValidateRequest returns a decoder for requests sent to
 // the ServiceBodyUserValidate MethodBodyUserValidate endpoint.
-func DecodeMethodBodyUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body string
 			err  error
@@ -3766,8 +3766,8 @@ func DecodeMethodBodyUserValidateRequest(mux goahttp.Muxer, decoder func(*http.R
 
 var PayloadBodyObjectDecodeCode = `// DecodeMethodBodyObjectRequest returns a decoder for requests sent to the
 // ServiceBodyObject MethodBodyObject endpoint.
-func DecodeMethodBodyObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body struct {
 				B *string ` + "`" + `form:"b" json:"b" xml:"b"` + "`" + `
@@ -3790,8 +3790,8 @@ func DecodeMethodBodyObjectRequest(mux goahttp.Muxer, decoder func(*http.Request
 
 var PayloadBodyObjectValidateDecodeCode = `// DecodeMethodBodyObjectValidateRequest returns a decoder for requests sent to
 // the ServiceBodyObjectValidate MethodBodyObjectValidate endpoint.
-func DecodeMethodBodyObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body struct {
 				B *string ` + "`" + `form:"b" json:"b" xml:"b"` + "`" + `
@@ -3814,8 +3814,8 @@ func DecodeMethodBodyObjectValidateRequest(mux goahttp.Muxer, decoder func(*http
 
 var PayloadBodyUnionDecodeCode = `// DecodeMethodBodyUnionRequest returns a decoder for requests sent to the
 // ServiceBodyUnion MethodBodyUnion endpoint.
-func DecodeMethodBodyUnionRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyUnionRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyUnionRequestBody
 			err  error
@@ -3840,8 +3840,8 @@ func DecodeMethodBodyUnionRequest(mux goahttp.Muxer, decoder func(*http.Request)
 
 var PayloadBodyUnionValidateDecodeCode = `// DecodeMethodBodyUnionValidateRequest returns a decoder for requests sent to
 // the ServiceBodyUnionValidate MethodBodyUnionValidate endpoint.
-func DecodeMethodBodyUnionValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyUnionValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyUnionValidateRequestBody
 			err  error
@@ -3866,8 +3866,8 @@ func DecodeMethodBodyUnionValidateRequest(mux goahttp.Muxer, decoder func(*http.
 
 var PayloadBodyUnionUserDecodeCode = `// DecodeMethodBodyUnionUserRequest returns a decoder for requests sent to the
 // ServiceBodyUnionUser MethodBodyUnionUser endpoint.
-func DecodeMethodBodyUnionUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyUnionUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyUnionUserRequestBody
 			err  error
@@ -3892,8 +3892,8 @@ func DecodeMethodBodyUnionUserRequest(mux goahttp.Muxer, decoder func(*http.Requ
 
 var PayloadBodyUnionUserValidateDecodeCode = `// DecodeMethodBodyUnionUserValidateRequest returns a decoder for requests sent
 // to the ServiceBodyUnionUserValidate MethodBodyUnionUserValidate endpoint.
-func DecodeMethodBodyUnionUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyUnionUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyUnionUserValidateRequestBody
 			err  error
@@ -3918,8 +3918,8 @@ func DecodeMethodBodyUnionUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 
 var PayloadBodyArrayStringDecodeCode = `// DecodeMethodBodyArrayStringRequest returns a decoder for requests sent to
 // the ServiceBodyArrayString MethodBodyArrayString endpoint.
-func DecodeMethodBodyArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyArrayStringRequestBody
 			err  error
@@ -3941,8 +3941,8 @@ func DecodeMethodBodyArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Re
 var PayloadBodyArrayStringValidateDecodeCode = `// DecodeMethodBodyArrayStringValidateRequest returns a decoder for requests
 // sent to the ServiceBodyArrayStringValidate MethodBodyArrayStringValidate
 // endpoint.
-func DecodeMethodBodyArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyArrayStringValidateRequestBody
 			err  error
@@ -3967,8 +3967,8 @@ func DecodeMethodBodyArrayStringValidateRequest(mux goahttp.Muxer, decoder func(
 
 var PayloadBodyArrayUserDecodeCode = `// DecodeMethodBodyArrayUserRequest returns a decoder for requests sent to the
 // ServiceBodyArrayUser MethodBodyArrayUser endpoint.
-func DecodeMethodBodyArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyArrayUserRequestBody
 			err  error
@@ -3993,8 +3993,8 @@ func DecodeMethodBodyArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Requ
 
 var PayloadBodyArrayUserValidateDecodeCode = `// DecodeMethodBodyArrayUserValidateRequest returns a decoder for requests sent
 // to the ServiceBodyArrayUserValidate MethodBodyArrayUserValidate endpoint.
-func DecodeMethodBodyArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyArrayUserValidateRequestBody
 			err  error
@@ -4019,8 +4019,8 @@ func DecodeMethodBodyArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 
 var PayloadBodyMapStringDecodeCode = `// DecodeMethodBodyMapStringRequest returns a decoder for requests sent to the
 // ServiceBodyMapString MethodBodyMapString endpoint.
-func DecodeMethodBodyMapStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyMapStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyMapStringRequestBody
 			err  error
@@ -4041,8 +4041,8 @@ func DecodeMethodBodyMapStringRequest(mux goahttp.Muxer, decoder func(*http.Requ
 
 var PayloadBodyMapStringValidateDecodeCode = `// DecodeMethodBodyMapStringValidateRequest returns a decoder for requests sent
 // to the ServiceBodyMapStringValidate MethodBodyMapStringValidate endpoint.
-func DecodeMethodBodyMapStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyMapStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyMapStringValidateRequestBody
 			err  error
@@ -4067,8 +4067,8 @@ func DecodeMethodBodyMapStringValidateRequest(mux goahttp.Muxer, decoder func(*h
 
 var PayloadBodyMapUserDecodeCode = `// DecodeMethodBodyMapUserRequest returns a decoder for requests sent to the
 // ServiceBodyMapUser MethodBodyMapUser endpoint.
-func DecodeMethodBodyMapUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyMapUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyMapUserRequestBody
 			err  error
@@ -4093,8 +4093,8 @@ func DecodeMethodBodyMapUserRequest(mux goahttp.Muxer, decoder func(*http.Reques
 
 var PayloadBodyMapUserValidateDecodeCode = `// DecodeMethodBodyMapUserValidateRequest returns a decoder for requests sent
 // to the ServiceBodyMapUserValidate MethodBodyMapUserValidate endpoint.
-func DecodeMethodBodyMapUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyMapUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyMapUserValidateRequestBody
 			err  error
@@ -4120,8 +4120,8 @@ func DecodeMethodBodyMapUserValidateRequest(mux goahttp.Muxer, decoder func(*htt
 var PayloadBodyPrimitiveStringValidateDecodeCode = `// DecodeMethodBodyPrimitiveStringValidateRequest returns a decoder for
 // requests sent to the ServiceBodyPrimitiveStringValidate
 // MethodBodyPrimitiveStringValidate endpoint.
-func DecodeMethodBodyPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body string
 			err  error
@@ -4134,7 +4134,7 @@ func DecodeMethodBodyPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder f
 			return nil, goa.DecodePayloadError(err.Error())
 		}
 		if !(body == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", body, []interface{}{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", body, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -4149,8 +4149,8 @@ func DecodeMethodBodyPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder f
 var PayloadBodyPrimitiveBoolValidateDecodeCode = `// DecodeMethodBodyPrimitiveBoolValidateRequest returns a decoder for requests
 // sent to the ServiceBodyPrimitiveBoolValidate MethodBodyPrimitiveBoolValidate
 // endpoint.
-func DecodeMethodBodyPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body bool
 			err  error
@@ -4163,7 +4163,7 @@ func DecodeMethodBodyPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fun
 			return nil, goa.DecodePayloadError(err.Error())
 		}
 		if !(body == true) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", body, []interface{}{true}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", body, []any{true}))
 		}
 		if err != nil {
 			return nil, err
@@ -4178,8 +4178,8 @@ func DecodeMethodBodyPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fun
 var PayloadBodyPrimitiveArrayStringValidateDecodeCode = `// DecodeMethodBodyPrimitiveArrayStringValidateRequest returns a decoder for
 // requests sent to the ServiceBodyPrimitiveArrayStringValidate
 // MethodBodyPrimitiveArrayStringValidate endpoint.
-func DecodeMethodBodyPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body []string
 			err  error
@@ -4196,7 +4196,7 @@ func DecodeMethodBodyPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, deco
 		}
 		for _, e := range body {
 			if !(e == "val") {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body[*]", e, []interface{}{"val"}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body[*]", e, []any{"val"}))
 			}
 		}
 		if err != nil {
@@ -4212,8 +4212,8 @@ func DecodeMethodBodyPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, deco
 var PayloadBodyPrimitiveArrayBoolValidateDecodeCode = `// DecodeMethodBodyPrimitiveArrayBoolValidateRequest returns a decoder for
 // requests sent to the ServiceBodyPrimitiveArrayBoolValidate
 // MethodBodyPrimitiveArrayBoolValidate endpoint.
-func DecodeMethodBodyPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body []bool
 			err  error
@@ -4230,7 +4230,7 @@ func DecodeMethodBodyPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decode
 		}
 		for _, e := range body {
 			if !(e == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body[*]", e, []interface{}{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("body[*]", e, []any{true}))
 			}
 		}
 		if err != nil {
@@ -4246,8 +4246,8 @@ func DecodeMethodBodyPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decode
 var PayloadBodyPrimitiveArrayUserValidateDecodeCode = `// DecodeMethodBodyPrimitiveArrayUserValidateRequest returns a decoder for
 // requests sent to the ServiceBodyPrimitiveArrayUserValidate
 // MethodBodyPrimitiveArrayUserValidate endpoint.
-func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body []*PayloadTypeRequestBody
 			err  error
@@ -4282,8 +4282,8 @@ func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decode
 var PayloadBodyPrimitiveFieldArrayUserDecodeCode = `// DecodeMethodBodyPrimitiveArrayUserRequest returns a decoder for requests
 // sent to the ServiceBodyPrimitiveArrayUser MethodBodyPrimitiveArrayUser
 // endpoint.
-func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body []string
 			err  error
@@ -4306,8 +4306,8 @@ func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*
 var PayloadBodyPrimitiveFieldStringDecodeCode = `// DecodeMethodBodyPrimitiveArrayUserRequest returns a decoder for requests
 // sent to the ServiceBodyPrimitiveArrayUser MethodBodyPrimitiveArrayUser
 // endpoint.
-func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body string
 			err  error
@@ -4330,8 +4330,8 @@ func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*
 var PayloadBodyPrimitiveFieldArrayUserValidateDecodeCode = `// DecodeMethodBodyPrimitiveArrayUserValidateRequest returns a decoder for
 // requests sent to the ServiceBodyPrimitiveArrayUserValidate
 // MethodBodyPrimitiveArrayUserValidate endpoint.
-func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body []string
 			err  error
@@ -4361,8 +4361,8 @@ func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decode
 
 var PayloadBodyQueryObjectDecodeCode = `// DecodeMethodBodyQueryObjectRequest returns a decoder for requests sent to
 // the ServiceBodyQueryObject MethodBodyQueryObject endpoint.
-func DecodeMethodBodyQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyQueryObjectRequestBody
 			err  error
@@ -4392,8 +4392,8 @@ func DecodeMethodBodyQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Re
 var PayloadBodyQueryObjectValidateDecodeCode = `// DecodeMethodBodyQueryObjectValidateRequest returns a decoder for requests
 // sent to the ServiceBodyQueryObjectValidate MethodBodyQueryObjectValidate
 // endpoint.
-func DecodeMethodBodyQueryObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyQueryObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyQueryObjectValidateRequestBody
 			err  error
@@ -4430,8 +4430,8 @@ func DecodeMethodBodyQueryObjectValidateRequest(mux goahttp.Muxer, decoder func(
 
 var PayloadBodyQueryUserDecodeCode = `// DecodeMethodBodyQueryUserRequest returns a decoder for requests sent to the
 // ServiceBodyQueryUser MethodBodyQueryUser endpoint.
-func DecodeMethodBodyQueryUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyQueryUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyQueryUserRequestBody
 			err  error
@@ -4460,8 +4460,8 @@ func DecodeMethodBodyQueryUserRequest(mux goahttp.Muxer, decoder func(*http.Requ
 
 var PayloadBodyQueryUserValidateDecodeCode = `// DecodeMethodBodyQueryUserValidateRequest returns a decoder for requests sent
 // to the ServiceBodyQueryUserValidate MethodBodyQueryUserValidate endpoint.
-func DecodeMethodBodyQueryUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyQueryUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyQueryUserValidateRequestBody
 			err  error
@@ -4498,8 +4498,8 @@ func DecodeMethodBodyQueryUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 
 var PayloadBodyPathObjectDecodeCode = `// DecodeMethodBodyPathObjectRequest returns a decoder for requests sent to the
 // ServiceBodyPathObject MethodBodyPathObject endpoint.
-func DecodeMethodBodyPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyPathObjectRequestBody
 			err  error
@@ -4528,8 +4528,8 @@ func DecodeMethodBodyPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Req
 var PayloadBodyPathObjectValidateDecodeCode = `// DecodeMethodBodyPathObjectValidateRequest returns a decoder for requests
 // sent to the ServiceBodyPathObjectValidate MethodBodyPathObjectValidate
 // endpoint.
-func DecodeMethodBodyPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyPathObjectValidateRequestBody
 			err  error
@@ -4565,8 +4565,8 @@ func DecodeMethodBodyPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*
 
 var PayloadBodyPathUserDecodeCode = `// DecodeMethodBodyPathUserRequest returns a decoder for requests sent to the
 // ServiceBodyPathUser MethodBodyPathUser endpoint.
-func DecodeMethodBodyPathUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyPathUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyPathUserRequestBody
 			err  error
@@ -4594,8 +4594,8 @@ func DecodeMethodBodyPathUserRequest(mux goahttp.Muxer, decoder func(*http.Reque
 
 var PayloadBodyPathUserValidateDecodeCode = `// DecodeMethodUserBodyPathValidateRequest returns a decoder for requests sent
 // to the ServiceBodyPathUserValidate MethodUserBodyPathValidate endpoint.
-func DecodeMethodUserBodyPathValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodUserBodyPathValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodUserBodyPathValidateRequestBody
 			err  error
@@ -4631,8 +4631,8 @@ func DecodeMethodUserBodyPathValidateRequest(mux goahttp.Muxer, decoder func(*ht
 
 var PayloadBodyQueryPathObjectDecodeCode = `// DecodeMethodBodyQueryPathObjectRequest returns a decoder for requests sent
 // to the ServiceBodyQueryPathObject MethodBodyQueryPathObject endpoint.
-func DecodeMethodBodyQueryPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyQueryPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyQueryPathObjectRequestBody
 			err  error
@@ -4666,8 +4666,8 @@ func DecodeMethodBodyQueryPathObjectRequest(mux goahttp.Muxer, decoder func(*htt
 var PayloadBodyQueryPathObjectValidateDecodeCode = `// DecodeMethodBodyQueryPathObjectValidateRequest returns a decoder for
 // requests sent to the ServiceBodyQueryPathObjectValidate
 // MethodBodyQueryPathObjectValidate endpoint.
-func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyQueryPathObjectValidateRequestBody
 			err  error
@@ -4709,8 +4709,8 @@ func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder f
 
 var PayloadBodyQueryPathUserDecodeCode = `// DecodeMethodBodyQueryPathUserRequest returns a decoder for requests sent to
 // the ServiceBodyQueryPathUser MethodBodyQueryPathUser endpoint.
-func DecodeMethodBodyQueryPathUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyQueryPathUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyQueryPathUserRequestBody
 			err  error
@@ -4744,8 +4744,8 @@ func DecodeMethodBodyQueryPathUserRequest(mux goahttp.Muxer, decoder func(*http.
 var PayloadBodyQueryPathUserValidateDecodeCode = `// DecodeMethodBodyQueryPathUserValidateRequest returns a decoder for requests
 // sent to the ServiceBodyQueryPathUserValidate MethodBodyQueryPathUserValidate
 // endpoint.
-func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodBodyQueryPathUserValidateRequestBody
 			err  error
@@ -4787,8 +4787,8 @@ func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder fun
 
 var PayloadMapQueryPrimitivePrimitiveDecodeCode = `// DecodeMapQueryPrimitivePrimitiveRequest returns a decoder for requests sent
 // to the ServiceMapQueryPrimitivePrimitive MapQueryPrimitivePrimitive endpoint.
-func DecodeMapQueryPrimitivePrimitiveRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMapQueryPrimitivePrimitiveRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			query map[string]string
 			err   error
@@ -4825,8 +4825,8 @@ func DecodeMapQueryPrimitivePrimitiveRequest(mux goahttp.Muxer, decoder func(*ht
 
 var PayloadMapQueryPrimitiveArrayDecodeCode = `// DecodeMapQueryPrimitiveArrayRequest returns a decoder for requests sent to
 // the ServiceMapQueryPrimitiveArray MapQueryPrimitiveArray endpoint.
-func DecodeMapQueryPrimitiveArrayRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMapQueryPrimitiveArrayRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			query map[string][]uint
 			err   error
@@ -4874,8 +4874,8 @@ func DecodeMapQueryPrimitiveArrayRequest(mux goahttp.Muxer, decoder func(*http.R
 
 var PayloadMapQueryObjectDecodeCode = `// DecodeMethodMapQueryObjectRequest returns a decoder for requests sent to the
 // ServiceMapQueryObject MethodMapQueryObject endpoint.
-func DecodeMethodMapQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodMapQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodMapQueryObjectRequestBody
 			err  error
@@ -4937,8 +4937,8 @@ func DecodeMethodMapQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Req
 
 var PayloadMultipartPrimitiveDecodeCode = `// DecodeMethodMultipartPrimitiveRequest returns a decoder for requests sent to
 // the ServiceMultipartPrimitive MethodMultipartPrimitive endpoint.
-func DecodeMethodMultipartPrimitiveRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodMultipartPrimitiveRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var payload string
 		if err := decoder(r).Decode(&payload); err != nil {
 			return nil, goa.DecodePayloadError(err.Error())
@@ -4951,8 +4951,8 @@ func DecodeMethodMultipartPrimitiveRequest(mux goahttp.Muxer, decoder func(*http
 
 var PayloadMultipartUserTypeDecodeCode = `// DecodeMethodMultipartUserTypeRequest returns a decoder for requests sent to
 // the ServiceMultipartUserType MethodMultipartUserType endpoint.
-func DecodeMethodMultipartUserTypeRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodMultipartUserTypeRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var payload *servicemultipartusertype.MethodMultipartUserTypePayload
 		if err := decoder(r).Decode(&payload); err != nil {
 			return nil, goa.DecodePayloadError(err.Error())
@@ -4965,8 +4965,8 @@ func DecodeMethodMultipartUserTypeRequest(mux goahttp.Muxer, decoder func(*http.
 
 var PayloadMultipartArrayTypeDecodeCode = `// DecodeMethodMultipartArrayTypeRequest returns a decoder for requests sent to
 // the ServiceMultipartArrayType MethodMultipartArrayType endpoint.
-func DecodeMethodMultipartArrayTypeRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodMultipartArrayTypeRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var payload []*servicemultipartarraytype.PayloadType
 		if err := decoder(r).Decode(&payload); err != nil {
 			return nil, goa.DecodePayloadError(err.Error())
@@ -4979,8 +4979,8 @@ func DecodeMethodMultipartArrayTypeRequest(mux goahttp.Muxer, decoder func(*http
 
 var PayloadMultipartMapTypeDecodeCode = `// DecodeMethodMultipartMapTypeRequest returns a decoder for requests sent to
 // the ServiceMultipartMapType MethodMultipartMapType endpoint.
-func DecodeMethodMultipartMapTypeRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodMultipartMapTypeRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var payload map[string]int
 		if err := decoder(r).Decode(&payload); err != nil {
 			return nil, goa.DecodePayloadError(err.Error())
@@ -4993,8 +4993,8 @@ func DecodeMethodMultipartMapTypeRequest(mux goahttp.Muxer, decoder func(*http.R
 
 var WithParamsAndHeadersBlockDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceWithParamsAndHeadersBlock MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			body MethodARequestBody
 			err  error
@@ -5073,8 +5073,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 
 var QueryIntAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceQueryIntAlias MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			int_   *int
 			int32_ *int32
@@ -5125,8 +5125,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 
 var QueryIntAliasValidateDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceQueryIntAliasValidate MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			int_   *int
 			int32_ *int32
@@ -5192,8 +5192,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 
 var QueryArrayAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceQueryArrayAlias MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			array []uint
 			err   error
@@ -5223,8 +5223,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 
 var QueryArrayAliasValidateDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceQueryArrayAliasValidate MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			array []uint
 			err   error
@@ -5261,8 +5261,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 `
 var QueryMapAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceQueryMapAlias MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			map_ map[float32]bool
 			err  error
@@ -5312,8 +5312,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 
 var QueryMapAliasValidateDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceQueryMapAliasValidate MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			map_ map[float32]bool
 			err  error
@@ -5366,8 +5366,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 
 var QueryArrayNestedAliasValidateDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceQueryArrayAliasValidate MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			array []float64
 			err   error
@@ -5402,8 +5402,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 
 var HeaderIntAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServiceHeaderIntAlias MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			int_   *int
 			int32_ *int32
@@ -5454,8 +5454,8 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 
 var PathIntAliasDecodeCode = `// DecodeMethodARequest returns a decoder for requests sent to the
 // ServicePathIntAlias MethodA endpoint.
-func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (interface{}, error) {
-	return func(r *http.Request) (interface{}, error) {
+func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (any, error) {
+	return func(r *http.Request) (any, error) {
 		var (
 			int_   int
 			int32_ int32

--- a/http/codegen/testdata/payload_encode_functions.go
+++ b/http/codegen/testdata/payload_encode_functions.go
@@ -2,8 +2,8 @@ package testdata
 
 var PayloadQueryBoolEncodeCode = `// EncodeMethodQueryBoolRequest returns an encoder for requests sent to the
 // ServiceQueryBool MethodQueryBool server.
-func EncodeMethodQueryBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerybool.MethodQueryBoolPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryBool", "MethodQueryBool", "*servicequerybool.MethodQueryBoolPayload", v)
@@ -20,8 +20,8 @@ func EncodeMethodQueryBoolRequest(encoder func(*http.Request) goahttp.Encoder) f
 
 var PayloadQueryBoolValidateEncodeCode = `// EncodeMethodQueryBoolValidateRequest returns an encoder for requests sent to
 // the ServiceQueryBoolValidate MethodQueryBoolValidate server.
-func EncodeMethodQueryBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryboolvalidate.MethodQueryBoolValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryBoolValidate", "MethodQueryBoolValidate", "*servicequeryboolvalidate.MethodQueryBoolValidatePayload", v)
@@ -36,8 +36,8 @@ func EncodeMethodQueryBoolValidateRequest(encoder func(*http.Request) goahttp.En
 
 var PayloadQueryIntEncodeCode = `// EncodeMethodQueryIntRequest returns an encoder for requests sent to the
 // ServiceQueryInt MethodQueryInt server.
-func EncodeMethodQueryIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryint.MethodQueryIntPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryInt", "MethodQueryInt", "*servicequeryint.MethodQueryIntPayload", v)
@@ -54,8 +54,8 @@ func EncodeMethodQueryIntRequest(encoder func(*http.Request) goahttp.Encoder) fu
 
 var PayloadQueryIntValidateEncodeCode = `// EncodeMethodQueryIntValidateRequest returns an encoder for requests sent to
 // the ServiceQueryIntValidate MethodQueryIntValidate server.
-func EncodeMethodQueryIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryintvalidate.MethodQueryIntValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryIntValidate", "MethodQueryIntValidate", "*servicequeryintvalidate.MethodQueryIntValidatePayload", v)
@@ -70,8 +70,8 @@ func EncodeMethodQueryIntValidateRequest(encoder func(*http.Request) goahttp.Enc
 
 var PayloadQueryInt32EncodeCode = `// EncodeMethodQueryInt32Request returns an encoder for requests sent to the
 // ServiceQueryInt32 MethodQueryInt32 server.
-func EncodeMethodQueryInt32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryInt32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryint32.MethodQueryInt32Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryInt32", "MethodQueryInt32", "*servicequeryint32.MethodQueryInt32Payload", v)
@@ -88,8 +88,8 @@ func EncodeMethodQueryInt32Request(encoder func(*http.Request) goahttp.Encoder) 
 
 var PayloadQueryInt32ValidateEncodeCode = `// EncodeMethodQueryInt32ValidateRequest returns an encoder for requests sent
 // to the ServiceQueryInt32Validate MethodQueryInt32Validate server.
-func EncodeMethodQueryInt32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryInt32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryint32validate.MethodQueryInt32ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryInt32Validate", "MethodQueryInt32Validate", "*servicequeryint32validate.MethodQueryInt32ValidatePayload", v)
@@ -104,8 +104,8 @@ func EncodeMethodQueryInt32ValidateRequest(encoder func(*http.Request) goahttp.E
 
 var PayloadQueryInt64EncodeCode = `// EncodeMethodQueryInt64Request returns an encoder for requests sent to the
 // ServiceQueryInt64 MethodQueryInt64 server.
-func EncodeMethodQueryInt64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryInt64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryint64.MethodQueryInt64Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryInt64", "MethodQueryInt64", "*servicequeryint64.MethodQueryInt64Payload", v)
@@ -122,8 +122,8 @@ func EncodeMethodQueryInt64Request(encoder func(*http.Request) goahttp.Encoder) 
 
 var PayloadQueryInt64ValidateEncodeCode = `// EncodeMethodQueryInt64ValidateRequest returns an encoder for requests sent
 // to the ServiceQueryInt64Validate MethodQueryInt64Validate server.
-func EncodeMethodQueryInt64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryInt64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryint64validate.MethodQueryInt64ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryInt64Validate", "MethodQueryInt64Validate", "*servicequeryint64validate.MethodQueryInt64ValidatePayload", v)
@@ -138,8 +138,8 @@ func EncodeMethodQueryInt64ValidateRequest(encoder func(*http.Request) goahttp.E
 
 var PayloadQueryUIntEncodeCode = `// EncodeMethodQueryUIntRequest returns an encoder for requests sent to the
 // ServiceQueryUInt MethodQueryUInt server.
-func EncodeMethodQueryUIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryUIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryuint.MethodQueryUIntPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryUInt", "MethodQueryUInt", "*servicequeryuint.MethodQueryUIntPayload", v)
@@ -156,8 +156,8 @@ func EncodeMethodQueryUIntRequest(encoder func(*http.Request) goahttp.Encoder) f
 
 var PayloadQueryUIntValidateEncodeCode = `// EncodeMethodQueryUIntValidateRequest returns an encoder for requests sent to
 // the ServiceQueryUIntValidate MethodQueryUIntValidate server.
-func EncodeMethodQueryUIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryUIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryuintvalidate.MethodQueryUIntValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryUIntValidate", "MethodQueryUIntValidate", "*servicequeryuintvalidate.MethodQueryUIntValidatePayload", v)
@@ -172,8 +172,8 @@ func EncodeMethodQueryUIntValidateRequest(encoder func(*http.Request) goahttp.En
 
 var PayloadQueryUInt32EncodeCode = `// EncodeMethodQueryUInt32Request returns an encoder for requests sent to the
 // ServiceQueryUInt32 MethodQueryUInt32 server.
-func EncodeMethodQueryUInt32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryUInt32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryuint32.MethodQueryUInt32Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryUInt32", "MethodQueryUInt32", "*servicequeryuint32.MethodQueryUInt32Payload", v)
@@ -190,8 +190,8 @@ func EncodeMethodQueryUInt32Request(encoder func(*http.Request) goahttp.Encoder)
 
 var PayloadQueryUInt32ValidateEncodeCode = `// EncodeMethodQueryUInt32ValidateRequest returns an encoder for requests sent
 // to the ServiceQueryUInt32Validate MethodQueryUInt32Validate server.
-func EncodeMethodQueryUInt32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryUInt32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryuint32validate.MethodQueryUInt32ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryUInt32Validate", "MethodQueryUInt32Validate", "*servicequeryuint32validate.MethodQueryUInt32ValidatePayload", v)
@@ -206,8 +206,8 @@ func EncodeMethodQueryUInt32ValidateRequest(encoder func(*http.Request) goahttp.
 
 var PayloadQueryUInt64EncodeCode = `// EncodeMethodQueryUInt64Request returns an encoder for requests sent to the
 // ServiceQueryUInt64 MethodQueryUInt64 server.
-func EncodeMethodQueryUInt64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryUInt64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryuint64.MethodQueryUInt64Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryUInt64", "MethodQueryUInt64", "*servicequeryuint64.MethodQueryUInt64Payload", v)
@@ -224,8 +224,8 @@ func EncodeMethodQueryUInt64Request(encoder func(*http.Request) goahttp.Encoder)
 
 var PayloadQueryUInt64ValidateEncodeCode = `// EncodeMethodQueryUInt64ValidateRequest returns an encoder for requests sent
 // to the ServiceQueryUInt64Validate MethodQueryUInt64Validate server.
-func EncodeMethodQueryUInt64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryUInt64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryuint64validate.MethodQueryUInt64ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryUInt64Validate", "MethodQueryUInt64Validate", "*servicequeryuint64validate.MethodQueryUInt64ValidatePayload", v)
@@ -240,8 +240,8 @@ func EncodeMethodQueryUInt64ValidateRequest(encoder func(*http.Request) goahttp.
 
 var PayloadQueryFloat32EncodeCode = `// EncodeMethodQueryFloat32Request returns an encoder for requests sent to the
 // ServiceQueryFloat32 MethodQueryFloat32 server.
-func EncodeMethodQueryFloat32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryFloat32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryfloat32.MethodQueryFloat32Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryFloat32", "MethodQueryFloat32", "*servicequeryfloat32.MethodQueryFloat32Payload", v)
@@ -258,8 +258,8 @@ func EncodeMethodQueryFloat32Request(encoder func(*http.Request) goahttp.Encoder
 
 var PayloadQueryFloat32ValidateEncodeCode = `// EncodeMethodQueryFloat32ValidateRequest returns an encoder for requests sent
 // to the ServiceQueryFloat32Validate MethodQueryFloat32Validate server.
-func EncodeMethodQueryFloat32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryFloat32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryfloat32validate.MethodQueryFloat32ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryFloat32Validate", "MethodQueryFloat32Validate", "*servicequeryfloat32validate.MethodQueryFloat32ValidatePayload", v)
@@ -274,8 +274,8 @@ func EncodeMethodQueryFloat32ValidateRequest(encoder func(*http.Request) goahttp
 
 var PayloadQueryFloat64EncodeCode = `// EncodeMethodQueryFloat64Request returns an encoder for requests sent to the
 // ServiceQueryFloat64 MethodQueryFloat64 server.
-func EncodeMethodQueryFloat64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryFloat64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryfloat64.MethodQueryFloat64Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryFloat64", "MethodQueryFloat64", "*servicequeryfloat64.MethodQueryFloat64Payload", v)
@@ -292,8 +292,8 @@ func EncodeMethodQueryFloat64Request(encoder func(*http.Request) goahttp.Encoder
 
 var PayloadQueryFloat64ValidateEncodeCode = `// EncodeMethodQueryFloat64ValidateRequest returns an encoder for requests sent
 // to the ServiceQueryFloat64Validate MethodQueryFloat64Validate server.
-func EncodeMethodQueryFloat64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryFloat64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryfloat64validate.MethodQueryFloat64ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryFloat64Validate", "MethodQueryFloat64Validate", "*servicequeryfloat64validate.MethodQueryFloat64ValidatePayload", v)
@@ -308,8 +308,8 @@ func EncodeMethodQueryFloat64ValidateRequest(encoder func(*http.Request) goahttp
 
 var PayloadQueryStringEncodeCode = `// EncodeMethodQueryStringRequest returns an encoder for requests sent to the
 // ServiceQueryString MethodQueryString server.
-func EncodeMethodQueryStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerystring.MethodQueryStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryString", "MethodQueryString", "*servicequerystring.MethodQueryStringPayload", v)
@@ -326,8 +326,8 @@ func EncodeMethodQueryStringRequest(encoder func(*http.Request) goahttp.Encoder)
 
 var PayloadQueryStringValidateEncodeCode = `// EncodeMethodQueryStringValidateRequest returns an encoder for requests sent
 // to the ServiceQueryStringValidate MethodQueryStringValidate server.
-func EncodeMethodQueryStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerystringvalidate.MethodQueryStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryStringValidate", "MethodQueryStringValidate", "*servicequerystringvalidate.MethodQueryStringValidatePayload", v)
@@ -342,8 +342,8 @@ func EncodeMethodQueryStringValidateRequest(encoder func(*http.Request) goahttp.
 
 var PayloadQueryBytesEncodeCode = `// EncodeMethodQueryBytesRequest returns an encoder for requests sent to the
 // ServiceQueryBytes MethodQueryBytes server.
-func EncodeMethodQueryBytesRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryBytesRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerybytes.MethodQueryBytesPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryBytes", "MethodQueryBytes", "*servicequerybytes.MethodQueryBytesPayload", v)
@@ -358,8 +358,8 @@ func EncodeMethodQueryBytesRequest(encoder func(*http.Request) goahttp.Encoder) 
 
 var PayloadQueryBytesValidateEncodeCode = `// EncodeMethodQueryBytesValidateRequest returns an encoder for requests sent
 // to the ServiceQueryBytesValidate MethodQueryBytesValidate server.
-func EncodeMethodQueryBytesValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryBytesValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerybytesvalidate.MethodQueryBytesValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryBytesValidate", "MethodQueryBytesValidate", "*servicequerybytesvalidate.MethodQueryBytesValidatePayload", v)
@@ -374,8 +374,8 @@ func EncodeMethodQueryBytesValidateRequest(encoder func(*http.Request) goahttp.E
 
 var PayloadQueryAnyEncodeCode = `// EncodeMethodQueryAnyRequest returns an encoder for requests sent to the
 // ServiceQueryAny MethodQueryAny server.
-func EncodeMethodQueryAnyRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryAnyRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryany.MethodQueryAnyPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryAny", "MethodQueryAny", "*servicequeryany.MethodQueryAnyPayload", v)
@@ -390,8 +390,8 @@ func EncodeMethodQueryAnyRequest(encoder func(*http.Request) goahttp.Encoder) fu
 
 var PayloadQueryAnyValidateEncodeCode = `// EncodeMethodQueryAnyValidateRequest returns an encoder for requests sent to
 // the ServiceQueryAnyValidate MethodQueryAnyValidate server.
-func EncodeMethodQueryAnyValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryAnyValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryanyvalidate.MethodQueryAnyValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryAnyValidate", "MethodQueryAnyValidate", "*servicequeryanyvalidate.MethodQueryAnyValidatePayload", v)
@@ -406,8 +406,8 @@ func EncodeMethodQueryAnyValidateRequest(encoder func(*http.Request) goahttp.Enc
 
 var PayloadQueryArrayBoolEncodeCode = `// EncodeMethodQueryArrayBoolRequest returns an encoder for requests sent to
 // the ServiceQueryArrayBool MethodQueryArrayBool server.
-func EncodeMethodQueryArrayBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarraybool.MethodQueryArrayBoolPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayBool", "MethodQueryArrayBool", "*servicequeryarraybool.MethodQueryArrayBoolPayload", v)
@@ -426,8 +426,8 @@ func EncodeMethodQueryArrayBoolRequest(encoder func(*http.Request) goahttp.Encod
 var PayloadQueryArrayBoolValidateEncodeCode = `// EncodeMethodQueryArrayBoolValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayBoolValidate MethodQueryArrayBoolValidate
 // server.
-func EncodeMethodQueryArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayboolvalidate.MethodQueryArrayBoolValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayBoolValidate", "MethodQueryArrayBoolValidate", "*servicequeryarrayboolvalidate.MethodQueryArrayBoolValidatePayload", v)
@@ -445,8 +445,8 @@ func EncodeMethodQueryArrayBoolValidateRequest(encoder func(*http.Request) goaht
 
 var PayloadQueryArrayIntEncodeCode = `// EncodeMethodQueryArrayIntRequest returns an encoder for requests sent to the
 // ServiceQueryArrayInt MethodQueryArrayInt server.
-func EncodeMethodQueryArrayIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayint.MethodQueryArrayIntPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayInt", "MethodQueryArrayInt", "*servicequeryarrayint.MethodQueryArrayIntPayload", v)
@@ -464,8 +464,8 @@ func EncodeMethodQueryArrayIntRequest(encoder func(*http.Request) goahttp.Encode
 
 var PayloadQueryArrayIntValidateEncodeCode = `// EncodeMethodQueryArrayIntValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayIntValidate MethodQueryArrayIntValidate server.
-func EncodeMethodQueryArrayIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayintvalidate.MethodQueryArrayIntValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayIntValidate", "MethodQueryArrayIntValidate", "*servicequeryarrayintvalidate.MethodQueryArrayIntValidatePayload", v)
@@ -483,8 +483,8 @@ func EncodeMethodQueryArrayIntValidateRequest(encoder func(*http.Request) goahtt
 
 var PayloadQueryArrayInt32EncodeCode = `// EncodeMethodQueryArrayInt32Request returns an encoder for requests sent to
 // the ServiceQueryArrayInt32 MethodQueryArrayInt32 server.
-func EncodeMethodQueryArrayInt32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayInt32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayint32.MethodQueryArrayInt32Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayInt32", "MethodQueryArrayInt32", "*servicequeryarrayint32.MethodQueryArrayInt32Payload", v)
@@ -503,8 +503,8 @@ func EncodeMethodQueryArrayInt32Request(encoder func(*http.Request) goahttp.Enco
 var PayloadQueryArrayInt32ValidateEncodeCode = `// EncodeMethodQueryArrayInt32ValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayInt32Validate MethodQueryArrayInt32Validate
 // server.
-func EncodeMethodQueryArrayInt32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayInt32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayint32validate.MethodQueryArrayInt32ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayInt32Validate", "MethodQueryArrayInt32Validate", "*servicequeryarrayint32validate.MethodQueryArrayInt32ValidatePayload", v)
@@ -522,8 +522,8 @@ func EncodeMethodQueryArrayInt32ValidateRequest(encoder func(*http.Request) goah
 
 var PayloadQueryArrayInt64EncodeCode = `// EncodeMethodQueryArrayInt64Request returns an encoder for requests sent to
 // the ServiceQueryArrayInt64 MethodQueryArrayInt64 server.
-func EncodeMethodQueryArrayInt64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayInt64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayint64.MethodQueryArrayInt64Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayInt64", "MethodQueryArrayInt64", "*servicequeryarrayint64.MethodQueryArrayInt64Payload", v)
@@ -542,8 +542,8 @@ func EncodeMethodQueryArrayInt64Request(encoder func(*http.Request) goahttp.Enco
 var PayloadQueryArrayInt64ValidateEncodeCode = `// EncodeMethodQueryArrayInt64ValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayInt64Validate MethodQueryArrayInt64Validate
 // server.
-func EncodeMethodQueryArrayInt64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayInt64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayint64validate.MethodQueryArrayInt64ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayInt64Validate", "MethodQueryArrayInt64Validate", "*servicequeryarrayint64validate.MethodQueryArrayInt64ValidatePayload", v)
@@ -561,8 +561,8 @@ func EncodeMethodQueryArrayInt64ValidateRequest(encoder func(*http.Request) goah
 
 var PayloadQueryArrayUIntEncodeCode = `// EncodeMethodQueryArrayUIntRequest returns an encoder for requests sent to
 // the ServiceQueryArrayUInt MethodQueryArrayUInt server.
-func EncodeMethodQueryArrayUIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayUIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayuint.MethodQueryArrayUIntPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayUInt", "MethodQueryArrayUInt", "*servicequeryarrayuint.MethodQueryArrayUIntPayload", v)
@@ -581,8 +581,8 @@ func EncodeMethodQueryArrayUIntRequest(encoder func(*http.Request) goahttp.Encod
 var PayloadQueryArrayUIntValidateEncodeCode = `// EncodeMethodQueryArrayUIntValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayUIntValidate MethodQueryArrayUIntValidate
 // server.
-func EncodeMethodQueryArrayUIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayUIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayuintvalidate.MethodQueryArrayUIntValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayUIntValidate", "MethodQueryArrayUIntValidate", "*servicequeryarrayuintvalidate.MethodQueryArrayUIntValidatePayload", v)
@@ -600,8 +600,8 @@ func EncodeMethodQueryArrayUIntValidateRequest(encoder func(*http.Request) goaht
 
 var PayloadQueryArrayUInt32EncodeCode = `// EncodeMethodQueryArrayUInt32Request returns an encoder for requests sent to
 // the ServiceQueryArrayUInt32 MethodQueryArrayUInt32 server.
-func EncodeMethodQueryArrayUInt32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayUInt32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayuint32.MethodQueryArrayUInt32Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayUInt32", "MethodQueryArrayUInt32", "*servicequeryarrayuint32.MethodQueryArrayUInt32Payload", v)
@@ -620,8 +620,8 @@ func EncodeMethodQueryArrayUInt32Request(encoder func(*http.Request) goahttp.Enc
 var PayloadQueryArrayUInt32ValidateEncodeCode = `// EncodeMethodQueryArrayUInt32ValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayUInt32Validate MethodQueryArrayUInt32Validate
 // server.
-func EncodeMethodQueryArrayUInt32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayUInt32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayuint32validate.MethodQueryArrayUInt32ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayUInt32Validate", "MethodQueryArrayUInt32Validate", "*servicequeryarrayuint32validate.MethodQueryArrayUInt32ValidatePayload", v)
@@ -639,8 +639,8 @@ func EncodeMethodQueryArrayUInt32ValidateRequest(encoder func(*http.Request) goa
 
 var PayloadQueryArrayUInt64EncodeCode = `// EncodeMethodQueryArrayUInt64Request returns an encoder for requests sent to
 // the ServiceQueryArrayUInt64 MethodQueryArrayUInt64 server.
-func EncodeMethodQueryArrayUInt64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayUInt64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayuint64.MethodQueryArrayUInt64Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayUInt64", "MethodQueryArrayUInt64", "*servicequeryarrayuint64.MethodQueryArrayUInt64Payload", v)
@@ -659,8 +659,8 @@ func EncodeMethodQueryArrayUInt64Request(encoder func(*http.Request) goahttp.Enc
 var PayloadQueryArrayUInt64ValidateEncodeCode = `// EncodeMethodQueryArrayUInt64ValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayUInt64Validate MethodQueryArrayUInt64Validate
 // server.
-func EncodeMethodQueryArrayUInt64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayUInt64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayuint64validate.MethodQueryArrayUInt64ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayUInt64Validate", "MethodQueryArrayUInt64Validate", "*servicequeryarrayuint64validate.MethodQueryArrayUInt64ValidatePayload", v)
@@ -678,8 +678,8 @@ func EncodeMethodQueryArrayUInt64ValidateRequest(encoder func(*http.Request) goa
 
 var PayloadQueryArrayFloat32EncodeCode = `// EncodeMethodQueryArrayFloat32Request returns an encoder for requests sent to
 // the ServiceQueryArrayFloat32 MethodQueryArrayFloat32 server.
-func EncodeMethodQueryArrayFloat32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayFloat32Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayfloat32.MethodQueryArrayFloat32Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayFloat32", "MethodQueryArrayFloat32", "*servicequeryarrayfloat32.MethodQueryArrayFloat32Payload", v)
@@ -698,8 +698,8 @@ func EncodeMethodQueryArrayFloat32Request(encoder func(*http.Request) goahttp.En
 var PayloadQueryArrayFloat32ValidateEncodeCode = `// EncodeMethodQueryArrayFloat32ValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayFloat32Validate MethodQueryArrayFloat32Validate
 // server.
-func EncodeMethodQueryArrayFloat32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayFloat32ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayfloat32validate.MethodQueryArrayFloat32ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayFloat32Validate", "MethodQueryArrayFloat32Validate", "*servicequeryarrayfloat32validate.MethodQueryArrayFloat32ValidatePayload", v)
@@ -717,8 +717,8 @@ func EncodeMethodQueryArrayFloat32ValidateRequest(encoder func(*http.Request) go
 
 var PayloadQueryArrayFloat64EncodeCode = `// EncodeMethodQueryArrayFloat64Request returns an encoder for requests sent to
 // the ServiceQueryArrayFloat64 MethodQueryArrayFloat64 server.
-func EncodeMethodQueryArrayFloat64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayFloat64Request(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayfloat64.MethodQueryArrayFloat64Payload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayFloat64", "MethodQueryArrayFloat64", "*servicequeryarrayfloat64.MethodQueryArrayFloat64Payload", v)
@@ -737,8 +737,8 @@ func EncodeMethodQueryArrayFloat64Request(encoder func(*http.Request) goahttp.En
 var PayloadQueryArrayFloat64ValidateEncodeCode = `// EncodeMethodQueryArrayFloat64ValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayFloat64Validate MethodQueryArrayFloat64Validate
 // server.
-func EncodeMethodQueryArrayFloat64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayFloat64ValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayfloat64validate.MethodQueryArrayFloat64ValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayFloat64Validate", "MethodQueryArrayFloat64Validate", "*servicequeryarrayfloat64validate.MethodQueryArrayFloat64ValidatePayload", v)
@@ -756,8 +756,8 @@ func EncodeMethodQueryArrayFloat64ValidateRequest(encoder func(*http.Request) go
 
 var PayloadQueryArrayStringEncodeCode = `// EncodeMethodQueryArrayStringRequest returns an encoder for requests sent to
 // the ServiceQueryArrayString MethodQueryArrayString server.
-func EncodeMethodQueryArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarraystring.MethodQueryArrayStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayString", "MethodQueryArrayString", "*servicequeryarraystring.MethodQueryArrayStringPayload", v)
@@ -775,8 +775,8 @@ func EncodeMethodQueryArrayStringRequest(encoder func(*http.Request) goahttp.Enc
 var PayloadQueryArrayStringValidateEncodeCode = `// EncodeMethodQueryArrayStringValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayStringValidate MethodQueryArrayStringValidate
 // server.
-func EncodeMethodQueryArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarraystringvalidate.MethodQueryArrayStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayStringValidate", "MethodQueryArrayStringValidate", "*servicequeryarraystringvalidate.MethodQueryArrayStringValidatePayload", v)
@@ -793,8 +793,8 @@ func EncodeMethodQueryArrayStringValidateRequest(encoder func(*http.Request) goa
 
 var PayloadQueryArrayBytesEncodeCode = `// EncodeMethodQueryArrayBytesRequest returns an encoder for requests sent to
 // the ServiceQueryArrayBytes MethodQueryArrayBytes server.
-func EncodeMethodQueryArrayBytesRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayBytesRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarraybytes.MethodQueryArrayBytesPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayBytes", "MethodQueryArrayBytes", "*servicequeryarraybytes.MethodQueryArrayBytesPayload", v)
@@ -813,8 +813,8 @@ func EncodeMethodQueryArrayBytesRequest(encoder func(*http.Request) goahttp.Enco
 var PayloadQueryArrayBytesValidateEncodeCode = `// EncodeMethodQueryArrayBytesValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayBytesValidate MethodQueryArrayBytesValidate
 // server.
-func EncodeMethodQueryArrayBytesValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayBytesValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarraybytesvalidate.MethodQueryArrayBytesValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayBytesValidate", "MethodQueryArrayBytesValidate", "*servicequeryarraybytesvalidate.MethodQueryArrayBytesValidatePayload", v)
@@ -832,8 +832,8 @@ func EncodeMethodQueryArrayBytesValidateRequest(encoder func(*http.Request) goah
 
 var PayloadQueryArrayAnyEncodeCode = `// EncodeMethodQueryArrayAnyRequest returns an encoder for requests sent to the
 // ServiceQueryArrayAny MethodQueryArrayAny server.
-func EncodeMethodQueryArrayAnyRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayAnyRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayany.MethodQueryArrayAnyPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayAny", "MethodQueryArrayAny", "*servicequeryarrayany.MethodQueryArrayAnyPayload", v)
@@ -851,8 +851,8 @@ func EncodeMethodQueryArrayAnyRequest(encoder func(*http.Request) goahttp.Encode
 
 var PayloadQueryArrayAnyValidateEncodeCode = `// EncodeMethodQueryArrayAnyValidateRequest returns an encoder for requests
 // sent to the ServiceQueryArrayAnyValidate MethodQueryArrayAnyValidate server.
-func EncodeMethodQueryArrayAnyValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayAnyValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayAnyValidate", "MethodQueryArrayAnyValidate", "*servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload", v)
@@ -870,8 +870,8 @@ func EncodeMethodQueryArrayAnyValidateRequest(encoder func(*http.Request) goahtt
 
 var PayloadQueryArrayAliasEncodeCode = `// EncodeMethodQueryArrayAliasRequest returns an encoder for requests sent to
 // the ServiceQueryArrayAlias MethodQueryArrayAlias server.
-func EncodeMethodQueryArrayAliasRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryArrayAliasRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayalias.MethodQueryArrayAliasPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayAlias", "MethodQueryArrayAlias", "*servicequeryarrayalias.MethodQueryArrayAliasPayload", v)
@@ -889,8 +889,8 @@ func EncodeMethodQueryArrayAliasRequest(encoder func(*http.Request) goahttp.Enco
 
 var PayloadQueryMapStringStringEncodeCode = `// EncodeMethodQueryMapStringStringRequest returns an encoder for requests sent
 // to the ServiceQueryMapStringString MethodQueryMapStringString server.
-func EncodeMethodQueryMapStringStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapstringstring.MethodQueryMapStringStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringString", "MethodQueryMapStringString", "*servicequerymapstringstring.MethodQueryMapStringStringPayload", v)
@@ -909,8 +909,8 @@ func EncodeMethodQueryMapStringStringRequest(encoder func(*http.Request) goahttp
 var PayloadQueryMapStringStringValidateEncodeCode = `// EncodeMethodQueryMapStringStringValidateRequest returns an encoder for
 // requests sent to the ServiceQueryMapStringStringValidate
 // MethodQueryMapStringStringValidate server.
-func EncodeMethodQueryMapStringStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapstringstringvalidate.MethodQueryMapStringStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringStringValidate", "MethodQueryMapStringStringValidate", "*servicequerymapstringstringvalidate.MethodQueryMapStringStringValidatePayload", v)
@@ -928,8 +928,8 @@ func EncodeMethodQueryMapStringStringValidateRequest(encoder func(*http.Request)
 
 var PayloadQueryMapStringBoolEncodeCode = `// EncodeMethodQueryMapStringBoolRequest returns an encoder for requests sent
 // to the ServiceQueryMapStringBool MethodQueryMapStringBool server.
-func EncodeMethodQueryMapStringBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapstringbool.MethodQueryMapStringBoolPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringBool", "MethodQueryMapStringBool", "*servicequerymapstringbool.MethodQueryMapStringBoolPayload", v)
@@ -949,8 +949,8 @@ func EncodeMethodQueryMapStringBoolRequest(encoder func(*http.Request) goahttp.E
 var PayloadQueryMapStringBoolValidateEncodeCode = `// EncodeMethodQueryMapStringBoolValidateRequest returns an encoder for
 // requests sent to the ServiceQueryMapStringBoolValidate
 // MethodQueryMapStringBoolValidate server.
-func EncodeMethodQueryMapStringBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapstringboolvalidate.MethodQueryMapStringBoolValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringBoolValidate", "MethodQueryMapStringBoolValidate", "*servicequerymapstringboolvalidate.MethodQueryMapStringBoolValidatePayload", v)
@@ -969,8 +969,8 @@ func EncodeMethodQueryMapStringBoolValidateRequest(encoder func(*http.Request) g
 
 var PayloadQueryMapBoolStringEncodeCode = `// EncodeMethodQueryMapBoolStringRequest returns an encoder for requests sent
 // to the ServiceQueryMapBoolString MethodQueryMapBoolString server.
-func EncodeMethodQueryMapBoolStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapBoolStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapboolstring.MethodQueryMapBoolStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapBoolString", "MethodQueryMapBoolString", "*servicequerymapboolstring.MethodQueryMapBoolStringPayload", v)
@@ -990,8 +990,8 @@ func EncodeMethodQueryMapBoolStringRequest(encoder func(*http.Request) goahttp.E
 var PayloadQueryMapBoolStringValidateEncodeCode = `// EncodeMethodQueryMapBoolStringValidateRequest returns an encoder for
 // requests sent to the ServiceQueryMapBoolStringValidate
 // MethodQueryMapBoolStringValidate server.
-func EncodeMethodQueryMapBoolStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapBoolStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapboolstringvalidate.MethodQueryMapBoolStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapBoolStringValidate", "MethodQueryMapBoolStringValidate", "*servicequerymapboolstringvalidate.MethodQueryMapBoolStringValidatePayload", v)
@@ -1010,8 +1010,8 @@ func EncodeMethodQueryMapBoolStringValidateRequest(encoder func(*http.Request) g
 
 var PayloadQueryMapBoolBoolEncodeCode = `// EncodeMethodQueryMapBoolBoolRequest returns an encoder for requests sent to
 // the ServiceQueryMapBoolBool MethodQueryMapBoolBool server.
-func EncodeMethodQueryMapBoolBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapBoolBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapboolbool.MethodQueryMapBoolBoolPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapBoolBool", "MethodQueryMapBoolBool", "*servicequerymapboolbool.MethodQueryMapBoolBoolPayload", v)
@@ -1032,8 +1032,8 @@ func EncodeMethodQueryMapBoolBoolRequest(encoder func(*http.Request) goahttp.Enc
 var PayloadQueryMapBoolBoolValidateEncodeCode = `// EncodeMethodQueryMapBoolBoolValidateRequest returns an encoder for requests
 // sent to the ServiceQueryMapBoolBoolValidate MethodQueryMapBoolBoolValidate
 // server.
-func EncodeMethodQueryMapBoolBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapBoolBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapboolboolvalidate.MethodQueryMapBoolBoolValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapBoolBoolValidate", "MethodQueryMapBoolBoolValidate", "*servicequerymapboolboolvalidate.MethodQueryMapBoolBoolValidatePayload", v)
@@ -1054,8 +1054,8 @@ func EncodeMethodQueryMapBoolBoolValidateRequest(encoder func(*http.Request) goa
 var PayloadQueryMapStringArrayStringEncodeCode = `// EncodeMethodQueryMapStringArrayStringRequest returns an encoder for requests
 // sent to the ServiceQueryMapStringArrayString MethodQueryMapStringArrayString
 // server.
-func EncodeMethodQueryMapStringArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapstringarraystring.MethodQueryMapStringArrayStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringArrayString", "MethodQueryMapStringArrayString", "*servicequerymapstringarraystring.MethodQueryMapStringArrayStringPayload", v)
@@ -1074,8 +1074,8 @@ func EncodeMethodQueryMapStringArrayStringRequest(encoder func(*http.Request) go
 var PayloadQueryMapStringArrayStringValidateEncodeCode = `// EncodeMethodQueryMapStringArrayStringValidateRequest returns an encoder for
 // requests sent to the ServiceQueryMapStringArrayStringValidate
 // MethodQueryMapStringArrayStringValidate server.
-func EncodeMethodQueryMapStringArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapstringarraystringvalidate.MethodQueryMapStringArrayStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringArrayStringValidate", "MethodQueryMapStringArrayStringValidate", "*servicequerymapstringarraystringvalidate.MethodQueryMapStringArrayStringValidatePayload", v)
@@ -1094,8 +1094,8 @@ func EncodeMethodQueryMapStringArrayStringValidateRequest(encoder func(*http.Req
 var PayloadQueryMapStringArrayBoolEncodeCode = `// EncodeMethodQueryMapStringArrayBoolRequest returns an encoder for requests
 // sent to the ServiceQueryMapStringArrayBool MethodQueryMapStringArrayBool
 // server.
-func EncodeMethodQueryMapStringArrayBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringArrayBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapstringarraybool.MethodQueryMapStringArrayBoolPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringArrayBool", "MethodQueryMapStringArrayBool", "*servicequerymapstringarraybool.MethodQueryMapStringArrayBoolPayload", v)
@@ -1117,8 +1117,8 @@ func EncodeMethodQueryMapStringArrayBoolRequest(encoder func(*http.Request) goah
 var PayloadQueryMapStringArrayBoolValidateEncodeCode = `// EncodeMethodQueryMapStringArrayBoolValidateRequest returns an encoder for
 // requests sent to the ServiceQueryMapStringArrayBoolValidate
 // MethodQueryMapStringArrayBoolValidate server.
-func EncodeMethodQueryMapStringArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapstringarrayboolvalidate.MethodQueryMapStringArrayBoolValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringArrayBoolValidate", "MethodQueryMapStringArrayBoolValidate", "*servicequerymapstringarrayboolvalidate.MethodQueryMapStringArrayBoolValidatePayload", v)
@@ -1140,8 +1140,8 @@ func EncodeMethodQueryMapStringArrayBoolValidateRequest(encoder func(*http.Reque
 var PayloadQueryMapBoolArrayStringEncodeCode = `// EncodeMethodQueryMapBoolArrayStringRequest returns an encoder for requests
 // sent to the ServiceQueryMapBoolArrayString MethodQueryMapBoolArrayString
 // server.
-func EncodeMethodQueryMapBoolArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapBoolArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapboolarraystring.MethodQueryMapBoolArrayStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapBoolArrayString", "MethodQueryMapBoolArrayString", "*servicequerymapboolarraystring.MethodQueryMapBoolArrayStringPayload", v)
@@ -1161,8 +1161,8 @@ func EncodeMethodQueryMapBoolArrayStringRequest(encoder func(*http.Request) goah
 var PayloadQueryMapBoolArrayStringValidateEncodeCode = `// EncodeMethodQueryMapBoolArrayStringValidateRequest returns an encoder for
 // requests sent to the ServiceQueryMapBoolArrayStringValidate
 // MethodQueryMapBoolArrayStringValidate server.
-func EncodeMethodQueryMapBoolArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapBoolArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapboolarraystringvalidate.MethodQueryMapBoolArrayStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapBoolArrayStringValidate", "MethodQueryMapBoolArrayStringValidate", "*servicequerymapboolarraystringvalidate.MethodQueryMapBoolArrayStringValidatePayload", v)
@@ -1181,8 +1181,8 @@ func EncodeMethodQueryMapBoolArrayStringValidateRequest(encoder func(*http.Reque
 
 var PayloadQueryMapBoolArrayBoolEncodeCode = `// EncodeMethodQueryMapBoolArrayBoolRequest returns an encoder for requests
 // sent to the ServiceQueryMapBoolArrayBool MethodQueryMapBoolArrayBool server.
-func EncodeMethodQueryMapBoolArrayBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapBoolArrayBoolRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapboolarraybool.MethodQueryMapBoolArrayBoolPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapBoolArrayBool", "MethodQueryMapBoolArrayBool", "*servicequerymapboolarraybool.MethodQueryMapBoolArrayBoolPayload", v)
@@ -1205,8 +1205,8 @@ func EncodeMethodQueryMapBoolArrayBoolRequest(encoder func(*http.Request) goahtt
 var PayloadQueryMapBoolArrayBoolValidateEncodeCode = `// EncodeMethodQueryMapBoolArrayBoolValidateRequest returns an encoder for
 // requests sent to the ServiceQueryMapBoolArrayBoolValidate
 // MethodQueryMapBoolArrayBoolValidate server.
-func EncodeMethodQueryMapBoolArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapBoolArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapboolarrayboolvalidate.MethodQueryMapBoolArrayBoolValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapBoolArrayBoolValidate", "MethodQueryMapBoolArrayBoolValidate", "*servicequerymapboolarrayboolvalidate.MethodQueryMapBoolArrayBoolValidatePayload", v)
@@ -1229,8 +1229,8 @@ func EncodeMethodQueryMapBoolArrayBoolValidateRequest(encoder func(*http.Request
 var PayloadQueryPrimitiveStringValidateEncodeCode = `// EncodeMethodQueryPrimitiveStringValidateRequest returns an encoder for
 // requests sent to the ServiceQueryPrimitiveStringValidate
 // MethodQueryPrimitiveStringValidate server.
-func EncodeMethodQueryPrimitiveStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryPrimitiveStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveStringValidate", "MethodQueryPrimitiveStringValidate", "string", v)
@@ -1246,8 +1246,8 @@ func EncodeMethodQueryPrimitiveStringValidateRequest(encoder func(*http.Request)
 var PayloadQueryPrimitiveBoolValidateEncodeCode = `// EncodeMethodQueryPrimitiveBoolValidateRequest returns an encoder for
 // requests sent to the ServiceQueryPrimitiveBoolValidate
 // MethodQueryPrimitiveBoolValidate server.
-func EncodeMethodQueryPrimitiveBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryPrimitiveBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(bool)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveBoolValidate", "MethodQueryPrimitiveBoolValidate", "bool", v)
@@ -1264,8 +1264,8 @@ func EncodeMethodQueryPrimitiveBoolValidateRequest(encoder func(*http.Request) g
 var PayloadQueryPrimitiveArrayStringValidateEncodeCode = `// EncodeMethodQueryPrimitiveArrayStringValidateRequest returns an encoder for
 // requests sent to the ServiceQueryPrimitiveArrayStringValidate
 // MethodQueryPrimitiveArrayStringValidate server.
-func EncodeMethodQueryPrimitiveArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryPrimitiveArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.([]string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveArrayStringValidate", "MethodQueryPrimitiveArrayStringValidate", "[]string", v)
@@ -1283,8 +1283,8 @@ func EncodeMethodQueryPrimitiveArrayStringValidateRequest(encoder func(*http.Req
 var PayloadQueryPrimitiveArrayBoolValidateEncodeCode = `// EncodeMethodQueryPrimitiveArrayBoolValidateRequest returns an encoder for
 // requests sent to the ServiceQueryPrimitiveArrayBoolValidate
 // MethodQueryPrimitiveArrayBoolValidate server.
-func EncodeMethodQueryPrimitiveArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryPrimitiveArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.([]bool)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveArrayBoolValidate", "MethodQueryPrimitiveArrayBoolValidate", "[]bool", v)
@@ -1304,8 +1304,8 @@ var PayloadQueryPrimitiveMapStringArrayStringValidateEncodeCode = `// EncodeMeth
 // encoder for requests sent to the
 // ServiceQueryPrimitiveMapStringArrayStringValidate
 // MethodQueryPrimitiveMapStringArrayStringValidate server.
-func EncodeMethodQueryPrimitiveMapStringArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryPrimitiveMapStringArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(map[string][]string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveMapStringArrayStringValidate", "MethodQueryPrimitiveMapStringArrayStringValidate", "map[string][]string", v)
@@ -1324,8 +1324,8 @@ func EncodeMethodQueryPrimitiveMapStringArrayStringValidateRequest(encoder func(
 var PayloadQueryPrimitiveMapStringBoolValidateEncodeCode = `// EncodeMethodQueryPrimitiveMapStringBoolValidateRequest returns an encoder
 // for requests sent to the ServiceQueryPrimitiveMapStringBoolValidate
 // MethodQueryPrimitiveMapStringBoolValidate server.
-func EncodeMethodQueryPrimitiveMapStringBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryPrimitiveMapStringBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(map[string]bool)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveMapStringBoolValidate", "MethodQueryPrimitiveMapStringBoolValidate", "map[string]bool", v)
@@ -1345,8 +1345,8 @@ func EncodeMethodQueryPrimitiveMapStringBoolValidateRequest(encoder func(*http.R
 var PayloadQueryPrimitiveMapBoolArrayBoolValidateEncodeCode = `// EncodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest returns an encoder
 // for requests sent to the ServiceQueryPrimitiveMapBoolArrayBoolValidate
 // MethodQueryPrimitiveMapBoolArrayBoolValidate server.
-func EncodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(map[bool][]bool)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveMapBoolArrayBoolValidate", "MethodQueryPrimitiveMapBoolArrayBoolValidate", "map[bool][]bool", v)
@@ -1369,8 +1369,8 @@ func EncodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(encoder func(*htt
 var PayloadQueryMapStringMapIntStringValidateEncodeCode = `// EncodeMethodQueryMapStringMapIntStringValidateRequest returns an encoder for
 // requests sent to the ServiceQueryMapStringMapIntStringValidate
 // MethodQueryMapStringMapIntStringValidate server.
-func EncodeMethodQueryMapStringMapIntStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapStringMapIntStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(map[string]map[int]string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapStringMapIntStringValidate", "MethodQueryMapStringMapIntStringValidate", "map[string]map[int]string", v)
@@ -1393,8 +1393,8 @@ func EncodeMethodQueryMapStringMapIntStringValidateRequest(encoder func(*http.Re
 var PayloadQueryMapIntMapStringArrayIntValidateEncodeCode = `// EncodeMethodQueryMapIntMapStringArrayIntValidateRequest returns an encoder
 // for requests sent to the ServiceQueryMapIntMapStringArrayIntValidate
 // MethodQueryMapIntMapStringArrayIntValidate server.
-func EncodeMethodQueryMapIntMapStringArrayIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryMapIntMapStringArrayIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(map[int]map[string][]int)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapIntMapStringArrayIntValidate", "MethodQueryMapIntMapStringArrayIntValidate", "map[int]map[string][]int", v)
@@ -1419,8 +1419,8 @@ func EncodeMethodQueryMapIntMapStringArrayIntValidateRequest(encoder func(*http.
 
 var PayloadQueryStringMappedEncodeCode = `// EncodeMethodQueryStringMappedRequest returns an encoder for requests sent to
 // the ServiceQueryStringMapped MethodQueryStringMapped server.
-func EncodeMethodQueryStringMappedRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryStringMappedRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerystringmapped.MethodQueryStringMappedPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryStringMapped", "MethodQueryStringMapped", "*servicequerystringmapped.MethodQueryStringMappedPayload", v)
@@ -1437,8 +1437,8 @@ func EncodeMethodQueryStringMappedRequest(encoder func(*http.Request) goahttp.En
 
 var PayloadQueryStringDefaultEncodeCode = `// EncodeMethodQueryStringDefaultRequest returns an encoder for requests sent
 // to the ServiceQueryStringDefault MethodQueryStringDefault server.
-func EncodeMethodQueryStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerystringdefault.MethodQueryStringDefaultPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryStringDefault", "MethodQueryStringDefault", "*servicequerystringdefault.MethodQueryStringDefaultPayload", v)
@@ -1454,8 +1454,8 @@ func EncodeMethodQueryStringDefaultRequest(encoder func(*http.Request) goahttp.E
 var PayloadQueryPrimitiveStringDefaultEncodeCode = `// EncodeMethodQueryPrimitiveStringDefaultRequest returns an encoder for
 // requests sent to the ServiceQueryPrimitiveStringDefault
 // MethodQueryPrimitiveStringDefault server.
-func EncodeMethodQueryPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodQueryPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryPrimitiveStringDefault", "MethodQueryPrimitiveStringDefault", "string", v)
@@ -1471,8 +1471,8 @@ func EncodeMethodQueryPrimitiveStringDefaultRequest(encoder func(*http.Request) 
 var PayloadJWTAuthorizationQueryEncodeCode = `// EncodeMethodHeaderPrimitiveStringDefaultRequest returns an encoder for
 // requests sent to the ServiceHeaderPrimitiveStringDefault
 // MethodHeaderPrimitiveStringDefault server.
-func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringDefault", "MethodHeaderPrimitiveStringDefault", "*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload", v)
@@ -1489,8 +1489,8 @@ func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request)
 
 var PayloadHeaderStringEncodeCode = `// EncodeMethodHeaderStringRequest returns an encoder for requests sent to the
 // ServiceHeaderString MethodHeaderString server.
-func EncodeMethodHeaderStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderstring.MethodHeaderStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderString", "MethodHeaderString", "*serviceheaderstring.MethodHeaderStringPayload", v)
@@ -1506,8 +1506,8 @@ func EncodeMethodHeaderStringRequest(encoder func(*http.Request) goahttp.Encoder
 
 var PayloadHeaderStringValidateEncodeCode = `// EncodeMethodHeaderStringValidateRequest returns an encoder for requests sent
 // to the ServiceHeaderStringValidate MethodHeaderStringValidate server.
-func EncodeMethodHeaderStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderstringvalidate.MethodHeaderStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderStringValidate", "MethodHeaderStringValidate", "*serviceheaderstringvalidate.MethodHeaderStringValidatePayload", v)
@@ -1523,8 +1523,8 @@ func EncodeMethodHeaderStringValidateRequest(encoder func(*http.Request) goahttp
 
 var PayloadHeaderArrayStringEncodeCode = `// EncodeMethodHeaderArrayStringRequest returns an encoder for requests sent to
 // the ServiceHeaderArrayString MethodHeaderArrayString server.
-func EncodeMethodHeaderArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderarraystring.MethodHeaderArrayStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderArrayString", "MethodHeaderArrayString", "*serviceheaderarraystring.MethodHeaderArrayStringPayload", v)
@@ -1543,8 +1543,8 @@ func EncodeMethodHeaderArrayStringRequest(encoder func(*http.Request) goahttp.En
 var PayloadHeaderArrayStringValidateEncodeCode = `// EncodeMethodHeaderArrayStringValidateRequest returns an encoder for requests
 // sent to the ServiceHeaderArrayStringValidate MethodHeaderArrayStringValidate
 // server.
-func EncodeMethodHeaderArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderarraystringvalidate.MethodHeaderArrayStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderArrayStringValidate", "MethodHeaderArrayStringValidate", "*serviceheaderarraystringvalidate.MethodHeaderArrayStringValidatePayload", v)
@@ -1562,8 +1562,8 @@ func EncodeMethodHeaderArrayStringValidateRequest(encoder func(*http.Request) go
 
 var PayloadHeaderIntEncodeCode = `// EncodeMethodHeaderIntRequest returns an encoder for requests sent to the
 // ServiceHeaderInt MethodHeaderInt server.
-func EncodeMethodHeaderIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderint.MethodHeaderIntPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderInt", "MethodHeaderInt", "*serviceheaderint.MethodHeaderIntPayload", v)
@@ -1580,8 +1580,8 @@ func EncodeMethodHeaderIntRequest(encoder func(*http.Request) goahttp.Encoder) f
 
 var PayloadHeaderIntValidateEncodeCode = `// EncodeMethodHeaderIntValidateRequest returns an encoder for requests sent to
 // the ServiceHeaderIntValidate MethodHeaderIntValidate server.
-func EncodeMethodHeaderIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderintvalidate.MethodHeaderIntValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderIntValidate", "MethodHeaderIntValidate", "*serviceheaderintvalidate.MethodHeaderIntValidatePayload", v)
@@ -1598,8 +1598,8 @@ func EncodeMethodHeaderIntValidateRequest(encoder func(*http.Request) goahttp.En
 
 var PayloadHeaderArrayIntEncodeCode = `// EncodeMethodHeaderArrayIntRequest returns an encoder for requests sent to
 // the ServiceHeaderArrayInt MethodHeaderArrayInt server.
-func EncodeMethodHeaderArrayIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderArrayIntRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderarrayint.MethodHeaderArrayIntPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderArrayInt", "MethodHeaderArrayInt", "*serviceheaderarrayint.MethodHeaderArrayIntPayload", v)
@@ -1619,8 +1619,8 @@ func EncodeMethodHeaderArrayIntRequest(encoder func(*http.Request) goahttp.Encod
 var PayloadHeaderArrayIntValidateEncodeCode = `// EncodeMethodHeaderArrayIntValidateRequest returns an encoder for requests
 // sent to the ServiceHeaderArrayIntValidate MethodHeaderArrayIntValidate
 // server.
-func EncodeMethodHeaderArrayIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderArrayIntValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderarrayintvalidate.MethodHeaderArrayIntValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderArrayIntValidate", "MethodHeaderArrayIntValidate", "*serviceheaderarrayintvalidate.MethodHeaderArrayIntValidatePayload", v)
@@ -1640,8 +1640,8 @@ func EncodeMethodHeaderArrayIntValidateRequest(encoder func(*http.Request) goaht
 var PayloadHeaderPrimitiveStringValidateEncodeCode = `// EncodeMethodHeaderPrimitiveStringValidateRequest returns an encoder for
 // requests sent to the ServiceHeaderPrimitiveStringValidate
 // MethodHeaderPrimitiveStringValidate server.
-func EncodeMethodHeaderPrimitiveStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderPrimitiveStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringValidate", "MethodHeaderPrimitiveStringValidate", "string", v)
@@ -1654,8 +1654,8 @@ func EncodeMethodHeaderPrimitiveStringValidateRequest(encoder func(*http.Request
 var PayloadHeaderPrimitiveBoolValidateEncodeCode = `// EncodeMethodHeaderPrimitiveBoolValidateRequest returns an encoder for
 // requests sent to the ServiceHeaderPrimitiveBoolValidate
 // MethodHeaderPrimitiveBoolValidate server.
-func EncodeMethodHeaderPrimitiveBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderPrimitiveBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(bool)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveBoolValidate", "MethodHeaderPrimitiveBoolValidate", "bool", v)
@@ -1668,8 +1668,8 @@ func EncodeMethodHeaderPrimitiveBoolValidateRequest(encoder func(*http.Request) 
 var PayloadHeaderPrimitiveArrayStringValidateEncodeCode = `// EncodeMethodHeaderPrimitiveArrayStringValidateRequest returns an encoder for
 // requests sent to the ServiceHeaderPrimitiveArrayStringValidate
 // MethodHeaderPrimitiveArrayStringValidate server.
-func EncodeMethodHeaderPrimitiveArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderPrimitiveArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.([]string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveArrayStringValidate", "MethodHeaderPrimitiveArrayStringValidate", "[]string", v)
@@ -1682,8 +1682,8 @@ func EncodeMethodHeaderPrimitiveArrayStringValidateRequest(encoder func(*http.Re
 var PayloadHeaderPrimitiveArrayBoolValidateEncodeCode = `// EncodeMethodHeaderPrimitiveArrayBoolValidateRequest returns an encoder for
 // requests sent to the ServiceHeaderPrimitiveArrayBoolValidate
 // MethodHeaderPrimitiveArrayBoolValidate server.
-func EncodeMethodHeaderPrimitiveArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderPrimitiveArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.([]bool)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveArrayBoolValidate", "MethodHeaderPrimitiveArrayBoolValidate", "[]bool", v)
@@ -1695,8 +1695,8 @@ func EncodeMethodHeaderPrimitiveArrayBoolValidateRequest(encoder func(*http.Requ
 
 var PayloadHeaderStringDefaultEncodeCode = `// EncodeMethodHeaderStringDefaultRequest returns an encoder for requests sent
 // to the ServiceHeaderStringDefault MethodHeaderStringDefault server.
-func EncodeMethodHeaderStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderstringdefault.MethodHeaderStringDefaultPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderStringDefault", "MethodHeaderStringDefault", "*serviceheaderstringdefault.MethodHeaderStringDefaultPayload", v)
@@ -1713,8 +1713,8 @@ func EncodeMethodHeaderStringDefaultRequest(encoder func(*http.Request) goahttp.
 var PayloadHeaderPrimitiveStringDefaultEncodeCode = `// EncodeMethodHeaderPrimitiveStringDefaultRequest returns an encoder for
 // requests sent to the ServiceHeaderPrimitiveStringDefault
 // MethodHeaderPrimitiveStringDefault server.
-func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringDefault", "MethodHeaderPrimitiveStringDefault", "string", v)
@@ -1727,8 +1727,8 @@ func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request)
 var PayloadJWTAuthorizationHeaderEncodeCode = `// EncodeMethodHeaderPrimitiveStringDefaultRequest returns an encoder for
 // requests sent to the ServiceHeaderPrimitiveStringDefault
 // MethodHeaderPrimitiveStringDefault server.
-func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringDefault", "MethodHeaderPrimitiveStringDefault", "*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload", v)
@@ -1749,8 +1749,8 @@ func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request)
 var PayloadJWTAuthorizationCustomHeaderEncodeCode = `// EncodeMethodHeaderPrimitiveStringDefaultRequest returns an encoder for
 // requests sent to the ServiceHeaderPrimitiveStringDefault
 // MethodHeaderPrimitiveStringDefault server.
-func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceHeaderPrimitiveStringDefault", "MethodHeaderPrimitiveStringDefault", "*serviceheaderprimitivestringdefault.MethodHeaderPrimitiveStringDefaultPayload", v)
@@ -1766,8 +1766,8 @@ func EncodeMethodHeaderPrimitiveStringDefaultRequest(encoder func(*http.Request)
 
 var PayloadBodyStringEncodeCode = `// EncodeMethodBodyStringRequest returns an encoder for requests sent to the
 // ServiceBodyString MethodBodyString server.
-func EncodeMethodBodyStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodystring.MethodBodyStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyString", "MethodBodyString", "*servicebodystring.MethodBodyStringPayload", v)
@@ -1783,8 +1783,8 @@ func EncodeMethodBodyStringRequest(encoder func(*http.Request) goahttp.Encoder) 
 
 var PayloadBodyStringValidateEncodeCode = `// EncodeMethodBodyStringValidateRequest returns an encoder for requests sent
 // to the ServiceBodyStringValidate MethodBodyStringValidate server.
-func EncodeMethodBodyStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodystringvalidate.MethodBodyStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyStringValidate", "MethodBodyStringValidate", "*servicebodystringvalidate.MethodBodyStringValidatePayload", v)
@@ -1800,8 +1800,8 @@ func EncodeMethodBodyStringValidateRequest(encoder func(*http.Request) goahttp.E
 
 var PayloadBodyUserEncodeCode = `// EncodeMethodBodyUserRequest returns an encoder for requests sent to the
 // ServiceBodyUser MethodBodyUser server.
-func EncodeMethodBodyUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyuser.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyUser", "MethodBodyUser", "*servicebodyuser.PayloadType", v)
@@ -1817,8 +1817,8 @@ func EncodeMethodBodyUserRequest(encoder func(*http.Request) goahttp.Encoder) fu
 
 var PayloadBodyUserValidateEncodeCode = `// EncodeMethodBodyUserValidateRequest returns an encoder for requests sent to
 // the ServiceBodyUserValidate MethodBodyUserValidate server.
-func EncodeMethodBodyUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyuservalidate.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyUserValidate", "MethodBodyUserValidate", "*servicebodyuservalidate.PayloadType", v)
@@ -1834,8 +1834,8 @@ func EncodeMethodBodyUserValidateRequest(encoder func(*http.Request) goahttp.Enc
 
 var PayloadBodyArrayStringEncodeCode = `// EncodeMethodBodyArrayStringRequest returns an encoder for requests sent to
 // the ServiceBodyArrayString MethodBodyArrayString server.
-func EncodeMethodBodyArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyArrayStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyarraystring.MethodBodyArrayStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyArrayString", "MethodBodyArrayString", "*servicebodyarraystring.MethodBodyArrayStringPayload", v)
@@ -1852,8 +1852,8 @@ func EncodeMethodBodyArrayStringRequest(encoder func(*http.Request) goahttp.Enco
 var PayloadBodyArrayStringValidateEncodeCode = `// EncodeMethodBodyArrayStringValidateRequest returns an encoder for requests
 // sent to the ServiceBodyArrayStringValidate MethodBodyArrayStringValidate
 // server.
-func EncodeMethodBodyArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyarraystringvalidate.MethodBodyArrayStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyArrayStringValidate", "MethodBodyArrayStringValidate", "*servicebodyarraystringvalidate.MethodBodyArrayStringValidatePayload", v)
@@ -1869,8 +1869,8 @@ func EncodeMethodBodyArrayStringValidateRequest(encoder func(*http.Request) goah
 
 var PayloadBodyArrayUserEncodeCode = `// EncodeMethodBodyArrayUserRequest returns an encoder for requests sent to the
 // ServiceBodyArrayUser MethodBodyArrayUser server.
-func EncodeMethodBodyArrayUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyArrayUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyarrayuser.MethodBodyArrayUserPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyArrayUser", "MethodBodyArrayUser", "*servicebodyarrayuser.MethodBodyArrayUserPayload", v)
@@ -1886,8 +1886,8 @@ func EncodeMethodBodyArrayUserRequest(encoder func(*http.Request) goahttp.Encode
 
 var PayloadBodyArrayUserValidateEncodeCode = `// EncodeMethodBodyArrayUserValidateRequest returns an encoder for requests
 // sent to the ServiceBodyArrayUserValidate MethodBodyArrayUserValidate server.
-func EncodeMethodBodyArrayUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyArrayUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyarrayuservalidate.MethodBodyArrayUserValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyArrayUserValidate", "MethodBodyArrayUserValidate", "*servicebodyarrayuservalidate.MethodBodyArrayUserValidatePayload", v)
@@ -1903,8 +1903,8 @@ func EncodeMethodBodyArrayUserValidateRequest(encoder func(*http.Request) goahtt
 
 var PayloadBodyMapStringEncodeCode = `// EncodeMethodBodyMapStringRequest returns an encoder for requests sent to the
 // ServiceBodyMapString MethodBodyMapString server.
-func EncodeMethodBodyMapStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyMapStringRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodymapstring.MethodBodyMapStringPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyMapString", "MethodBodyMapString", "*servicebodymapstring.MethodBodyMapStringPayload", v)
@@ -1920,8 +1920,8 @@ func EncodeMethodBodyMapStringRequest(encoder func(*http.Request) goahttp.Encode
 
 var PayloadBodyMapStringValidateEncodeCode = `// EncodeMethodBodyMapStringValidateRequest returns an encoder for requests
 // sent to the ServiceBodyMapStringValidate MethodBodyMapStringValidate server.
-func EncodeMethodBodyMapStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyMapStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodymapstringvalidate.MethodBodyMapStringValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyMapStringValidate", "MethodBodyMapStringValidate", "*servicebodymapstringvalidate.MethodBodyMapStringValidatePayload", v)
@@ -1937,8 +1937,8 @@ func EncodeMethodBodyMapStringValidateRequest(encoder func(*http.Request) goahtt
 
 var PayloadBodyMapUserEncodeCode = `// EncodeMethodBodyMapUserRequest returns an encoder for requests sent to the
 // ServiceBodyMapUser MethodBodyMapUser server.
-func EncodeMethodBodyMapUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyMapUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodymapuser.MethodBodyMapUserPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyMapUser", "MethodBodyMapUser", "*servicebodymapuser.MethodBodyMapUserPayload", v)
@@ -1954,8 +1954,8 @@ func EncodeMethodBodyMapUserRequest(encoder func(*http.Request) goahttp.Encoder)
 
 var PayloadBodyMapUserValidateEncodeCode = `// EncodeMethodBodyMapUserValidateRequest returns an encoder for requests sent
 // to the ServiceBodyMapUserValidate MethodBodyMapUserValidate server.
-func EncodeMethodBodyMapUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyMapUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodymapuservalidate.MethodBodyMapUserValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyMapUserValidate", "MethodBodyMapUserValidate", "*servicebodymapuservalidate.MethodBodyMapUserValidatePayload", v)
@@ -1972,8 +1972,8 @@ func EncodeMethodBodyMapUserValidateRequest(encoder func(*http.Request) goahttp.
 var PayloadBodyPrimitiveStringValidateEncodeCode = `// EncodeMethodBodyPrimitiveStringValidateRequest returns an encoder for
 // requests sent to the ServiceBodyPrimitiveStringValidate
 // MethodBodyPrimitiveStringValidate server.
-func EncodeMethodBodyPrimitiveStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPrimitiveStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPrimitiveStringValidate", "MethodBodyPrimitiveStringValidate", "string", v)
@@ -1990,8 +1990,8 @@ func EncodeMethodBodyPrimitiveStringValidateRequest(encoder func(*http.Request) 
 var PayloadBodyPrimitiveBoolValidateEncodeCode = `// EncodeMethodBodyPrimitiveBoolValidateRequest returns an encoder for requests
 // sent to the ServiceBodyPrimitiveBoolValidate MethodBodyPrimitiveBoolValidate
 // server.
-func EncodeMethodBodyPrimitiveBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPrimitiveBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(bool)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPrimitiveBoolValidate", "MethodBodyPrimitiveBoolValidate", "bool", v)
@@ -2008,8 +2008,8 @@ func EncodeMethodBodyPrimitiveBoolValidateRequest(encoder func(*http.Request) go
 var PayloadBodyPrimitiveArrayStringValidateEncodeCode = `// EncodeMethodBodyPrimitiveArrayStringValidateRequest returns an encoder for
 // requests sent to the ServiceBodyPrimitiveArrayStringValidate
 // MethodBodyPrimitiveArrayStringValidate server.
-func EncodeMethodBodyPrimitiveArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPrimitiveArrayStringValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.([]string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPrimitiveArrayStringValidate", "MethodBodyPrimitiveArrayStringValidate", "[]string", v)
@@ -2026,8 +2026,8 @@ func EncodeMethodBodyPrimitiveArrayStringValidateRequest(encoder func(*http.Requ
 var PayloadBodyPrimitiveArrayBoolValidateEncodeCode = `// EncodeMethodBodyPrimitiveArrayBoolValidateRequest returns an encoder for
 // requests sent to the ServiceBodyPrimitiveArrayBoolValidate
 // MethodBodyPrimitiveArrayBoolValidate server.
-func EncodeMethodBodyPrimitiveArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPrimitiveArrayBoolValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.([]bool)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPrimitiveArrayBoolValidate", "MethodBodyPrimitiveArrayBoolValidate", "[]bool", v)
@@ -2044,8 +2044,8 @@ func EncodeMethodBodyPrimitiveArrayBoolValidateRequest(encoder func(*http.Reques
 var PayloadBodyPrimitiveArrayUserValidateEncodeCode = `// EncodeMethodBodyPrimitiveArrayUserValidateRequest returns an encoder for
 // requests sent to the ServiceBodyPrimitiveArrayUserValidate
 // MethodBodyPrimitiveArrayUserValidate server.
-func EncodeMethodBodyPrimitiveArrayUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPrimitiveArrayUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.([]*servicebodyprimitivearrayuservalidate.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPrimitiveArrayUserValidate", "MethodBodyPrimitiveArrayUserValidate", "[]*servicebodyprimitivearrayuservalidate.PayloadType", v)
@@ -2062,8 +2062,8 @@ func EncodeMethodBodyPrimitiveArrayUserValidateRequest(encoder func(*http.Reques
 var PayloadBodyPrimitiveFieldArrayUserEncodeCode = `// EncodeMethodBodyPrimitiveArrayUserRequest returns an encoder for requests
 // sent to the ServiceBodyPrimitiveArrayUser MethodBodyPrimitiveArrayUser
 // server.
-func EncodeMethodBodyPrimitiveArrayUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPrimitiveArrayUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyprimitivearrayuser.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPrimitiveArrayUser", "MethodBodyPrimitiveArrayUser", "*servicebodyprimitivearrayuser.PayloadType", v)
@@ -2080,8 +2080,8 @@ func EncodeMethodBodyPrimitiveArrayUserRequest(encoder func(*http.Request) goaht
 var PayloadBodyPrimitiveFieldArrayUserValidateEncodeCode = `// EncodeMethodBodyPrimitiveArrayUserValidateRequest returns an encoder for
 // requests sent to the ServiceBodyPrimitiveArrayUserValidate
 // MethodBodyPrimitiveArrayUserValidate server.
-func EncodeMethodBodyPrimitiveArrayUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPrimitiveArrayUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyprimitivearrayuservalidate.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPrimitiveArrayUserValidate", "MethodBodyPrimitiveArrayUserValidate", "*servicebodyprimitivearrayuservalidate.PayloadType", v)
@@ -2097,8 +2097,8 @@ func EncodeMethodBodyPrimitiveArrayUserValidateRequest(encoder func(*http.Reques
 
 var PayloadBodyQueryObjectEncodeCode = `// EncodeMethodBodyQueryObjectRequest returns an encoder for requests sent to
 // the ServiceBodyQueryObject MethodBodyQueryObject server.
-func EncodeMethodBodyQueryObjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyQueryObjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyqueryobject.MethodBodyQueryObjectPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyQueryObject", "MethodBodyQueryObject", "*servicebodyqueryobject.MethodBodyQueryObjectPayload", v)
@@ -2120,8 +2120,8 @@ func EncodeMethodBodyQueryObjectRequest(encoder func(*http.Request) goahttp.Enco
 var PayloadBodyQueryObjectValidateEncodeCode = `// EncodeMethodBodyQueryObjectValidateRequest returns an encoder for requests
 // sent to the ServiceBodyQueryObjectValidate MethodBodyQueryObjectValidate
 // server.
-func EncodeMethodBodyQueryObjectValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyQueryObjectValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyqueryobjectvalidate.MethodBodyQueryObjectValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyQueryObjectValidate", "MethodBodyQueryObjectValidate", "*servicebodyqueryobjectvalidate.MethodBodyQueryObjectValidatePayload", v)
@@ -2140,8 +2140,8 @@ func EncodeMethodBodyQueryObjectValidateRequest(encoder func(*http.Request) goah
 
 var PayloadBodyQueryUserEncodeCode = `// EncodeMethodBodyQueryUserRequest returns an encoder for requests sent to the
 // ServiceBodyQueryUser MethodBodyQueryUser server.
-func EncodeMethodBodyQueryUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyQueryUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyqueryuser.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyQueryUser", "MethodBodyQueryUser", "*servicebodyqueryuser.PayloadType", v)
@@ -2162,8 +2162,8 @@ func EncodeMethodBodyQueryUserRequest(encoder func(*http.Request) goahttp.Encode
 
 var PayloadBodyQueryUserValidateEncodeCode = `// EncodeMethodBodyQueryUserValidateRequest returns an encoder for requests
 // sent to the ServiceBodyQueryUserValidate MethodBodyQueryUserValidate server.
-func EncodeMethodBodyQueryUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyQueryUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyqueryuservalidate.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyQueryUserValidate", "MethodBodyQueryUserValidate", "*servicebodyqueryuservalidate.PayloadType", v)
@@ -2182,8 +2182,8 @@ func EncodeMethodBodyQueryUserValidateRequest(encoder func(*http.Request) goahtt
 
 var PayloadBodyPathObjectEncodeCode = `// EncodeMethodBodyPathObjectRequest returns an encoder for requests sent to
 // the ServiceBodyPathObject MethodBodyPathObject server.
-func EncodeMethodBodyPathObjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPathObjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodypathobject.MethodBodyPathObjectPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPathObject", "MethodBodyPathObject", "*servicebodypathobject.MethodBodyPathObjectPayload", v)
@@ -2200,8 +2200,8 @@ func EncodeMethodBodyPathObjectRequest(encoder func(*http.Request) goahttp.Encod
 var PayloadBodyPathObjectValidateEncodeCode = `// EncodeMethodBodyPathObjectValidateRequest returns an encoder for requests
 // sent to the ServiceBodyPathObjectValidate MethodBodyPathObjectValidate
 // server.
-func EncodeMethodBodyPathObjectValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPathObjectValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodypathobjectvalidate.MethodBodyPathObjectValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPathObjectValidate", "MethodBodyPathObjectValidate", "*servicebodypathobjectvalidate.MethodBodyPathObjectValidatePayload", v)
@@ -2217,8 +2217,8 @@ func EncodeMethodBodyPathObjectValidateRequest(encoder func(*http.Request) goaht
 
 var PayloadBodyPathUserEncodeCode = `// EncodeMethodBodyPathUserRequest returns an encoder for requests sent to the
 // ServiceBodyPathUser MethodBodyPathUser server.
-func EncodeMethodBodyPathUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyPathUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodypathuser.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPathUser", "MethodBodyPathUser", "*servicebodypathuser.PayloadType", v)
@@ -2234,8 +2234,8 @@ func EncodeMethodBodyPathUserRequest(encoder func(*http.Request) goahttp.Encoder
 
 var PayloadBodyPathUserValidateEncodeCode = `// EncodeMethodUserBodyPathValidateRequest returns an encoder for requests sent
 // to the ServiceBodyPathUserValidate MethodUserBodyPathValidate server.
-func EncodeMethodUserBodyPathValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodUserBodyPathValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodypathuservalidate.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyPathUserValidate", "MethodUserBodyPathValidate", "*servicebodypathuservalidate.PayloadType", v)
@@ -2251,8 +2251,8 @@ func EncodeMethodUserBodyPathValidateRequest(encoder func(*http.Request) goahttp
 
 var PayloadBodyQueryPathObjectEncodeCode = `// EncodeMethodBodyQueryPathObjectRequest returns an encoder for requests sent
 // to the ServiceBodyQueryPathObject MethodBodyQueryPathObject server.
-func EncodeMethodBodyQueryPathObjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyQueryPathObjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyquerypathobject.MethodBodyQueryPathObjectPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyQueryPathObject", "MethodBodyQueryPathObject", "*servicebodyquerypathobject.MethodBodyQueryPathObjectPayload", v)
@@ -2274,8 +2274,8 @@ func EncodeMethodBodyQueryPathObjectRequest(encoder func(*http.Request) goahttp.
 var PayloadBodyQueryPathObjectValidateEncodeCode = `// EncodeMethodBodyQueryPathObjectValidateRequest returns an encoder for
 // requests sent to the ServiceBodyQueryPathObjectValidate
 // MethodBodyQueryPathObjectValidate server.
-func EncodeMethodBodyQueryPathObjectValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyQueryPathObjectValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyquerypathobjectvalidate.MethodBodyQueryPathObjectValidatePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyQueryPathObjectValidate", "MethodBodyQueryPathObjectValidate", "*servicebodyquerypathobjectvalidate.MethodBodyQueryPathObjectValidatePayload", v)
@@ -2294,8 +2294,8 @@ func EncodeMethodBodyQueryPathObjectValidateRequest(encoder func(*http.Request) 
 
 var PayloadBodyQueryPathUserEncodeCode = `// EncodeMethodBodyQueryPathUserRequest returns an encoder for requests sent to
 // the ServiceBodyQueryPathUser MethodBodyQueryPathUser server.
-func EncodeMethodBodyQueryPathUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyQueryPathUserRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyquerypathuser.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyQueryPathUser", "MethodBodyQueryPathUser", "*servicebodyquerypathuser.PayloadType", v)
@@ -2317,8 +2317,8 @@ func EncodeMethodBodyQueryPathUserRequest(encoder func(*http.Request) goahttp.En
 var PayloadBodyQueryPathUserValidateEncodeCode = `// EncodeMethodBodyQueryPathUserValidateRequest returns an encoder for requests
 // sent to the ServiceBodyQueryPathUserValidate MethodBodyQueryPathUserValidate
 // server.
-func EncodeMethodBodyQueryPathUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodBodyQueryPathUserValidateRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicebodyquerypathuservalidate.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceBodyQueryPathUserValidate", "MethodBodyQueryPathUserValidate", "*servicebodyquerypathuservalidate.PayloadType", v)
@@ -2337,8 +2337,8 @@ func EncodeMethodBodyQueryPathUserValidateRequest(encoder func(*http.Request) go
 
 var PayloadMapQueryPrimitivePrimitiveEncodeCode = `// EncodeMapQueryPrimitivePrimitiveRequest returns an encoder for requests sent
 // to the ServiceMapQueryPrimitivePrimitive MapQueryPrimitivePrimitive server.
-func EncodeMapQueryPrimitivePrimitiveRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMapQueryPrimitivePrimitiveRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(map[string]string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceMapQueryPrimitivePrimitive", "MapQueryPrimitivePrimitive", "map[string]string", v)
@@ -2357,8 +2357,8 @@ func EncodeMapQueryPrimitivePrimitiveRequest(encoder func(*http.Request) goahttp
 
 var PayloadMapQueryPrimitiveArrayEncodeCode = `// EncodeMapQueryPrimitiveArrayRequest returns an encoder for requests sent to
 // the ServiceMapQueryPrimitiveArray MapQueryPrimitiveArray server.
-func EncodeMapQueryPrimitiveArrayRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMapQueryPrimitiveArrayRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(map[string][]uint)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceMapQueryPrimitiveArray", "MapQueryPrimitiveArray", "map[string][]uint", v)
@@ -2379,8 +2379,8 @@ func EncodeMapQueryPrimitiveArrayRequest(encoder func(*http.Request) goahttp.Enc
 
 var PayloadMapQueryObjectEncodeCode = `// EncodeMethodMapQueryObjectRequest returns an encoder for requests sent to
 // the ServiceMapQueryObject MethodMapQueryObject server.
-func EncodeMethodMapQueryObjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodMapQueryObjectRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicemapqueryobject.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceMapQueryObject", "MethodMapQueryObject", "*servicemapqueryobject.PayloadType", v)
@@ -2405,8 +2405,8 @@ func EncodeMethodMapQueryObjectRequest(encoder func(*http.Request) goahttp.Encod
 
 var PayloadMultipartBodyPrimitiveEncodeCode = `// EncodeMethodMultipartPrimitiveRequest returns an encoder for requests sent
 // to the ServiceMultipartPrimitive MethodMultipartPrimitive server.
-func EncodeMethodMultipartPrimitiveRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodMultipartPrimitiveRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(string)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceMultipartPrimitive", "MethodMultipartPrimitive", "string", v)
@@ -2421,8 +2421,8 @@ func EncodeMethodMultipartPrimitiveRequest(encoder func(*http.Request) goahttp.E
 
 var PayloadMultipartBodyUserTypeEncodeCode = `// EncodeMethodMultipartUserTypeRequest returns an encoder for requests sent to
 // the ServiceMultipartUserType MethodMultipartUserType server.
-func EncodeMethodMultipartUserTypeRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodMultipartUserTypeRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicemultipartusertype.MethodMultipartUserTypePayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceMultipartUserType", "MethodMultipartUserType", "*servicemultipartusertype.MethodMultipartUserTypePayload", v)
@@ -2437,8 +2437,8 @@ func EncodeMethodMultipartUserTypeRequest(encoder func(*http.Request) goahttp.En
 
 var PayloadMultipartBodyArrayTypeEncodeCode = `// EncodeMethodMultipartArrayTypeRequest returns an encoder for requests sent
 // to the ServiceMultipartArrayType MethodMultipartArrayType server.
-func EncodeMethodMultipartArrayTypeRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodMultipartArrayTypeRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.([]*servicemultipartarraytype.PayloadType)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceMultipartArrayType", "MethodMultipartArrayType", "[]*servicemultipartarraytype.PayloadType", v)
@@ -2453,8 +2453,8 @@ func EncodeMethodMultipartArrayTypeRequest(encoder func(*http.Request) goahttp.E
 
 var PayloadMultipartBodyMapTypeEncodeCode = `// EncodeMethodMultipartMapTypeRequest returns an encoder for requests sent to
 // the ServiceMultipartMapType MethodMultipartMapType server.
-func EncodeMethodMultipartMapTypeRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodMultipartMapTypeRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(map[string]int)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceMultipartMapType", "MethodMultipartMapType", "map[string]int", v)
@@ -2469,8 +2469,8 @@ func EncodeMethodMultipartMapTypeRequest(encoder func(*http.Request) goahttp.Enc
 
 var QueryIntAliasEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
 // ServiceQueryIntAlias MethodA server.
-func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryintalias.MethodAPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryIntAlias", "MethodA", "*servicequeryintalias.MethodAPayload", v)
@@ -2493,8 +2493,8 @@ func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 
 var QueryIntAliasValidateEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
 // ServiceQueryIntAliasValidate MethodA server.
-func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryintaliasvalidate.MethodAPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryIntAliasValidate", "MethodA", "*servicequeryintaliasvalidate.MethodAPayload", v)
@@ -2517,8 +2517,8 @@ func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 
 var QueryArrayAliasEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
 // ServiceQueryArrayAlias MethodA server.
-func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayalias.MethodAPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayAlias", "MethodA", "*servicequeryarrayalias.MethodAPayload", v)
@@ -2536,8 +2536,8 @@ func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 
 var QueryArrayAliasValidateEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
 // ServiceQueryArrayAliasValidate MethodA server.
-func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayaliasvalidate.MethodAPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayAliasValidate", "MethodA", "*servicequeryarrayaliasvalidate.MethodAPayload", v)
@@ -2555,8 +2555,8 @@ func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 
 var QueryMapAliasEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
 // ServiceQueryMapAlias MethodA server.
-func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapalias.MethodAPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapAlias", "MethodA", "*servicequerymapalias.MethodAPayload", v)
@@ -2576,8 +2576,8 @@ func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 
 var QueryMapAliasValidateEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
 // ServiceQueryMapAliasValidate MethodA server.
-func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequerymapaliasvalidate.MethodAPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryMapAliasValidate", "MethodA", "*servicequerymapaliasvalidate.MethodAPayload", v)
@@ -2597,8 +2597,8 @@ func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*htt
 
 var QueryArrayNestedAliasValidateEncodeCode = `// EncodeMethodARequest returns an encoder for requests sent to the
 // ServiceQueryArrayAliasValidate MethodA server.
-func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, interface{}) error {
-	return func(req *http.Request, v interface{}) error {
+func EncodeMethodARequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Request, any) error {
+	return func(req *http.Request, v any) error {
 		p, ok := v.(*servicequeryarrayaliasvalidate.MethodAPayload)
 		if !ok {
 			return goahttp.ErrInvalidType("ServiceQueryArrayAliasValidate", "MethodA", "*servicequeryarrayaliasvalidate.MethodAPayload", v)

--- a/http/codegen/testdata/result_decode_functions.go
+++ b/http/codegen/testdata/result_decode_functions.go
@@ -4,8 +4,8 @@ var EmptyServerResponseDecodeCode = `// DecodeMethodEmptyServerResponseResponse 
 // returned by the ServiceEmptyServerResponse MethodEmptyServerResponse
 // endpoint. restoreBody controls whether the response body should be restored
 // after having been read.
-func DecodeMethodEmptyServerResponseResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodEmptyServerResponseResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -34,8 +34,8 @@ var ResultBodyMultipleViewsDecodeCode = `// DecodeMethodBodyMultipleViewResponse
 // returned by the ServiceBodyMultipleView MethodBodyMultipleView endpoint.
 // restoreBody controls whether the response body should be restored after
 // having been read.
-func DecodeMethodBodyMultipleViewResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodBodyMultipleViewResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -85,8 +85,8 @@ var EmptyBodyResultMultipleViewsDecodeCode = `// DecodeMethodEmptyBodyResultMult
 // responses returned by the ServiceEmptyBodyResultMultipleView
 // MethodEmptyBodyResultMultipleView endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
-func DecodeMethodEmptyBodyResultMultipleViewResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodEmptyBodyResultMultipleViewResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -126,8 +126,8 @@ var ExplicitBodyPrimitiveResultDecodeCode = `// DecodeMethodExplicitBodyPrimitiv
 // ServiceExplicitBodyPrimitiveResultMultipleView
 // MethodExplicitBodyPrimitiveResultMultipleView endpoint. restoreBody controls
 // whether the response body should be restored after having been read.
-func DecodeMethodExplicitBodyPrimitiveResultMultipleViewResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodExplicitBodyPrimitiveResultMultipleViewResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -183,8 +183,8 @@ var ExplicitBodyUserResultMultipleViewsDecodeCode = `// DecodeMethodExplicitBody
 // responses returned by the ServiceExplicitBodyUserResultMultipleView
 // MethodExplicitBodyUserResultMultipleView endpoint. restoreBody controls
 // whether the response body should be restored after having been read.
-func DecodeMethodExplicitBodyUserResultMultipleViewResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodExplicitBodyUserResultMultipleViewResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -234,8 +234,8 @@ var ExplicitBodyResultCollectionDecodeCode = `// DecodeMethodExplicitBodyResultC
 // responses returned by the ServiceExplicitBodyResultCollection
 // MethodExplicitBodyResultCollection endpoint. restoreBody controls whether
 // the response body should be restored after having been read.
-func DecodeMethodExplicitBodyResultCollectionResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodExplicitBodyResultCollectionResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -276,8 +276,8 @@ var ResultMultipleViewsTagDecodeCode = `// DecodeMethodTagMultipleViewsResponse 
 // returned by the ServiceTagMultipleViews MethodTagMultipleViews endpoint.
 // restoreBody controls whether the response body should be restored after
 // having been read.
-func DecodeMethodTagMultipleViewsResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodTagMultipleViewsResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -346,8 +346,8 @@ var EmptyServerResponseWithTagsDecodeCode = `// DecodeMethodEmptyServerResponseW
 // responses returned by the ServiceEmptyServerResponseWithTags
 // MethodEmptyServerResponseWithTags endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
-func DecodeMethodEmptyServerResponseWithTagsResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodEmptyServerResponseWithTagsResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -380,8 +380,8 @@ var ResultHeaderStringImplicitResponseDecodeCode = `// DecodeMethodHeaderStringI
 // returned by the ServiceHeaderStringImplicit MethodHeaderStringImplicit
 // endpoint. restoreBody controls whether the response body should be restored
 // after having been read.
-func DecodeMethodHeaderStringImplicitResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodHeaderStringImplicitResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -420,8 +420,8 @@ func DecodeMethodHeaderStringImplicitResponse(decoder func(*http.Response) goaht
 var ResultHeaderStringArrayResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
 // ServiceHeaderStringArrayResponse MethodA endpoint. restoreBody controls
 // whether the response body should be restored after having been read.
-func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -454,8 +454,8 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 var ResultHeaderStringArrayValidateResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
 // ServiceHeaderStringArrayValidateResponse MethodA endpoint. restoreBody
 // controls whether the response body should be restored after having been read.
-func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -495,8 +495,8 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 var ResultHeaderArrayResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
 // ServiceHeaderArrayResponse MethodA endpoint. restoreBody controls whether
 // the response body should be restored after having been read.
-func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -545,8 +545,8 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 var ResultHeaderArrayValidateResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
 // ServiceHeaderArrayValidateResponse MethodA endpoint. restoreBody controls
 // whether the response body should be restored after having been read.
-func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -600,8 +600,8 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 var WithHeadersBlockResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
 // ServiceWithHeadersBlock MethodA endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
-func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -671,8 +671,8 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 var WithHeadersBlockViewedResultResponseDecodeCode = `// DecodeMethodAResponse returns a decoder for responses returned by the
 // ServiceWithHeadersBlockViewedResult MethodA endpoint. restoreBody controls
 // whether the response body should be restored after having been read.
-func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -748,8 +748,8 @@ var ValidateErrorResponseTypeDecodeCode = `// DecodeMethodAResponse returns a de
 // DecodeMethodAResponse may return the following errors:
 //   - "some_error" (type *validateerrorresponsetype.AError): http.StatusBadRequest
 //   - error: internal error
-func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -834,8 +834,8 @@ var EmptyErrorResponseBodyDecodeCode = `// DecodeMethodEmptyErrorResponseBodyRes
 //   - "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
 //   - "not_found" (type serviceemptyerrorresponsebody.NotFound): http.StatusNotFound
 //   - error: internal error
-func DecodeMethodEmptyErrorResponseBodyResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
-	return func(resp *http.Response) (interface{}, error) {
+func DecodeMethodEmptyErrorResponseBodyResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (any, error) {
+	return func(resp *http.Response) (any, error) {
 		if restoreBody {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {

--- a/http/codegen/testdata/result_encode_functions.go
+++ b/http/codegen/testdata/result_encode_functions.go
@@ -2,8 +2,8 @@ package testdata
 
 var ResultHeaderBoolEncodeCode = `// EncodeMethodHeaderBoolResponse returns an encoder for responses returned by
 // the ServiceHeaderBool MethodHeaderBool endpoint.
-func EncodeMethodHeaderBoolResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderBoolResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderbool.MethodHeaderBoolResult)
 		if res.H != nil {
 			val := res.H
@@ -18,8 +18,8 @@ func EncodeMethodHeaderBoolResponse(encoder func(context.Context, http.ResponseW
 
 var ResultHeaderIntEncodeCode = `// EncodeMethodHeaderIntResponse returns an encoder for responses returned by
 // the ServiceHeaderInt MethodHeaderInt endpoint.
-func EncodeMethodHeaderIntResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderIntResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderint.MethodHeaderIntResult)
 		if res.H != nil {
 			val := res.H
@@ -34,8 +34,8 @@ func EncodeMethodHeaderIntResponse(encoder func(context.Context, http.ResponseWr
 
 var ResultHeaderInt32EncodeCode = `// EncodeMethodHeaderInt32Response returns an encoder for responses returned by
 // the ServiceHeaderInt32 MethodHeaderInt32 endpoint.
-func EncodeMethodHeaderInt32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderInt32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderint32.MethodHeaderInt32Result)
 		if res.H != nil {
 			val := res.H
@@ -50,8 +50,8 @@ func EncodeMethodHeaderInt32Response(encoder func(context.Context, http.Response
 
 var ResultHeaderInt64EncodeCode = `// EncodeMethodHeaderInt64Response returns an encoder for responses returned by
 // the ServiceHeaderInt64 MethodHeaderInt64 endpoint.
-func EncodeMethodHeaderInt64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderInt64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderint64.MethodHeaderInt64Result)
 		if res.H != nil {
 			val := res.H
@@ -66,8 +66,8 @@ func EncodeMethodHeaderInt64Response(encoder func(context.Context, http.Response
 
 var ResultHeaderUIntEncodeCode = `// EncodeMethodHeaderUIntResponse returns an encoder for responses returned by
 // the ServiceHeaderUInt MethodHeaderUInt endpoint.
-func EncodeMethodHeaderUIntResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderUIntResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderuint.MethodHeaderUIntResult)
 		if res.H != nil {
 			val := res.H
@@ -82,8 +82,8 @@ func EncodeMethodHeaderUIntResponse(encoder func(context.Context, http.ResponseW
 
 var ResultHeaderUInt32EncodeCode = `// EncodeMethodHeaderUInt32Response returns an encoder for responses returned
 // by the ServiceHeaderUInt32 MethodHeaderUInt32 endpoint.
-func EncodeMethodHeaderUInt32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderUInt32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderuint32.MethodHeaderUInt32Result)
 		if res.H != nil {
 			val := res.H
@@ -98,8 +98,8 @@ func EncodeMethodHeaderUInt32Response(encoder func(context.Context, http.Respons
 
 var ResultHeaderUInt64EncodeCode = `// EncodeMethodHeaderUInt64Response returns an encoder for responses returned
 // by the ServiceHeaderUInt64 MethodHeaderUInt64 endpoint.
-func EncodeMethodHeaderUInt64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderUInt64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderuint64.MethodHeaderUInt64Result)
 		if res.H != nil {
 			val := res.H
@@ -114,8 +114,8 @@ func EncodeMethodHeaderUInt64Response(encoder func(context.Context, http.Respons
 
 var ResultHeaderFloat32EncodeCode = `// EncodeMethodHeaderFloat32Response returns an encoder for responses returned
 // by the ServiceHeaderFloat32 MethodHeaderFloat32 endpoint.
-func EncodeMethodHeaderFloat32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderFloat32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderfloat32.MethodHeaderFloat32Result)
 		if res.H != nil {
 			val := res.H
@@ -130,8 +130,8 @@ func EncodeMethodHeaderFloat32Response(encoder func(context.Context, http.Respon
 
 var ResultHeaderFloat64EncodeCode = `// EncodeMethodHeaderFloat64Response returns an encoder for responses returned
 // by the ServiceHeaderFloat64 MethodHeaderFloat64 endpoint.
-func EncodeMethodHeaderFloat64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderFloat64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderfloat64.MethodHeaderFloat64Result)
 		if res.H != nil {
 			val := res.H
@@ -146,8 +146,8 @@ func EncodeMethodHeaderFloat64Response(encoder func(context.Context, http.Respon
 
 var ResultHeaderStringEncodeCode = `// EncodeMethodHeaderStringResponse returns an encoder for responses returned
 // by the ServiceHeaderString MethodHeaderString endpoint.
-func EncodeMethodHeaderStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderstring.MethodHeaderStringResult)
 		if res.H != nil {
 			w.Header().Set("H", *res.H)
@@ -160,8 +160,8 @@ func EncodeMethodHeaderStringResponse(encoder func(context.Context, http.Respons
 
 var ResultHeaderBytesEncodeCode = `// EncodeMethodHeaderBytesResponse returns an encoder for responses returned by
 // the ServiceHeaderBytes MethodHeaderBytes endpoint.
-func EncodeMethodHeaderBytesResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderBytesResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderbytes.MethodHeaderBytesResult)
 		if res.H != nil {
 			val := res.H
@@ -176,8 +176,8 @@ func EncodeMethodHeaderBytesResponse(encoder func(context.Context, http.Response
 
 var ResultHeaderAnyEncodeCode = `// EncodeMethodHeaderAnyResponse returns an encoder for responses returned by
 // the ServiceHeaderAny MethodHeaderAny endpoint.
-func EncodeMethodHeaderAnyResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderAnyResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderany.MethodHeaderAnyResult)
 		if res.H != nil {
 			val := res.H
@@ -192,8 +192,8 @@ func EncodeMethodHeaderAnyResponse(encoder func(context.Context, http.ResponseWr
 
 var ResultHeaderArrayBoolEncodeCode = `// EncodeMethodHeaderArrayBoolResponse returns an encoder for responses
 // returned by the ServiceHeaderArrayBool MethodHeaderArrayBool endpoint.
-func EncodeMethodHeaderArrayBoolResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayBoolResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarraybool.MethodHeaderArrayBoolResult)
 		if res.H != nil {
 			val := res.H
@@ -213,8 +213,8 @@ func EncodeMethodHeaderArrayBoolResponse(encoder func(context.Context, http.Resp
 
 var ResultHeaderArrayIntEncodeCode = `// EncodeMethodHeaderArrayIntResponse returns an encoder for responses returned
 // by the ServiceHeaderArrayInt MethodHeaderArrayInt endpoint.
-func EncodeMethodHeaderArrayIntResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayIntResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayint.MethodHeaderArrayIntResult)
 		if res.H != nil {
 			val := res.H
@@ -234,8 +234,8 @@ func EncodeMethodHeaderArrayIntResponse(encoder func(context.Context, http.Respo
 
 var ResultHeaderArrayInt32EncodeCode = `// EncodeMethodHeaderArrayInt32Response returns an encoder for responses
 // returned by the ServiceHeaderArrayInt32 MethodHeaderArrayInt32 endpoint.
-func EncodeMethodHeaderArrayInt32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayInt32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayint32.MethodHeaderArrayInt32Result)
 		if res.H != nil {
 			val := res.H
@@ -255,8 +255,8 @@ func EncodeMethodHeaderArrayInt32Response(encoder func(context.Context, http.Res
 
 var ResultHeaderArrayInt64EncodeCode = `// EncodeMethodHeaderArrayInt64Response returns an encoder for responses
 // returned by the ServiceHeaderArrayInt64 MethodHeaderArrayInt64 endpoint.
-func EncodeMethodHeaderArrayInt64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayInt64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayint64.MethodHeaderArrayInt64Result)
 		if res.H != nil {
 			val := res.H
@@ -276,8 +276,8 @@ func EncodeMethodHeaderArrayInt64Response(encoder func(context.Context, http.Res
 
 var ResultHeaderArrayUIntEncodeCode = `// EncodeMethodHeaderArrayUIntResponse returns an encoder for responses
 // returned by the ServiceHeaderArrayUInt MethodHeaderArrayUInt endpoint.
-func EncodeMethodHeaderArrayUIntResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayUIntResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayuint.MethodHeaderArrayUIntResult)
 		if res.H != nil {
 			val := res.H
@@ -297,8 +297,8 @@ func EncodeMethodHeaderArrayUIntResponse(encoder func(context.Context, http.Resp
 
 var ResultHeaderArrayUInt32EncodeCode = `// EncodeMethodHeaderArrayUInt32Response returns an encoder for responses
 // returned by the ServiceHeaderArrayUInt32 MethodHeaderArrayUInt32 endpoint.
-func EncodeMethodHeaderArrayUInt32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayUInt32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayuint32.MethodHeaderArrayUInt32Result)
 		if res.H != nil {
 			val := res.H
@@ -318,8 +318,8 @@ func EncodeMethodHeaderArrayUInt32Response(encoder func(context.Context, http.Re
 
 var ResultHeaderArrayUInt64EncodeCode = `// EncodeMethodHeaderArrayUInt64Response returns an encoder for responses
 // returned by the ServiceHeaderArrayUInt64 MethodHeaderArrayUInt64 endpoint.
-func EncodeMethodHeaderArrayUInt64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayUInt64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayuint64.MethodHeaderArrayUInt64Result)
 		if res.H != nil {
 			val := res.H
@@ -339,8 +339,8 @@ func EncodeMethodHeaderArrayUInt64Response(encoder func(context.Context, http.Re
 
 var ResultHeaderArrayFloat32EncodeCode = `// EncodeMethodHeaderArrayFloat32Response returns an encoder for responses
 // returned by the ServiceHeaderArrayFloat32 MethodHeaderArrayFloat32 endpoint.
-func EncodeMethodHeaderArrayFloat32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayFloat32Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayfloat32.MethodHeaderArrayFloat32Result)
 		if res.H != nil {
 			val := res.H
@@ -360,8 +360,8 @@ func EncodeMethodHeaderArrayFloat32Response(encoder func(context.Context, http.R
 
 var ResultHeaderArrayFloat64EncodeCode = `// EncodeMethodHeaderArrayFloat64Response returns an encoder for responses
 // returned by the ServiceHeaderArrayFloat64 MethodHeaderArrayFloat64 endpoint.
-func EncodeMethodHeaderArrayFloat64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayFloat64Response(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayfloat64.MethodHeaderArrayFloat64Result)
 		if res.H != nil {
 			val := res.H
@@ -381,8 +381,8 @@ func EncodeMethodHeaderArrayFloat64Response(encoder func(context.Context, http.R
 
 var ResultHeaderArrayStringEncodeCode = `// EncodeMethodHeaderArrayStringResponse returns an encoder for responses
 // returned by the ServiceHeaderArrayString MethodHeaderArrayString endpoint.
-func EncodeMethodHeaderArrayStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarraystring.MethodHeaderArrayStringResult)
 		if res.H != nil {
 			val := res.H
@@ -397,8 +397,8 @@ func EncodeMethodHeaderArrayStringResponse(encoder func(context.Context, http.Re
 
 var ResultHeaderArrayBytesEncodeCode = `// EncodeMethodHeaderArrayBytesResponse returns an encoder for responses
 // returned by the ServiceHeaderArrayBytes MethodHeaderArrayBytes endpoint.
-func EncodeMethodHeaderArrayBytesResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayBytesResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarraybytes.MethodHeaderArrayBytesResult)
 		if res.H != nil {
 			val := res.H
@@ -418,8 +418,8 @@ func EncodeMethodHeaderArrayBytesResponse(encoder func(context.Context, http.Res
 
 var ResultHeaderArrayAnyEncodeCode = `// EncodeMethodHeaderArrayAnyResponse returns an encoder for responses returned
 // by the ServiceHeaderArrayAny MethodHeaderArrayAny endpoint.
-func EncodeMethodHeaderArrayAnyResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayAnyResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayany.MethodHeaderArrayAnyResult)
 		if res.H != nil {
 			val := res.H
@@ -439,8 +439,8 @@ func EncodeMethodHeaderArrayAnyResponse(encoder func(context.Context, http.Respo
 
 var ResultHeaderBoolDefaultEncodeCode = `// EncodeMethodHeaderBoolDefaultResponse returns an encoder for responses
 // returned by the ServiceHeaderBoolDefault MethodHeaderBoolDefault endpoint.
-func EncodeMethodHeaderBoolDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderBoolDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderbooldefault.MethodHeaderBoolDefaultResult)
 		{
 			val := res.H
@@ -456,8 +456,8 @@ func EncodeMethodHeaderBoolDefaultResponse(encoder func(context.Context, http.Re
 var ResultHeaderBoolRequiredDefaultEncodeCode = `// EncodeMethodHeaderBoolRequiredDefaultResponse returns an encoder for
 // responses returned by the ServiceHeaderBoolRequiredDefault
 // MethodHeaderBoolRequiredDefault endpoint.
-func EncodeMethodHeaderBoolRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderBoolRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderboolrequireddefault.MethodHeaderBoolRequiredDefaultResult)
 		{
 			val := res.H
@@ -473,8 +473,8 @@ func EncodeMethodHeaderBoolRequiredDefaultResponse(encoder func(context.Context,
 var ResultHeaderStringDefaultEncodeCode = `// EncodeMethodHeaderStringDefaultResponse returns an encoder for responses
 // returned by the ServiceHeaderStringDefault MethodHeaderStringDefault
 // endpoint.
-func EncodeMethodHeaderStringDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderStringDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderstringdefault.MethodHeaderStringDefaultResult)
 		w.Header().Set("H", res.H)
 		w.WriteHeader(http.StatusOK)
@@ -486,8 +486,8 @@ func EncodeMethodHeaderStringDefaultResponse(encoder func(context.Context, http.
 var ResultHeaderStringRequiredDefaultEncodeCode = `// EncodeMethodHeaderStringRequiredDefaultResponse returns an encoder for
 // responses returned by the ServiceHeaderStringRequiredDefault
 // MethodHeaderStringRequiredDefault endpoint.
-func EncodeMethodHeaderStringRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderStringRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderstringrequireddefault.MethodHeaderStringRequiredDefaultResult)
 		w.Header().Set("H", res.H)
 		w.WriteHeader(http.StatusOK)
@@ -499,8 +499,8 @@ func EncodeMethodHeaderStringRequiredDefaultResponse(encoder func(context.Contex
 var ResultHeaderArrayBoolDefaultEncodeCode = `// EncodeMethodHeaderArrayBoolDefaultResponse returns an encoder for responses
 // returned by the ServiceHeaderArrayBoolDefault MethodHeaderArrayBoolDefault
 // endpoint.
-func EncodeMethodHeaderArrayBoolDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayBoolDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarraybooldefault.MethodHeaderArrayBoolDefaultResult)
 		if res.H != nil {
 			val := res.H
@@ -523,8 +523,8 @@ func EncodeMethodHeaderArrayBoolDefaultResponse(encoder func(context.Context, ht
 var ResultHeaderArrayBoolRequiredDefaultEncodeCode = `// EncodeMethodHeaderArrayBoolRequiredDefaultResponse returns an encoder for
 // responses returned by the ServiceHeaderArrayBoolRequiredDefault
 // MethodHeaderArrayBoolRequiredDefault endpoint.
-func EncodeMethodHeaderArrayBoolRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayBoolRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarrayboolrequireddefault.MethodHeaderArrayBoolRequiredDefaultResult)
 		if res.H != nil {
 			val := res.H
@@ -547,8 +547,8 @@ func EncodeMethodHeaderArrayBoolRequiredDefaultResponse(encoder func(context.Con
 var ResultHeaderArrayStringDefaultEncodeCode = `// EncodeMethodHeaderArrayStringDefaultResponse returns an encoder for
 // responses returned by the ServiceHeaderArrayStringDefault
 // MethodHeaderArrayStringDefault endpoint.
-func EncodeMethodHeaderArrayStringDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayStringDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarraystringdefault.MethodHeaderArrayStringDefaultResult)
 		if res.H != nil {
 			val := res.H
@@ -566,8 +566,8 @@ func EncodeMethodHeaderArrayStringDefaultResponse(encoder func(context.Context, 
 var ResultHeaderArrayStringRequiredDefaultEncodeCode = `// EncodeMethodHeaderArrayStringRequiredDefaultResponse returns an encoder for
 // responses returned by the ServiceHeaderArrayStringRequiredDefault
 // MethodHeaderArrayStringRequiredDefault endpoint.
-func EncodeMethodHeaderArrayStringRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodHeaderArrayStringRequiredDefaultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceheaderarraystringrequireddefault.MethodHeaderArrayStringRequiredDefaultResult)
 		if res.H != nil {
 			val := res.H
@@ -584,8 +584,8 @@ func EncodeMethodHeaderArrayStringRequiredDefaultResponse(encoder func(context.C
 
 var ResultBodyStringEncodeCode = `// EncodeMethodBodyStringResponse returns an encoder for responses returned by
 // the ServiceBodyString MethodBodyString endpoint.
-func EncodeMethodBodyStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodystring.MethodBodyStringResult)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyStringResponseBody(res)
@@ -597,8 +597,8 @@ func EncodeMethodBodyStringResponse(encoder func(context.Context, http.ResponseW
 
 var ResultBodyObjectEncodeCode = `// EncodeMethodBodyObjectResponse returns an encoder for responses returned by
 // the ServiceBodyObject MethodBodyObject endpoint.
-func EncodeMethodBodyObjectResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyObjectResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodyobject.MethodBodyObjectResult)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyObjectResponseBody(res)
@@ -610,8 +610,8 @@ func EncodeMethodBodyObjectResponse(encoder func(context.Context, http.ResponseW
 
 var ResultBodyUserEncodeCode = `// EncodeMethodBodyUserResponse returns an encoder for responses returned by
 // the ServiceBodyUser MethodBodyUser endpoint.
-func EncodeMethodBodyUserResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyUserResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodyuser.ResultType)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyUserResponseBody(res)
@@ -623,8 +623,8 @@ func EncodeMethodBodyUserResponse(encoder func(context.Context, http.ResponseWri
 
 var ResultBodyUnionEncodeCode = `// EncodeMethodBodyUnionResponse returns an encoder for responses returned by
 // the ServiceBodyUnion MethodBodyUnion endpoint.
-func EncodeMethodBodyUnionResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyUnionResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodyunion.Union)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyUnionResponseBody(res)
@@ -636,12 +636,12 @@ func EncodeMethodBodyUnionResponse(encoder func(context.Context, http.ResponseWr
 
 var ResultBodyMultipleViewsEncodeCode = `// EncodeMethodBodyMultipleViewResponse returns an encoder for responses
 // returned by the ServiceBodyMultipleView MethodBodyMultipleView endpoint.
-func EncodeMethodBodyMultipleViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyMultipleViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(*servicebodymultipleviewviews.Resulttypemultipleviews)
 		w.Header().Set("goa-view", res.View)
 		enc := encoder(ctx, w)
-		var body interface{}
+		var body any
 		switch res.View {
 		case "default", "":
 			body = NewMethodBodyMultipleViewResponseBody(res.Projected)
@@ -659,12 +659,12 @@ func EncodeMethodBodyMultipleViewResponse(encoder func(context.Context, http.Res
 
 var ResultBodyCollectionMultipleViewsEncodeCode = `// EncodeMethodBodyCollectionResponse returns an encoder for responses returned
 // by the ServiceBodyCollection MethodBodyCollection endpoint.
-func EncodeMethodBodyCollectionResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyCollectionResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(servicebodycollectionviews.ResulttypecollectionCollection)
 		w.Header().Set("goa-view", res.View)
 		enc := encoder(ctx, w)
-		var body interface{}
+		var body any
 		switch res.View {
 		case "default", "":
 			body = NewResulttypecollectionResponseCollection(res.Projected)
@@ -680,8 +680,8 @@ func EncodeMethodBodyCollectionResponse(encoder func(context.Context, http.Respo
 var ResultBodyCollectionExplicitViewEncodeCode = `// EncodeMethodBodyCollectionExplicitViewResponse returns an encoder for
 // responses returned by the ServiceBodyCollectionExplicitView
 // MethodBodyCollectionExplicitView endpoint.
-func EncodeMethodBodyCollectionExplicitViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyCollectionExplicitViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(servicebodycollectionexplicitviewviews.ResulttypecollectionCollection)
 		enc := encoder(ctx, w)
 		body := NewResulttypecollectionResponseTinyCollection(res.Projected)
@@ -694,8 +694,8 @@ func EncodeMethodBodyCollectionExplicitViewResponse(encoder func(context.Context
 var EmptyBodyResultMultipleViewsEncodeCode = `// EncodeMethodEmptyBodyResultMultipleViewResponse returns an encoder for
 // responses returned by the ServiceEmptyBodyResultMultipleView
 // MethodEmptyBodyResultMultipleView endpoint.
-func EncodeMethodEmptyBodyResultMultipleViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodEmptyBodyResultMultipleViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(*serviceemptybodyresultmultipleviewviews.Resulttypemultipleviews)
 		w.Header().Set("goa-view", res.View)
 		if res.Projected.C != nil {
@@ -709,8 +709,8 @@ func EncodeMethodEmptyBodyResultMultipleViewResponse(encoder func(context.Contex
 
 var ResultBodyArrayStringEncodeCode = `// EncodeMethodBodyArrayStringResponse returns an encoder for responses
 // returned by the ServiceBodyArrayString MethodBodyArrayString endpoint.
-func EncodeMethodBodyArrayStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyArrayStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodyarraystring.MethodBodyArrayStringResult)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyArrayStringResponseBody(res)
@@ -722,8 +722,8 @@ func EncodeMethodBodyArrayStringResponse(encoder func(context.Context, http.Resp
 
 var ResultBodyArrayUserEncodeCode = `// EncodeMethodBodyArrayUserResponse returns an encoder for responses returned
 // by the ServiceBodyArrayUser MethodBodyArrayUser endpoint.
-func EncodeMethodBodyArrayUserResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyArrayUserResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodyarrayuser.MethodBodyArrayUserResult)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyArrayUserResponseBody(res)
@@ -737,8 +737,8 @@ var ExplicitBodyPrimitiveResultMultipleViewsEncodeCode = `// EncodeMethodExplici
 // encoder for responses returned by the
 // ServiceExplicitBodyPrimitiveResultMultipleView
 // MethodExplicitBodyPrimitiveResultMultipleView endpoint.
-func EncodeMethodExplicitBodyPrimitiveResultMultipleViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodExplicitBodyPrimitiveResultMultipleViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(*serviceexplicitbodyprimitiveresultmultipleviewviews.Resulttypemultipleviews)
 		w.Header().Set("goa-view", res.View)
 		enc := encoder(ctx, w)
@@ -755,8 +755,8 @@ func EncodeMethodExplicitBodyPrimitiveResultMultipleViewResponse(encoder func(co
 var ExplicitBodyUserResultMultipleViewsEncodeCode = `// EncodeMethodExplicitBodyUserResultMultipleViewResponse returns an encoder
 // for responses returned by the ServiceExplicitBodyUserResultMultipleView
 // MethodExplicitBodyUserResultMultipleView endpoint.
-func EncodeMethodExplicitBodyUserResultMultipleViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodExplicitBodyUserResultMultipleViewResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(*serviceexplicitbodyuserresultmultipleviewviews.Resulttypemultipleviews)
 		w.Header().Set("goa-view", res.View)
 		enc := encoder(ctx, w)
@@ -773,8 +773,8 @@ func EncodeMethodExplicitBodyUserResultMultipleViewResponse(encoder func(context
 var ExplicitBodyResultCollectionEncodeCode = `// EncodeMethodExplicitBodyResultCollectionResponse returns an encoder for
 // responses returned by the ServiceExplicitBodyResultCollection
 // MethodExplicitBodyResultCollection endpoint.
-func EncodeMethodExplicitBodyResultCollectionResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodExplicitBodyResultCollectionResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceexplicitbodyresultcollection.MethodExplicitBodyResultCollectionResult)
 		enc := encoder(ctx, w)
 		body := NewResulttypeCollection(res)
@@ -787,8 +787,8 @@ func EncodeMethodExplicitBodyResultCollectionResponse(encoder func(context.Conte
 var ExplicitContentTypeResultEncodeCode = `// EncodeMethodExplicitContentTypeResultResponse returns an encoder for
 // responses returned by the ServiceExplicitContentTypeResult
 // MethodExplicitContentTypeResult endpoint.
-func EncodeMethodExplicitContentTypeResultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodExplicitContentTypeResultResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(*serviceexplicitcontenttyperesultviews.Resulttype)
 		ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/custom+json")
 		enc := encoder(ctx, w)
@@ -802,8 +802,8 @@ func EncodeMethodExplicitContentTypeResultResponse(encoder func(context.Context,
 var ExplicitContentTypeResponseEncodeCode = `// EncodeMethodExplicitContentTypeResponseResponse returns an encoder for
 // responses returned by the ServiceExplicitContentTypeResponse
 // MethodExplicitContentTypeResponse endpoint.
-func EncodeMethodExplicitContentTypeResponseResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodExplicitContentTypeResponseResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(*serviceexplicitcontenttyperesponseviews.Resulttype)
 		ctx = context.WithValue(ctx, goahttp.ContentTypeKey, "application/custom+json")
 		enc := encoder(ctx, w)
@@ -817,8 +817,8 @@ func EncodeMethodExplicitContentTypeResponseResponse(encoder func(context.Contex
 var ResultBodyPrimitiveStringEncodeCode = `// EncodeMethodBodyPrimitiveStringResponse returns an encoder for responses
 // returned by the ServiceBodyPrimitiveString MethodBodyPrimitiveString
 // endpoint.
-func EncodeMethodBodyPrimitiveStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyPrimitiveStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(string)
 		enc := encoder(ctx, w)
 		body := res
@@ -830,8 +830,8 @@ func EncodeMethodBodyPrimitiveStringResponse(encoder func(context.Context, http.
 
 var ResultBodyPrimitiveBoolEncodeCode = `// EncodeMethodBodyPrimitiveBoolResponse returns an encoder for responses
 // returned by the ServiceBodyPrimitiveBool MethodBodyPrimitiveBool endpoint.
-func EncodeMethodBodyPrimitiveBoolResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyPrimitiveBoolResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(bool)
 		enc := encoder(ctx, w)
 		body := res
@@ -842,9 +842,9 @@ func EncodeMethodBodyPrimitiveBoolResponse(encoder func(context.Context, http.Re
 `
 var ResultBodyPrimitiveAnyEncodeCode = `// EncodeMethodBodyPrimitiveAnyResponse returns an encoder for responses
 // returned by the ServiceBodyPrimitiveAny MethodBodyPrimitiveAny endpoint.
-func EncodeMethodBodyPrimitiveAnyResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
-		res, _ := v.(interface{})
+func EncodeMethodBodyPrimitiveAnyResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
+		res, _ := v.(any)
 		enc := encoder(ctx, w)
 		body := res
 		w.WriteHeader(http.StatusOK)
@@ -856,8 +856,8 @@ func EncodeMethodBodyPrimitiveAnyResponse(encoder func(context.Context, http.Res
 var ResultBodyPrimitiveArrayStringEncodeCode = `// EncodeMethodBodyPrimitiveArrayStringResponse returns an encoder for
 // responses returned by the ServiceBodyPrimitiveArrayString
 // MethodBodyPrimitiveArrayString endpoint.
-func EncodeMethodBodyPrimitiveArrayStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyPrimitiveArrayStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.([]string)
 		enc := encoder(ctx, w)
 		body := res
@@ -870,8 +870,8 @@ func EncodeMethodBodyPrimitiveArrayStringResponse(encoder func(context.Context, 
 var ResultBodyPrimitiveArrayBoolEncodeCode = `// EncodeMethodBodyPrimitiveArrayBoolResponse returns an encoder for responses
 // returned by the ServiceBodyPrimitiveArrayBool MethodBodyPrimitiveArrayBool
 // endpoint.
-func EncodeMethodBodyPrimitiveArrayBoolResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyPrimitiveArrayBoolResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.([]bool)
 		enc := encoder(ctx, w)
 		body := res
@@ -884,8 +884,8 @@ func EncodeMethodBodyPrimitiveArrayBoolResponse(encoder func(context.Context, ht
 var ResultBodyPrimitiveArrayUserEncodeCode = `// EncodeMethodBodyPrimitiveArrayUserResponse returns an encoder for responses
 // returned by the ServiceBodyPrimitiveArrayUser MethodBodyPrimitiveArrayUser
 // endpoint.
-func EncodeMethodBodyPrimitiveArrayUserResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyPrimitiveArrayUserResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.([]*servicebodyprimitivearrayuser.ResultType)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyPrimitiveArrayUserResponseBody(res)
@@ -897,8 +897,8 @@ func EncodeMethodBodyPrimitiveArrayUserResponse(encoder func(context.Context, ht
 
 var ResultBodyInlineObjectEncodeCode = `// EncodeMethodBodyInlineObjectResponse returns an encoder for responses
 // returned by the ServiceBodyInlineObject MethodBodyInlineObject endpoint.
-func EncodeMethodBodyInlineObjectResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyInlineObjectResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodyinlineobject.ResultType)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyInlineObjectResponseBody(res)
@@ -910,8 +910,8 @@ func EncodeMethodBodyInlineObjectResponse(encoder func(context.Context, http.Res
 
 var ResultBodyHeaderObjectEncodeCode = `// EncodeMethodBodyHeaderObjectResponse returns an encoder for responses
 // returned by the ServiceBodyHeaderObject MethodBodyHeaderObject endpoint.
-func EncodeMethodBodyHeaderObjectResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyHeaderObjectResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodyheaderobject.MethodBodyHeaderObjectResult)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyHeaderObjectResponseBody(res)
@@ -926,8 +926,8 @@ func EncodeMethodBodyHeaderObjectResponse(encoder func(context.Context, http.Res
 
 var ResultBodyHeaderUserEncodeCode = `// EncodeMethodBodyHeaderUserResponse returns an encoder for responses returned
 // by the ServiceBodyHeaderUser MethodBodyHeaderUser endpoint.
-func EncodeMethodBodyHeaderUserResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodBodyHeaderUserResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicebodyheaderuser.ResultType)
 		enc := encoder(ctx, w)
 		body := NewMethodBodyHeaderUserResponseBody(res)
@@ -942,8 +942,8 @@ func EncodeMethodBodyHeaderUserResponse(encoder func(context.Context, http.Respo
 
 var ResultTagStringEncodeCode = `// EncodeMethodTagStringResponse returns an encoder for responses returned by
 // the ServiceTagString MethodTagString endpoint.
-func EncodeMethodTagStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodTagStringResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicetagstring.MethodTagStringResult)
 		if res.H != nil && *res.H == "value" {
 			w.Header().Set("H", *res.H)
@@ -960,8 +960,8 @@ func EncodeMethodTagStringResponse(encoder func(context.Context, http.ResponseWr
 
 var ResultTagStringRequiredEncodeCode = `// EncodeMethodTagStringRequiredResponse returns an encoder for responses
 // returned by the ServiceTagStringRequired MethodTagStringRequired endpoint.
-func EncodeMethodTagStringRequiredResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodTagStringRequiredResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*servicetagstringrequired.MethodTagStringRequiredResult)
 		if res.H == "value" {
 			w.Header().Set("H", res.H)
@@ -978,13 +978,13 @@ func EncodeMethodTagStringRequiredResponse(encoder func(context.Context, http.Re
 
 var ResultMultipleViewsTagEncodeCode = `// EncodeMethodTagMultipleViewsResponse returns an encoder for responses
 // returned by the ServiceTagMultipleViews MethodTagMultipleViews endpoint.
-func EncodeMethodTagMultipleViewsResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodTagMultipleViewsResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res := v.(*servicetagmultipleviewsviews.Resulttypemultipleviews)
 		w.Header().Set("goa-view", res.View)
 		if res.Projected.B != nil && *res.Projected.B == "value" {
 			enc := encoder(ctx, w)
-			var body interface{}
+			var body any
 			switch res.View {
 			case "default", "":
 				body = NewMethodTagMultipleViewsAcceptedResponseBody(res.Projected)
@@ -996,7 +996,7 @@ func EncodeMethodTagMultipleViewsResponse(encoder func(context.Context, http.Res
 			return enc.Encode(body)
 		}
 		enc := encoder(ctx, w)
-		var body interface{}
+		var body any
 		switch res.View {
 		case "default", "":
 			body = NewMethodTagMultipleViewsOKResponseBody(res.Projected)
@@ -1012,8 +1012,8 @@ func EncodeMethodTagMultipleViewsResponse(encoder func(context.Context, http.Res
 var EmptyServerResponseEncodeCode = `// EncodeMethodEmptyServerResponseResponse returns an encoder for responses
 // returned by the ServiceEmptyServerResponse MethodEmptyServerResponse
 // endpoint.
-func EncodeMethodEmptyServerResponseResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodEmptyServerResponseResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		w.WriteHeader(http.StatusOK)
 		return nil
 	}
@@ -1023,8 +1023,8 @@ func EncodeMethodEmptyServerResponseResponse(encoder func(context.Context, http.
 var EmptyServerResponseWithTagsEncodeCode = `// EncodeMethodEmptyServerResponseWithTagsResponse returns an encoder for
 // responses returned by the ServiceEmptyServerResponseWithTags
 // MethodEmptyServerResponseWithTags endpoint.
-func EncodeMethodEmptyServerResponseWithTagsResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodEmptyServerResponseWithTagsResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceemptyserverresponsewithtags.MethodEmptyServerResponseWithTagsResult)
 		if res.H == "true" {
 			w.WriteHeader(http.StatusNotModified)
@@ -1039,8 +1039,8 @@ func EncodeMethodEmptyServerResponseWithTagsResponse(encoder func(context.Contex
 var ResultWithCustomPkgTypeEncodeCode = `// EncodeMethodResultWithCustomPkgTypeDSLResponse returns an encoder for
 // responses returned by the ServiceResultWithCustomPkgTypeDSL
 // MethodResultWithCustomPkgTypeDSL endpoint.
-func EncodeMethodResultWithCustomPkgTypeDSLResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodResultWithCustomPkgTypeDSLResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*foo.Foo)
 		enc := encoder(ctx, w)
 		body := NewMethodResultWithCustomPkgTypeDSLResponseBody(res)
@@ -1053,8 +1053,8 @@ func EncodeMethodResultWithCustomPkgTypeDSLResponse(encoder func(context.Context
 var ResultWithEmbeddedCustomPkgTypeEncodeCode = `// EncodeMethodResultWithEmbeddedCustomPkgTypeDSLResponse returns an encoder
 // for responses returned by the ServiceResultWithEmbeddedCustomPkgTypeDSL
 // MethodResultWithEmbeddedCustomPkgTypeDSL endpoint.
-func EncodeMethodResultWithEmbeddedCustomPkgTypeDSLResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, interface{}) error {
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+func EncodeMethodResultWithEmbeddedCustomPkgTypeDSLResponse(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, any) error {
+	return func(ctx context.Context, w http.ResponseWriter, v any) error {
 		res, _ := v.(*serviceresultwithembeddedcustompkgtypedsl.ContainedFoo)
 		enc := encoder(ctx, w)
 		body := NewMethodResultWithEmbeddedCustomPkgTypeDSLResponseBody(res)

--- a/http/codegen/testdata/streaming_code.go
+++ b/http/codegen/testdata/streaming_code.go
@@ -140,7 +140,7 @@ func (s *StreamingResultWithViewsMethodServerStream) Send(v *streamingresultwith
 		return err
 	}
 	res := streamingresultwithviewsservice.NewViewedUsertype(v, s.view)
-	var body interface{}
+	var body any
 	switch s.view {
 	case "tiny":
 		body = NewStreamingResultWithViewsMethodResponseBodyTiny(res.Projected)
@@ -215,7 +215,7 @@ func (c *Client) StreamingResultMethod() goa.Endpoint {
 	var (
 		decodeResponse = DecodeStreamingResultMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildStreamingResultMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -293,7 +293,7 @@ func (c *Client) StreamingResultWithViewsMethod() goa.Endpoint {
 	var (
 		decodeResponse = DecodeStreamingResultWithViewsMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildStreamingResultWithViewsMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -366,7 +366,7 @@ func (c *Client) StreamingResultWithExplicitViewMethod() goa.Endpoint {
 	var (
 		decodeResponse = DecodeStreamingResultWithExplicitViewMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildStreamingResultWithExplicitViewMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -476,7 +476,7 @@ func (s *StreamingResultCollectionWithViewsMethodServerStream) Send(v streamingr
 		return err
 	}
 	res := streamingresultcollectionwithviewsservice.NewViewedUsertypeCollection(v, s.view)
-	var body interface{}
+	var body any
 	switch s.view {
 	case "tiny":
 		body = NewUsertypeResponseTinyCollection(res.Projected)
@@ -567,7 +567,7 @@ func (c *Client) StreamingResultCollectionWithExplicitViewMethod() goa.Endpoint 
 	var (
 		decodeResponse = DecodeStreamingResultCollectionWithExplicitViewMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildStreamingResultCollectionWithExplicitViewMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -869,7 +869,7 @@ func (c *Client) StreamingResultNoPayloadMethod() goa.Endpoint {
 	var (
 		decodeResponse = DecodeStreamingResultNoPayloadMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildStreamingResultNoPayloadMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -1010,7 +1010,7 @@ func (c *Client) StreamingPayloadMethod() goa.Endpoint {
 		encodeRequest  = EncodeStreamingPayloadMethodRequest(c.encoder)
 		decodeResponse = DecodeStreamingPayloadMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildStreamingPayloadMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -1127,7 +1127,7 @@ func (c *Client) StreamingPayloadNoPayloadMethod() goa.Endpoint {
 	var (
 		decodeResponse = DecodeStreamingPayloadNoPayloadMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildStreamingPayloadNoPayloadMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -1264,7 +1264,7 @@ var StreamingPayloadResultWithViewsServerStreamSendCode = `// SendAndClose strea
 func (s *StreamingPayloadResultWithViewsMethodServerStream) SendAndClose(v *streamingpayloadresultwithviewsservice.Usertype) error {
 	defer s.conn.Close()
 	res := streamingpayloadresultwithviewsservice.NewViewedUsertype(v, s.view)
-	var body interface{}
+	var body any
 	switch s.view {
 	case "tiny":
 		body = NewStreamingPayloadResultWithViewsMethodResponseBodyTiny(res.Projected)
@@ -1459,7 +1459,7 @@ var StreamingPayloadResultCollectionWithViewsServerStreamSendCode = `// SendAndC
 func (s *StreamingPayloadResultCollectionWithViewsMethodServerStream) SendAndClose(v streamingpayloadresultcollectionwithviewsservice.UsertypeCollection) error {
 	defer s.conn.Close()
 	res := streamingpayloadresultcollectionwithviewsservice.NewViewedUsertypeCollection(v, s.view)
-	var body interface{}
+	var body any
 	switch s.view {
 	case "tiny":
 		body = NewUsertypeResponseTinyCollection(res.Projected)
@@ -1472,13 +1472,13 @@ func (s *StreamingPayloadResultCollectionWithViewsMethodServerStream) SendAndClo
 }
 `
 
-var StreamingPayloadResultCollectionWithViewsServerStreamRecvCode = `// Recv reads instances of "interface{}" from the
+var StreamingPayloadResultCollectionWithViewsServerStreamRecvCode = `// Recv reads instances of "any" from the
 // "StreamingPayloadResultCollectionWithViewsMethod" endpoint websocket
 // connection.
-func (s *StreamingPayloadResultCollectionWithViewsMethodServerStream) Recv() (interface{}, error) {
+func (s *StreamingPayloadResultCollectionWithViewsMethodServerStream) Recv() (any, error) {
 	var (
-		rv  interface{}
-		msg *interface{}
+		rv  any
+		msg *any
 		err error
 	)
 	// Upgrade the HTTP connection to a websocket connection only once. Connection
@@ -1517,10 +1517,10 @@ func (s *StreamingPayloadResultCollectionWithViewsMethodServerStream) SetView(vi
 }
 `
 
-var StreamingPayloadResultCollectionWithViewsClientStreamSendCode = `// Send streams instances of "interface{}" to the
+var StreamingPayloadResultCollectionWithViewsClientStreamSendCode = `// Send streams instances of "any" to the
 // "StreamingPayloadResultCollectionWithViewsMethod" endpoint websocket
 // connection.
-func (s *StreamingPayloadResultCollectionWithViewsMethodClientStream) Send(v interface{}) error {
+func (s *StreamingPayloadResultCollectionWithViewsMethodClientStream) Send(v any) error {
 	return s.conn.WriteJSON(v)
 }
 `
@@ -1558,7 +1558,7 @@ func (s *StreamingPayloadResultCollectionWithViewsMethodClientStream) CloseAndRe
 }
 `
 
-var StreamingPayloadResultCollectionWithViewsClientStreamSetViewCode = `// SetView sets the view to render the interface{} type before sending to the
+var StreamingPayloadResultCollectionWithViewsClientStreamSetViewCode = `// SetView sets the view to render the any type before sending to the
 // "StreamingPayloadResultCollectionWithViewsMethod" endpoint websocket
 // connection.
 func (s *StreamingPayloadResultCollectionWithViewsMethodClientStream) SetView(view string) {
@@ -1578,13 +1578,13 @@ func (s *StreamingPayloadResultCollectionWithExplicitViewMethodServerStream) Sen
 }
 `
 
-var StreamingPayloadResultCollectionWithExplicitViewServerStreamRecvCode = `// Recv reads instances of "interface{}" from the
+var StreamingPayloadResultCollectionWithExplicitViewServerStreamRecvCode = `// Recv reads instances of "any" from the
 // "StreamingPayloadResultCollectionWithExplicitViewMethod" endpoint websocket
 // connection.
-func (s *StreamingPayloadResultCollectionWithExplicitViewMethodServerStream) Recv() (interface{}, error) {
+func (s *StreamingPayloadResultCollectionWithExplicitViewMethodServerStream) Recv() (any, error) {
 	var (
-		rv  interface{}
-		msg *interface{}
+		rv  any
+		msg *any
 		err error
 	)
 	// Upgrade the HTTP connection to a websocket connection only once. Connection
@@ -1614,10 +1614,10 @@ func (s *StreamingPayloadResultCollectionWithExplicitViewMethodServerStream) Rec
 }
 `
 
-var StreamingPayloadResultCollectionWithExplicitViewClientStreamSendCode = `// Send streams instances of "interface{}" to the
+var StreamingPayloadResultCollectionWithExplicitViewClientStreamSendCode = `// Send streams instances of "any" to the
 // "StreamingPayloadResultCollectionWithExplicitViewMethod" endpoint websocket
 // connection.
-func (s *StreamingPayloadResultCollectionWithExplicitViewMethodClientStream) Send(v interface{}) error {
+func (s *StreamingPayloadResultCollectionWithExplicitViewMethodClientStream) Send(v any) error {
 	return s.conn.WriteJSON(v)
 }
 `
@@ -2195,7 +2195,7 @@ func (c *Client) BidirectionalStreamingMethod() goa.Endpoint {
 		encodeRequest  = EncodeBidirectionalStreamingMethodRequest(c.encoder)
 		decodeResponse = DecodeBidirectionalStreamingMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildBidirectionalStreamingMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -2336,7 +2336,7 @@ func (c *Client) BidirectionalStreamingNoPayloadMethod() goa.Endpoint {
 	var (
 		decodeResponse = DecodeBidirectionalStreamingNoPayloadMethodResponse(c.decoder, c.RestoreResponseBody)
 	)
-	return func(ctx context.Context, v interface{}) (interface{}, error) {
+	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.BuildBidirectionalStreamingNoPayloadMethodRequest(ctx, v)
 		if err != nil {
 			return nil, err
@@ -2425,7 +2425,7 @@ func (s *BidirectionalStreamingResultWithViewsMethodServerStream) Send(v *bidire
 		return err
 	}
 	res := bidirectionalstreamingresultwithviewsservice.NewViewedUsertype(v, s.view)
-	var body interface{}
+	var body any
 	switch s.view {
 	case "tiny":
 		body = NewBidirectionalStreamingResultWithViewsMethodResponseBodyTiny(res.Projected)
@@ -2676,7 +2676,7 @@ func (s *BidirectionalStreamingResultCollectionWithViewsMethodServerStream) Send
 		return err
 	}
 	res := bidirectionalstreamingresultcollectionwithviewsservice.NewViewedUsertypeCollection(v, s.view)
-	var body interface{}
+	var body any
 	switch s.view {
 	case "tiny":
 		body = NewUsertypeResponseTinyCollection(res.Projected)
@@ -2689,13 +2689,13 @@ func (s *BidirectionalStreamingResultCollectionWithViewsMethodServerStream) Send
 }
 `
 
-var BidirectionalStreamingResultCollectionWithViewsServerStreamRecvCode = `// Recv reads instances of "interface{}" from the
+var BidirectionalStreamingResultCollectionWithViewsServerStreamRecvCode = `// Recv reads instances of "any" from the
 // "BidirectionalStreamingResultCollectionWithViewsMethod" endpoint websocket
 // connection.
-func (s *BidirectionalStreamingResultCollectionWithViewsMethodServerStream) Recv() (interface{}, error) {
+func (s *BidirectionalStreamingResultCollectionWithViewsMethodServerStream) Recv() (any, error) {
 	var (
-		rv  interface{}
-		msg *interface{}
+		rv  any
+		msg *any
 		err error
 	)
 	// Upgrade the HTTP connection to a websocket connection only once. Connection
@@ -2735,10 +2735,10 @@ func (s *BidirectionalStreamingResultCollectionWithViewsMethodServerStream) SetV
 }
 `
 
-var BidirectionalStreamingResultCollectionWithViewsClientStreamSendCode = `// Send streams instances of "interface{}" to the
+var BidirectionalStreamingResultCollectionWithViewsClientStreamSendCode = `// Send streams instances of "any" to the
 // "BidirectionalStreamingResultCollectionWithViewsMethod" endpoint websocket
 // connection.
-func (s *BidirectionalStreamingResultCollectionWithViewsMethodClientStream) Send(v interface{}) error {
+func (s *BidirectionalStreamingResultCollectionWithViewsMethodClientStream) Send(v any) error {
 	return s.conn.WriteJSON(v)
 }
 `
@@ -2769,7 +2769,7 @@ func (s *BidirectionalStreamingResultCollectionWithViewsMethodClientStream) Recv
 }
 `
 
-var BidirectionalStreamingResultCollectionWithViewsClientStreamSetViewCode = `// SetView sets the view to render the interface{} type before sending to the
+var BidirectionalStreamingResultCollectionWithViewsClientStreamSetViewCode = `// SetView sets the view to render the any type before sending to the
 // "BidirectionalStreamingResultCollectionWithViewsMethod" endpoint websocket
 // connection.
 func (s *BidirectionalStreamingResultCollectionWithViewsMethodClientStream) SetView(view string) {
@@ -2806,13 +2806,13 @@ func (s *BidirectionalStreamingResultCollectionWithExplicitViewMethodServerStrea
 }
 `
 
-var BidirectionalStreamingResultCollectionWithExplicitViewServerStreamRecvCode = `// Recv reads instances of "interface{}" from the
+var BidirectionalStreamingResultCollectionWithExplicitViewServerStreamRecvCode = `// Recv reads instances of "any" from the
 // "BidirectionalStreamingResultCollectionWithExplicitViewMethod" endpoint
 // websocket connection.
-func (s *BidirectionalStreamingResultCollectionWithExplicitViewMethodServerStream) Recv() (interface{}, error) {
+func (s *BidirectionalStreamingResultCollectionWithExplicitViewMethodServerStream) Recv() (any, error) {
 	var (
-		rv  interface{}
-		msg *interface{}
+		rv  any
+		msg *any
 		err error
 	)
 	// Upgrade the HTTP connection to a websocket connection only once. Connection
@@ -2842,10 +2842,10 @@ func (s *BidirectionalStreamingResultCollectionWithExplicitViewMethodServerStrea
 }
 `
 
-var BidirectionalStreamingResultCollectionWithExplicitViewClientStreamSendCode = `// Send streams instances of "interface{}" to the
+var BidirectionalStreamingResultCollectionWithExplicitViewClientStreamSendCode = `// Send streams instances of "any" to the
 // "BidirectionalStreamingResultCollectionWithExplicitViewMethod" endpoint
 // websocket connection.
-func (s *BidirectionalStreamingResultCollectionWithExplicitViewMethodClientStream) Send(v interface{}) error {
+func (s *BidirectionalStreamingResultCollectionWithExplicitViewMethodClientStream) Send(v any) error {
 	return s.conn.WriteJSON(v)
 }
 `

--- a/http/codegen/typedef_test.go
+++ b/http/codegen/typedef_test.go
@@ -90,11 +90,11 @@ var (
 	Default *int ` + "`" + `form:"default,omitempty" json:"default,omitempty" xml:"default,omitempty"` + "`" + `
 	Optional *float32 ` + "`" + `form:"optional,omitempty" json:"optional,omitempty" xml:"optional,omitempty"` + "`" + `
 	Bytes []byte ` + "`" + `form:"bytes,omitempty" json:"bytes,omitempty" xml:"bytes,omitempty"` + "`" + `
-	Any interface{} ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
+	Any any ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
 	RequiredBytes []byte ` + "`" + `form:"required_bytes" json:"required_bytes" xml:"required_bytes"` + "`" + `
-	RequiredAny interface{} ` + "`" + `form:"required_any" json:"required_any" xml:"required_any"` + "`" + `
+	RequiredAny any ` + "`" + `form:"required_any" json:"required_any" xml:"required_any"` + "`" + `
 	DefaultBytes []byte ` + "`" + `form:"default_bytes,omitempty" json:"default_bytes,omitempty" xml:"default_bytes,omitempty"` + "`" + `
-	DefaultAny interface{} ` + "`" + `form:"default_any,omitempty" json:"default_any,omitempty" xml:"default_any,omitempty"` + "`" + `
+	DefaultAny any ` + "`" + `form:"default_any,omitempty" json:"default_any,omitempty" xml:"default_any,omitempty"` + "`" + `
 	CustomType *pkg.String ` + "`" + `form:"custom_type,omitempty" json:"custom_type,omitempty" xml:"custom_type,omitempty"` + "`" + `
 	CustomTag *string ` + "`" + `foo:"bar"` + "`" + `
 }`
@@ -104,11 +104,11 @@ var (
 	Default int ` + "`" + `form:"default" json:"default" xml:"default"` + "`" + `
 	Optional *float32 ` + "`" + `form:"optional,omitempty" json:"optional,omitempty" xml:"optional,omitempty"` + "`" + `
 	Bytes []byte ` + "`" + `form:"bytes,omitempty" json:"bytes,omitempty" xml:"bytes,omitempty"` + "`" + `
-	Any interface{} ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
+	Any any ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
 	RequiredBytes []byte ` + "`" + `form:"required_bytes" json:"required_bytes" xml:"required_bytes"` + "`" + `
-	RequiredAny interface{} ` + "`" + `form:"required_any" json:"required_any" xml:"required_any"` + "`" + `
+	RequiredAny any ` + "`" + `form:"required_any" json:"required_any" xml:"required_any"` + "`" + `
 	DefaultBytes []byte ` + "`" + `form:"default_bytes" json:"default_bytes" xml:"default_bytes"` + "`" + `
-	DefaultAny interface{} ` + "`" + `form:"default_any" json:"default_any" xml:"default_any"` + "`" + `
+	DefaultAny any ` + "`" + `form:"default_any" json:"default_any" xml:"default_any"` + "`" + `
 	CustomType *pkg.String ` + "`" + `form:"custom_type,omitempty" json:"custom_type,omitempty" xml:"custom_type,omitempty"` + "`" + `
 	CustomTag *string ` + "`" + `foo:"bar"` + "`" + `
 }`
@@ -118,11 +118,11 @@ var (
 	Default *int ` + "`" + `form:"default,omitempty" json:"default,omitempty" xml:"default,omitempty"` + "`" + `
 	Optional *float32 ` + "`" + `form:"optional,omitempty" json:"optional,omitempty" xml:"optional,omitempty"` + "`" + `
 	Bytes []byte ` + "`" + `form:"bytes,omitempty" json:"bytes,omitempty" xml:"bytes,omitempty"` + "`" + `
-	Any interface{} ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
+	Any any ` + "`" + `form:"any,omitempty" json:"any,omitempty" xml:"any,omitempty"` + "`" + `
 	RequiredBytes []byte ` + "`" + `form:"required_bytes,omitempty" json:"required_bytes,omitempty" xml:"required_bytes,omitempty"` + "`" + `
-	RequiredAny interface{} ` + "`" + `form:"required_any,omitempty" json:"required_any,omitempty" xml:"required_any,omitempty"` + "`" + `
+	RequiredAny any ` + "`" + `form:"required_any,omitempty" json:"required_any,omitempty" xml:"required_any,omitempty"` + "`" + `
 	DefaultBytes []byte ` + "`" + `form:"default_bytes,omitempty" json:"default_bytes,omitempty" xml:"default_bytes,omitempty"` + "`" + `
-	DefaultAny interface{} ` + "`" + `form:"default_any,omitempty" json:"default_any,omitempty" xml:"default_any,omitempty"` + "`" + `
+	DefaultAny any ` + "`" + `form:"default_any,omitempty" json:"default_any,omitempty" xml:"default_any,omitempty"` + "`" + `
 	CustomType *pkg.String ` + "`" + `form:"custom_type,omitempty" json:"custom_type,omitempty" xml:"custom_type,omitempty"` + "`" + `
 	CustomTag *string ` + "`" + `foo:"bar"` + "`" + `
 }`

--- a/http/codegen/websocket.go
+++ b/http/codegen/websocket.go
@@ -292,7 +292,7 @@ func serverStructWSSections(data *ServiceData) []*codegen.SectionTemplate {
 		Name:    "server-websocket-conn-configurer-struct",
 		Source:  webSocketConnConfigurerStructT,
 		Data:    data,
-		FuncMap: map[string]interface{}{"isWebSocketEndpoint": isWebSocketEndpoint},
+		FuncMap: map[string]any{"isWebSocketEndpoint": isWebSocketEndpoint},
 	})
 	for _, e := range data.Endpoints {
 		if e.ServerWebSocket != nil {
@@ -315,7 +315,7 @@ func serverWSSections(data *ServiceData) []*codegen.SectionTemplate {
 		Name:    "server-websocket-conn-configurer-struct-init",
 		Source:  webSocketConnConfigurerStructInitT,
 		Data:    data,
-		FuncMap: map[string]interface{}{"isWebSocketEndpoint": isWebSocketEndpoint},
+		FuncMap: map[string]any{"isWebSocketEndpoint": isWebSocketEndpoint},
 	})
 	for _, e := range data.Endpoints {
 		if e.ServerWebSocket != nil {
@@ -324,7 +324,7 @@ func serverWSSections(data *ServiceData) []*codegen.SectionTemplate {
 					Name:   "server-websocket-send",
 					Source: webSocketSendT,
 					Data:   e.ServerWebSocket,
-					FuncMap: map[string]interface{}{
+					FuncMap: map[string]any{
 						"upgradeParams":    upgradeParams,
 						"viewedServerBody": viewedServerBody,
 					},
@@ -336,7 +336,7 @@ func serverWSSections(data *ServiceData) []*codegen.SectionTemplate {
 					Name:    "server-websocket-recv",
 					Source:  webSocketRecvT,
 					Data:    e.ServerWebSocket,
-					FuncMap: map[string]interface{}{"upgradeParams": upgradeParams},
+					FuncMap: map[string]any{"upgradeParams": upgradeParams},
 				})
 			}
 			if e.ServerWebSocket.MustClose {
@@ -344,7 +344,7 @@ func serverWSSections(data *ServiceData) []*codegen.SectionTemplate {
 					Name:    "server-websocket-close",
 					Source:  webSocketCloseT,
 					Data:    e.ServerWebSocket,
-					FuncMap: map[string]interface{}{"upgradeParams": upgradeParams},
+					FuncMap: map[string]any{"upgradeParams": upgradeParams},
 				})
 			}
 			if e.Method.ViewedResult != nil && e.Method.ViewedResult.ViewName == "" {
@@ -367,7 +367,7 @@ func clientStructWSSections(data *ServiceData) []*codegen.SectionTemplate {
 		Name:    "client-websocket-conn-configurer-struct",
 		Source:  webSocketConnConfigurerStructT,
 		Data:    data,
-		FuncMap: map[string]interface{}{"isWebSocketEndpoint": isWebSocketEndpoint},
+		FuncMap: map[string]any{"isWebSocketEndpoint": isWebSocketEndpoint},
 	})
 	for _, e := range data.Endpoints {
 		if e.ClientWebSocket != nil {
@@ -389,7 +389,7 @@ func clientWSSections(data *ServiceData) []*codegen.SectionTemplate {
 		Name:    "client-websocket-conn-configurer-struct-init",
 		Source:  webSocketConnConfigurerStructInitT,
 		Data:    data,
-		FuncMap: map[string]interface{}{"isWebSocketEndpoint": isWebSocketEndpoint},
+		FuncMap: map[string]any{"isWebSocketEndpoint": isWebSocketEndpoint},
 	})
 	for _, e := range data.Endpoints {
 		if e.ClientWebSocket != nil {
@@ -398,7 +398,7 @@ func clientWSSections(data *ServiceData) []*codegen.SectionTemplate {
 					Name:    "client-websocket-recv",
 					Source:  webSocketRecvT,
 					Data:    e.ClientWebSocket,
-					FuncMap: map[string]interface{}{"upgradeParams": upgradeParams},
+					FuncMap: map[string]any{"upgradeParams": upgradeParams},
 				})
 			}
 			switch e.ClientWebSocket.Kind {
@@ -407,7 +407,7 @@ func clientWSSections(data *ServiceData) []*codegen.SectionTemplate {
 					Name:   "client-websocket-send",
 					Source: webSocketSendT,
 					Data:   e.ClientWebSocket,
-					FuncMap: map[string]interface{}{
+					FuncMap: map[string]any{
 						"upgradeParams":    upgradeParams,
 						"viewedServerBody": viewedServerBody,
 					},
@@ -418,7 +418,7 @@ func clientWSSections(data *ServiceData) []*codegen.SectionTemplate {
 					Name:    "client-websocket-close",
 					Source:  webSocketCloseT,
 					Data:    e.ClientWebSocket,
-					FuncMap: map[string]interface{}{"upgradeParams": upgradeParams},
+					FuncMap: map[string]any{"upgradeParams": upgradeParams},
 				})
 			}
 			if e.Method.ViewedResult != nil && e.Method.ViewedResult.ViewName == "" {
@@ -538,7 +538,7 @@ func (s *{{ .VarName }}) {{ .SendName }}(v {{ .SendTypeRef }}) error {
 					{{- $vsb := (viewedServerBody $.Response.ServerBody .Endpoint.Method.ViewedResult.ViewName) }}
 					body := {{ $vsb.Init.Name }}({{ range $vsb.Init.ServerArgs }}{{ .Ref }}, {{ end }})
 				{{- else }}
-					var body interface{}
+					var body any
 					switch s.view {
 					{{- range .Endpoint.Method.ViewedResult.Views }}
 						case {{ printf "%q" .Name }}{{ if eq .Name "default" }}, ""{{ end }}:

--- a/http/encoding.go
+++ b/http/encoding.go
@@ -30,19 +30,19 @@ type (
 	// request and response bodies.
 	Decoder interface {
 		// Decode decodes into v.
-		Decode(v interface{}) error
+		Decode(v any) error
 	}
 
 	// Encoder provides the actual encoding algorithm used to write HTTP
 	// request and response bodies.
 	Encoder interface {
 		// Encode encodes v.
-		Encode(v interface{}) error
+		Encode(v any) error
 	}
 
 	// EncodingFunc allows a function with appropriate signature to act as a
 	// Decoder/Encoder.
-	EncodingFunc func(v interface{}) error
+	EncodingFunc func(v any) error
 
 	// private type used to define context keys.
 	contextKey int
@@ -228,10 +228,10 @@ func ErrorEncoder(encoder func(context.Context, http.ResponseWriter) Encoder, fo
 }
 
 // Decode implements the Decoder interface. It simply calls f(v).
-func (f EncodingFunc) Decode(v interface{}) error { return f(v) }
+func (f EncodingFunc) Decode(v any) error { return f(v) }
 
 // Encode implements the Encoder interface. It simply calls f(v).
-func (f EncodingFunc) Encode(v interface{}) error { return f(v) }
+func (f EncodingFunc) Encode(v any) error { return f(v) }
 
 // SetContentType initializes the response Content-Type header given a MIME
 // type. If the Content-Type header is already set and the MIME type is
@@ -268,7 +268,7 @@ type textEncoder struct {
 	ct string
 }
 
-func (e *textEncoder) Encode(v interface{}) (err error) {
+func (e *textEncoder) Encode(v any) (err error) {
 	switch c := v.(type) {
 	case string:
 		_, err = e.w.Write([]byte(c))
@@ -291,7 +291,7 @@ type textDecoder struct {
 	ct string
 }
 
-func (e *textDecoder) Decode(v interface{}) error {
+func (e *textDecoder) Decode(v any) error {
 	b, err := io.ReadAll(e.r)
 	if err != nil {
 		return err

--- a/http/encoding_test.go
+++ b/http/encoding_test.go
@@ -149,7 +149,7 @@ func TestResponseDecoder(t *testing.T) {
 func TestTextEncoder_Encode(t *testing.T) {
 	cases := []struct {
 		name  string
-		value interface{}
+		value any
 		error error
 	}{
 		{"string", testString, nil},

--- a/http/middleware/context.go
+++ b/http/middleware/context.go
@@ -16,7 +16,7 @@ func RequestContext(ctx context.Context) func(http.Handler) http.Handler {
 
 // RequestContextKeyVals returns a middleware which adds the given key/value pairs to the
 // request context.
-func RequestContextKeyVals(keyvals ...interface{}) func(http.Handler) http.Handler {
+func RequestContextKeyVals(keyvals ...any) func(http.Handler) http.Handler {
 	if len(keyvals)%2 != 0 {
 		panic("initctx: invalid number of key/value elements, must be an even number")
 	}

--- a/middleware/log.go
+++ b/middleware/log.go
@@ -13,7 +13,7 @@ type (
 	Logger interface {
 		// Log creates a log entry using a sequence of alternating keys
 		// and values.
-		Log(keyvals ...interface{}) error
+		Log(keyvals ...any) error
 	}
 
 	// adapter is a thin wrapper around the stdlib logger that adapts it to
@@ -28,13 +28,13 @@ func NewLogger(l *log.Logger) Logger {
 	return &adapter{l}
 }
 
-func (a *adapter) Log(keyvals ...interface{}) error {
+func (a *adapter) Log(keyvals ...any) error {
 	n := (len(keyvals) + 1) / 2
 	if len(keyvals)%2 != 0 {
 		keyvals = append(keyvals, "MISSING")
 	}
 	var fm bytes.Buffer
-	vals := make([]interface{}, n)
+	vals := make([]any, n)
 	for i := 0; i < len(keyvals); i += 2 {
 		k := keyvals[i]
 		v := keyvals[i+1]

--- a/middleware/trace.go
+++ b/middleware/trace.go
@@ -170,12 +170,12 @@ func WrapLogger(l Logger, traceID string) Logger {
 }
 
 // Log logs the trace ID when present then the values passed as argument.
-func (l *tracedLogger) Log(keyvals ...interface{}) error {
+func (l *tracedLogger) Log(keyvals ...any) error {
 	if l.traceID == "" {
 		l.logger.Log(keyvals...)
 		return nil
 	}
-	keyvals = append([]interface{}{"trace", l.traceID}, keyvals...)
+	keyvals = append([]any{"trace", l.traceID}, keyvals...)
 	l.logger.Log(keyvals)
 	return nil
 }

--- a/middleware/xray/segment.go
+++ b/middleware/xray/segment.go
@@ -55,9 +55,9 @@ type (
 		// 429. Client code may set it to true manually as well.
 		Throttle bool `json:"throttle,omitempty"`
 		// Annotations contains the segment annotations.
-		Annotations map[string]interface{} `json:"annotations,omitempty"`
+		Annotations map[string]any `json:"annotations,omitempty"`
 		// Metadata contains the segment metadata.
-		Metadata map[string]map[string]interface{} `json:"metadata,omitempty"`
+		Metadata map[string]map[string]any `json:"metadata,omitempty"`
 		// Subsegments contains all the subsegments.
 		Subsegments []*Segment `json:"subsegments,omitempty"`
 		// Parent is the subsegment parent, it's nil for the root
@@ -240,12 +240,12 @@ func (s *Segment) AddBoolAnnotation(key string, value bool) {
 
 // addAnnotation adds a key-value pair that can be queried by AWS X-Ray.
 // AWS X-Ray only supports annotations of type string, integer or boolean.
-func (s *Segment) addAnnotation(key string, value interface{}) {
+func (s *Segment) addAnnotation(key string, value any) {
 	s.Lock()
 	defer s.Unlock()
 
 	if s.Annotations == nil {
-		s.Annotations = make(map[string]interface{})
+		s.Annotations = make(map[string]any)
 	}
 	s.Annotations[key] = value
 }
@@ -268,13 +268,13 @@ func (s *Segment) AddBoolMetadata(key string, value bool) {
 
 // addMetadata adds a key-value pair that can be queried by AWS X-Ray.
 // AWS X-Ray only supports annotations of type string, integer or boolean.
-func (s *Segment) addMetadata(key string, value interface{}) {
+func (s *Segment) addMetadata(key string, value any) {
 	s.Lock()
 	defer s.Unlock()
 
 	if s.Metadata == nil {
-		s.Metadata = make(map[string]map[string]interface{})
-		s.Metadata["default"] = make(map[string]interface{})
+		s.Metadata = make(map[string]map[string]any)
+		s.Metadata["default"] = make(map[string]any)
 	}
 	s.Metadata["default"][key] = value
 }

--- a/pkg/endpoint.go
+++ b/pkg/endpoint.go
@@ -21,4 +21,4 @@ type (
 
 // Endpoint exposes service methods to remote clients independently of the
 // underlying transport.
-type Endpoint func(ctx context.Context, request interface{}) (response interface{}, err error)
+type Endpoint func(ctx context.Context, request any) (response any, err error)

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -73,13 +73,13 @@ func NewServiceError(err error, name string, timeout, temporary, fault bool) *Se
 
 // Fault creates an error given a format and values a la fmt.Printf. The error
 // has the Fault field set to true.
-func Fault(format string, v ...interface{}) *ServiceError {
+func Fault(format string, v ...any) *ServiceError {
 	return newError("fault", false, false, true, format, v...)
 }
 
 // PermanentError creates an error given a name and a format and values a la
 // fmt.Printf.
-func PermanentError(name, format string, v ...interface{}) *ServiceError {
+func PermanentError(name, format string, v ...any) *ServiceError {
 	return newError(name, false, false, false, format, v...)
 }
 
@@ -87,20 +87,20 @@ func PermanentError(name, format string, v ...interface{}) *ServiceError {
 // and that retrying the request may be successful. TemporaryError creates an
 // error given a name and a format and values a la fmt.Printf. The error has the
 // Temporary field set to true.
-func TemporaryError(name, format string, v ...interface{}) *ServiceError {
+func TemporaryError(name, format string, v ...any) *ServiceError {
 	return newError(name, false, true, false, format, v...)
 }
 
 // PermanentTimeoutError creates an error given a name and a format and values a
 // la fmt.Printf. The error has the Timeout field set to true.
-func PermanentTimeoutError(name, format string, v ...interface{}) *ServiceError {
+func PermanentTimeoutError(name, format string, v ...any) *ServiceError {
 	return newError(name, true, false, false, format, v...)
 }
 
 // TemporaryTimeoutError creates an error given a name and a format and values a
 // la fmt.Printf. The error has both the Timeout and Temporary fields set to
 // true.
-func TemporaryTimeoutError(name, format string, v ...interface{}) *ServiceError {
+func TemporaryTimeoutError(name, format string, v ...any) *ServiceError {
 	return newError(name, true, true, false, format, v...)
 }
 
@@ -118,7 +118,7 @@ func DecodePayloadError(msg string) error {
 
 // InvalidFieldTypeError is the error produced by the generated code when the
 // type of a payload field does not match the type defined in the design.
-func InvalidFieldTypeError(name string, val interface{}, expected string) error {
+func InvalidFieldTypeError(name string, val any, expected string) error {
 	return withField(name, PermanentError(
 		InvalidFieldType, "invalid value %#v for %q, must be a %s", val, name, expected))
 }
@@ -133,7 +133,7 @@ func MissingFieldError(name, context string) error {
 // InvalidEnumValueError is the error produced by the generated code when the
 // value of a payload field does not match one the values defined in the design
 // Enum validation.
-func InvalidEnumValueError(name string, val interface{}, allowed []interface{}) error {
+func InvalidEnumValueError(name string, val any, allowed []any) error {
 	elems := make([]string, len(allowed))
 	for i, a := range allowed {
 		elems[i] = fmt.Sprintf("%#v", a)
@@ -161,7 +161,7 @@ func InvalidPatternError(name, target string, pattern string) error {
 // InvalidRangeError is the error produced by the generated code when the value
 // of a payload field does not match the range validation defined in the design.
 // value may be an int or a float64.
-func InvalidRangeError(name string, target interface{}, value interface{}, min bool) error {
+func InvalidRangeError(name string, target any, value any, min bool) error {
 	comp := "greater or equal"
 	if !min {
 		comp = "lesser or equal"
@@ -173,7 +173,7 @@ func InvalidRangeError(name string, target interface{}, value interface{}, min b
 // InvalidLengthError is the error produced by the generated code when the value
 // of a payload field does not match the length validation defined in the
 // design.
-func InvalidLengthError(name string, target interface{}, ln, value int, min bool) error {
+func InvalidLengthError(name string, target any, ln, value int, min bool) error {
 	comp := "greater or equal"
 	if !min {
 		comp = "lesser or equal"
@@ -264,7 +264,7 @@ func withField(field string, err *ServiceError) *ServiceError {
 	return err
 }
 
-func newError(name string, timeout, temporary, fault bool, format string, v ...interface{}) *ServiceError {
+func newError(name string, timeout, temporary, fault bool, format string, v ...any) *ServiceError {
 	return &ServiceError{
 		Name:      name,
 		ID:        NewErrorID(),


### PR DESCRIPTION
Now that Goa requires Go version 1.20 or higher, I think it is time to rewrite `interface{}` with `any `.

* Replace `interface{}` to `any`
* Not applicable for the following:
    * grpc/pb/goadesign_goa_error.pb.go
* Adjust tests
    * 679a041a27ef469d80bb9bcc195734df832045b9,  91735ff4817971fc14b39302f6d5e04872d6f992