### PR TITLE
Add missing codegen tool import

### DIFF
--- a/dsl/doc.go
+++ b/dsl/doc.go
@@ -56,8 +56,10 @@ package dsl
 
 import (
 	// The imports below add dependencies needed by the generated temporary
-	// code generation tool. Go cannot detect these dependencies so we must
-	// add them explicitly.
+	// code generation tool which reuses the project's go.mod. Go cannot detect
+	// these dependencies since they are not used by the DSL. We must add them
+	// explicitly so that `go mod tidy` adds them to the go.mod file.
+	_ "github.com/gohugoio/hashstructure"
 	_ "golang.org/x/tools/go/ast/astutil"
 	_ "golang.org/x/tools/go/packages"
 	_ "golang.org/x/tools/imports"


### PR DESCRIPTION
The `hashstructure` package is used by the OpenAPI code generation algorithm and is not imported by the `dsl` package or its dependencies.

Fix https://github.com/goadesign/goa/issues/3675