### PR TITLE
Customize proto message name

### DIFF
--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -103,6 +103,15 @@ import (
 //	    })
 //	})
 //
+// - "struct:name:proto" overrides the generated protobuf message name. Applicable
+// to Type and ResultType only.
+//
+//	var MyType = Type("MyType", func() {
+//	    Meta("struct:name:proto", "MyProtoType")
+//	    Field(1, "name", String)
+//	    Field(2, "age", Int32)
+//	})
+//
 // - "struct:tag:xxx" sets a generated Go struct field tag and overrides tags
 // that Goa would otherwise set. If the metadata value is a slice then the
 // strings are joined with the space character as separator. Applicable to

--- a/expr/grpc_endpoint.go
+++ b/expr/grpc_endpoint.go
@@ -332,6 +332,16 @@ func (e *GRPCEndpointExpr) Finalize() {
 				nat.Attribute.Meta.Merge(patt.Meta)
 			}
 		}
+		if ut, ok := e.MethodExpr.Payload.Type.(UserType); ok {
+			// merge Meta defined in the method result type with the response
+			if ut.Attribute().Meta != nil {
+				if e.Request.Meta == nil {
+					e.Request.Meta = ut.Attribute().Meta
+				} else {
+					e.Request.Meta.Merge(ut.Attribute().Meta)
+				}
+			}
+		}
 	} else {
 		// method payload is not an object type.
 		if e.MethodExpr.StreamingPayload.Type != Empty {

--- a/expr/grpc_endpoint.go
+++ b/expr/grpc_endpoint.go
@@ -333,7 +333,7 @@ func (e *GRPCEndpointExpr) Finalize() {
 			}
 		}
 		if ut, ok := e.MethodExpr.Payload.Type.(UserType); ok {
-			// merge Meta defined in the method result type with the response
+			// merge Meta defined in the method payload type with the request
 			if ut.Attribute().Meta != nil {
 				if e.Request.Meta == nil {
 					e.Request.Meta = ut.Attribute().Meta

--- a/expr/grpc_response.go
+++ b/expr/grpc_response.go
@@ -186,6 +186,16 @@ func (r *GRPCResponseExpr) Finalize(a *GRPCEndpointExpr, svcAtt *AttributeExpr) 
 				nat.Attribute.Meta.Merge(svcAtt.Meta)
 			}
 		}
+		if ut, ok := svcAtt.Type.(UserType); ok {
+			// merge Meta defined in the method result type with the response
+			if ut.Attribute().Meta != nil {
+				if r.Message.Meta == nil {
+					r.Message.Meta = ut.Attribute().Meta
+				} else {
+					r.Message.Meta.Merge(ut.Attribute().Meta)
+				}
+			}
+		}
 	} else {
 		// method result is not an object type. Initialize response header or
 		// trailer metadata if defined or else initialize response message.

--- a/grpc/codegen/proto_test.go
+++ b/grpc/codegen/proto_test.go
@@ -27,6 +27,7 @@ func TestProtoFiles(t *testing.T) {
 		{"protofiles-custom-package-name", testdata.ServiceWithPackageDSL, testdata.ServiceWithPackageCode},
 		{"protofiles-struct-meta-type", testdata.StructMetaTypeDSL, testdata.StructMetaTypePackageCode},
 		{"protofiles-default-fields", testdata.DefaultFieldsDSL, testdata.DefaultFieldsPackageCode},
+		{"protofiles-custom-message-name", testdata.CustomMessageNameDSL, testdata.CustomMessageNamePackageCode},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -199,6 +199,9 @@ func protoBufFullMessageName(att *expr.AttributeExpr, pkg string, s *codegen.Nam
 	switch actual := att.Type.(type) {
 	case expr.UserType, *expr.Union:
 		n := s.HashedUnique(actual, protoBufify(actual.Name(), true, true), "")
+		if name := att.Meta["struct:name:proto"]; len(name) > 0 {
+			n = name[0]
+		}
 		if pkg == "" {
 			return n
 		}

--- a/grpc/codegen/testdata/dsls.go
+++ b/grpc/codegen/testdata/dsls.go
@@ -975,3 +975,23 @@ var DefaultFieldsDSL = func() {
 		})
 	})
 }
+
+var CustomMessageNameDSL = func() {
+	var CustomType = Type("CustomType", func() {
+		Meta("struct:name:proto", "CustomType")
+		Field(1, "a", Int)
+		Field(2, "b", String)
+	})
+	Service("CustomMessageName", func() {
+		Method("Unary", func() {
+			Payload(CustomType)
+			Result(CustomType)
+			GRPC(func() {})
+		})
+		Method("Stream", func() {
+			StreamingPayload(CustomType)
+			StreamingResult(CustomType)
+			GRPC(func() {})
+		})
+	})
+}

--- a/grpc/codegen/testdata/proto_code.go
+++ b/grpc/codegen/testdata/proto_code.go
@@ -504,3 +504,24 @@ message MethodRequest {
 message MethodResponse {
 }
 `
+
+const CustomMessageNamePackageCode = `
+syntax = "proto3";
+
+package custom_message_name;
+
+option go_package = "/custom_message_namepb";
+
+// Service is the CustomMessageName service interface.
+service CustomMessageName {
+	// Unary implements Unary.
+	rpc Unary (CustomType) returns (CustomType);
+	// Stream implements Stream.
+	rpc Stream (stream CustomType) returns (stream CustomType);
+}
+
+message CustomType {
+	optional sint32 a = 1;
+	optional string b = 2;
+}
+`


### PR DESCRIPTION
This PR adds a `struct:name:proto` Meta key to customize the protobuf `Message` name generated in proto file.