### PR TITLE
Unescape HTTP path parameters

### DIFF
--- a/http/mux.go
+++ b/http/mux.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 
 	chi "github.com/go-chi/chi/v5"
@@ -113,12 +114,20 @@ func (m *mux) Vars(r *http.Request) map[string]string {
 	for i, k := range params.Keys {
 		if k == "*" {
 			wildcard := m.wildcards[r.Method+"::"+rctx.RoutePattern()]
-			vars[wildcard] = params.Values[i]
+			vars[wildcard] = unescape(params.Values[i])
 			continue
 		}
-		vars[k] = params.Values[i]
+		vars[k] = unescape(params.Values[i])
 	}
 	return vars
+}
+
+func unescape(s string) string {
+	u, err := url.PathUnescape(s)
+	if err != nil {
+		return s
+	}
+	return u
 }
 
 // Use appends a middleware to the list of middlewares to be applied

--- a/http/mux_test.go
+++ b/http/mux_test.go
@@ -105,6 +105,23 @@ func TestVars(t *testing.T) {
 			},
 		},
 		{
+			Name:    "escaped",
+			Pattern: "/users/{id}",
+			URL:     "/users/%40123",
+			Expected: map[string]string{
+				"id": "@123",
+			},
+		},
+		{
+			Name:    "escaped wildcard",
+			Pattern: "/users/{id}/posts/{*post_id}",
+			URL:     "/users/%40123/posts/456/789%24",
+			Expected: map[string]string{
+				"id":      "@123",
+				"post_id": "456/789$",
+			},
+		},
+		{
 			Name:     "no var",
 			Pattern:  "/users",
 			URL:      "/users",


### PR DESCRIPTION
This is a fix about the change from httptreemux to chi.

httptreemux unescapes http path parameters but chi does not.
This fix restores the previous httptreemux-like behavior.

https://github.com/dimfeld/httptreemux/blob/v5.5.0/unescape_18.go