### PR TITLE
meta openapi:example work at APIExpr level too

### DIFF
--- a/expr/example.go
+++ b/expr/example.go
@@ -26,6 +26,10 @@ func (a *AttributeExpr) Example(r *ExampleGenerator) any {
 		return ex[len(ex)-1].Value
 	}
 
+	if r.Randomizer == nil {
+		return nil
+	}
+
 	value, ok := a.Meta.Last("openapi:example")
 	if !ok {
 		value, ok = a.Meta.Last("swagger:example")

--- a/expr/random.go
+++ b/expr/random.go
@@ -14,6 +14,8 @@ import (
 //
 // The random values should be consistent in that given the same seed the same
 // random values get generated.
+//
+// Setting the randomizer to nil disables example generation.
 type Randomizer interface {
 	// ArrayLength decides how long an example array will be
 	ArrayLength() int

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -30,6 +30,14 @@ func New(root *expr.RootExpr) *OpenAPI {
 		return nil
 	}
 
+	m, ok := root.API.Meta.Last("openapi:example")
+	if !ok {
+		m, ok = root.API.Meta.Last("swagger:example")
+	}
+	if ok && m == "false" {
+		root.API.ExampleGenerator.Randomizer = nil
+	}
+
 	var (
 		bodies, types = buildBodyTypes(root.API)
 


### PR DESCRIPTION
As mentioned in my issue #3316 this meta doesn't work as the documentation says.

```
// - "swagger:example" DEPRECATED, use "openapi:example" instead
//
// - "openapi:example" specifies whether to generate random example. Defaults to
// true. Applicable to API (applies to all attributes) or individual attributes.
//
//	var _ = API("MyAPI", func() {
//	    Meta("openapi:example", "false")
//	})
```

I've looked into the code for a while and really couldn't find a better way than this. The problem is that examples are generated on the Attribute expression, and the meta will work only there. My solution checks for the API meta during the generation of the openapi schema and sets the random generator seed to nil, and then adding the check to the `Example` method that created the example.

I found the codebase kinda confusing and I won't be surprised if there's a better, cleaner way, but since nobody was looking into it I tried myself.