### PR TITLE
Fix OneOf validation with format constraints in view types (#3747)

### DIFF
--- a/codegen/testdata/union_format_validation_dsl.go
+++ b/codegen/testdata/union_format_validation_dsl.go
@@ -1,0 +1,15 @@
+package testdata
+
+import . "goa.design/goa/v3/dsl"
+
+// UnionWithFormatValidationDSL defines a OneOf with format validation to test Issue #3747
+var UnionWithFormatValidationDSL = func() {
+	_ = Type("OneOfWithFormat", func() {
+		OneOf("response", func() {
+			Attribute("message", String, "Textual greeting")
+			Attribute("timestamp", String, func() {
+				Format(FormatDateTime)
+			})
+		})
+	})
+}

--- a/codegen/testdata/validation_code.go
+++ b/codegen/testdata/validation_code.go
@@ -584,4 +584,13 @@ const (
 	}
 }
 `
+
+	// UnionWithFormatValidationCode contains the expected validation code for Issue #3747
+	UnionWithFormatValidationCode = `func Validate() (err error) {
+	switch v := target.Response.(type) {
+	case ResponseTimestamp:
+		err = goa.MergeErrors(err, goa.ValidateFormat("target.response.value", string(v), goa.FormatDateTime))
+	}
+}
+`
 )

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -329,8 +329,8 @@ func validationCode(att *expr.AttributeExpr, attCtx *AttributeContext, req, alia
 			res = append(res, val)
 		}
 	}
-	if min := validation.Minimum; min != nil {
-		data["min"] = *min
+	if minVal := validation.Minimum; minVal != nil {
+		data["min"] = *minVal
 		data["isMin"] = true
 		if val := runTemplate(minMaxValT, data); val != "" {
 			res = append(res, val)
@@ -343,8 +343,8 @@ func validationCode(att *expr.AttributeExpr, attCtx *AttributeContext, req, alia
 			res = append(res, val)
 		}
 	}
-	if max := validation.Maximum; max != nil {
-		data["max"] = *max
+	if maxVal := validation.Maximum; maxVal != nil {
+		data["max"] = *maxVal
 		data["isMin"] = false
 		if val := runTemplate(minMaxValT, data); val != "" {
 			res = append(res, val)

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -170,7 +170,10 @@ func recurseValidationCode(att *expr.AttributeExpr, put expr.UserType, attCtx *A
 		for _, v := range u.Values {
 			vatt := v.Attribute
 			if view {
-				val := validateAttribute(attCtx, vatt, put, "v", context+".value", true, view)
+				// Union values in views are never pointers - they are concrete typed values
+				unionCtx := attCtx.Dup()
+				unionCtx.Pointer = false
+				val := validateAttribute(unionCtx, vatt, put, "v", context+".value", true, view)
 				if val != "" {
 					types = append(types, attCtx.Scope.Ref(vatt, attCtx.DefaultPkg))
 					vals = append(vals, val)

--- a/codegen/validation_test.go
+++ b/codegen/validation_test.go
@@ -78,4 +78,15 @@ func TestRecursiveValidationCode(t *testing.T) {
 		code = FormatTestCode(t, "package foo\nfunc Validate() (err error){\n"+code+"}")
 		assert.Equal(t, testdata.UnionWithViewValidationCode, code)
 	})
+
+	// Test case for OneOf with format validation in views (Issue #3747)
+	t.Run("union-with-format-validation", func(t *testing.T) {
+		// Test with pointer context (typical for views) to ensure union values are not treated as pointers
+		ctx := NewAttributeContext(true, false, true, "", scope)
+		root := RunDSL(t, testdata.UnionWithFormatValidationDSL)
+		oneofT := root.UserType("OneOfWithFormat")
+		code := ValidationCode(&expr.AttributeExpr{Type: oneofT}, nil, ctx, true, false, true, "target")
+		code = FormatTestCode(t, "package foo\nfunc Validate() (err error){\n"+code+"}")
+		assert.Equal(t, testdata.UnionWithFormatValidationCode, code)
+	})
 }


### PR DESCRIPTION
Union values in view types were incorrectly treated as pointers during validation code generation, causing compilation errors when format validation was applied. This fix ensures union values use non-pointer context for validation in views.