### PR TITLE
add support for path params in middle of the path

### DIFF
--- a/expr/http.go
+++ b/expr/http.go
@@ -37,7 +37,7 @@ type (
 
 // HTTPWildcardRegex is the regular expression used to capture path
 // parameters.
-var HTTPWildcardRegex = regexp.MustCompile(`/{\*?([a-zA-Z0-9_]+)}`)
+var HTTPWildcardRegex = regexp.MustCompile(`{\*?([a-zA-Z0-9_]+)}`)
 
 // ExtractHTTPWildcards returns the names of the wildcards that appear in
 // a HTTP path.

--- a/http/codegen/openapi/json_schema.go
+++ b/http/codegen/openapi/json_schema.go
@@ -550,7 +550,7 @@ func toSchemaHrefs(r *expr.RouteExpr) []string {
 		params := expr.ExtractHTTPWildcards(path)
 		args := make([]any, len(params))
 		for j, p := range params {
-			args[j] = fmt.Sprintf("/{%s}", p)
+			args[j] = fmt.Sprintf("{%s}", p)
 		}
 		tmpl := expr.HTTPWildcardRegex.ReplaceAllLiteralString(path, "%s")
 		res[i] = fmt.Sprintf(tmpl, args...)

--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -475,7 +475,7 @@ func buildPathFromFileServer(s *V2, root *expr.RootExpr, fs *expr.HTTPFileServer
 			Tags:         tagNames,
 		}
 
-		key := expr.HTTPWildcardRegex.ReplaceAllString(path, "/{$1}")
+		key := expr.HTTPWildcardRegex.ReplaceAllString(path, "{$1}")
 		if key == "" {
 			key = "/"
 		}
@@ -502,7 +502,7 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 	for _, key := range route.FullPaths() {
 		// Remove any wildcards that is defined in path as a workaround to
 		// https://github.com/OAI/OpenAPI-Specification/issues/291
-		key = expr.HTTPWildcardRegex.ReplaceAllString(key, "/{$1}")
+		key = expr.HTTPWildcardRegex.ReplaceAllString(key, "{$1}")
 		params := paramsFromExpr(endpoint.Params, key)
 		params = append(params, paramsFromHeaders(endpoint)...)
 		var produces []string
@@ -644,7 +644,7 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 		bp := expr.HTTPWildcardRegex.ReplaceAllStringFunc(
 			basePath,
 			func(w string) string {
-				return fmt.Sprintf("/{%s}", w[2:])
+				return fmt.Sprintf("{%s}", w[2:])
 			},
 		)
 		if bp != "/" {

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -135,7 +135,7 @@ func buildPaths(h *expr.HTTPExpr, bodies map[string]map[string]*EndpointBodies, 
 				for _, key := range r.FullPaths() {
 					// Remove any wildcards that is defined in path as a workaround to
 					// https://github.com/OAI/OpenAPI-Specification/issues/291
-					key = expr.HTTPWildcardRegex.ReplaceAllString(key, "/{$1}")
+					key = expr.HTTPWildcardRegex.ReplaceAllString(key, "{$1}")
 					operation := buildOperation(key, r, sbod[e.Name()], api.ExampleGenerator)
 					path, ok := paths[key]
 					if !ok {

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -703,7 +703,7 @@ func (ServicesData) analyze(httpSvc *expr.HTTPServiceExpr) *ServiceData {
 					}
 
 					var buffer bytes.Buffer
-					pf := expr.HTTPWildcardRegex.ReplaceAllString(rpath, "/%v")
+					pf := expr.HTTPWildcardRegex.ReplaceAllString(rpath, "%v")
 					err := pathInitTmpl.Execute(&buffer, map[string]any{
 						"Args":       initArgs,
 						"PathParams": pathParamsObj,


### PR DESCRIPTION
Added support for path params in the middles of the paths as well

Earlier `/user/@{username}` didn't register `username` as a path param.
Similarly `/{month}-{day}-{year}` from chi's [readme examples](https://github.com/go-chi/chi?tab=readme-ov-file#examples) would only detect `{month}` as a param and nothing else.

After this change, all these path params should be detected and should work .