### PR TITLE
OpenAPIv3: description bugs

### DIFF
--- a/http/codegen/openapi/v3/testdata/dsls/types.go
+++ b/http/codegen/openapi/v3/testdata/dsls/types.go
@@ -24,9 +24,14 @@ func StringEnumBodyDSL() func() {
 		})
 
 		var T2 = Type("T2", func() {
-			Attribute("my_attr", String, func() {
+			Attribute("my_attr", String, "Description 2", func() {
 				Enum("d", "e")
 			})
+		})
+
+		var T3 = Type("T3", func() {
+			Attribute("my_attr", T2, "Description 3")
+			Required("my_attr")
 		})
 
 		var _ = Service("svc_enum_1", func() {
@@ -52,6 +57,14 @@ func StringEnumBodyDSL() func() {
 
 				HTTP(func() {
 					POST("/other")
+				})
+			})
+
+			Method("method_enum_3", func() {
+				Payload(T3)
+
+				HTTP(func() {
+					POST("/third_one")
 				})
 			})
 		})

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -450,6 +450,11 @@ func hashAttribute(att *expr.AttributeExpr, h hash.Hash64, seen map[string]*uint
 		}
 	}
 
+	// Add description to the hash, since different descriptions must not be deduplicated
+	if att.Description != "" {
+		*res = orderedHash(*res, hashString(att.Description, h), h)
+	}
+
 	return res
 }
 

--- a/http/codegen/openapi/v3/types_test.go
+++ b/http/codegen/openapi/v3/types_test.go
@@ -282,7 +282,12 @@ func TestTypesOnlyDifferByEnum(t *testing.T) {
 		derefed := types[name]
 		jsoned, _ := json.Marshal(derefed)
 		t.Errorf("shared referenced type (%s) was: %v", name, string(jsoned))
-		return
+	}
+
+	type3 := types["T3"]
+	t3AttrDesc := type3.Properties["my_attr"].Description
+	if t3AttrDesc != "Description 3" {
+		t.Errorf("expected description on referenc attribute, got %q", t3AttrDesc)
 	}
 }
 


### PR DESCRIPTION
1. Include description when hashing an attribute.

This means that if you have two types in your design which are structurally identical but with different descriptions on some attributes they will no longer be deduped. This is useful if descriptions are used in generated documentation or clients.

2. Include descriptions on reference attributes in the generated schema

Previously any attribute which was defined as a `ref` to another schema in the output would not have the description included. This is now included!