### PR TITLE
OpenAPIv3: count different validation rules as different types

### DIFF
--- a/http/codegen/openapi/v3/testdata/dsls/types.go
+++ b/http/codegen/openapi/v3/testdata/dsls/types.go
@@ -15,6 +15,49 @@ func StringBodyDSL(svcName, metName string) func() {
 	}
 }
 
+func StringEnumBodyDSL() func() {
+	return func() {
+		var T1 = Type("T1", func() {
+			Attribute("my_attr", String, func() {
+				Enum("a", "b", "c")
+			})
+		})
+
+		var T2 = Type("T2", func() {
+			Attribute("my_attr", String, func() {
+				Enum("d", "e")
+			})
+		})
+
+		var _ = Service("svc_enum_1", func() {
+			Method("method_enum", func() {
+				Payload(func() {
+					Reference(T1)
+					Attribute("my_attr")
+					Required("my_attr")
+				})
+				HTTP(func() {
+					POST("/")
+				})
+			})
+		})
+
+		var _ = Service("svc_enum_2", func() {
+			Method("method_enum", func() {
+				Payload(func() {
+					Reference(T2)
+					Attribute("my_attr")
+					Required("my_attr")
+				})
+
+				HTTP(func() {
+					POST("/other")
+				})
+			})
+		})
+	}
+}
+
 func AliasStringBodyDSL(svcName, metName string) func() {
 	return func() {
 		var UUID = Type("UUID", String, func() {

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -440,6 +440,87 @@ func hashAttribute(att *expr.AttributeExpr, h hash.Hash64, seen map[string]*uint
 		*res = hashString(t.Name(), h)
 	}
 
+	// Validations can change the type of an attribute: just because two things
+	// are strings, if they have different validation rules, we cannot treat them
+	// as the same type.
+	hv := hashValidation(att.Validation, h)
+	if hv != 0 {
+		*res = orderedHash(*res, hv, h)
+	}
+
+	return res
+}
+
+func hashValidation(val *expr.ValidationExpr, h hash.Hash64) uint64 {
+	h.Reset()
+	if val == nil {
+		return 0
+	}
+	var parts []uint64
+	if val.Format != "" {
+		parts = append(parts, hashString(string(val.Format), h))
+	}
+	if val.Pattern != "" {
+		parts = append(parts, hashString(val.Pattern, h))
+	}
+	if val.MinLength != nil {
+		parts = append(parts, hashString(strconv.Itoa(*val.MinLength), h))
+	}
+	if val.MaxLength != nil {
+		parts = append(parts, hashString(strconv.Itoa(*val.MaxLength), h))
+	}
+	if val.Minimum != nil {
+		parts = append(parts, hashString(strconv.FormatFloat(*val.Minimum, 'f', -1, 64), h))
+	}
+	if val.Maximum != nil {
+		parts = append(parts, hashString(strconv.FormatFloat(*val.Maximum, 'f', -1, 64), h))
+	}
+	if val.ExclusiveMinimum != nil {
+		parts = append(parts, hashString(strconv.FormatFloat(*val.ExclusiveMinimum, 'f', -1, 64), h))
+	}
+	if val.ExclusiveMaximum != nil {
+		parts = append(parts, hashString(strconv.FormatFloat(*val.ExclusiveMaximum, 'f', -1, 64), h))
+	}
+	for _, v := range val.Values {
+		// Try to handle as many types as Goa supports
+		switch v := v.(type) {
+		case string:
+			parts = append(parts, hashString(v, h))
+		case int:
+			parts = append(parts, hashString(strconv.Itoa(v), h))
+		case int64:
+			parts = append(parts, hashString(strconv.FormatInt(v, 10), h))
+		case int32:
+			parts = append(parts, hashString(strconv.FormatInt(int64(v), 10), h))
+		case float64:
+			parts = append(parts, hashString(strconv.FormatFloat(v, 'f', -1, 64), h))
+		case float32:
+			parts = append(parts, hashString(strconv.FormatFloat(float64(v), 'f', -1, 64), h))
+		case bool:
+			parts = append(parts, hashString(strconv.FormatBool(v), h))
+		case uint:
+			parts = append(parts, hashString(strconv.FormatUint(uint64(v), 10), h))
+		case uint64:
+			parts = append(parts, hashString(strconv.FormatUint(v, 10), h))
+		case uint32:
+			parts = append(parts, hashString(strconv.FormatUint(uint64(v), 10), h))
+		case uint16:
+			parts = append(parts, hashString(strconv.FormatUint(uint64(v), 10), h))
+		case uint8:
+			parts = append(parts, hashString(strconv.FormatUint(uint64(v), 10), h))
+		case []byte:
+			parts = append(parts, hashString(string(v), h))
+		}
+	}
+
+	var res uint64
+	for _, part := range parts {
+		if res == 0 {
+			res = part
+		} else {
+			res = orderedHash(res, part, h)
+		}
+	}
 	return res
 }
 

--- a/http/codegen/openapi/v3/types_test.go
+++ b/http/codegen/openapi/v3/types_test.go
@@ -1,6 +1,7 @@
 package openapiv3
 
 import (
+	"encoding/json"
 	"hash/fnv"
 	"strings"
 	"testing"
@@ -252,6 +253,36 @@ func matchesSchemaWithPrefix(t *testing.T, ctx string, s *openapi.Schema, types 
 			}
 			matchesSchemaWithPrefix(t, ctx, v, types, p, n+": ")
 		}
+	}
+}
+
+func TestTypesOnlyDifferByEnum(t *testing.T) {
+	api := codegen.RunDSL(t, dsls.StringEnumBodyDSL()).API
+
+	bodies, types := buildBodyTypes(api)
+
+	svc1, ok := bodies["svc_enum_1"]
+	if !ok {
+		t.Errorf("bodies does not contain details for service %q", "svc_enum_1")
+		return
+	}
+	svc2, ok := bodies["svc_enum_2"]
+	if !ok {
+		t.Errorf("bodies does not contain details for service %q", "svc_enum_2")
+		return
+	}
+
+	svc1MethodRB := svc1["method_enum"].RequestBody.Ref
+	svc2MethodRB := svc2["method_enum"].RequestBody.Ref
+
+	if svc1MethodRB == svc2MethodRB {
+		t.Errorf("expected different refs, got %q", svc1MethodRB)
+
+		name := nameFromRef(svc1MethodRB)
+		derefed := types[name]
+		jsoned, _ := json.Marshal(derefed)
+		t.Errorf("shared referenced type (%s) was: %v", name, string(jsoned))
+		return
 	}
 }
 


### PR DESCRIPTION
This replicates an issue we're seeing in the OpenAPIv3 generator, where if two request bodies are structurally similar (i.e. same primitive types), but not identical (in this example both have a single string attribute with the same name, but with different enum validations), the request body for those two methods points at the same type schema.

There's a (previously-failing) test, where:
- two types which are 'similar' (both have a string-type attr called `my_attr`), but not identical (they are different enums)
- two different services with the same method, each referencing different types

The resulting OpenAPIv3 schema generates a single
`MethodEnumRequestBody` type, and uses it for the `requestBody` type of both methods.

This is incorrect, since the two methods use a different enum!

The fix here is to update the `hashAttribute` method to hash the `.Validation` of the attribute, if it is set :tada: