### PR TITLE
Add CookieSameSite DSL

### DIFF
--- a/dsl/http.go
+++ b/dsl/http.go
@@ -591,6 +591,34 @@ func CookieHTTPOnly() {
 	cookieAttribute("http-only", "HttpOnly")
 }
 
+// CookieSameSite initializes the "same-site" attribute of a HTTP response
+// cookie with "Strict", "Lax", or "None".
+//
+// CookieSameSite must appear in a Cookie expression.
+//
+// Example:
+//
+//    var _ = Service("account", func() {
+//        Method("create", func() {
+//            Result(Account)
+//            HTTP(func() {
+//                Response(StatusCreated, func() {
+//                    Cookie("session:SID", String)
+//                    CookieSameSite("Strict")
+//                })
+//            })
+//        })
+//    })
+//
+func CookieSameSite(s string) {
+	_, ok := eval.Current().(*expr.HTTPResponseExpr)
+	if !ok {
+		eval.IncompatibleDSL()
+		return
+	}
+	cookieAttribute("same-site", s)
+}
+
 // Params groups a set of Param expressions. It makes it possible to list
 // required parameters using the Required function.
 //

--- a/dsl/http.go
+++ b/dsl/http.go
@@ -592,31 +592,31 @@ func CookieHTTPOnly() {
 }
 
 // CookieSameSite initializes the "same-site" attribute of a HTTP response
-// cookie with "Strict", "Lax", or "None".
+// cookie with "CookieSameSiteStrict", "CookieSameSiteLax", "CookieSameSiteNone",
+// or "CookieSameSiteDefault".
 //
 // CookieSameSite must appear in a Cookie expression.
 //
 // Example:
 //
-//    var _ = Service("account", func() {
-//        Method("create", func() {
-//            Result(Account)
-//            HTTP(func() {
-//                Response(StatusCreated, func() {
-//                    Cookie("session:SID", String)
-//                    CookieSameSite("Strict")
-//                })
-//            })
-//        })
-//    })
-//
-func CookieSameSite(s string) {
+//	var _ = Service("account", func() {
+//	    Method("create", func() {
+//	        Result(Account)
+//	        HTTP(func() {
+//	            Response(StatusCreated, func() {
+//	                Cookie("session:SID", String)
+//	                CookieSameSite(CookieSameSiteStrict)
+//	            })
+//	        })
+//	    })
+//	})
+func CookieSameSite(s expr.CookieSameSiteValue) {
 	_, ok := eval.Current().(*expr.HTTPResponseExpr)
 	if !ok {
 		eval.IncompatibleDSL()
 		return
 	}
-	cookieAttribute("same-site", s)
+	cookieAttribute("same-site", string(s))
 }
 
 // Params groups a set of Param expressions. It makes it possible to list

--- a/dsl/http.go
+++ b/dsl/http.go
@@ -76,6 +76,13 @@ const (
 	StatusNetworkAuthenticationRequired = expr.StatusNetworkAuthenticationRequired
 )
 
+const (
+	CookieSameSiteStrict   = expr.CookieSameSiteStrict
+	CookieSameSiteLax      = expr.CookieSameSiteLax
+	CookieSameSiteNone     = expr.CookieSameSiteNone
+	CookieSameSiteDefault  = expr.CookieSameSiteDefault
+)
+
 // HTTP defines the HTTP transport specific properties of an API, a service or a
 // single method. The function maps the method payload and result types to HTTP
 // properties such as parameters (via path wildcards or query strings), request

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -102,6 +102,10 @@ type (
 	// ValidationFormat is the type used to enumerate the possible string
 	// formats.
 	ValidationFormat string
+
+	// CookieSameSiteValue is the type used to enumerate the possible cookie
+	// SameSite values.
+	CookieSameSiteValue string
 )
 
 const (
@@ -146,6 +150,13 @@ const (
 
 	// FormatRFC1123 describes RFC1123 date time values.
 	FormatRFC1123 = "rfc1123"
+)
+
+const (
+	CookieSameSiteStrict  CookieSameSiteValue = "strict"
+	CookieSameSiteLax     CookieSameSiteValue = "lax"
+	CookieSameSiteNone    CookieSameSiteValue = "none"
+	CookieSameSiteDefault CookieSameSiteValue = "default"
 )
 
 // EvalName returns the name used by the DSL evaluation.

--- a/expr/http_cookie_test.go
+++ b/expr/http_cookie_test.go
@@ -23,6 +23,7 @@ func TestHTTPResponseCookie(t *testing.T) {
 		{"path", testdata.CookiePathDSL, Props{"cookie:path": testdata.CookiePathValue}},
 		{"secure", testdata.CookieSecureDSL, Props{"cookie:secure": "Secure"}},
 		{"http-only", testdata.CookieHTTPOnlyDSL, Props{"cookie:http-only": "HttpOnly"}},
+		{"same-site", testdata.CookieSameSiteDSL, Props{"cookie:same-site": testdata.CookieSameSiteValue}},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/expr/testdata/cookie_dsls.go
+++ b/expr/testdata/cookie_dsls.go
@@ -2,7 +2,6 @@ package testdata
 
 import (
 	. "goa.design/goa/v3/dsl"
-	"goa.design/goa/v3/expr"
 )
 
 var CookieObjectResultDSL = func() {
@@ -126,7 +125,7 @@ var CookieHTTPOnlyDSL = func() {
 	})
 }
 
-const CookieSameSiteValue = expr.CookieSameSiteStrict
+const CookieSameSiteValue = CookieSameSiteStrict
 
 var CookieSameSiteDSL = func() {
 	Service("CookieSvc", func() {

--- a/expr/testdata/cookie_dsls.go
+++ b/expr/testdata/cookie_dsls.go
@@ -2,6 +2,7 @@ package testdata
 
 import (
 	. "goa.design/goa/v3/dsl"
+	"goa.design/goa/v3/expr"
 )
 
 var CookieObjectResultDSL = func() {
@@ -125,7 +126,7 @@ var CookieHTTPOnlyDSL = func() {
 	})
 }
 
-const CookieSameSiteValue = "Strict"
+const CookieSameSiteValue = expr.CookieSameSiteStrict
 
 var CookieSameSiteDSL = func() {
 	Service("CookieSvc", func() {

--- a/expr/testdata/cookie_dsls.go
+++ b/expr/testdata/cookie_dsls.go
@@ -124,3 +124,22 @@ var CookieHTTPOnlyDSL = func() {
 		})
 	})
 }
+
+const CookieSameSiteValue = "Strict"
+
+var CookieSameSiteDSL = func() {
+	Service("CookieSvc", func() {
+		Method("Method", func() {
+			Result(func() {
+				Attribute("cookie", String)
+			})
+			HTTP(func() {
+				POST("/")
+				Response(StatusOK, func() {
+					Cookie("cookie")
+					CookieSameSite(CookieSameSiteValue)
+				})
+			})
+		})
+	})
+}

--- a/http/codegen/client.go
+++ b/http/codegen/client.go
@@ -486,6 +486,9 @@ func {{ .RequestEncoder }}(encoder func(*http.Request) goahttp.Encoder) func(*ht
 				{{- if .HTTPOnly }}
 				HttpOnly: true,
 				{{- end }}
+				{{- if .SameSite }}
+				SameSite: {{ .SameSite }},
+				{{- end }}
 			})
 		}
 		{{- end }}

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1353,7 +1353,7 @@ const responseT = `{{ define "response" -}}
 			HttpOnly: true,
 			{{- end }}
 			{{- if .SameSite }}
-			SameSite: {{ printf "%q" .SameSite }},
+			SameSite: {{ .SameSite }},
 			{{- end }}
 		})
 		{{- if or $checkNil $initDef }}

--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -1352,6 +1352,9 @@ const responseT = `{{ define "response" -}}
 			{{- if .HTTPOnly }}
 			HttpOnly: true,
 			{{- end }}
+			{{- if .SameSite }}
+			SameSite: {{ printf "%q" .SameSite }},
+			{{- end }}
 		})
 		{{- if or $checkNil $initDef }}
 	}

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -507,7 +507,7 @@ type (
 		// HTTPOnly sets the cookie "http-only" attribute to "HttpOnly" if true.
 		HTTPOnly bool
 		// SameSite sets the cookie "same-site" attribute to the given value.
-		SameSite string
+		SameSite http.SameSite
 	}
 
 	// TypeData contains the data needed to render a type definition.
@@ -2537,7 +2537,16 @@ func extractCookies(a *expr.MappedAttributeExpr, svcAtt *expr.AttributeExpr, svc
 			case "cookie:http-only":
 				c.HTTPOnly = v[0] == "HttpOnly"
 			case "cookie:same-site":
-				c.SameSite = v[0]
+				switch v[0] {
+				case string(expr.CookieSameSiteLax):
+					c.SameSite = http.SameSiteLaxMode
+				case string(expr.CookieSameSiteStrict):
+					c.SameSite = http.SameSiteStrictMode
+				case string(expr.CookieSameSiteNone):
+					c.SameSite = http.SameSiteNoneMode
+				case string(expr.CookieSameSiteDefault):
+					c.SameSite = http.SameSiteDefaultMode
+				}
 			}
 		}
 		cookies = append(cookies, c)

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -506,6 +506,8 @@ type (
 		Secure bool
 		// HTTPOnly sets the cookie "http-only" attribute to "HttpOnly" if true.
 		HTTPOnly bool
+		// SameSite sets the cookie "same-site" attribute to the given value.
+		SameSite string
 	}
 
 	// TypeData contains the data needed to render a type definition.
@@ -2534,6 +2536,8 @@ func extractCookies(a *expr.MappedAttributeExpr, svcAtt *expr.AttributeExpr, svc
 				c.Secure = v[0] == "Secure"
 			case "cookie:http-only":
 				c.HTTPOnly = v[0] == "HttpOnly"
+			case "cookie:same-site":
+				c.SameSite = v[0]
 			}
 		}
 		cookies = append(cookies, c)

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -507,7 +507,7 @@ type (
 		// HTTPOnly sets the cookie "http-only" attribute to "HttpOnly" if true.
 		HTTPOnly bool
 		// SameSite sets the cookie "same-site" attribute to the given value.
-		SameSite http.SameSite
+		SameSite string
 	}
 
 	// TypeData contains the data needed to render a type definition.
@@ -2539,13 +2539,13 @@ func extractCookies(a *expr.MappedAttributeExpr, svcAtt *expr.AttributeExpr, svc
 			case "cookie:same-site":
 				switch v[0] {
 				case string(expr.CookieSameSiteLax):
-					c.SameSite = http.SameSiteLaxMode
+					c.SameSite = "http.SameSiteLaxMode"
 				case string(expr.CookieSameSiteStrict):
-					c.SameSite = http.SameSiteStrictMode
+					c.SameSite = "http.SameSiteStrictMode"
 				case string(expr.CookieSameSiteNone):
-					c.SameSite = http.SameSiteNoneMode
+					c.SameSite = "http.SameSiteNoneMode"
 				case string(expr.CookieSameSiteDefault):
-					c.SameSite = http.SameSiteDefaultMode
+					c.SameSite = "http.SameSiteDefaultMode"
 				}
 			}
 		}


### PR DESCRIPTION
Adds support for the [SameSite](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-cookie-same-site-00) cookie attribute available in `net/http` [since Go 1.11](https://github.com/golang/go/commit/3d5703babe9c5344252db3fb8e96f20cd036535a).

I think this covers everything, but let me know if there's anything else I can/need to do.