### PR TITLE
Skip flaky tests

### DIFF
--- a/grpc/middleware/xray/middleware_test.go
+++ b/grpc/middleware/xray/middleware_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package xray
 
 import (

--- a/grpc/middleware/xray/segment_test.go
+++ b/grpc/middleware/xray/segment_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package xray
 
 import (


### PR DESCRIPTION
Prevent random test failures during CI with the error message:

listen udp 127.0.0.1:62112: bind: An attempt was made to access a socket in a way forbidden by its access permissions.

Re-running tests fixes it but testing on Linux is enough anyway for these tests.