### PR TITLE
Support Go 1.23+ only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ['1.21', '1.22', '1.23', '1.24']
+        go: ['1.23', '1.24']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module goa.design/goa/v3
 
 go 1.23.0
 
-toolchain go1.23.6
-
 require (
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598
 	github.com/getkin/kin-openapi v0.132.0


### PR DESCRIPTION
* There is no need to specify a toolchain.
* There is no need to test for Go 1.20 and 1.21.
    * They should be removed from required status checks.