### PR TITLE
Handle reader errors in SkipResponseBodyEncodeDecode

### DIFF
--- a/http/codegen/handler_test.go
+++ b/http/codegen/handler_test.go
@@ -24,6 +24,7 @@ func TestHandlerInit(t *testing.T) {
 		{"no payload result", testdata.ServerNoPayloadResultDSL, testdata.ServerNoPayloadResultHandlerConstructorCode},
 		{"payload result", testdata.ServerPayloadResultDSL, testdata.ServerPayloadResultHandlerConstructorCode},
 		{"payload result error", testdata.ServerPayloadResultErrorDSL, testdata.ServerPayloadResultErrorHandlerConstructorCode},
+		{"skip response body encode decode", testdata.ServerSkipResponseBodyEncodeDecodeDSL, testdata.ServerSkipResponseBodyEncodeDecodeCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -531,6 +531,9 @@ func {{ .HandlerInit }}(
 	{{- end }}
 	{{- if .Method.SkipResponseBodyEncodeDecode }}
 		if _, err := io.Copy(w, buf); err != nil {
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
 			panic(http.ErrAbortHandler) // too late to write an error
 		}
 	{{- end }}

--- a/http/codegen/testdata/handler_init_functions.go
+++ b/http/codegen/testdata/handler_init_functions.go
@@ -241,3 +241,51 @@ func NewMethodPayloadResultErrorHandler(
 	})
 }
 `
+
+var ServerSkipResponseBodyEncodeDecodeCode = `// NewMethodSkipResponseBodyEncodeDecodeHandler creates a HTTP handler which
+// loads the HTTP request and calls the "ServiceSkipResponseBodyEncodeDecode"
+// service "MethodSkipResponseBodyEncodeDecode" endpoint.
+func NewMethodSkipResponseBodyEncodeDecodeHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		encodeResponse = EncodeMethodSkipResponseBodyEncodeDecodeResponse(encoder)
+		encodeError    = EncodeMethodSkipResponseBodyEncodeDecodeError(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "MethodSkipResponseBodyEncodeDecode")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "ServiceSkipResponseBodyEncodeDecode")
+		var err error
+		res, err := endpoint(ctx, nil)
+		if err != nil {
+			if err := encodeError(ctx, w, err); err != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		o := res.(*serviceskipresponsebodyencodedecode.MethodSkipResponseBodyEncodeDecodeResponseData)
+		defer o.Body.Close()
+		// handle immediate read error like a returned error
+		buf := bufio.NewReader(o.Body)
+		if _, err := buf.Peek(1); err != nil && err != io.EOF {
+			if err := encodeError(ctx, w, err); err != nil {
+				errhandler(ctx, w, err)
+			}
+			return
+		}
+		if err := encodeResponse(ctx, w, res); err != nil {
+			errhandler(ctx, w, err)
+			return
+		}
+		if _, err := io.Copy(w, buf); err != nil {
+			panic(http.ErrAbortHandler) // too late to write an error
+		}
+	})
+}
+`

--- a/http/codegen/testdata/handler_init_functions.go
+++ b/http/codegen/testdata/handler_init_functions.go
@@ -284,6 +284,9 @@ func NewMethodSkipResponseBodyEncodeDecodeHandler(
 			return
 		}
 		if _, err := io.Copy(w, buf); err != nil {
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
 			panic(http.ErrAbortHandler) // too late to write an error
 		}
 	})

--- a/http/codegen/testdata/server_dsls.go
+++ b/http/codegen/testdata/server_dsls.go
@@ -268,3 +268,17 @@ var ServerSimpleRoutingWithRedirectDSL = func() {
 		})
 	})
 }
+
+var ServerSkipResponseBodyEncodeDecodeDSL = func() {
+	Service("ServiceSkipResponseBodyEncodeDecode", func() {
+		Method("MethodSkipResponseBodyEncodeDecode", func() {
+			Error("internal_error", ErrorResult, "Fault while processing download.")
+			HTTP(func() {
+				GET("/")
+				SkipResponseBodyEncodeDecode()
+				Response(StatusOK)
+				Response("internal_error", StatusInternalServerError)
+			})
+		})
+	})
+}


### PR DESCRIPTION
Once we've started writing the body, it's too late for normal error handling. Instead issue the sentinal panic(http.ErrAbortHandler) to interrupt the stream.

Since the interrupted stream is much less meaningful than the normal error handling, and servers using SkipResponseBodyEncodeDecode may issue errors early in the stream, read a chunk of the stream looking for an error. If encountered, use normal error handling. Otherwise write the chunk plus whatever remains.

For context, I'm attempting to use Transfer-Encoding: Chunked. Go does this for us, automatically, so long as Content-Length hasn't been specified. But that also means there's no way for it to know if the writes were complete. See related documentation at https://stackoverflow.com/questions/40291861/how-to-break-a-chunked-in-go-using-net-http and https://github.com/golang/go/issues/17790.