### PR TITLE
jsonrpc: fix client streaming result handling

### DIFF
--- a/codegen/service/templates/client_interceptor_stream_wrappers.go.tpl
+++ b/codegen/service/templates/client_interceptor_stream_wrappers.go.tpl
@@ -3,7 +3,7 @@
 	{{- if ne .SendTypeRef "" }}
 
 {{ comment (print "Unwrap returns the underlying stream type.") }}
-func (w *wrapped{{ .Interface }}) Unwrap() interface{} {
+func (w *wrapped{{ .Interface }}) Unwrap() any {
        return w.stream
 }
 

--- a/codegen/service/templates/service.go.tpl
+++ b/codegen/service/templates/service.go.tpl
@@ -114,7 +114,9 @@ type {{ .Stream.Interface }} interface {
 	SendError(ctx context.Context, id string, err error) error
 }
 {{- else }}
-{{ printf "%s allows streaming instances of %s to the client." .Stream.Interface .Stream.SendTypeRef | comment }}
+{{- $elemType := .Stream.SendTypeRef -}}
+{{- if not $elemType }}{{- $elemType = .Stream.RecvTypeRef }}{{- end }}
+{{ printf "%s allows streaming instances of %s to the client." .Stream.Interface $elemType | comment }}
 type {{ .Stream.Interface }} interface {
 	{{- if .Stream.SendTypeRef }}
 		{{- if .IsJSONRPCWebSocket }}

--- a/codegen/service/templates/service.go.tpl
+++ b/codegen/service/templates/service.go.tpl
@@ -68,9 +68,9 @@ var MethodNames = [{{ len .Methods }}]string{ {{ range .Methods }}{{ printf "%q"
 {{- range .Methods }}
 	{{- if .ServerStream }}
 		{{ template "stream_interface" (streamInterfaceFor "server" . .ServerStream) }}
-		{{- /* Emit client stream interface: for JSON-RPC keep conditional; for non-JSON-RPC always emit (HTTP WebSocket) */ -}}
+		{{- /* Emit client stream interface */ -}}
 		{{- if .IsJSONRPC }}
-			{{- if and .ClientStream .ClientStream.SendTypeRef }}
+			{{- if .ClientStream }}
 			{{ template "stream_interface" (streamInterfaceFor "client" . .ClientStream) }}
 			{{- end }}
 		{{- else }}

--- a/codegen/service/templates/service_client_method.go.tpl
+++ b/codegen/service/templates/service_client_method.go.tpl
@@ -9,12 +9,8 @@
 {{- end }}
 {{- $resultType := .ResultRef }}
 {{- if .ClientStream }}
-	{{- /* For server-only streaming (no SendTypeRef), don't return a stream */ -}}
-	{{- if .ClientStream.SendTypeRef }}
-		{{- $resultType = .ClientStream.Interface }}
-	{{- else }}
-		{{- $resultType = "" }}
-	{{- end }}
+	{{- /* When a client stream exists, always return it from the client method. */ -}}
+	{{- $resultType = .ClientStream.Interface }}
 {{- end }}
 func (c *{{ .ClientVarName }}) {{ .VarName }}(ctx context.Context{{ if .PayloadRef }}, p {{ .PayloadRef }}{{ end }}{{ if .MethodData.SkipRequestBodyEncodeDecode}}, req io.ReadCloser{{ end }}) ({{ if $resultType }}res {{ $resultType }}, {{ end }}{{ if .MethodData.SkipResponseBodyEncodeDecode }}resp io.ReadCloser, {{ end }}err error) {
 	{{- if or $resultType .MethodData.SkipResponseBodyEncodeDecode }}

--- a/codegen/service/testdata/client_code.go
+++ b/codegen/service/testdata/client_code.go
@@ -123,9 +123,13 @@ func NewClient(streamingResultMethod goa.Endpoint) *Client {
 
 // StreamingResultMethod calls the "StreamingResultMethod" endpoint of the
 // "StreamingResultService" service.
-func (c *Client) StreamingResultMethod(ctx context.Context, p *APayload) (err error) {
-	_, err = c.StreamingResultMethodEndpoint(ctx, p)
-	return
+func (c *Client) StreamingResultMethod(ctx context.Context, p *APayload) (res StreamingResultMethodClientStream, err error) {
+	var ires any
+	ires, err = c.StreamingResultMethodEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(StreamingResultMethodClientStream), nil
 }
 `
 
@@ -144,9 +148,13 @@ func NewClient(streamingResultNoPayloadMethod goa.Endpoint) *Client {
 
 // StreamingResultNoPayloadMethod calls the "StreamingResultNoPayloadMethod"
 // endpoint of the "StreamingResultNoPayloadService" service.
-func (c *Client) StreamingResultNoPayloadMethod(ctx context.Context) (err error) {
-	_, err = c.StreamingResultNoPayloadMethodEndpoint(ctx, nil)
-	return
+func (c *Client) StreamingResultNoPayloadMethod(ctx context.Context) (res StreamingResultNoPayloadMethodClientStream, err error) {
+	var ires any
+	ires, err = c.StreamingResultNoPayloadMethodEndpoint(ctx, nil)
+	if err != nil {
+		return
+	}
+	return ires.(StreamingResultNoPayloadMethodClientStream), nil
 }
 `
 

--- a/codegen/service/testdata/golden/service_service-streaming-payload-no-result.go.golden
+++ b/codegen/service/testdata/golden/service_service-streaming-payload-no-result.go.golden
@@ -21,8 +21,8 @@ const ServiceName = "StreamingPayloadNoResultService"
 // MethodKey key.
 var MethodNames = [1]string{"StreamingPayloadNoResultMethod"}
 
-// StreamingPayloadNoResultMethodServerStream allows streaming instances of  to
-// the client.
+// StreamingPayloadNoResultMethodServerStream allows streaming instances of int
+// to the client.
 type StreamingPayloadNoResultMethodServerStream interface {
 	Recv() (int, error)
 	RecvWithContext(context.Context) (int, error)

--- a/codegen/service/testdata/golden/service_service-streaming-result-no-payload.go.golden
+++ b/codegen/service/testdata/golden/service_service-streaming-result-no-payload.go.golden
@@ -31,8 +31,8 @@ type StreamingResultNoPayloadMethodServerStream interface {
 	Close() error
 }
 
-// StreamingResultNoPayloadMethodClientStream allows streaming instances of  to
-// the client.
+// StreamingResultNoPayloadMethodClientStream allows streaming instances of
+// *AResult to the client.
 type StreamingResultNoPayloadMethodClientStream interface {
 	Recv() (*AResult, error)
 	RecvWithContext(context.Context) (*AResult, error)

--- a/codegen/service/testdata/golden/service_service-streaming-result-with-explicit-view.go.golden
+++ b/codegen/service/testdata/golden/service_service-streaming-result-with-explicit-view.go.golden
@@ -33,7 +33,7 @@ type StreamingResultWithExplicitViewMethodServerStream interface {
 }
 
 // StreamingResultWithExplicitViewMethodClientStream allows streaming instances
-// of  to the client.
+// of *MultipleViews to the client.
 type StreamingResultWithExplicitViewMethodClientStream interface {
 	Recv() (*MultipleViews, error)
 	RecvWithContext(context.Context) (*MultipleViews, error)

--- a/codegen/service/testdata/golden/service_service-streaming-result-with-views.go.golden
+++ b/codegen/service/testdata/golden/service_service-streaming-result-with-views.go.golden
@@ -36,8 +36,8 @@ type StreamingResultWithViewsMethodServerStream interface {
 	SetView(view string)
 }
 
-// StreamingResultWithViewsMethodClientStream allows streaming instances of  to
-// the client.
+// StreamingResultWithViewsMethodClientStream allows streaming instances of
+// *MultipleViews to the client.
 type StreamingResultWithViewsMethodClientStream interface {
 	Recv() (*MultipleViews, error)
 	RecvWithContext(context.Context) (*MultipleViews, error)

--- a/codegen/service/testdata/golden/service_service-streaming-result.go.golden
+++ b/codegen/service/testdata/golden/service_service-streaming-result.go.golden
@@ -31,8 +31,8 @@ type StreamingResultMethodServerStream interface {
 	Close() error
 }
 
-// StreamingResultMethodClientStream allows streaming instances of  to the
-// client.
+// StreamingResultMethodClientStream allows streaming instances of *AResult to
+// the client.
 type StreamingResultMethodClientStream interface {
 	Recv() (*AResult, error)
 	RecvWithContext(context.Context) (*AResult, error)

--- a/codegen/service/testdata/interceptors/streaming-interceptors-with-read-payload-and-read-streaming-payload_interceptor_wrappers.go.golden
+++ b/codegen/service/testdata/interceptors/streaming-interceptors-with-read-payload-and-read-streaming-payload_interceptor_wrappers.go.golden
@@ -106,7 +106,7 @@ func (w *wrappedMethodServerStream) Close() error {
 }
 
 // Unwrap returns the underlying stream type.
-func (w *wrappedMethodClientStream) Unwrap() interface{} {
+func (w *wrappedMethodClientStream) Unwrap() any {
 	return w.stream
 }
 

--- a/codegen/service/testdata/interceptors/streaming-interceptors_interceptor_wrappers.go.golden
+++ b/codegen/service/testdata/interceptors/streaming-interceptors_interceptor_wrappers.go.golden
@@ -136,7 +136,7 @@ func (w *wrappedMethodServerStream) Close() error {
 }
 
 // Unwrap returns the underlying stream type.
-func (w *wrappedMethodClientStream) Unwrap() interface{} {
+func (w *wrappedMethodClientStream) Unwrap() any {
 	return w.stream
 }
 


### PR DESCRIPTION
Fixes client generation for server-to-client streaming methods to return the stream from client methods again. Also ensures JSON-RPC SSE remains server-stream-only and emits client interfaces consistently when present.

- Service client methods for streaming result now return the typed client stream (regression from v3.22.x)
- Template update to always generate client stream interfaces when available (without changing SSE semantics)
- All unit tests and JSON-RPC integration tests pass

Context: [#3771](https://github.com/goadesign/goa/issues/3771)