### PR TITLE
Fix to handle time.Time slice and other slices as type override

### DIFF
--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -288,7 +288,6 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 				} else {
 					code += fmt.Sprintf("var zero %s\n\t", GoNativeTypeName(tgtc.Type))
 				}
-
 				if typeName, _ := GetMetaType(tgtc); typeName != "" && metaTypeIsMapOrSlice(typeName) {
 					code += fmt.Sprintf("if %s == nil ", tgtVar)
 				} else {

--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -307,7 +307,9 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 	return buffer.String(), nil
 }
 
-func metaTypeIsMapOrSlice(typeName string) bool {
+// typeStringIsNilable takes a go type as a string and checks for a '[]' or
+// 'map[' prefix to see if it's a nilable primitive type.
+func typeStringIsNilable(typeName string) bool {
 	return strings.HasPrefix(typeName, "[]") || strings.HasPrefix(typeName, "map[")
 }
 

--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -279,7 +279,7 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 				// (the field is not a pointer in this case)
 				code += "{\n\t"
 				if typeName, _ := GetMetaType(tgtc); typeName != "" {
-					if !metaTypeIsMapOrSlice(typeName) {
+					if !typeStringIsNilable(typeName) {
 						code += fmt.Sprintf("var zero %s\n\t", typeName)
 					}
 				} else if _, ok := tgtc.Type.(expr.UserType); ok {
@@ -288,7 +288,7 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 				} else {
 					code += fmt.Sprintf("var zero %s\n\t", GoNativeTypeName(tgtc.Type))
 				}
-				if typeName, _ := GetMetaType(tgtc); typeName != "" && metaTypeIsMapOrSlice(typeName) {
+				if typeName, _ := GetMetaType(tgtc); typeName != "" && typeStringIsNilable(typeName) {
 					code += fmt.Sprintf("if %s == nil ", tgtVar)
 				} else {
 					code += fmt.Sprintf("if %s == zero ", tgtVar)

--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -279,14 +279,22 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 				// (the field is not a pointer in this case)
 				code += "{\n\t"
 				if typeName, _ := GetMetaType(tgtc); typeName != "" {
-					code += fmt.Sprintf("var zero %s\n\t", typeName)
+					if !metaTypeIsMapOrSlice(typeName) {
+						code += fmt.Sprintf("var zero %s\n\t", typeName)
+					}
 				} else if _, ok := tgtc.Type.(expr.UserType); ok {
 					// aliased primitive
 					code += fmt.Sprintf("var zero %s\n\t", ta.TargetCtx.Scope.Ref(tgtc, ta.TargetCtx.Pkg(tgtc)))
 				} else {
 					code += fmt.Sprintf("var zero %s\n\t", GoNativeTypeName(tgtc.Type))
 				}
-				code += fmt.Sprintf("if %s == zero {\n\t%s = %#v\n}\n", tgtVar, tgtVar, tdef)
+
+				if typeName, _ := GetMetaType(tgtc); typeName != "" && metaTypeIsMapOrSlice(typeName) {
+					code += fmt.Sprintf("if %s == nil ", tgtVar)
+				} else {
+					code += fmt.Sprintf("if %s == zero ", tgtVar)
+				}
+				code += fmt.Sprintf("{\n\t%s = %#v\n}\n", tgtVar, tdef)
 				code += "}\n"
 			}
 		}
@@ -297,6 +305,10 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 	}
 
 	return buffer.String(), nil
+}
+
+func metaTypeIsMapOrSlice(typeName string) bool {
+	return strings.HasPrefix(typeName, "[]") || strings.HasPrefix(typeName, "map[")
 }
 
 // transformArray generates Go code to transform source array to target array.


### PR DESCRIPTION
Hello. A while ago I was working on this fix to handle custom types: https://github.com/goadesign/goa/pull/3010

That fix was originally intended to be a fix for use of `[]time.Time` but I changed it to `json.RawMessage` to make it easier to fix the protobuf tests. I didn't end up fixing the `[]time.Time` case and that issue is still preventing us from upgrading to newer versions of goa.

This PR fixes the issue for HTTP. It does not add to the tests. I tried to extend `types_dsl.go` but ran into protobuf errors that I couldn't figure out how to fix. Before proceeding I wanted to check:

1. Does this fix makes sense, is it worth fixing this use case for HTTP code generation.
2. Is it worth also making this fix in protobuf. Protobuf can't use `[]time.Time` in serialization, but maybe the `[]int` case could surface in protobuf (although imagine you'd just use `ArrayOf(Int)` and be done with it :/)?
3. If it's not worth making the protobuf fix, is there a suggestion for how I can write a test for this without hitting the protobuf code paths?

Repo here with a reproduction of the issue and some description of possible fixes: https://github.com/maxmcd/goa-timeslice-poc

cc: @vbrown608 who worked on this with me

edit: worth noting that you have basically answered this same question previously: https://github.com/goadesign/goa/pull/3010#issuecomment-1051081846, if the stance is still the same I'm down to get grpc custom types working as well, maybe just with a better test case this time