### PR TITLE
Generate empty array for required types in response

### DIFF
--- a/codegen/codegentest/codegentest.go
+++ b/codegen/codegentest/codegentest.go
@@ -1,5 +1,5 @@
 // Package codegentest provides utilities to assist writing unit test for
-// codegen pacakges.
+// codegen packages.
 package codegentest
 
 import (

--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -252,7 +252,12 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 			checkNil = isRef || marshalNonPrimitive
 		}
 		if code != "" && checkNil {
-			code = fmt.Sprintf("if %s != nil {\n\t%s}\n", srcVar, code)
+			code = fmt.Sprintf("if %s != nil {\n\t%s}", srcVar, code)
+			if expr.IsArray(srcc.Type) && srcMatt.IsRequired(n) {
+				code += fmt.Sprintf("else {\n\t%s = []%s{}\n}\n", tgtVar, ta.TargetCtx.Scope.Ref(expr.AsArray(tgtc.Type).ElemType, ta.TargetCtx.Pkg(expr.AsArray(tgtc.Type).ElemType)))
+			} else {
+				code += "\n"
+			}
 		}
 
 		// Default value handling. We need to handle default values if the target

--- a/codegen/go_transform_test.go
+++ b/codegen/go_transform_test.go
@@ -483,6 +483,8 @@ const (
 		for i, val := range source.StringArray {
 			target.StringArray[i] = val
 		}
+	} else {
+		target.StringArray = []string{}
 	}
 }
 `
@@ -519,6 +521,8 @@ const (
 		for i, val := range source.StringArray {
 			target.StringArray[i] = val
 		}
+	} else {
+		target.StringArray = []string{}
 	}
 }
 `
@@ -667,6 +671,8 @@ const (
 		for i, val := range source.MyArray {
 			target.Array[i] = val
 		}
+	} else {
+		target.Array = []string{}
 	}
 }
 `
@@ -784,6 +790,8 @@ const (
 		for i, val := range source.RequiredArray {
 			target.RequiredArray[i] = val
 		}
+	} else {
+		target.RequiredArray = []string{}
 	}
 	if source.Map != nil {
 		target.Map = make(map[int]string, len(source.Map))

--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -308,6 +308,8 @@ func NewMethodARequestBody(p *servicemixedpayloadinbody.APayload) *MethodAReques
 		for i, val := range p.Array {
 			body.Array[i] = val
 		}
+	} else {
+		body.Array = []float32{}
 	}
 	if p.Map != nil {
 		body.Map = make(map[uint]any, len(p.Map))


### PR DESCRIPTION
As mentioned in #3216. This code change makes sure that an empty array is initialized in the response if the field is required