### PR TITLE
Fix issue with primitive alias type handling

### DIFF
--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -791,7 +791,7 @@ func (sds *ServicesData) analyze(httpSvc *expr.HTTPServiceExpr) *ServiceData {
 					_, ca.IsAliased = ca.FieldType.(expr.UserType)
 					if ca.IsAliased {
 						if svcData := sds.ServicesData.Get(svc.Name); svcData != nil {
-							ca.ServiceTypeRef = svcData.Scope.GoTypeRef(&expr.AttributeExpr{Type: ca.FieldType})
+							ca.ServiceTypeRef = svcData.Scope.GoTypeRef(&expr.AttributeExpr{Type: ca.Type})
 						} else {
 							ca.ServiceTypeRef = codegen.Goify(ca.FieldType.Name(), true)
 						}


### PR DESCRIPTION
In request building logic. We want to cast to the underlying type - not to the service type (e.g. string  instead of UUID).