### PR TITLE
http: reserve 'websocket' in code generation to prevent name collisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,10 @@ endif
 test:
 	go test ./... --coverprofile=cover.out
 
-integration-test: build-goa
+integration-test:
 ifneq ($(GOOS),windows)
 	cd jsonrpc/integration_tests && go test -count=1 -timeout 10m ./...
 endif
-
-build-goa:
-	cd cmd/goa && go install .
 
 release: release-goa release-examples release-plugins
 	@echo "Release v$(MAJOR).$(MINOR).$(BUILD) complete"

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,14 @@ endif
 test:
 	go test ./... --coverprofile=cover.out
 
-integration-test:
+integration-test: build-goa
 ifneq ($(GOOS),windows)
 	cd jsonrpc/integration_tests && go test -count=1 -timeout 10m ./...
 endif
+
+# Needed for CI to run integration tests
+build-goa:
+	cd cmd/goa && go install .
 
 release: release-goa release-examples release-plugins
 	@echo "Release v$(MAJOR).$(MINOR).$(BUILD) complete"

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -613,6 +613,8 @@ func (sds *ServicesData) analyze(httpSvc *expr.HTTPServiceExpr) *ServiceData {
 	scope := codegen.NewNameScope()
 	scope.Unique("c") // 'c' is reserved as the client's receiver name.
 	scope.Unique("v") // 'v' is reserved as the request builder payload argument name.
+	// Reserve 'websocket' to avoid collision with gorilla/websocket
+	scope.Unique("websocket")
 	// Reserve the service package name to avoid collision with parameter names in generated code
 	scope.Unique(svc.PkgName)
 	sd := &ServiceData{


### PR DESCRIPTION
- Updated the analyze method in ServicesData to reserve the 'websocket' identifier, ensuring it does not conflict with the gorilla/websocket package.

Tests: all unit tests pass.