### PR TITLE
Fix eval.IncompatibleDSL() to not show internal DSL

### DIFF
--- a/expr/http_endpoint_test.go
+++ b/expr/http_endpoint_test.go
@@ -15,7 +15,7 @@ func TestHTTPRouteValidation(t *testing.T) {
 		Error string
 	}{
 		{"valid", testdata.ValidRouteDSL, ""},
-		{"invalid", testdata.DuplicateWCRouteDSL, `route POST "/{id}" of service "InvalidRoute" HTTP endpoint "Method": Wildcard "id" appears multiple times in full path "/{id}/{id}"`},
+		{"duplicate-wc-route", testdata.DuplicateWCRouteDSL, `route POST "/{id}" of service "DuplicateWCRoute" HTTP endpoint "Method": Wildcard "id" appears multiple times in full path "/{id}/{id}"`},
 		{"disallow-response-body", testdata.DisallowResponseBodyHeadDSL, `route HEAD "/" of service "DisallowResponseBody" HTTP endpoint "Method": HTTP status 200: Response body defined for HEAD method which does not allow response body.
 route HEAD "/" of service "DisallowResponseBody" HTTP endpoint "Method": HTTP status 404: Response body defined for HEAD method which does not allow response body.`,
 		},

--- a/expr/http_endpoint_test.go
+++ b/expr/http_endpoint_test.go
@@ -1,6 +1,7 @@
 package expr_test
 
 import (
+	"strings"
 	"testing"
 
 	"goa.design/goa/v3/eval"
@@ -19,6 +20,7 @@ func TestHTTPRouteValidation(t *testing.T) {
 		{"disallow-response-body", testdata.DisallowResponseBodyHeadDSL, `route HEAD "/" of service "DisallowResponseBody" HTTP endpoint "Method": HTTP status 200: Response body defined for HEAD method which does not allow response body.
 route HEAD "/" of service "DisallowResponseBody" HTTP endpoint "Method": HTTP status 404: Response body defined for HEAD method which does not allow response body.`,
 		},
+		{"invalid", testdata.InvalidRouteDSL, "invalid use of POST in service \"InvalidRoute\""},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -26,7 +28,7 @@ route HEAD "/" of service "DisallowResponseBody" HTTP endpoint "Method": HTTP st
 				expr.RunDSL(t, c.DSL)
 			} else {
 				err := expr.RunInvalidDSL(t, c.DSL)
-				if err.Error() != c.Error {
+				if !strings.HasSuffix(err.Error(), c.Error) {
 					t.Errorf("got error %q\nexpected %q", err.Error(), c.Error)
 				}
 			}

--- a/expr/testdata/endpoint_dsls.go
+++ b/expr/testdata/endpoint_dsls.go
@@ -22,7 +22,7 @@ var ValidRouteDSL = func() {
 }
 
 var DuplicateWCRouteDSL = func() {
-	Service("InvalidRoute", func() {
+	Service("DuplicateWCRoute", func() {
 		HTTP(func() {
 			Path("/{id}")
 		})

--- a/expr/testdata/endpoint_dsls.go
+++ b/expr/testdata/endpoint_dsls.go
@@ -52,6 +52,14 @@ var DisallowResponseBodyHeadDSL = func() {
 	})
 }
 
+var InvalidRouteDSL = func() {
+	Service("InvalidRoute", func() {
+		HTTP(func() {
+			POST("/{id}")
+		})
+	})
+}
+
 var EndpointWithParentDSL = func() {
 	Service("Parent", func() {
 		Method("show", func() {


### PR DESCRIPTION
The `caller()` function is from v1, but had to be modified for v3.

https://github.com/goadesign/goa/blob/v1/dslengine/runner.go#L419-L429