### PR TITLE
codegen(grpc): remove handling for Goa Any in protobuf type mapping

### DIFF
--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -440,9 +440,6 @@ func protoNativeType(t expr.DataType) string {
 		return "string"
 	case expr.BytesKind:
 		return "bytes"
-	case expr.AnyKind:
-		// Treat Goa Any as bytes in protobuf to avoid panic and ensure stability
-		return "bytes"
 	default:
 		panic(fmt.Sprintf("cannot compute native protocol buffer type for %T", t)) // bug
 	}
@@ -474,9 +471,6 @@ func protoBufNativeGoTypeName(t expr.DataType) string {
 	case expr.StringKind:
 		return "string"
 	case expr.BytesKind:
-		return "[]byte"
-	case expr.AnyKind:
-		// Map Goa Any to []byte for Go type compiled from protobuf
 		return "[]byte"
 	default:
 		panic(fmt.Sprintf("cannot compute native protocol buffer type for %T %v", t, t)) // bug


### PR DESCRIPTION
Any is a type that gRPC cannot handle by definition: gRPC requires strong typing to be able to proper serialize the content of the messages into protobuf.

Using bytes is problematic since not all Goa types can be easily mapped to bytes. Goa should not automatically marshal using an arbitrary codec (e.g. JSON) -  this should be left to the end-user.