### PR TITLE
Use HTTPName for cookies in response encoders

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1335,7 +1335,7 @@ const responseT = `{{ define "response" -}}
 		{{ .VarName }} := "{{ printValue .Type .DefaultValue }}"
 		{{- end }}
 		http.SetCookie(w, &http.Cookie{
-			Name: {{ printf "%q" .Name }},
+			Name: {{ printf "%q" .HTTPName }},
 			Value: {{ .VarName }},
 			{{- if .MaxAge }}
 			MaxAge: {{ .MaxAge }},


### PR DESCRIPTION
I believe this was an oversight in https://github.com/goadesign/goa/commit/27c249ff742d378bea3f6b8779b9470dcaba29ab (included in v3.12.0 and newer),
breaking cookie name mapping to some extent.

The upgrade to v3.12.1 in the cookie example shows how the name assigned to the
cookie inadequately changes from `SID` (cookie name) to session_id` (attr name).

https://github.com/goadesign/examples/commit/45ca83513f27b41e5351f5cce50e4dd3eaac79b9#diff-c31b43a7b7656de4c0d63b7ac526bfbad82aa335c79f08e186f5d78c6ddc0802R97
