### PR TITLE
codegen/service: reserve "websocket" in naming scope

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -706,7 +706,8 @@ func (d *ServicesData) analyze(service *expr.ServiceExpr) *Data {
 		viewedRTs        []*ViewedResultTypeData
 	)
 	scope := codegen.NewNameScope()
-	scope.Unique("Use") // Reserve "Use" for Endpoints struct Use method.
+	scope.Unique("Use")       // Reserve "Use" for Endpoints struct Use method.
+	scope.Unique("websocket") // Reserve "websocket" to avoid collision with gorilla/websocket
 	viewScope := codegen.NewNameScope()
 	pkgName := scope.HashedUnique(service, strings.ToLower(codegen.Goify(service.Name, false)), "svc")
 	viewspkg := pkgName + "views"


### PR DESCRIPTION
Reserve "websocket" in the service codegen naming scope to avoid collisions with the gorilla/websocket import and user services named "websocket".

- Adds scope.Unique("websocket") when initializing service scope.
- Complements existing reservation in HTTP codegen.
