### PR TITLE
Fix potential leak in Websocket configuration

### DIFF
--- a/codegen/service/client_test.go
+++ b/codegen/service/client_test.go
@@ -17,18 +17,18 @@ func TestClient(t *testing.T) {
 		DSL  func()
 		Code string
 	}{
-		{"single", testdata.SingleEndpointDSL, testdata.SingleMethodClient},
-		{"use", testdata.UseEndpointDSL, testdata.UseMethodClient},
-		{"multiple", testdata.MultipleEndpointsDSL, testdata.MultipleMethodsClient},
-		{"no-payload", testdata.NoPayloadEndpointDSL, testdata.NoPayloadMethodsClient},
-		{"with-result", testdata.WithResultEndpointDSL, testdata.WithResultMethodClient},
-		{"streaming-result", testdata.StreamingResultMethodDSL, testdata.StreamingResultMethodClient},
-		{"streaming-result-no-payload", testdata.StreamingResultNoPayloadMethodDSL, testdata.StreamingResultNoPayloadMethodClient},
-		{"streaming-payload", testdata.StreamingPayloadMethodDSL, testdata.StreamingPayloadMethodClient},
-		{"streaming-payload-no-payload", testdata.StreamingPayloadNoPayloadMethodDSL, testdata.StreamingPayloadNoPayloadMethodClient},
-		{"streaming-payload-no-result", testdata.StreamingPayloadNoResultMethodDSL, testdata.StreamingPayloadNoResultMethodClient},
-		{"bidirectional-streaming", testdata.BidirectionalStreamingMethodDSL, testdata.BidirectionalStreamingMethodClient},
-		{"bidirectional-streaming-no-payload", testdata.BidirectionalStreamingNoPayloadMethodDSL, testdata.BidirectionalStreamingNoPayloadMethodClient},
+		{"client-single", testdata.SingleEndpointDSL, testdata.SingleMethodClient},
+		{"client-use", testdata.UseEndpointDSL, testdata.UseMethodClient},
+		{"client-multiple", testdata.MultipleEndpointsDSL, testdata.MultipleMethodsClient},
+		{"client-no-payload", testdata.NoPayloadEndpointDSL, testdata.NoPayloadMethodsClient},
+		{"client-with-result", testdata.WithResultEndpointDSL, testdata.WithResultMethodClient},
+		{"client-streaming-result", testdata.StreamingResultMethodDSL, testdata.StreamingResultMethodClient},
+		{"client-streaming-result-no-payload", testdata.StreamingResultNoPayloadMethodDSL, testdata.StreamingResultNoPayloadMethodClient},
+		{"client-streaming-payload", testdata.StreamingPayloadMethodDSL, testdata.StreamingPayloadMethodClient},
+		{"client-streaming-payload-no-payload", testdata.StreamingPayloadNoPayloadMethodDSL, testdata.StreamingPayloadNoPayloadMethodClient},
+		{"client-streaming-payload-no-result", testdata.StreamingPayloadNoResultMethodDSL, testdata.StreamingPayloadNoResultMethodClient},
+		{"client-bidirectional-streaming", testdata.BidirectionalStreamingMethodDSL, testdata.BidirectionalStreamingMethodClient},
+		{"client-bidirectional-streaming-no-payload", testdata.BidirectionalStreamingNoPayloadMethodDSL, testdata.BidirectionalStreamingNoPayloadMethodClient},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/codegen/service/endpoint_test.go
+++ b/codegen/service/endpoint_test.go
@@ -17,20 +17,20 @@ func TestEndpoint(t *testing.T) {
 		DSL  func()
 		Code string
 	}{
-		{"single", testdata.SingleEndpointDSL, testdata.SingleEndpoint},
-		{"use", testdata.UseEndpointDSL, testdata.UseEndpoint},
-		{"multiple", testdata.MultipleEndpointsDSL, testdata.MultipleEndpoints},
-		{"no-payload", testdata.NoPayloadEndpointDSL, testdata.NoPayloadEndpoint},
-		{"with-result", testdata.WithResultEndpointDSL, testdata.WithResultEndpoint},
-		{"with-result-multiple-views", testdata.WithResultMultipleViewsEndpointDSL, testdata.WithResultMultipleViewsEndpoint},
-		{"streaming-result", testdata.StreamingResultEndpointDSL, testdata.StreamingResultMethodEndpoint},
-		{"streaming-result-no-payload", testdata.StreamingResultNoPayloadEndpointDSL, testdata.StreamingResultNoPayloadMethodEndpoint},
-		{"streaming-result-with-views", testdata.StreamingResultWithViewsMethodDSL, testdata.StreamingResultWithViewsMethodEndpoint},
-		{"streaming-payload", testdata.StreamingPayloadEndpointDSL, testdata.StreamingPayloadMethodEndpoint},
-		{"streaming-payload-no-payload", testdata.StreamingPayloadNoPayloadMethodDSL, testdata.StreamingPayloadNoPayloadMethodEndpoint},
-		{"streaming-payload-no-result", testdata.StreamingPayloadNoResultMethodDSL, testdata.StreamingPayloadNoResultMethodEndpoint},
-		{"bidirectional-streaming", testdata.BidirectionalStreamingEndpointDSL, testdata.BidirectionalStreamingMethodEndpoint},
-		{"bidirectional-streaming-no-payload", testdata.BidirectionalStreamingNoPayloadMethodDSL, testdata.BidirectionalStreamingNoPayloadMethodEndpoint},
+		{"endpoint-single", testdata.SingleEndpointDSL, testdata.SingleEndpoint},
+		{"endpoint-use", testdata.UseEndpointDSL, testdata.UseEndpoint},
+		{"endpoint-multiple", testdata.MultipleEndpointsDSL, testdata.MultipleEndpoints},
+		{"endpoint-no-payload", testdata.NoPayloadEndpointDSL, testdata.NoPayloadEndpoint},
+		{"endpoint-with-result", testdata.WithResultEndpointDSL, testdata.WithResultEndpoint},
+		{"endpoint-with-result-multiple-views", testdata.WithResultMultipleViewsEndpointDSL, testdata.WithResultMultipleViewsEndpoint},
+		{"endpoint-streaming-result", testdata.StreamingResultEndpointDSL, testdata.StreamingResultMethodEndpoint},
+		{"endpoint-streaming-result-no-payload", testdata.StreamingResultNoPayloadEndpointDSL, testdata.StreamingResultNoPayloadMethodEndpoint},
+		{"endpoint-streaming-result-with-views", testdata.StreamingResultWithViewsMethodDSL, testdata.StreamingResultWithViewsMethodEndpoint},
+		{"endpoint-streaming-payload", testdata.StreamingPayloadEndpointDSL, testdata.StreamingPayloadMethodEndpoint},
+		{"endpoint-streaming-payload-no-payload", testdata.StreamingPayloadNoPayloadMethodDSL, testdata.StreamingPayloadNoPayloadMethodEndpoint},
+		{"endpoint-streaming-payload-no-result", testdata.StreamingPayloadNoResultMethodDSL, testdata.StreamingPayloadNoResultMethodEndpoint},
+		{"endpoint-bidirectional-streaming", testdata.BidirectionalStreamingEndpointDSL, testdata.BidirectionalStreamingMethodEndpoint},
+		{"endpoint-bidirectional-streaming-no-payload", testdata.BidirectionalStreamingNoPayloadMethodDSL, testdata.BidirectionalStreamingNoPayloadMethodEndpoint},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -349,9 +349,13 @@ func (c *{{ .ClientStruct }}) {{ .EndpointInit }}({{ if .MultipartRequestEncoder
 			return nil, goahttp.ErrRequestError("{{ .ServiceName }}", "{{ .Method.Name }}", err)
 		}
 		if c.configurer.{{ .Method.VarName }}Fn != nil {
+			{{- if eq .ClientWebSocket.SendName "" }}
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithCancel(ctx)
 			conn = c.configurer.{{ .Method.VarName }}Fn(conn, cancel)
+			{{- else }}
+			conn = c.configurer.{{ .Method.VarName }}Fn(conn, nil)
+			{{- end }}
 		}
 		{{- if eq .ClientWebSocket.SendName "" }}
 		go func() {

--- a/http/codegen/streaming_test.go
+++ b/http/codegen/streaming_test.go
@@ -204,176 +204,176 @@ func TestServerStreaming(t *testing.T) {
 
 func TestClientStreaming(t *testing.T) {
 	cases := []*testCase{
-		{"mixed-endpoints", testdata.StreamingResultDSL, []*sectionExpectation{
+		{"client-mixed-endpoints", testdata.StreamingResultDSL, []*sectionExpectation{
 			{"client-websocket-conn-configurer-struct", &testdata.MixedEndpointsConnConfigurerStructCode},
 			{"client-websocket-conn-configurer-struct-init", &testdata.MixedEndpointsConnConfigurerInitCode},
 		}},
 
 		// streaming result
-		{"streaming-result", testdata.StreamingResultDSL, []*sectionExpectation{
+		{"client-streaming-result", testdata.StreamingResultDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.StreamingResultClientEndpointCode},
 			{"client-websocket-recv", &testdata.StreamingResultClientStreamRecvCode},
 			{"client-websocket-close", nil},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-result-with-views", testdata.StreamingResultWithViewsDSL, []*sectionExpectation{
+		{"client-streaming-result-with-views", testdata.StreamingResultWithViewsDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.StreamingResultWithViewsClientEndpointCode},
 			{"client-websocket-recv", &testdata.StreamingResultWithViewsClientStreamRecvCode},
 			{"client-websocket-close", nil},
 			{"client-websocket-set-view", &testdata.StreamingResultWithViewsClientStreamSetViewCode},
 		}},
-		{"streaming-result-with-explicit-view", testdata.StreamingResultWithExplicitViewDSL, []*sectionExpectation{
+		{"client-streaming-result-with-explicit-view", testdata.StreamingResultWithExplicitViewDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.StreamingResultWithExplicitViewClientEndpointCode},
 			{"client-websocket-recv", &testdata.StreamingResultWithExplicitViewClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-result-collection-with-views", testdata.StreamingResultCollectionWithViewsDSL, []*sectionExpectation{
+		{"client-streaming-result-collection-with-views", testdata.StreamingResultCollectionWithViewsDSL, []*sectionExpectation{
 			{"client-websocket-recv", &testdata.StreamingResultCollectionWithViewsClientStreamRecvCode},
 			{"client-websocket-set-view", &testdata.StreamingResultCollectionWithViewsClientStreamSetViewCode},
 		}},
-		{"streaming-result-collection-with-explicit-view", testdata.StreamingResultCollectionWithExplicitViewDSL, []*sectionExpectation{
+		{"client-streaming-result-collection-with-explicit-view", testdata.StreamingResultCollectionWithExplicitViewDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.StreamingResultCollectionWithExplicitViewClientEndpointCode},
 			{"client-websocket-recv", &testdata.StreamingResultCollectionWithExplicitViewClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-result-primitive", testdata.StreamingResultPrimitiveDSL, []*sectionExpectation{
+		{"client-streaming-result-primitive", testdata.StreamingResultPrimitiveDSL, []*sectionExpectation{
 			{"client-websocket-recv", &testdata.StreamingResultPrimitiveClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-result-primitive-array", testdata.StreamingResultPrimitiveArrayDSL, []*sectionExpectation{
+		{"client-streaming-result-primitive-array", testdata.StreamingResultPrimitiveArrayDSL, []*sectionExpectation{
 			{"client-websocket-recv", &testdata.StreamingResultPrimitiveArrayClientStreamRecvCode},
 		}},
-		{"streaming-result-primitive-map", testdata.StreamingResultPrimitiveMapDSL, []*sectionExpectation{
+		{"client-streaming-result-primitive-map", testdata.StreamingResultPrimitiveMapDSL, []*sectionExpectation{
 			{"client-websocket-recv", &testdata.StreamingResultPrimitiveMapClientStreamRecvCode},
 		}},
-		{"streaming-result-user-type-array", testdata.StreamingResultUserTypeArrayDSL, []*sectionExpectation{
+		{"client-streaming-result-user-type-array", testdata.StreamingResultUserTypeArrayDSL, []*sectionExpectation{
 			{"client-websocket-recv", &testdata.StreamingResultUserTypeArrayClientStreamRecvCode},
 		}},
-		{"streaming-result-user-type-map", testdata.StreamingResultUserTypeMapDSL, []*sectionExpectation{
+		{"client-streaming-result-user-type-map", testdata.StreamingResultUserTypeMapDSL, []*sectionExpectation{
 			{"client-websocket-recv", &testdata.StreamingResultUserTypeMapClientStreamRecvCode},
 		}},
-		{"streaming-result-no-payload", testdata.StreamingResultNoPayloadDSL, []*sectionExpectation{
+		{"client-streaming-result-no-payload", testdata.StreamingResultNoPayloadDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.StreamingResultNoPayloadClientEndpointCode},
 		}},
 
 		// streaming payload
 
-		{"streaming-payload", testdata.StreamingPayloadDSL, []*sectionExpectation{
+		{"client-streaming-payload", testdata.StreamingPayloadDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.StreamingPayloadClientEndpointCode},
 			{"client-websocket-send", &testdata.StreamingPayloadClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadClientStreamRecvCode},
 			{"client-websocket-close", nil},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-payload-no-payload", testdata.StreamingPayloadNoPayloadDSL, []*sectionExpectation{
+		{"client-streaming-payload-no-payload", testdata.StreamingPayloadNoPayloadDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.StreamingPayloadNoPayloadClientEndpointCode},
 			{"client-websocket-send", &testdata.StreamingPayloadNoPayloadClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadNoPayloadClientStreamRecvCode},
 			{"client-websocket-close", nil},
 		}},
-		{"streaming-payload-no-result", testdata.StreamingPayloadNoResultDSL, []*sectionExpectation{
+		{"client-streaming-payload-no-result", testdata.StreamingPayloadNoResultDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadNoResultClientStreamSendCode},
 			{"client-websocket-recv", nil},
 			{"client-websocket-close", &testdata.StreamingPayloadNoResultClientStreamCloseCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-payload-result-with-views", testdata.StreamingPayloadResultWithViewsDSL, []*sectionExpectation{
+		{"client-streaming-payload-result-with-views", testdata.StreamingPayloadResultWithViewsDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadResultWithViewsClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadResultWithViewsClientStreamRecvCode},
 			{"client-websocket-close", nil},
 			{"client-websocket-set-view", &testdata.StreamingPayloadResultWithViewsClientStreamSetViewCode},
 		}},
-		{"streaming-payload-result-with-explicit-view", testdata.StreamingPayloadResultWithExplicitViewDSL, []*sectionExpectation{
+		{"client-streaming-payload-result-with-explicit-view", testdata.StreamingPayloadResultWithExplicitViewDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadResultWithExplicitViewClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadResultWithExplicitViewClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-payload-result-collection-with-views", testdata.StreamingPayloadResultCollectionWithViewsDSL, []*sectionExpectation{
+		{"client-streaming-payload-result-collection-with-views", testdata.StreamingPayloadResultCollectionWithViewsDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadResultCollectionWithViewsClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadResultCollectionWithViewsClientStreamRecvCode},
 			{"client-websocket-set-view", &testdata.StreamingPayloadResultCollectionWithViewsClientStreamSetViewCode},
 		}},
-		{"streaming-payload-result-collection-with-explicit-view", testdata.StreamingPayloadResultCollectionWithExplicitViewDSL, []*sectionExpectation{
+		{"client-streaming-payload-result-collection-with-explicit-view", testdata.StreamingPayloadResultCollectionWithExplicitViewDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadResultCollectionWithExplicitViewClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadResultCollectionWithExplicitViewClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-payload-primitive", testdata.StreamingPayloadPrimitiveDSL, []*sectionExpectation{
+		{"client-streaming-payload-primitive", testdata.StreamingPayloadPrimitiveDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadPrimitiveClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadPrimitiveClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"streaming-payload-primitive-array", testdata.StreamingPayloadPrimitiveArrayDSL, []*sectionExpectation{
+		{"client-streaming-payload-primitive-array", testdata.StreamingPayloadPrimitiveArrayDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadPrimitiveArrayClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadPrimitiveArrayClientStreamRecvCode},
 		}},
-		{"streaming-payload-primitive-map", testdata.StreamingPayloadPrimitiveMapDSL, []*sectionExpectation{
+		{"client-streaming-payload-primitive-map", testdata.StreamingPayloadPrimitiveMapDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadPrimitiveMapClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadPrimitiveMapClientStreamRecvCode},
 		}},
-		{"streaming-payload-user-type-array", testdata.StreamingPayloadUserTypeArrayDSL, []*sectionExpectation{
+		{"client-streaming-payload-user-type-array", testdata.StreamingPayloadUserTypeArrayDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadUserTypeArrayClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadUserTypeArrayClientStreamRecvCode},
 		}},
-		{"streaming-payload-user-type-map", testdata.StreamingPayloadUserTypeMapDSL, []*sectionExpectation{
+		{"client-streaming-payload-user-type-map", testdata.StreamingPayloadUserTypeMapDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.StreamingPayloadUserTypeMapClientStreamSendCode},
 			{"client-websocket-recv", &testdata.StreamingPayloadUserTypeMapClientStreamRecvCode},
 		}},
 
 		// bidirectional streaming
 
-		{"bidirectional-streaming", testdata.BidirectionalStreamingDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming", testdata.BidirectionalStreamingDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.BidirectionalStreamingClientEndpointCode},
 			{"client-websocket-send", &testdata.BidirectionalStreamingClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingClientStreamRecvCode},
 			{"client-websocket-close", &testdata.BidirectionalStreamingClientStreamCloseCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"bidirectional-streaming-no-payload", testdata.BidirectionalStreamingNoPayloadDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-no-payload", testdata.BidirectionalStreamingNoPayloadDSL, []*sectionExpectation{
 			{"client-endpoint-init", &testdata.BidirectionalStreamingNoPayloadClientEndpointCode},
 			{"client-websocket-send", &testdata.BidirectionalStreamingNoPayloadClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingNoPayloadClientStreamRecvCode},
 			{"client-websocket-close", &testdata.BidirectionalStreamingNoPayloadClientStreamCloseCode},
 		}},
-		{"bidirectional-streaming-result-with-views", testdata.BidirectionalStreamingResultWithViewsDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-result-with-views", testdata.BidirectionalStreamingResultWithViewsDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingResultWithViewsClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingResultWithViewsClientStreamRecvCode},
 			{"client-websocket-close", &testdata.BidirectionalStreamingResultWithViewsClientStreamCloseCode},
 			{"client-websocket-set-view", &testdata.BidirectionalStreamingResultWithViewsClientStreamSetViewCode},
 		}},
-		{"bidirectional-streaming-result-with-explicit-view", testdata.BidirectionalStreamingResultWithExplicitViewDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-result-with-explicit-view", testdata.BidirectionalStreamingResultWithExplicitViewDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingResultWithExplicitViewClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingResultWithExplicitViewClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"bidirectional-streaming-result-collection-with-views", testdata.BidirectionalStreamingResultCollectionWithViewsDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-result-collection-with-views", testdata.BidirectionalStreamingResultCollectionWithViewsDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingResultCollectionWithViewsClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingResultCollectionWithViewsClientStreamRecvCode},
 			{"client-websocket-set-view", &testdata.BidirectionalStreamingResultCollectionWithViewsClientStreamSetViewCode},
 		}},
-		{"bidirectional-streaming-result-collection-with-explicit-view", testdata.BidirectionalStreamingResultCollectionWithExplicitViewDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-result-collection-with-explicit-view", testdata.BidirectionalStreamingResultCollectionWithExplicitViewDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingResultCollectionWithExplicitViewClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingResultCollectionWithExplicitViewClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"bidirectional-streaming-primitive", testdata.BidirectionalStreamingPrimitiveDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-primitive", testdata.BidirectionalStreamingPrimitiveDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingPrimitiveClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingPrimitiveClientStreamRecvCode},
 			{"client-websocket-set-view", nil},
 		}},
-		{"bidirectional-streaming-primitive-array", testdata.BidirectionalStreamingPrimitiveArrayDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-primitive-array", testdata.BidirectionalStreamingPrimitiveArrayDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingPrimitiveArrayClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingPrimitiveArrayClientStreamRecvCode},
 		}},
-		{"bidirectional-streaming-primitive-map", testdata.BidirectionalStreamingPrimitiveMapDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-primitive-map", testdata.BidirectionalStreamingPrimitiveMapDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingPrimitiveMapClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingPrimitiveMapClientStreamRecvCode},
 		}},
-		{"bidirectional-streaming-user-type-array", testdata.BidirectionalStreamingUserTypeArrayDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-user-type-array", testdata.BidirectionalStreamingUserTypeArrayDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingUserTypeArrayClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingUserTypeArrayClientStreamRecvCode},
 		}},
-		{"bidirectional-streaming-user-type-map", testdata.BidirectionalStreamingUserTypeMapDSL, []*sectionExpectation{
+		{"client-bidirectional-streaming-user-type-map", testdata.BidirectionalStreamingUserTypeMapDSL, []*sectionExpectation{
 			{"client-websocket-send", &testdata.BidirectionalStreamingUserTypeMapClientStreamSendCode},
 			{"client-websocket-recv", &testdata.BidirectionalStreamingUserTypeMapClientStreamRecvCode},
 		}},

--- a/http/codegen/testdata/streaming_code.go
+++ b/http/codegen/testdata/streaming_code.go
@@ -1027,9 +1027,7 @@ func (c *Client) StreamingPayloadMethod() goa.Endpoint {
 			return nil, goahttp.ErrRequestError("StreamingPayloadService", "StreamingPayloadMethod", err)
 		}
 		if c.configurer.StreamingPayloadMethodFn != nil {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithCancel(ctx)
-			conn = c.configurer.StreamingPayloadMethodFn(conn, cancel)
+			conn = c.configurer.StreamingPayloadMethodFn(conn, nil)
 		}
 		stream := &StreamingPayloadMethodClientStream{conn: conn}
 		return stream, nil
@@ -1140,9 +1138,7 @@ func (c *Client) StreamingPayloadNoPayloadMethod() goa.Endpoint {
 			return nil, goahttp.ErrRequestError("StreamingPayloadNoPayloadService", "StreamingPayloadNoPayloadMethod", err)
 		}
 		if c.configurer.StreamingPayloadNoPayloadMethodFn != nil {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithCancel(ctx)
-			conn = c.configurer.StreamingPayloadNoPayloadMethodFn(conn, cancel)
+			conn = c.configurer.StreamingPayloadNoPayloadMethodFn(conn, nil)
 		}
 		stream := &StreamingPayloadNoPayloadMethodClientStream{conn: conn}
 		return stream, nil
@@ -2212,9 +2208,7 @@ func (c *Client) BidirectionalStreamingMethod() goa.Endpoint {
 			return nil, goahttp.ErrRequestError("BidirectionalStreamingService", "BidirectionalStreamingMethod", err)
 		}
 		if c.configurer.BidirectionalStreamingMethodFn != nil {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithCancel(ctx)
-			conn = c.configurer.BidirectionalStreamingMethodFn(conn, cancel)
+			conn = c.configurer.BidirectionalStreamingMethodFn(conn, nil)
 		}
 		stream := &BidirectionalStreamingMethodClientStream{conn: conn}
 		return stream, nil
@@ -2349,9 +2343,7 @@ func (c *Client) BidirectionalStreamingNoPayloadMethod() goa.Endpoint {
 			return nil, goahttp.ErrRequestError("BidirectionalStreamingNoPayloadService", "BidirectionalStreamingNoPayloadMethod", err)
 		}
 		if c.configurer.BidirectionalStreamingNoPayloadMethodFn != nil {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithCancel(ctx)
-			conn = c.configurer.BidirectionalStreamingNoPayloadMethodFn(conn, cancel)
+			conn = c.configurer.BidirectionalStreamingNoPayloadMethodFn(conn, nil)
 		}
 		stream := &BidirectionalStreamingNoPayloadMethodClientStream{conn: conn}
 		return stream, nil


### PR DESCRIPTION
When setting up a WebSocket connection for receiving data the generated code would create a context cancel function that would never be called.