### PR TITLE
Fix issues with `struct:pkg:path` Meta and gRPC

### DIFF
--- a/codegen/testdata/types_dsl.go
+++ b/codegen/testdata/types_dsl.go
@@ -288,5 +288,15 @@ var TestTypesDSL = func() {
 				Attribute("recurse", "RecursiveOneOf")
 			})
 		})
+
+		WithOverride = Type("WithOverride", func() {
+			Attribute("string", String)
+			Meta("struct:pkg:path", "types")
+		})
+
+		_ = Type("CompositePkgOverride", func() {
+			Attribute("withOverride", WithOverride)
+			Meta("struct:pkg:path", "types")
+		})
 	)
 }


### PR DESCRIPTION
* Make sure union type methods are only generated once
* Fix name of helper transform method in generated call

fixes #3294 