### PR TITLE
chore: Tweak release-examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,7 @@ release-goa:
 
 release-examples:
 	cd $(GOPATH)/src/goa.design/examples && \
-		sed 's/goa.design\/goa\/v.*/goa.design\/goa\/v$(MAJOR) v$(MAJOR).$(MINOR).$(BUILD)/' go.mod > _tmp && mv _tmp go.mod && \
-		make && \
+		make GOA_VERSION=v$(MAJOR).$(MINOR).$(BUILD)&& \
 		git add . && \
 		git commit -m "Release v$(MAJOR).$(MINOR).$(BUILD)" && \
 		git tag v$(MAJOR).$(MINOR).$(BUILD) && \


### PR DESCRIPTION
issue: https://github.com/goadesign/examples/issues/131
ref. https://github.com/goadesign/examples/pull/138

In response to feedback on the Makefile dependency for Goa's release process, I've adjusted it accordingly. Following the merge of [PR](https://github.com/goadesign/examples/pull/138) in the examples repository, I've updated the Makefile here for consistency. Please review.

