### PR TITLE
Properly propagate alias types user examples

### DIFF
--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -949,6 +949,7 @@ func makeHTTPTypeRecursive(att *expr.AttributeExpr, seen map[string]struct{}) *e
 				}
 			}
 			att.DefaultValue = dt.Attribute().DefaultValue
+			att.UserExamples = dt.Attribute().UserExamples
 		}
 		if _, ok := seen[dt.ID()]; ok {
 			return att


### PR DESCRIPTION
When used in HTTP bodies.