### PR TITLE
Fix handling of result types used in bodies

### DIFF
--- a/dsl/http.go
+++ b/dsl/http.go
@@ -959,8 +959,8 @@ func Body(args ...any) {
 		}
 		attr = expr.DupAtt(attr)
 		attr.AddMeta("origin:attribute", a)
-		if rt, ok := attr.Type.(*expr.ResultTypeExpr); ok {
-			// If the attribute type is a result type add the type to the
+		if rt, ok := attr.Type.(*expr.ResultTypeExpr); ok && expr.IsArray(rt.Type) {
+			// If the attribute type is a result type collection add the type to the
 			// GeneratedTypes so that the type's DSLFunc is executed.
 			*expr.Root.GeneratedTypes = append(*expr.Root.GeneratedTypes, rt)
 		}

--- a/expr/http_body_types.go
+++ b/expr/http_body_types.go
@@ -426,6 +426,7 @@ func concat(strs ...string) string {
 }
 
 func renameType(att *AttributeExpr, name, suffix string) {
+	RemovePkgPath(att)
 	rt := att.Type
 	switch rtt := rt.(type) {
 	case UserType:


### PR DESCRIPTION
Only Collection result types need to be added to the generated roots. Adding other result types to it causes their DSL to run twice and therefore their views to get defined twice which causes the generation to fail.