### PR TITLE
Generate valid OpenAPI specifications

### DIFF
--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -258,6 +258,16 @@ func summaryFromExpr(name string, e *expr.HTTPEndpointExpr) string {
 			return mdata[0]
 		}
 	}
+	for n, mdata := range e.Service.ServiceExpr.Meta {
+		if (n == "openapi:summary" || n == "swagger:summary") && len(mdata) > 0 {
+			return mdata[0]
+		}
+	}
+	for n, mdata := range expr.Root.API.Meta {
+		if (n == "openapi:summary" || n == "swagger:summary") && len(mdata) > 0 {
+			return mdata[0]
+		}
+	}
 	return name
 }
 
@@ -623,7 +633,9 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 				requirement[s.Hash()] = []string{}
 				switch s.Kind {
 				case expr.OAuth2Kind:
-					requirement[s.Hash()] = append(requirement[s.Hash()], req.Scopes...)
+					if len(req.Scopes) > 0 {
+						requirement[s.Hash()] = req.Scopes
+					}
 				case expr.BasicAuthKind, expr.APIKeyKind, expr.JWTKind:
 					lines := make([]string, 0, len(req.Scopes))
 					for _, scope := range req.Scopes {

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -213,6 +213,7 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 	{
 		summary = fmt.Sprintf("%s %s", e.Name(), svc.Name())
 		setSummary(expr.Root.API.Meta)
+		setSummary(svc.ServiceExpr.Meta)
 		setSummary(r.Endpoint.Meta)
 		setSummary(m.Meta)
 	}
@@ -548,12 +549,14 @@ func buildSecurityRequirements(reqs []*expr.SecurityExpr) []map[string][]string 
 	for i, req := range reqs {
 		sr := make(map[string][]string, len(req.Schemes))
 		for _, sch := range req.Schemes {
+			scopes := []string{}
 			switch sch.Kind {
-			case expr.BasicAuthKind, expr.APIKeyKind:
-				sr[sch.Hash()] = []string{}
 			case expr.OAuth2Kind, expr.JWTKind:
-				sr[sch.Hash()] = req.Scopes
+				if len(req.Scopes) > 0 {
+					scopes = req.Scopes
+				}
 			}
+			sr[sch.Hash()] = scopes
 		}
 		srs[i] = sr
 	}


### PR DESCRIPTION
When security requirements are empty (needs to be empty array and not nil). Also take into consideration metadata set at service level to generate summary.