### PR TITLE
Use attribute names in error messages

### DIFF
--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -44,6 +44,15 @@ func init() {
 	userValT = template.Must(template.New("user").Funcs(fm).Parse(userValTmpl))
 }
 
+// AttributeValidationCode produces Go code that runs the validations defined
+// in the given attribute against the value held by the variable named target.
+//
+// See ValidationCode for a description of the arguments.
+func AttributeValidationCode(att *expr.AttributeExpr, put expr.UserType, attCtx *AttributeContext, req, alias bool, target, attName string) string {
+	seen := make(map[string]*bytes.Buffer)
+	return recurseValidationCode(att, put, attCtx, req, alias, target, attName, seen).String()
+}
+
 // ValidationCode produces Go code that runs the validations defined in the
 // given attribute and its children recursively against the value held by the
 // variable named target.

--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -766,7 +766,7 @@ func addValidation(att *expr.AttributeExpr, attName string, sd *ServiceData, req
 // req if true indicates that the validations are generated for validating
 // request messages.
 func collectValidations(att *expr.AttributeExpr, attName string, ctx *codegen.AttributeContext, req bool, sd *ServiceData) {
-	attName = codegen.Goify(attName, false)
+	gattName := codegen.Goify(attName, false)
 	switch dt := att.Type.(type) {
 	case expr.UserType:
 		if expr.IsPrimitive(dt) {
@@ -774,7 +774,7 @@ func collectValidations(att *expr.AttributeExpr, attName string, ctx *codegen.At
 			return
 		}
 		vtx := protoBufTypeContext(sd.PkgName, sd.Scope, false)
-		def := codegen.ValidationCode(att, dt, vtx, true, false, attName)
+		def := codegen.AttributeValidationCode(att, dt, vtx, true, false, gattName, attName)
 		name := protoBufMessageName(att, sd.Scope)
 		kind := validateClient
 		if req {
@@ -793,7 +793,7 @@ func collectValidations(att *expr.AttributeExpr, attName string, ctx *codegen.At
 			sd.validations = append(sd.validations, &ValidationData{
 				Name:    "Validate" + name,
 				Def:     def,
-				ArgName: attName,
+				ArgName: gattName,
 				SrcName: name,
 				SrcRef:  protoBufGoFullTypeRef(att, sd.PkgName, sd.Scope),
 				Kind:    kind,
@@ -1299,7 +1299,7 @@ func extractMetadata(a *expr.MappedAttributeExpr, service *expr.AttributeExpr, s
 				mp.KeyType.Type.Kind() == expr.StringKind &&
 				mp.ElemType.Type.Kind() == expr.ArrayKind &&
 				expr.AsArray(mp.ElemType.Type).ElemType.Type.Kind() == expr.StringKind,
-			Validate:     codegen.ValidationCode(c, nil, ctx, required, false, varn),
+			Validate:     codegen.AttributeValidationCode(c, nil, ctx, required, false, varn, name),
 			DefaultValue: c.DefaultValue,
 			Example:      c.Example(expr.Root.API.ExampleGenerator),
 		})

--- a/grpc/codegen/testdata/client_cli_code.go
+++ b/grpc/codegen/testdata/client_cli_code.go
@@ -31,10 +31,10 @@ func BuildMethodAPayload(payloadWithValidationMethodAMetadataInt string, payload
 				return nil, fmt.Errorf("invalid value for metadataInt, must be INT")
 			}
 			if *metadataInt < 0 {
-				err = goa.MergeErrors(err, goa.InvalidRangeError("metadataInt", *metadataInt, 0, true))
+				err = goa.MergeErrors(err, goa.InvalidRangeError("MetadataInt", *metadataInt, 0, true))
 			}
 			if *metadataInt > 100 {
-				err = goa.MergeErrors(err, goa.InvalidRangeError("metadataInt", *metadataInt, 100, false))
+				err = goa.MergeErrors(err, goa.InvalidRangeError("MetadataInt", *metadataInt, 100, false))
 			}
 			if err != nil {
 				return nil, err
@@ -46,10 +46,10 @@ func BuildMethodAPayload(payloadWithValidationMethodAMetadataInt string, payload
 		if payloadWithValidationMethodAMetadataString != "" {
 			metadataString = &payloadWithValidationMethodAMetadataString
 			if utf8.RuneCountInString(*metadataString) < 5 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("metadataString", *metadataString, utf8.RuneCountInString(*metadataString), 5, true))
+				err = goa.MergeErrors(err, goa.InvalidLengthError("MetadataString", *metadataString, utf8.RuneCountInString(*metadataString), 5, true))
 			}
 			if utf8.RuneCountInString(*metadataString) > 10 {
-				err = goa.MergeErrors(err, goa.InvalidLengthError("metadataString", *metadataString, utf8.RuneCountInString(*metadataString), 10, false))
+				err = goa.MergeErrors(err, goa.InvalidLengthError("MetadataString", *metadataString, utf8.RuneCountInString(*metadataString), 10, false))
 			}
 			if err != nil {
 				return nil, err

--- a/grpc/codegen/testdata/request_decoder_code.go
+++ b/grpc/codegen/testdata/request_decoder_code.go
@@ -210,7 +210,7 @@ func DecodeMethodMessageWithValidateRequest(ctx context.Context, v any, md metad
 		}
 		if inMetadata != nil {
 			if *inMetadata > 100 {
-				err = goa.MergeErrors(err, goa.InvalidRangeError("inMetadata", *inMetadata, 100, false))
+				err = goa.MergeErrors(err, goa.InvalidRangeError("InMetadata", *inMetadata, 100, false))
 			}
 		}
 	}

--- a/grpc/codegen/testdata/response_decoder_code.go
+++ b/grpc/codegen/testdata/response_decoder_code.go
@@ -137,7 +137,7 @@ func DecodeMethodMessageWithValidateResponse(ctx context.Context, v any, hdr, tr
 		}
 		if inHeader != nil {
 			if *inHeader < 1 {
-				err = goa.MergeErrors(err, goa.InvalidRangeError("inHeader", *inHeader, 1, true))
+				err = goa.MergeErrors(err, goa.InvalidRangeError("InHeader", *inHeader, 1, true))
 			}
 		}
 
@@ -152,7 +152,7 @@ func DecodeMethodMessageWithValidateResponse(ctx context.Context, v any, hdr, tr
 		}
 		if inTrailer != nil {
 			if !(*inTrailer == true) {
-				err = goa.MergeErrors(err, goa.InvalidEnumValueError("inTrailer", *inTrailer, []any{true}))
+				err = goa.MergeErrors(err, goa.InvalidEnumValueError("InTrailer", *inTrailer, []any{true}))
 			}
 		}
 	}

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -423,31 +423,31 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 			{
 			{{- end }}
 			head := {{ if .FieldPointer }}*{{ end }}p.{{ .FieldName }}
-			{{- if (and (eq .Name "Authorization") (isBearer $.HeaderSchemes)) }}
+			{{- if (and (eq .HTTPName "Authorization") (isBearer $.HeaderSchemes)) }}
 		if !strings.Contains(head, " ") {
-			req.Header.Set({{ printf "%q" .Name }}, "Bearer "+head)
+			req.Header.Set({{ printf "%q" .HTTPName }}, "Bearer "+head)
 		} else {
 			{{- end }}
 			{{- if eq .Type.Name "array" }}
 			for _, val := range head {
 				{{- if eq .Type.ElemType.Type.Name "string" }}
-				req.Header.Add({{ printf "%q" .Name }}, val)
+				req.Header.Add({{ printf "%q" .HTTPName }}, val)
 				{{- else if (and (isAlias .Type.ElemType.Type) (eq (underlyingType .Type.ElemType.Type).Name "string")) }}
-				req.Header.Set({{ printf "%q" .Name }}, string(val))
+				req.Header.Set({{ printf "%q" .HTTPName }}, string(val))
 				{{- else }}
 				{{ template "type_conversion" (typeConversionData .Type.ElemType.Type (aliasedType .FieldType).ElemType.Type "valStr" "val") }}
-				req.Header.Add({{ printf "%q" .Name }}, valStr)
+				req.Header.Add({{ printf "%q" .HTTPName }}, valStr)
 				{{- end }}
 			}
 			{{- else if (and (isAlias .FieldType) (eq (underlyingType .FieldType).Name "string")) }}
-			req.Header.Set({{ printf "%q" .Name }}, string(head))
+			req.Header.Set({{ printf "%q" .HTTPName }}, string(head))
 			{{- else if eq .Type.Name "string" }}
-			req.Header.Set({{ printf "%q" .Name }}, head)
+			req.Header.Set({{ printf "%q" .HTTPName }}, head)
 			{{- else }}
 			{{ template "type_conversion" (typeConversionData .Type .FieldType "headStr" "head") }}
-			req.Header.Set({{ printf "%q" .Name }}, headStr)
+			req.Header.Set({{ printf "%q" .HTTPName }}, headStr)
 			{{- end }}
-			{{- if (and (eq .Name "Authorization") (isBearer $.HeaderSchemes)) }}
+			{{- if (and (eq .HTTPName "Authorization") (isBearer $.HeaderSchemes)) }}
 		}
 			{{- end }}
 		}
@@ -465,7 +465,7 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 			{{ template "type_conversion" (typeConversionData .Type .FieldType "vraw" "v") }}
 			{{- end }}
 			req.AddCookie(&http.Cookie{
-				Name: {{ printf "%q" .Name }},
+				Name: {{ printf "%q" .HTTPName }},
 				Value: v,
 				{{- if .MaxAge }}
 				MaxAge: {{ .MaxAge }},
@@ -505,20 +505,20 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
     }
 		{{- else if .StringSlice }}
 			for _, value := range p{{ if .FieldName }}.{{ .FieldName }}{{ end }} {
-				values.Add("{{ .Name }}", value)
+				values.Add("{{ .HTTPName }}", value)
 			}
 		{{- else if .Slice }}
 			for _, value := range p{{ if .FieldName }}.{{ .FieldName }}{{ end }} {
 				{{ template "type_conversion" (typeConversionData .Type.ElemType.Type (aliasedType .FieldType).ElemType.Type "valueStr" "value") }}
-				values.Add("{{ .Name }}", valueStr)
+				values.Add("{{ .HTTPName }}", valueStr)
 			}
 		{{- else if .Map }}
-			{{- template "map_conversion" (mapConversionData .Type .FieldType .Name "p" .FieldName true) }}
+			{{- template "map_conversion" (mapConversionData .Type .FieldType .HTTPName "p" .FieldName true) }}
 		{{- else if .FieldName }}
 			{{- if .FieldPointer }}
 		if p.{{ .FieldName }} != nil {
 			{{- end }}
-		values.Add("{{ .Name }}",
+		values.Add("{{ .HTTPName }}",
 			{{- if or (eq .Type.Name "bytes") (and (isAlias .FieldType) (eq (underlyingType .FieldType).Name "string")) }} string(
 			{{- else if not (eq .Type.Name "string") }} fmt.Sprintf("%v",
 			{{- end }}
@@ -530,12 +530,12 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 			{{- end }}
 		{{- else }}
 			{{- if eq .Type.Name "string" }}
-				values.Add("{{ .Name }}", p)
+				values.Add("{{ .HTTPName }}", p)
 			{{- else if (and (isAlias .Type) (eq (underlyingType .Type).Name "string")) }}
-				values.Add("{{ .Name }}", string(p))
+				values.Add("{{ .HTTPName }}", string(p))
 			{{- else }}
 				{{ template "type_conversion" (typeConversionData .Type .FieldType "pStr" "p") }}
-				values.Add("{{ .Name }}", pStr)
+				values.Add("{{ .HTTPName }}", pStr)
 			{{- end }}
 		{{- end }}
 	{{- end }}
@@ -877,7 +877,7 @@ const singleResponseT = ` {{- if .ClientBody }}
         for _, c := range cookies {
 			switch c.Name {
 		{{- range .Cookies }}
-			case {{ printf "%q" .Name }}:
+			case {{ printf "%q" .HTTPName }}:
 				{{ .VarName }}Raw = c.Value
 		{{- end }}
 			}

--- a/http/codegen/multipart_test.go
+++ b/http/codegen/multipart_test.go
@@ -77,12 +77,12 @@ func TestServerMultipartNewFunc(t *testing.T) {
 		DSL  func()
 		Code string
 	}{
-		{"multipart-body-primitive", testdata.PayloadMultipartPrimitiveDSL, testdata.MultipartPrimitiveDecoderFuncCode},
-		{"multipart-body-user-type", testdata.PayloadMultipartUserTypeDSL, testdata.MultipartUserTypeDecoderFuncCode},
-		{"multipart-body-array-type", testdata.PayloadMultipartArrayTypeDSL, testdata.MultipartArrayTypeDecoderFuncCode},
-		{"multipart-body-map-type", testdata.PayloadMultipartMapTypeDSL, testdata.MultipartMapTypeDecoderFuncCode},
-		{"multipart-with-param", testdata.PayloadMultipartWithParamDSL, testdata.MultipartWithParamDecoderFuncCode},
-		{"multipart-with-params-and-headers", testdata.PayloadMultipartWithParamsAndHeadersDSL, testdata.MultipartWithParamsAndHeadersDecoderFuncCode},
+		{"server-multipart-body-primitive", testdata.PayloadMultipartPrimitiveDSL, testdata.MultipartPrimitiveDecoderFuncCode},
+		{"server-multipart-body-user-type", testdata.PayloadMultipartUserTypeDSL, testdata.MultipartUserTypeDecoderFuncCode},
+		{"server-multipart-body-array-type", testdata.PayloadMultipartArrayTypeDSL, testdata.MultipartArrayTypeDecoderFuncCode},
+		{"server-multipart-body-map-type", testdata.PayloadMultipartMapTypeDSL, testdata.MultipartMapTypeDecoderFuncCode},
+		{"server-multipart-with-param", testdata.PayloadMultipartWithParamDSL, testdata.MultipartWithParamDecoderFuncCode},
+		{"server-multipart-with-params-and-headers", testdata.PayloadMultipartWithParamsAndHeadersDSL, testdata.MultipartWithParamsAndHeadersDecoderFuncCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -110,12 +110,12 @@ func TestClientMultipartNewFunc(t *testing.T) {
 		DSL  func()
 		Code string
 	}{
-		{"multipart-body-primitive", testdata.PayloadMultipartPrimitiveDSL, testdata.MultipartPrimitiveEncoderFuncCode},
-		{"multipart-body-user-type", testdata.PayloadMultipartUserTypeDSL, testdata.MultipartUserTypeEncoderFuncCode},
-		{"multipart-body-array-type", testdata.PayloadMultipartArrayTypeDSL, testdata.MultipartArrayTypeEncoderFuncCode},
-		{"multipart-body-map-type", testdata.PayloadMultipartMapTypeDSL, testdata.MultipartMapTypeEncoderFuncCode},
-		{"multipart-with-param", testdata.PayloadMultipartWithParamDSL, testdata.MultipartWithParamEncoderFuncCode},
-		{"multipart-with-params-and-headers", testdata.PayloadMultipartWithParamsAndHeadersDSL, testdata.MultipartWithParamsAndHeadersEncoderFuncCode},
+		{"client-multipart-body-primitive", testdata.PayloadMultipartPrimitiveDSL, testdata.MultipartPrimitiveEncoderFuncCode},
+		{"client-multipart-body-user-type", testdata.PayloadMultipartUserTypeDSL, testdata.MultipartUserTypeEncoderFuncCode},
+		{"client-multipart-body-array-type", testdata.PayloadMultipartArrayTypeDSL, testdata.MultipartArrayTypeEncoderFuncCode},
+		{"client-multipart-body-map-type", testdata.PayloadMultipartMapTypeDSL, testdata.MultipartMapTypeEncoderFuncCode},
+		{"client-multipart-with-param", testdata.PayloadMultipartWithParamDSL, testdata.MultipartWithParamEncoderFuncCode},
+		{"client-multipart-with-params-and-headers", testdata.PayloadMultipartWithParamsAndHeadersDSL, testdata.MultipartWithParamsAndHeadersEncoderFuncCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -652,11 +652,11 @@ const requestElementsT = `{{- define "request_elements" }}
 
 {{- range .PathParams }}
 	{{- if and (or (eq .Type.Name "string") (eq .Type.Name "any")) }}
-		{{ .VarName }} = params["{{ .Name }}"]
+		{{ .VarName }} = params["{{ .HTTPName }}"]
 
 	{{- else }}{{/* not string and not any */}}
 		{
-			{{ .VarName }}Raw := params["{{ .Name }}"]
+			{{ .VarName }}Raw := params["{{ .HTTPName }}"]
 			{{- template "path_conversion" . }}
 		}
 
@@ -668,13 +668,13 @@ const requestElementsT = `{{- define "request_elements" }}
 
 {{- range .QueryParams }}
 	{{- if and (or (eq .Type.Name "string") (eq .Type.Name "any")) .Required }}
-		{{ .VarName }} = r.URL.Query().Get("{{ .Name }}")
+		{{ .VarName }} = r.URL.Query().Get("{{ .HTTPName }}")
 		if {{ .VarName }} == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("{{ .Name }}", "query string"))
 		}
 
 	{{- else if (or (eq .Type.Name "string") (eq .Type.Name "any")) }}
-		{{ .VarName }}Raw := r.URL.Query().Get("{{ .Name }}")
+		{{ .VarName }}Raw := r.URL.Query().Get("{{ .HTTPName }}")
 		if {{ .VarName }}Raw != "" {
 			{{ .VarName }} = {{ if and (eq .Type.Name "string") .Pointer }}&{{ end }}{{ .VarName }}Raw
 		}
@@ -684,7 +684,7 @@ const requestElementsT = `{{- define "request_elements" }}
 		{{- end }}
 
 	{{- else if .StringSlice }}
-		{{ .VarName }} = r.URL.Query()["{{ .Name }}"]
+		{{ .VarName }} = r.URL.Query()["{{ .HTTPName }}"]
 		{{- if .Required }}
 		if {{ .VarName }} == nil {
 			err = goa.MergeErrors(err, goa.MissingFieldError("{{ .Name }}", "query string"))
@@ -701,7 +701,7 @@ const requestElementsT = `{{- define "request_elements" }}
 
 	{{- else if .Slice }}
 	{
-		{{ .VarName }}Raw := r.URL.Query()["{{ .Name }}"]
+		{{ .VarName }}Raw := r.URL.Query()["{{ .HTTPName }}"]
 		{{- if .Required }}
 		if {{ .VarName }}Raw == nil {
 			err = goa.MergeErrors(err, goa.MissingFieldError("{{ .Name }}", "query string"))
@@ -740,7 +740,7 @@ const requestElementsT = `{{- define "request_elements" }}
 		if len({{ .VarName }}Raw) != 0 {
 		{{- end }}
 		for keyRaw, valRaw := range {{ .VarName }}Raw {
-			if strings.HasPrefix(keyRaw, "{{ .Name }}[") {
+			if strings.HasPrefix(keyRaw, "{{ .HTTPName }}[") {
 				{{- template "map_conversion" (mapQueryDecodeData .Type .VarName 0) }}
 			}
 		}
@@ -767,7 +767,7 @@ const requestElementsT = `{{- define "request_elements" }}
 		if len({{ .VarName }}Raw) != 0 {
 		{{- end }}
 		for keyRaw, valRaw := range {{ .VarName }}Raw {
-			if strings.HasPrefix(keyRaw, "{{ .Name }}[") {
+			if strings.HasPrefix(keyRaw, "{{ .HTTPName }}[") {
 				{{- template "map_conversion" (mapQueryDecodeData .Type .VarName 0) }}
 			}
 		}
@@ -778,7 +778,7 @@ const requestElementsT = `{{- define "request_elements" }}
 
 	{{- else }}{{/* not string, not any, not slice and not map */}}
 	{
-		{{ .VarName }}Raw := r.URL.Query().Get("{{ .Name }}")
+		{{ .VarName }}Raw := r.URL.Query().Get("{{ .HTTPName }}")
 		{{- if .Required }}
 		if {{ .VarName }}Raw == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("{{ .Name }}", "query string"))
@@ -807,13 +807,13 @@ const requestElementsT = `{{- define "request_elements" }}
 
 {{- range .Headers }}
 	{{- if and (or (eq .Type.Name "string") (eq .Type.Name "any")) .Required }}
-		{{ .VarName }} = r.Header.Get("{{ .Name }}")
+		{{ .VarName }} = r.Header.Get("{{ .HTTPName }}")
 		if {{ .VarName }} == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("{{ .Name }}", "header"))
 		}
 
 	{{- else if (or (eq .Type.Name "string") (eq .Type.Name "any")) }}
-		{{ .VarName }}Raw := r.Header.Get("{{ .Name }}")
+		{{ .VarName }}Raw := r.Header.Get("{{ .HTTPName }}")
 		if {{ .VarName }}Raw != "" {
 			{{ .VarName }} = {{ if and (eq .Type.Name "string") .Pointer }}&{{ end }}{{ .VarName }}Raw
 		}
@@ -858,7 +858,7 @@ const requestElementsT = `{{- define "request_elements" }}
 
 	{{- else }}{{/* not string, not any and not slice */}}
 	{
-		{{ .VarName }}Raw := r.Header.Get("{{ .Name }}")
+		{{ .VarName }}Raw := r.Header.Get("{{ .HTTPName }}")
 		{{- if .Required }}
 		if {{ .VarName }}Raw == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("{{ .Name }}", "header"))
@@ -885,7 +885,7 @@ const requestElementsT = `{{- define "request_elements" }}
 {{- end }}
 
 {{- range .Cookies }}
-	c, {{ if not .Required }}_{{ else }}err{{ end }} = r.Cookie("{{ .Name }}")
+	c, {{ if not .Required }}_{{ else }}err{{ end }} = r.Cookie("{{ .HTTPName }}")
 	{{- if and (or (eq .Type.Name "string") (eq .Type.Name "any")) .Required }}
 		if err == http.ErrNoCookie {
 			err = goa.MergeErrors(err, goa.MissingFieldError("{{ .Name }}", "cookie"))
@@ -963,7 +963,7 @@ const requestElementsT = `{{- define "request_elements" }}
 		key{{ .Loop }} = keyRaw[openIdx+1 : closeIdx]
 	{{- else }}
 		key{{ .Loop }}Raw := keyRaw[openIdx+1 : closeIdx]
-		{{- template "type_conversion" (conversionData (printf "key%s" .Loop) (printf "%q" "query") .Type.KeyType.Type) }}
+		{{- template "type_conversion" (conversionData (printf "key%s" .Loop) "query" .Type.KeyType.Type) }}
 	{{- end }}
 		{{- if gt .Depth 0 }}
 			keyRaw = keyRaw[closeIdx+1:]
@@ -977,7 +977,7 @@ const requestElementsT = `{{- define "request_elements" }}
 		{{- else }}
 			var val {{ goTypeRef .Type.ElemType.Type }}
 			{
-				{{- template "slice_conversion" (conversionData "val" (printf "%q" "query") .Type.ElemType.Type) }}
+				{{- template "slice_conversion" (conversionData "val" "query" .Type.ElemType.Type) }}
 			}
 			{{ .VarName }}[key{{ .Loop }}] = val
 		{{- end }}
@@ -987,7 +987,7 @@ const requestElementsT = `{{- define "request_elements" }}
 		var val{{ .Loop }} {{ goTypeRef .Type.ElemType.Type }}
 		{
 			val{{ .Loop }}Raw := valRaw[0]
-			{{- template "type_conversion" (conversionData (printf "val%s" .Loop)  (printf "%q" "query") .Type.ElemType.Type) }}
+			{{- template "type_conversion" (conversionData (printf "val%s" .Loop) "query" .Type.ElemType.Type) }}
 		}
 		{{ .VarName }}[key{{ .Loop }}] = val{{ .Loop }}
 	{{- end }}
@@ -1007,7 +1007,7 @@ const typeConversionT = `{{- define "slice_conversion" }}
 	{{- else if eq .Type.Name "int" }}
 		v, err2 := strconv.ParseInt({{ .VarName }}Raw, 10, strconv.IntSize)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "integer"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "integer"))
 		}
 		{{- if .Pointer }}
 		pv := int(v)
@@ -1018,7 +1018,7 @@ const typeConversionT = `{{- define "slice_conversion" }}
 	{{- else if eq .Type.Name "int32" }}
 		v, err2 := strconv.ParseInt({{ .VarName }}Raw, 10, 32)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "integer"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "integer"))
 		}
 		{{- if .Pointer }}
 		pv := int32(v)
@@ -1029,13 +1029,13 @@ const typeConversionT = `{{- define "slice_conversion" }}
 	{{- else if eq .Type.Name "int64" }}
 		v, err2 := strconv.ParseInt({{ .VarName }}Raw, 10, 64)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "integer"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "integer"))
 		}
 		{{ .VarName }} = {{ if .Pointer}}&{{ end }}v
 	{{- else if eq .Type.Name "uint" }}
 		v, err2 := strconv.ParseUint({{ .VarName }}Raw, 10, strconv.IntSize)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "unsigned integer"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "unsigned integer"))
 		}
 		{{- if .Pointer }}
 		pv := uint(v)
@@ -1046,7 +1046,7 @@ const typeConversionT = `{{- define "slice_conversion" }}
 	{{- else if eq .Type.Name "uint32" }}
 		v, err2 := strconv.ParseUint({{ .VarName }}Raw, 10, 32)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "unsigned integer"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "unsigned integer"))
 		}
 		{{- if .Pointer }}
 		pv := uint32(v)
@@ -1057,13 +1057,13 @@ const typeConversionT = `{{- define "slice_conversion" }}
 	{{- else if eq .Type.Name "uint64" }}
 		v, err2 := strconv.ParseUint({{ .VarName }}Raw, 10, 64)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "unsigned integer"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "unsigned integer"))
 		}
 		{{ .VarName }} = {{ if .Pointer }}&{{ end }}v
 	{{- else if eq .Type.Name "float32" }}
 		v, err2 := strconv.ParseFloat({{ .VarName }}Raw, 32)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "float"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "float"))
 		}
 		{{- if .Pointer }}
 		pv := float32(v)
@@ -1074,13 +1074,13 @@ const typeConversionT = `{{- define "slice_conversion" }}
 	{{- else if eq .Type.Name "float64" }}
 		v, err2 := strconv.ParseFloat({{ .VarName }}Raw, 64)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "float"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "float"))
 		}
 		{{ .VarName }} = {{ if .Pointer }}&{{ end }}v
 	{{- else if eq .Type.Name "boolean" }}
 		v, err2 := strconv.ParseBool({{ .VarName }}Raw)
 		if err2 != nil {
-			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "boolean"))
+			err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "boolean"))
 		}
 		{{ .VarName }} = {{ if .Pointer }}&{{ end }}v
 	{{- else }}
@@ -1095,55 +1095,55 @@ const typeConversionT = `{{- define "slice_conversion" }}
 		{{- else if eq .Type.ElemType.Type.Name "int" }}
 			v, err2 := strconv.ParseInt(rv, 10, strconv.IntSize)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of integers"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of integers"))
 			}
 			{{ .VarName }}[i] = int(v)
 		{{- else if eq .Type.ElemType.Type.Name "int32" }}
 			v, err2 := strconv.ParseInt(rv, 10, 32)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of integers"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of integers"))
 			}
 			{{ .VarName }}[i] = int32(v)
 		{{- else if eq .Type.ElemType.Type.Name "int64" }}
 			v, err2 := strconv.ParseInt(rv, 10, 64)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of integers"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of integers"))
 			}
 			{{ .VarName }}[i] = v
 		{{- else if eq .Type.ElemType.Type.Name "uint" }}
 			v, err2 := strconv.ParseUint(rv, 10, strconv.IntSize)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of unsigned integers"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of unsigned integers"))
 			}
 			{{ .VarName }}[i] = uint(v)
 		{{- else if eq .Type.ElemType.Type.Name "uint32" }}
 			v, err2 := strconv.ParseUint(rv, 10, 32)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of unsigned integers"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of unsigned integers"))
 			}
 			{{ .VarName }}[i] = uint32(v)
 		{{- else if eq .Type.ElemType.Type.Name "uint64" }}
 			v, err2 := strconv.ParseUint(rv, 10, 64)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of unsigned integers"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of unsigned integers"))
 			}
 			{{ .VarName }}[i] = v
 		{{- else if eq .Type.ElemType.Type.Name "float32" }}
 			v, err2 := strconv.ParseFloat(rv, 32)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of floats"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of floats"))
 			}
 			{{ .VarName }}[i] = float32(v)
 		{{- else if eq .Type.ElemType.Type.Name "float64" }}
 			v, err2 := strconv.ParseFloat(rv, 64)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of floats"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of floats"))
 			}
 			{{ .VarName }}[i] = v
 		{{- else if eq .Type.ElemType.Type.Name "boolean" }}
 			v, err2 := strconv.ParseBool(rv)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .VarName }}, {{ .VarName}}Raw, "array of booleans"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError({{ printf "%q" .Name }}, {{ .VarName}}Raw, "array of booleans"))
 			}
 			{{ .VarName }}[i] = v
 		{{- else if eq .Type.ElemType.Type.Name "any" }}

--- a/http/codegen/testdata/multipart_code.go
+++ b/http/codegen/testdata/multipart_code.go
@@ -164,7 +164,7 @@ func NewServiceMultipartWithParamMethodMultipartWithParamDecoder(mux goahttp.Mux
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseInt(keyaRaw, 10, strconv.IntSize)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "integer"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "integer"))
 							}
 							keya = int(v)
 						}
@@ -224,7 +224,7 @@ func NewServiceMultipartWithParamsAndHeadersMethodMultipartWithParamsAndHeadersD
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseInt(keyaRaw, 10, strconv.IntSize)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "integer"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "integer"))
 							}
 							keya = int(v)
 						}

--- a/http/codegen/testdata/payload_decode_functions.go
+++ b/http/codegen/testdata/payload_decode_functions.go
@@ -1629,7 +1629,7 @@ func DecodeMethodQueryMapStringBoolRequest(mux goahttp.Muxer, decoder func(*http
 							valaRaw := valRaw[0]
 							v, err2 := strconv.ParseBool(valaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valaRaw, "boolean"))
 							}
 							vala = v
 						}
@@ -1678,7 +1678,7 @@ func DecodeMethodQueryMapStringBoolValidateRequest(mux goahttp.Muxer, decoder fu
 						valaRaw := valRaw[0]
 						v, err2 := strconv.ParseBool(valaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valaRaw, "boolean"))
 						}
 						vala = v
 					}
@@ -1730,7 +1730,7 @@ func DecodeMethodQueryMapBoolStringRequest(mux goahttp.Muxer, decoder func(*http
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseBool(keyaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 							}
 							keya = v
 						}
@@ -1775,7 +1775,7 @@ func DecodeMethodQueryMapBoolStringValidateRequest(mux goahttp.Muxer, decoder fu
 						keyaRaw := keyRaw[openIdx+1 : closeIdx]
 						v, err2 := strconv.ParseBool(keyaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 						}
 						keya = v
 					}
@@ -1827,7 +1827,7 @@ func DecodeMethodQueryMapBoolBoolRequest(mux goahttp.Muxer, decoder func(*http.R
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseBool(keyaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 							}
 							keya = v
 						}
@@ -1836,7 +1836,7 @@ func DecodeMethodQueryMapBoolBoolRequest(mux goahttp.Muxer, decoder func(*http.R
 							valaRaw := valRaw[0]
 							v, err2 := strconv.ParseBool(valaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valaRaw, "boolean"))
 							}
 							vala = v
 						}
@@ -1881,7 +1881,7 @@ func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func
 						keyaRaw := keyRaw[openIdx+1 : closeIdx]
 						v, err2 := strconv.ParseBool(keyaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 						}
 						keya = v
 					}
@@ -1890,7 +1890,7 @@ func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func
 						valaRaw := valRaw[0]
 						v, err2 := strconv.ParseBool(valaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valaRaw, "boolean"))
 						}
 						vala = v
 					}
@@ -2032,7 +2032,7 @@ func DecodeMethodQueryMapStringArrayBoolRequest(mux goahttp.Muxer, decoder func(
 							for i, rv := range valRaw {
 								v, err2 := strconv.ParseBool(rv)
 								if err2 != nil {
-									err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "array of booleans"))
+									err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valRaw, "array of booleans"))
 								}
 								val[i] = v
 							}
@@ -2083,7 +2083,7 @@ func DecodeMethodQueryMapStringArrayBoolValidateRequest(mux goahttp.Muxer, decod
 						for i, rv := range valRaw {
 							v, err2 := strconv.ParseBool(rv)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "array of booleans"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valRaw, "array of booleans"))
 							}
 							val[i] = v
 						}
@@ -2137,7 +2137,7 @@ func DecodeMethodQueryMapBoolArrayStringRequest(mux goahttp.Muxer, decoder func(
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseBool(keyaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 							}
 							keya = v
 						}
@@ -2180,7 +2180,7 @@ func DecodeMethodQueryMapBoolArrayStringValidateRequest(mux goahttp.Muxer, decod
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseBool(keyaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 							}
 							keya = v
 						}
@@ -2233,7 +2233,7 @@ func DecodeMethodQueryMapBoolArrayBoolRequest(mux goahttp.Muxer, decoder func(*h
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseBool(keyaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 							}
 							keya = v
 						}
@@ -2243,7 +2243,7 @@ func DecodeMethodQueryMapBoolArrayBoolRequest(mux goahttp.Muxer, decoder func(*h
 							for i, rv := range valRaw {
 								v, err2 := strconv.ParseBool(rv)
 								if err2 != nil {
-									err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "array of booleans"))
+									err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valRaw, "array of booleans"))
 								}
 								val[i] = v
 							}
@@ -2289,7 +2289,7 @@ func DecodeMethodQueryMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder
 						keyaRaw := keyRaw[openIdx+1 : closeIdx]
 						v, err2 := strconv.ParseBool(keyaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 						}
 						keya = v
 					}
@@ -2299,7 +2299,7 @@ func DecodeMethodQueryMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder
 						for i, rv := range valRaw {
 							v, err2 := strconv.ParseBool(rv)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "array of booleans"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valRaw, "array of booleans"))
 							}
 							val[i] = v
 						}
@@ -2542,7 +2542,7 @@ func DecodeMethodQueryPrimitiveMapStringBoolValidateRequest(mux goahttp.Muxer, d
 						valaRaw := valRaw[0]
 						v, err2 := strconv.ParseBool(valaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valaRaw, "boolean"))
 						}
 						vala = v
 					}
@@ -2595,7 +2595,7 @@ func DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(mux goahttp.Muxer
 						keyaRaw := keyRaw[openIdx+1 : closeIdx]
 						v, err2 := strconv.ParseBool(keyaRaw)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "boolean"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "boolean"))
 						}
 						keya = v
 					}
@@ -2605,7 +2605,7 @@ func DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(mux goahttp.Muxer
 						for i, rv := range valRaw {
 							v, err2 := strconv.ParseBool(rv)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "array of booleans"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valRaw, "array of booleans"))
 							}
 							val[i] = v
 						}
@@ -2676,7 +2676,7 @@ func DecodeMethodQueryMapStringMapIntStringValidateRequest(mux goahttp.Muxer, de
 						keybRaw := keyRaw[openIdx+1 : closeIdx]
 						v, err2 := strconv.ParseInt(keybRaw, 10, strconv.IntSize)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keyb", keybRaw, "integer"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keybRaw, "integer"))
 						}
 						keyb = int(v)
 					}
@@ -2725,7 +2725,7 @@ func DecodeMethodQueryMapIntMapStringArrayIntValidateRequest(mux goahttp.Muxer, 
 						keyaRaw := keyRaw[openIdx+1 : closeIdx]
 						v, err2 := strconv.ParseInt(keyaRaw, 10, strconv.IntSize)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "integer"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "integer"))
 						}
 						keya = int(v)
 						keyRaw = keyRaw[closeIdx+1:]
@@ -2745,7 +2745,7 @@ func DecodeMethodQueryMapIntMapStringArrayIntValidateRequest(mux goahttp.Muxer, 
 						for i, rv := range valRaw {
 							v, err2 := strconv.ParseInt(rv, 10, strconv.IntSize)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "array of integers"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valRaw, "array of integers"))
 							}
 							val[i] = int(v)
 						}
@@ -3452,7 +3452,7 @@ func DecodeMethodCookieStringValidateRequest(mux goahttp.Muxer, decoder func(*ht
 			c2 = &c2Raw
 		}
 		if c2 != nil {
-			err = goa.MergeErrors(err, goa.ValidatePattern("c2", *c2, "cookie"))
+			err = goa.MergeErrors(err, goa.ValidatePattern("c", *c2, "cookie"))
 		}
 		if err != nil {
 			return nil, err
@@ -3481,7 +3481,7 @@ func DecodeMethodCookiePrimitiveStringValidateRequest(mux goahttp.Muxer, decoder
 			c2 = c.Value
 		}
 		if !(c2 == "val") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []any{"val"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c", c2, []any{"val"}))
 		}
 		if err != nil {
 			return nil, err
@@ -3514,12 +3514,12 @@ func DecodeMethodCookiePrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder f
 			}
 			v, err2 := strconv.ParseBool(c2Raw)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("c2", c2Raw, "boolean"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("c", c2Raw, "boolean"))
 			}
 			c2 = v
 		}
 		if !(c2 == true) {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []any{true}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c", c2, []any{true}))
 		}
 		if err != nil {
 			return nil, err
@@ -3577,7 +3577,7 @@ func DecodeMethodCookieStringDefaultValidateRequest(mux goahttp.Muxer, decoder f
 			c2 = "def"
 		}
 		if !(c2 == "def") {
-			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c2", c2, []any{"def"}))
+			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c", c2, []any{"def"}))
 		}
 		if err != nil {
 			return nil, err
@@ -4691,7 +4691,7 @@ func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder f
 			params = mux.Vars(r)
 		)
 		c2 = params["c"]
-		err = goa.MergeErrors(err, goa.ValidatePattern("c2", c2, "patternc"))
+		err = goa.MergeErrors(err, goa.ValidatePattern("c", c2, "patternc"))
 		b = r.URL.Query().Get("b")
 		if b == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("b", "query string"))
@@ -4769,7 +4769,7 @@ func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder fun
 			params = mux.Vars(r)
 		)
 		c2 = params["c"]
-		err = goa.MergeErrors(err, goa.ValidatePattern("c2", c2, "patternc"))
+		err = goa.MergeErrors(err, goa.ValidatePattern("c", c2, "patternc"))
 		b = r.URL.Query().Get("b")
 		if b == "" {
 			err = goa.MergeErrors(err, goa.MissingFieldError("b", "query string"))
@@ -4853,7 +4853,7 @@ func DecodeMapQueryPrimitiveArrayRequest(mux goahttp.Muxer, decoder func(*http.R
 						for i, rv := range valRaw {
 							v, err2 := strconv.ParseUint(rv, 10, strconv.IntSize)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("val", valRaw, "array of unsigned integers"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valRaw, "array of unsigned integers"))
 							}
 							val[i] = uint(v)
 						}
@@ -4917,7 +4917,7 @@ func DecodeMethodMapQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Req
 						keyaRaw := keyRaw[openIdx+1 : closeIdx]
 						v, err2 := strconv.ParseInt(keyaRaw, 10, strconv.IntSize)
 						if err2 != nil {
-							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "integer"))
+							err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "integer"))
 						}
 						keya = int(v)
 					}
@@ -5042,7 +5042,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 			v, err2 := strconv.ParseFloat(optionalButRequiredParamRaw, 32)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optionalButRequiredParam", optionalButRequiredParamRaw, "float"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optional_but_required_param", optionalButRequiredParamRaw, "float"))
 			}
 			optionalButRequiredParam = float32(v)
 		}
@@ -5057,7 +5057,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 			v, err2 := strconv.ParseFloat(optionalButRequiredHeaderRaw, 32)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optionalButRequiredHeader", optionalButRequiredHeaderRaw, "float"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optional_but_required_header", optionalButRequiredHeaderRaw, "float"))
 			}
 			optionalButRequiredHeader = float32(v)
 		}
@@ -5086,7 +5086,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int_Raw != "" {
 				v, err2 := strconv.ParseInt(int_Raw, 10, strconv.IntSize)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int_", int_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int", int_Raw, "integer"))
 				}
 				pv := int(v)
 				int_ = &pv
@@ -5097,7 +5097,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int32_Raw != "" {
 				v, err2 := strconv.ParseInt(int32_Raw, 10, 32)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32_", int32_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32", int32_Raw, "integer"))
 				}
 				pv := int32(v)
 				int32_ = &pv
@@ -5108,7 +5108,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int64_Raw != "" {
 				v, err2 := strconv.ParseInt(int64_Raw, 10, 64)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64_", int64_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64", int64_Raw, "integer"))
 				}
 				int64_ = &v
 			}
@@ -5138,7 +5138,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int_Raw != "" {
 				v, err2 := strconv.ParseInt(int_Raw, 10, strconv.IntSize)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int_", int_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int", int_Raw, "integer"))
 				}
 				pv := int(v)
 				int_ = &pv
@@ -5146,7 +5146,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 		}
 		if int_ != nil {
 			if *int_ < 10 {
-				err = goa.MergeErrors(err, goa.InvalidRangeError("int_", *int_, 10, true))
+				err = goa.MergeErrors(err, goa.InvalidRangeError("int", *int_, 10, true))
 			}
 		}
 		{
@@ -5154,7 +5154,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int32_Raw != "" {
 				v, err2 := strconv.ParseInt(int32_Raw, 10, 32)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32_", int32_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32", int32_Raw, "integer"))
 				}
 				pv := int32(v)
 				int32_ = &pv
@@ -5162,7 +5162,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 		}
 		if int32_ != nil {
 			if *int32_ > 100 {
-				err = goa.MergeErrors(err, goa.InvalidRangeError("int32_", *int32_, 100, false))
+				err = goa.MergeErrors(err, goa.InvalidRangeError("int32", *int32_, 100, false))
 			}
 		}
 		{
@@ -5170,14 +5170,14 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int64_Raw != "" {
 				v, err2 := strconv.ParseInt(int64_Raw, 10, 64)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64_", int64_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64", int64_Raw, "integer"))
 				}
 				int64_ = &v
 			}
 		}
 		if int64_ != nil {
 			if *int64_ < 0 {
-				err = goa.MergeErrors(err, goa.InvalidRangeError("int64_", *int64_, 0, true))
+				err = goa.MergeErrors(err, goa.InvalidRangeError("int64", *int64_, 0, true))
 			}
 		}
 		if err != nil {
@@ -5282,7 +5282,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseFloat(keyaRaw, 32)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "float"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "float"))
 							}
 							keya = float32(v)
 						}
@@ -5291,7 +5291,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 							valaRaw := valRaw[0]
 							v, err2 := strconv.ParseBool(valaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valaRaw, "boolean"))
 							}
 							vala = v
 						}
@@ -5333,7 +5333,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 							keyaRaw := keyRaw[openIdx+1 : closeIdx]
 							v, err2 := strconv.ParseFloat(keyaRaw, 32)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("keya", keyaRaw, "float"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", keyaRaw, "float"))
 							}
 							keya = float32(v)
 						}
@@ -5342,7 +5342,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 							valaRaw := valRaw[0]
 							v, err2 := strconv.ParseBool(valaRaw)
 							if err2 != nil {
-								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("vala", valaRaw, "boolean"))
+								err = goa.MergeErrors(err, goa.InvalidFieldTypeError("query", valaRaw, "boolean"))
 							}
 							vala = v
 						}
@@ -5352,7 +5352,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 		}
 		if len(map_) < 5 {
-			err = goa.MergeErrors(err, goa.InvalidLengthError("map_", map_, len(map_), 5, true))
+			err = goa.MergeErrors(err, goa.InvalidLengthError("map", map_, len(map_), 5, true))
 		}
 		if err != nil {
 			return nil, err
@@ -5415,7 +5415,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int_Raw != "" {
 				v, err2 := strconv.ParseInt(int_Raw, 10, strconv.IntSize)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int_", int_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int", int_Raw, "integer"))
 				}
 				pv := int(v)
 				int_ = &pv
@@ -5426,7 +5426,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int32_Raw != "" {
 				v, err2 := strconv.ParseInt(int32_Raw, 10, 32)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32_", int32_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32", int32_Raw, "integer"))
 				}
 				pv := int32(v)
 				int32_ = &pv
@@ -5437,7 +5437,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			if int64_Raw != "" {
 				v, err2 := strconv.ParseInt(int64_Raw, 10, 64)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64_", int64_Raw, "integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64", int64_Raw, "integer"))
 				}
 				int64_ = &v
 			}
@@ -5468,7 +5468,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			int_Raw := params["int"]
 			v, err2 := strconv.ParseInt(int_Raw, 10, strconv.IntSize)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int_", int_Raw, "integer"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int", int_Raw, "integer"))
 			}
 			int_ = int(v)
 		}
@@ -5476,7 +5476,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			int32_Raw := params["int32"]
 			v, err2 := strconv.ParseInt(int32_Raw, 10, 32)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32_", int32_Raw, "integer"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int32", int32_Raw, "integer"))
 			}
 			int32_ = int32(v)
 		}
@@ -5484,7 +5484,7 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			int64_Raw := params["int64"]
 			v, err2 := strconv.ParseInt(int64_Raw, 10, 64)
 			if err2 != nil {
-				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64_", int64_Raw, "integer"))
+				err = goa.MergeErrors(err, goa.InvalidFieldTypeError("int64", int64_Raw, "integer"))
 			}
 			int64_ = v
 		}

--- a/http/codegen/testdata/result_decode_functions.go
+++ b/http/codegen/testdata/result_decode_functions.go
@@ -625,7 +625,7 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			{
 				requiredRaw := resp.Header.Get("X-Request-Id")
 				if requiredRaw == "" {
-					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlock", "MethodA", goa.MissingFieldError("X-Request-ID", "header"))
+					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlock", "MethodA", goa.MissingFieldError("required", "header"))
 				}
 				v, err2 := strconv.ParseInt(requiredRaw, 10, strconv.IntSize)
 				if err2 != nil {
@@ -647,11 +647,11 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			{
 				optionalButRequiredRaw := resp.Header.Get("Location")
 				if optionalButRequiredRaw == "" {
-					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlock", "MethodA", goa.MissingFieldError("Location", "header"))
+					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlock", "MethodA", goa.MissingFieldError("optional_but_required", "header"))
 				}
 				v, err2 := strconv.ParseUint(optionalButRequiredRaw, 10, strconv.IntSize)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optionalButRequired", optionalButRequiredRaw, "unsigned integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optional_but_required", optionalButRequiredRaw, "unsigned integer"))
 				}
 				optionalButRequired = uint(v)
 			}
@@ -696,7 +696,7 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			{
 				requiredRaw := resp.Header.Get("X-Request-Id")
 				if requiredRaw == "" {
-					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlockViewedResult", "MethodA", goa.MissingFieldError("X-Request-ID", "header"))
+					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlockViewedResult", "MethodA", goa.MissingFieldError("required", "header"))
 				}
 				v, err2 := strconv.ParseInt(requiredRaw, 10, strconv.IntSize)
 				if err2 != nil {
@@ -718,11 +718,11 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			{
 				optionalButRequiredRaw := resp.Header.Get("Location")
 				if optionalButRequiredRaw == "" {
-					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlockViewedResult", "MethodA", goa.MissingFieldError("Location", "header"))
+					return nil, goahttp.ErrValidationError("ServiceWithHeadersBlockViewedResult", "MethodA", goa.MissingFieldError("optional_but_required", "header"))
 				}
 				v, err2 := strconv.ParseUint(optionalButRequiredRaw, 10, strconv.IntSize)
 				if err2 != nil {
-					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optionalButRequired", optionalButRequiredRaw, "unsigned integer"))
+					err = goa.MergeErrors(err, goa.InvalidFieldTypeError("optional_but_required", optionalButRequiredRaw, "unsigned integer"))
 				}
 				optionalButRequired = uint(v)
 			}
@@ -771,7 +771,7 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			{
 				requiredRaw := resp.Header.Get("X-Request-Id")
 				if requiredRaw == "" {
-					return nil, goahttp.ErrValidationError("ValidateErrorResponseType", "MethodA", goa.MissingFieldError("X-Request-ID", "header"))
+					return nil, goahttp.ErrValidationError("ValidateErrorResponseType", "MethodA", goa.MissingFieldError("required", "header"))
 				}
 				v, err2 := strconv.ParseInt(requiredRaw, 10, strconv.IntSize)
 				if err2 != nil {
@@ -795,7 +795,7 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			)
 			errorRaw := resp.Header.Get("X-Application-Error")
 			if errorRaw == "" {
-				err = goa.MergeErrors(err, goa.MissingFieldError("X-Application-Error", "header"))
+				err = goa.MergeErrors(err, goa.MissingFieldError("error", "header"))
 			}
 			error = errorRaw
 			{
@@ -803,7 +803,7 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 				if numOccurRaw != "" {
 					v, err2 := strconv.ParseInt(numOccurRaw, 10, strconv.IntSize)
 					if err2 != nil {
-						err = goa.MergeErrors(err, goa.InvalidFieldTypeError("numOccur", numOccurRaw, "integer"))
+						err = goa.MergeErrors(err, goa.InvalidFieldTypeError("num_occur", numOccurRaw, "integer"))
 					}
 					pv := int(v)
 					numOccur = &pv
@@ -811,7 +811,7 @@ func DecodeMethodAResponse(decoder func(*http.Response) goahttp.Decoder, restore
 			}
 			if numOccur != nil {
 				if *numOccur < 1 {
-					err = goa.MergeErrors(err, goa.InvalidRangeError("numOccur", *numOccur, 1, true))
+					err = goa.MergeErrors(err, goa.InvalidRangeError("num_occur", *numOccur, 1, true))
 				}
 			}
 			if err != nil {
@@ -863,23 +863,23 @@ func DecodeMethodEmptyErrorResponseBodyResponse(decoder func(*http.Response) goa
 			)
 			nameRaw := resp.Header.Get("Error-Name")
 			if nameRaw == "" {
-				err = goa.MergeErrors(err, goa.MissingFieldError("Error-Name", "header"))
+				err = goa.MergeErrors(err, goa.MissingFieldError("name", "header"))
 			}
 			name = nameRaw
 			idRaw := resp.Header.Get("Goa-Attribute-Id")
 			if idRaw == "" {
-				err = goa.MergeErrors(err, goa.MissingFieldError("goa-attribute-id", "header"))
+				err = goa.MergeErrors(err, goa.MissingFieldError("id", "header"))
 			}
 			id = idRaw
 			messageRaw := resp.Header.Get("Goa-Attribute-Message")
 			if messageRaw == "" {
-				err = goa.MergeErrors(err, goa.MissingFieldError("goa-attribute-message", "header"))
+				err = goa.MergeErrors(err, goa.MissingFieldError("message", "header"))
 			}
 			message = messageRaw
 			{
 				temporaryRaw := resp.Header.Get("Goa-Attribute-Temporary")
 				if temporaryRaw == "" {
-					return nil, goahttp.ErrValidationError("ServiceEmptyErrorResponseBody", "MethodEmptyErrorResponseBody", goa.MissingFieldError("goa-attribute-temporary", "header"))
+					return nil, goahttp.ErrValidationError("ServiceEmptyErrorResponseBody", "MethodEmptyErrorResponseBody", goa.MissingFieldError("temporary", "header"))
 				}
 				v, err2 := strconv.ParseBool(temporaryRaw)
 				if err2 != nil {
@@ -890,7 +890,7 @@ func DecodeMethodEmptyErrorResponseBodyResponse(decoder func(*http.Response) goa
 			{
 				timeoutRaw := resp.Header.Get("Goa-Attribute-Timeout")
 				if timeoutRaw == "" {
-					return nil, goahttp.ErrValidationError("ServiceEmptyErrorResponseBody", "MethodEmptyErrorResponseBody", goa.MissingFieldError("goa-attribute-timeout", "header"))
+					return nil, goahttp.ErrValidationError("ServiceEmptyErrorResponseBody", "MethodEmptyErrorResponseBody", goa.MissingFieldError("timeout", "header"))
 				}
 				v, err2 := strconv.ParseBool(timeoutRaw)
 				if err2 != nil {
@@ -901,7 +901,7 @@ func DecodeMethodEmptyErrorResponseBodyResponse(decoder func(*http.Response) goa
 			{
 				faultRaw := resp.Header.Get("Goa-Attribute-Fault")
 				if faultRaw == "" {
-					return nil, goahttp.ErrValidationError("ServiceEmptyErrorResponseBody", "MethodEmptyErrorResponseBody", goa.MissingFieldError("goa-attribute-fault", "header"))
+					return nil, goahttp.ErrValidationError("ServiceEmptyErrorResponseBody", "MethodEmptyErrorResponseBody", goa.MissingFieldError("fault", "header"))
 				}
 				v, err2 := strconv.ParseBool(faultRaw)
 				if err2 != nil {

--- a/http/codegen/websocket.go
+++ b/http/codegen/websocket.go
@@ -134,6 +134,7 @@ func initWebSocketData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceDa
 						serverArgs = []*InitArgData{{
 							Ref: ref,
 							AttributeData: &AttributeData{
+								Name:     "payload",
 								VarName:  "body",
 								TypeName: sd.Scope.GoTypeName(e.StreamingBody),
 								TypeRef:  sd.Scope.GoTypeRef(e.StreamingBody),


### PR DESCRIPTION
Instead of generated variable names.

Fix #3281 