### PR TITLE
codegen: reserve service package name; fix JSON-RPC SSE error handling

### DIFF
--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -613,6 +613,8 @@ func (sds *ServicesData) analyze(httpSvc *expr.HTTPServiceExpr) *ServiceData {
 	scope := codegen.NewNameScope()
 	scope.Unique("c") // 'c' is reserved as the client's receiver name.
 	scope.Unique("v") // 'v' is reserved as the request builder payload argument name.
+	// Reserve the service package name to avoid collision with parameter names in generated code
+	scope.Unique(svc.PkgName)
 	sd := &ServiceData{
 		Service:          svc,
 		ServerStruct:     "Server",

--- a/jsonrpc/codegen/templates/sse_server_stream.go.tpl
+++ b/jsonrpc/codegen/templates/sse_server_stream.go.tpl
@@ -145,10 +145,12 @@ func (s *{{ .SSE.StructName }}) SendError(ctx context.Context, id string, err er
 		return s.sendError(ctx, id, code, err.Error(), nil)
 	}
 	switch en.GoaErrorName() {
-	{{- range .Errors }}
-	case {{ printf "%q" .Name }}:
-		{{- with .Response}}
+	{{- range $gerr := .Errors }}
+		{{- range $err := $gerr.Errors }}
+	case {{ printf "%q" $err.Name }}:
+			{{- with $err.Response}}
 		return s.sendError(ctx, id, {{ .Code }}, err.Error(), err)
+			{{- end }}
 		{{- end }}
 	{{- end }}
 	default:


### PR DESCRIPTION
**Summary**

- Reserve service package name in HTTP code generation to avoid parameter name collisions.
- Fix SSE error handling in JSON-RPC code generation templates.

**Details**

- HTTP: Reserve the service package identifier so generated endpoint parameter names do not collide with it in user code.
- JSON-RPC (SSE): Ensure errors are surfaced correctly during server-sent events streaming.

**Scope**

- 2 files changed, 7 insertions, 3 deletions.

**Risk/Compatibility**

- No breaking API changes.
- Improves correctness in code generation templates.
