### PR TITLE
Update wildcard handling for chi router

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -415,7 +415,7 @@ func {{ .MountHandler }}(mux goahttp.Muxer, h http.Handler) {
 	{{- if .IsDir }}
 		{{- range .RequestPaths }}
 	mux.Handle("GET", "{{ . }}{{if ne . "/"}}/{{end}}", h.ServeHTTP)
-	mux.Handle("GET", "{{ . }}{{if ne . "/"}}/{{end}}*{{ $.PathParam }}", h.ServeHTTP)
+	mux.Handle("GET", "{{ . }}{{if ne . "/"}}/{{end}}{*{{ $.PathParam }}}", h.ServeHTTP)
 		{{- end }}
 	{{- else }}
 		{{- range .RequestPaths }}

--- a/http/codegen/testdata/server_init_functions.go
+++ b/http/codegen/testdata/server_init_functions.go
@@ -235,7 +235,7 @@ func (s *Server) Mount(mux goahttp.Muxer) {
 var ServerMultipleFilesMounterCode = `// MountPathToFolder configures the mux to serve GET request made to "/".
 func MountPathToFolder(mux goahttp.Muxer, h http.Handler) {
 	mux.Handle("GET", "/", h.ServeHTTP)
-	mux.Handle("GET", "/*wildcard", h.ServeHTTP)
+	mux.Handle("GET", "/{*wildcard}", h.ServeHTTP)
 }
 `
 
@@ -243,7 +243,7 @@ var ServerMultipleFilesWithPrefixPathMounterCode = `// MountPathToFolder configu
 // "/server_file_server".
 func MountPathToFolder(mux goahttp.Muxer, h http.Handler) {
 	mux.Handle("GET", "/server_file_server/", h.ServeHTTP)
-	mux.Handle("GET", "/server_file_server/*wildcard", h.ServeHTTP)
+	mux.Handle("GET", "/server_file_server/{*wildcard}", h.ServeHTTP)
 }
 `
 


### PR DESCRIPTION
The upgrade to chi caused a regression for file servers using wildcards.

Fix #3357 