### PR TITLE
Properly handle serving renamed files

### DIFF
--- a/http/codegen/server.go
+++ b/http/codegen/server.go
@@ -88,7 +88,20 @@ func serverFile(genpkg string, svc *expr.HTTPServiceExpr) *codegen.File {
 		sections = append(sections, &codegen.SectionTemplate{Name: "server-handler-init", Source: readTemplate("server_handler_init"), FuncMap: funcs, Data: e})
 	}
 	if len(data.FileServers) > 0 {
-		sections = append(sections, &codegen.SectionTemplate{Name: "append-fs", Source: readTemplate("append_fs"), FuncMap: funcs, Data: data})
+		mappedFiles := make(map[string]string)
+		for _, fs := range data.FileServers {
+			if !fs.IsDir {
+				for _, p := range fs.RequestPaths {
+					baseFilePath := "/" + filepath.Base(fs.FilePath)
+					baseRequestPath := "/" + filepath.Base(p)
+					if baseFilePath == baseRequestPath {
+						continue
+					}
+					mappedFiles[baseRequestPath] = baseFilePath
+				}
+			}
+		}
+		sections = append(sections, &codegen.SectionTemplate{Name: "append-fs", Source: readTemplate("append_fs"), FuncMap: funcs, Data: mappedFiles})
 	}
 	for _, s := range data.FileServers {
 		sections = append(sections, &codegen.SectionTemplate{Name: "server-files", Source: readTemplate("file_server"), FuncMap: funcs, Data: s})

--- a/http/codegen/templates/append_fs.go.tpl
+++ b/http/codegen/templates/append_fs.go.tpl
@@ -8,6 +8,12 @@ type appendFS struct {
 // Open opens the named file, appending the prefix to the file path before
 // passing it to the underlying fs.FS.
 func (s appendFS) Open(name string) (http.File, error) {
+	switch name {
+	{{- range $requested, $embedded := . }}
+	case {{ printf "%q" $requested }}:
+		name = {{ printf "%q" $embedded }}
+	{{- end }}
+	}
 	return s.fs.Open(path.Join(s.prefix, name))
 }
 


### PR DESCRIPTION
This fixes a regression introduced by #3588 that broke the generation of file servers when the served filename differs from the request path filename, .e.g:
```go
Files("/index.html", "/www/data/another.html")
```