### PR TITLE
Add acronym "SDK" to commonInitialisms

### DIFF
--- a/codegen/funcs.go
+++ b/codegen/funcs.go
@@ -403,6 +403,7 @@ var (
 		"RAM":   true,
 		"RHS":   true,
 		"RPC":   true,
+		"SDK":   true,
 		"SLA":   true,
 		"SMTP":  true,
 		"SQL":   true,


### PR DESCRIPTION
Hello, I have an issue that the acronym `SDK` is not generated with UPPERCASE.

So I would like to add it as an initialisms which stand for Software Development Kit to commonInitialisms.

Please take a look.
