### PR TITLE
chore: change ci process to use matrix for versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,66 +1,35 @@
 name: build
 on: [push, pull_request]
 jobs:
-
-  Linux:
-    name: Linux
-    runs-on: ubuntu-latest
+  ci:
+    strategy:
+      fail-fast: true
+      matrix:
+        go: ['1.20', '1.21']
+        os: ['ubuntu-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
     steps:
-
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v4.1.0
-      with:
-        go-version: '1.20'
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3    
-
-    - name: Extract branch name
-      run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
-
-    - name: Add $GOPATH/bin to PATH
-      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      id: setup_path
-
-    - name: Build
-      run: make ci
-      env:
-        GOA_BRANCH: ${{ steps.extract_branch.outputs.branch }}
-
-    - name: Report test-coverage to DeepSource
-      run: |
-        curl https://deepsource.io/cli | sh
-        ./bin/deepsource report --analyzer test-coverage --key go --value-file ./cover.out
-      env:
-        DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
-
-  Windows:
-    name: Windows
-    runs-on: windows-latest
-    steps:
-
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v4.1.0
-      with:
-        go-version: '1.20'
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3    
-
-    - name: Extract branch name
-      shell: bash
-      run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
-      id: extract_branch
-
-    - name: Add $GOPATH/bin to PATH
-      shell: bash
-      run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      id: setup_path
-
-    - name: Build
-      run: make ci
-      env:
-        GOA_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+      - name: Set up Go ${{ matrix.go }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+      - name: Extract branch name
+        run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+      - name: Add $GOPATH/bin to PATH
+        run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        id: setup_path
+      - name: Build
+        run: make ci
+        env:
+          GOA_BRANCH: ${{ steps.extract_branch.outputs.branch }}
+      - name: Report test-coverage to DeepSource
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          curl https://deepsource.io/cli | sh
+          ./bin/deepsource report --analyzer test-coverage --key go --value-file ./cover.out
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}


### PR DESCRIPTION
This PR changes the CI to use the matrix API from GH. (It's currently failing on my fork because I don't have the token for the coverage)

![image](https://github.com/goadesign/goa/assets/5471469/1ace68e4-60a5-4e82-8c76-f69ada0583d8)
