### PR TITLE
Fix warning QF1004 of staticcheck

### DIFF
--- a/codegen/example/templates/client_usage.go.tpl
+++ b/codegen/example/templates/client_usage.go.tpl
@@ -28,5 +28,5 @@ func indent(s string) string {
 	if s == "" {
 		return ""
 	}
-	return "    " + strings.Replace(s, "\n", "\n    ", -1)
+	return "    " + strings.ReplaceAll(s, "\n", "\n    ")
 }

--- a/codegen/example/templates/client_var_init.go.tpl
+++ b/codegen/example/templates/client_var_init.go.tpl
@@ -27,7 +27,7 @@ var (
 						os.Exit(1)
 					}
 				{{- end }}
-				addr = strings.Replace(addr, "{{ printf "{%s}" .Name }}", *{{ .VarName }}F, -1)
+				addr = strings.ReplaceAll(addr, "{{ printf "{%s}" .Name }}", *{{ .VarName }}F)
 			{{- end }}
 		{{- end }}
 			default:

--- a/codegen/example/templates/server_handler.go.tpl
+++ b/codegen/example/templates/server_handler.go.tpl
@@ -23,7 +23,7 @@
 						log.Fatal(ctx, fmt.Errorf("invalid value for URL '{{ .Name }}' variable: %q (valid values: {{ join .Values "," }})\n", *{{ .VarName }}F))
 					}
 				{{- end }}
-				addr = strings.Replace(addr, "{{ printf "{%s}" .Name }}", *{{ .VarName }}F, -1)
+				addr = strings.ReplaceAll(addr, "{{ printf "{%s}" .Name }}", *{{ .VarName }}F)
 			{{- end }}
 			u, err := url.Parse(addr)
 			if err != nil {

--- a/codegen/example/testdata/client-no-server.golden
+++ b/codegen/example/testdata/client-no-server.golden
@@ -104,5 +104,5 @@ func indent(s string) string {
 	if s == "" {
 		return ""
 	}
-	return "    " + strings.Replace(s, "\n", "\n    ", -1)
+	return "    " + strings.ReplaceAll(s, "\n", "\n    ")
 }

--- a/codegen/example/testdata/client-single-server-multiple-hosts-with-variables.golden
+++ b/codegen/example/testdata/client-single-server-multiple-hosts-with-variables.golden
@@ -36,11 +36,11 @@ func main() {
 					fmt.Fprintf(os.Stderr, "invalid value for URL 'version' variable: %q (valid values: v1,v2)\n", *versionF)
 					os.Exit(1)
 				}
-				addr = strings.Replace(addr, "{version}", *versionF, -1)
+				addr = strings.ReplaceAll(addr, "{version}", *versionF)
 			case "stage":
 				addr = "https://example-{domain}:{port}"
-				addr = strings.Replace(addr, "{domain}", *domainF, -1)
-				addr = strings.Replace(addr, "{port}", *portF, -1)
+				addr = strings.ReplaceAll(addr, "{domain}", *domainF)
+				addr = strings.ReplaceAll(addr, "{port}", *portF)
 			default:
 				fmt.Fprintf(os.Stderr, "invalid host argument: %q (valid hosts: dev|stage)\n", *hostF)
 				os.Exit(1)
@@ -126,5 +126,5 @@ func indent(s string) string {
 	if s == "" {
 		return ""
 	}
-	return "    " + strings.Replace(s, "\n", "\n    ", -1)
+	return "    " + strings.ReplaceAll(s, "\n", "\n    ")
 }

--- a/codegen/example/testdata/client-single-server-multiple-hosts.golden
+++ b/codegen/example/testdata/client-single-server-multiple-hosts.golden
@@ -104,5 +104,5 @@ func indent(s string) string {
 	if s == "" {
 		return ""
 	}
-	return "    " + strings.Replace(s, "\n", "\n    ", -1)
+	return "    " + strings.ReplaceAll(s, "\n", "\n    ")
 }

--- a/codegen/example/testdata/client-single-server-single-host-with-variables.golden
+++ b/codegen/example/testdata/client-single-server-single-host-with-variables.golden
@@ -29,15 +29,15 @@ func main() {
 			switch *hostF {
 			case "dev":
 				addr = "http://example-{int}-{uint}-{float32}:8090"
-				addr = strings.Replace(addr, "{int}", *int_F, -1)
-				addr = strings.Replace(addr, "{uint}", *uint_F, -1)
-				addr = strings.Replace(addr, "{float32}", *float32_F, -1)
-				addr = strings.Replace(addr, "{int32}", *int32_F, -1)
-				addr = strings.Replace(addr, "{int64}", *int64_F, -1)
-				addr = strings.Replace(addr, "{uint32}", *uint32_F, -1)
-				addr = strings.Replace(addr, "{uint64}", *uint64_F, -1)
-				addr = strings.Replace(addr, "{float64}", *float64_F, -1)
-				addr = strings.Replace(addr, "{bool}", *bool_F, -1)
+				addr = strings.ReplaceAll(addr, "{int}", *int_F)
+				addr = strings.ReplaceAll(addr, "{uint}", *uint_F)
+				addr = strings.ReplaceAll(addr, "{float32}", *float32_F)
+				addr = strings.ReplaceAll(addr, "{int32}", *int32_F)
+				addr = strings.ReplaceAll(addr, "{int64}", *int64_F)
+				addr = strings.ReplaceAll(addr, "{uint32}", *uint32_F)
+				addr = strings.ReplaceAll(addr, "{uint64}", *uint64_F)
+				addr = strings.ReplaceAll(addr, "{float64}", *float64_F)
+				addr = strings.ReplaceAll(addr, "{bool}", *bool_F)
 			default:
 				fmt.Fprintf(os.Stderr, "invalid host argument: %q (valid hosts: dev)\n", *hostF)
 				os.Exit(1)
@@ -129,5 +129,5 @@ func indent(s string) string {
 	if s == "" {
 		return ""
 	}
-	return "    " + strings.Replace(s, "\n", "\n    ", -1)
+	return "    " + strings.ReplaceAll(s, "\n", "\n    ")
 }

--- a/codegen/example/testdata/client-single-server-single-host.golden
+++ b/codegen/example/testdata/client-single-server-single-host.golden
@@ -104,5 +104,5 @@ func indent(s string) string {
 	if s == "" {
 		return ""
 	}
-	return "    " + strings.Replace(s, "\n", "\n    ", -1)
+	return "    " + strings.ReplaceAll(s, "\n", "\n    ")
 }

--- a/codegen/example/testdata/server-single-server-multiple-hosts-with-variables.golden
+++ b/codegen/example/testdata/server-single-server-multiple-hosts-with-variables.golden
@@ -76,7 +76,7 @@ func main() {
 			if !versionSeen {
 				log.Fatal(ctx, fmt.Errorf("invalid value for URL 'version' variable: %q (valid values: v1,v2)\n", *versionF))
 			}
-			addr = strings.Replace(addr, "{version}", *versionF, -1)
+			addr = strings.ReplaceAll(addr, "{version}", *versionF)
 			u, err := url.Parse(addr)
 			if err != nil {
 				log.Fatalf(ctx, err, "invalid URL %#v\n", addr)
@@ -102,8 +102,8 @@ func main() {
 	case "stage":
 		{
 			addr := "https://example-{domain}:{port}"
-			addr = strings.Replace(addr, "{domain}", *domainF, -1)
-			addr = strings.Replace(addr, "{port}", *portF, -1)
+			addr = strings.ReplaceAll(addr, "{domain}", *domainF)
+			addr = strings.ReplaceAll(addr, "{port}", *portF)
 			u, err := url.Parse(addr)
 			if err != nil {
 				log.Fatalf(ctx, err, "invalid URL %#v\n", addr)

--- a/codegen/example/testdata/server-single-server-single-host-with-variables.golden
+++ b/codegen/example/testdata/server-single-server-single-host-with-variables.golden
@@ -70,15 +70,15 @@ func main() {
 	case "dev":
 		{
 			addr := "http://example-{int}-{uint}-{float32}:8090"
-			addr = strings.Replace(addr, "{int}", *int_F, -1)
-			addr = strings.Replace(addr, "{uint}", *uint_F, -1)
-			addr = strings.Replace(addr, "{float32}", *float32_F, -1)
-			addr = strings.Replace(addr, "{int32}", *int32_F, -1)
-			addr = strings.Replace(addr, "{int64}", *int64_F, -1)
-			addr = strings.Replace(addr, "{uint32}", *uint32_F, -1)
-			addr = strings.Replace(addr, "{uint64}", *uint64_F, -1)
-			addr = strings.Replace(addr, "{float64}", *float64_F, -1)
-			addr = strings.Replace(addr, "{bool}", *bool_F, -1)
+			addr = strings.ReplaceAll(addr, "{int}", *int_F)
+			addr = strings.ReplaceAll(addr, "{uint}", *uint_F)
+			addr = strings.ReplaceAll(addr, "{float32}", *float32_F)
+			addr = strings.ReplaceAll(addr, "{int32}", *int32_F)
+			addr = strings.ReplaceAll(addr, "{int64}", *int64_F)
+			addr = strings.ReplaceAll(addr, "{uint32}", *uint32_F)
+			addr = strings.ReplaceAll(addr, "{uint64}", *uint64_F)
+			addr = strings.ReplaceAll(addr, "{float64}", *float64_F)
+			addr = strings.ReplaceAll(addr, "{bool}", *bool_F)
 			u, err := url.Parse(addr)
 			if err != nil {
 				log.Fatalf(ctx, err, "invalid URL %#v\n", addr)
@@ -103,15 +103,15 @@ func main() {
 
 		{
 			addr := "https://example-{int32}-{int64}-{uint32}-{uint64}-{float64}:80/{bool}"
-			addr = strings.Replace(addr, "{int}", *int_F, -1)
-			addr = strings.Replace(addr, "{uint}", *uint_F, -1)
-			addr = strings.Replace(addr, "{float32}", *float32_F, -1)
-			addr = strings.Replace(addr, "{int32}", *int32_F, -1)
-			addr = strings.Replace(addr, "{int64}", *int64_F, -1)
-			addr = strings.Replace(addr, "{uint32}", *uint32_F, -1)
-			addr = strings.Replace(addr, "{uint64}", *uint64_F, -1)
-			addr = strings.Replace(addr, "{float64}", *float64_F, -1)
-			addr = strings.Replace(addr, "{bool}", *bool_F, -1)
+			addr = strings.ReplaceAll(addr, "{int}", *int_F)
+			addr = strings.ReplaceAll(addr, "{uint}", *uint_F)
+			addr = strings.ReplaceAll(addr, "{float32}", *float32_F)
+			addr = strings.ReplaceAll(addr, "{int32}", *int32_F)
+			addr = strings.ReplaceAll(addr, "{int64}", *int64_F)
+			addr = strings.ReplaceAll(addr, "{uint32}", *uint32_F)
+			addr = strings.ReplaceAll(addr, "{uint64}", *uint64_F)
+			addr = strings.ReplaceAll(addr, "{float64}", *float64_F)
+			addr = strings.ReplaceAll(addr, "{bool}", *bool_F)
 			u, err := url.Parse(addr)
 			if err != nil {
 				log.Fatalf(ctx, err, "invalid URL %#v\n", addr)


### PR DESCRIPTION
## Problem

A linter [Staticcheck](https://staticcheck.dev/), which could be included in golangci-lint, warns QF1004 in the generated code:  
https://staticcheck.dev/docs/checks/#QF1004

>Use strings.ReplaceAll instead of strings.Replace with n == -1

## Solution

Do what the linter says.  
There seems not to be any drawback so all replacement are applied in an automatic manner (including test data).