### PR TITLE
expr(grpc): validate Any in unions/arrays/maps and add tests

### DIFF
--- a/expr/grpc_endpoint.go
+++ b/expr/grpc_endpoint.go
@@ -577,6 +577,16 @@ func (e *GRPCEndpointExpr) hasAnyType(a *AttributeExpr, typ string, seen ...map[
 			}
 			verr.Merge(e.hasAnyType(nat.Attribute, typ, seen...))
 		}
+	case *Union:
+		for _, nat := range actual.Values {
+			if IsPrimitive(nat.Attribute.Type) {
+				if nat.Attribute.Type == Any {
+					verr.Add(e, "Union member %q is Any type which is not supported in gRPC", nat.Name)
+				}
+				continue
+			}
+			verr.Merge(e.hasAnyType(nat.Attribute, typ, seen...))
+		}
 	}
 	return verr
 }

--- a/expr/grpc_endpoint_test.go
+++ b/expr/grpc_endpoint_test.go
@@ -48,6 +48,14 @@ service "Service" gRPC endpoint "Method": field number 2 in attribute "key_dup_i
 			DSL:    testdata.GRPCEndpointWithInheritErrorDSL,
 			Errors: []string{},
 		},
+		"endpoint-union-containing-any": {
+			DSL: testdata.GRPCEndpointWithUnionContainingAny,
+			Errors: []string{
+				`service "Service" method "MethodUnion": union type choice has array elements, not supported by gRPC
+service "Service" method "MethodUnion": union type choice has map elements, not supported by gRPC`,
+				`service "Service" gRPC endpoint "MethodUnion": Attribute "value" is Any type which is not supported in gRPC`,
+			},
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/expr/testdata/endpoint_dsls.go
+++ b/expr/testdata/endpoint_dsls.go
@@ -730,3 +730,24 @@ var GRPCEndpointWithInheritErrorDSL = func() {
 		})
 	})
 }
+
+var GRPCEndpointWithUnionContainingAny = func() {
+	var AnyAlias = Type("AnyAlias", func() {
+		Attribute("value", Any)
+	})
+
+	var U = Type("U", func() {
+		OneOf("choice", func() {
+			Field(1, "plain_any", Any)
+			Field(2, "array_any", ArrayOf(AnyAlias))
+			Field(3, "map_any", MapOf(String, AnyAlias))
+		})
+	})
+
+	Service("Service", func() {
+		Method("MethodUnion", func() {
+			Payload(U)
+			GRPC(func() {})
+		})
+	})
+}


### PR DESCRIPTION
expr(grpc): validate Any in unions/arrays/maps and add tests

- Disallow Any in gRPC payloads, results, and errors
- Recurse arrays, maps, and union members to flag Any
- Add DSL fixture and tests for union containing Any
- Align expectations with existing union gRPC constraints (no array/map members)
