### PR TITLE
grpc/cli: fix usage format with % in examples

### DIFF
--- a/codegen/cli/templates/command_usage.go.tpl
+++ b/codegen/cli/templates/command_usage.go.tpl
@@ -16,15 +16,14 @@ Additional help:
 
 {{- range .Subcommands }}
 func {{ .FullName }}Usage() {
-	fmt.Fprintf(os.Stderr, `%[1]s [flags] {{ $.Name }} {{ .Name }}{{range .Flags }} -{{ .Name }} {{ .Type }}{{ end }}
-
-{{ printDescription .Description}}
+	fmt.Fprintf(os.Stderr, "%s [flags] {{ $.Name }} {{ .Name }}{{range .Flags }} -{{ .Name }} {{ .Type }}{{ end }}\n\n", os.Args[0])
+	fmt.Fprint(os.Stderr, `{{ printDescription .Description}}
 	{{- range .Flags }}
     -{{ .Name }} {{ .Type }}: {{ .Description }}
 	{{- end }}
 
 Example:
-    %[1]s {{ .Example }}
-`, os.Args[0])
+    `)
+	fmt.Fprintf(os.Stderr, "%s %s\n", os.Args[0], `{{ .Example }}`)
 }
 {{ end }}

--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -471,6 +471,13 @@ func transformUnion(source, target *expr.AttributeExpr, sourceVar, targetVar str
 	// Need to type assert targetVar before assigning field values.
 	ta.TargetCtx.IsInterface = true
 
+	base := "obj"
+	if strings.HasPrefix(targetVar, "obj.") {
+		base = "tmp"
+	}
+	// Use deterministic temp var: 'obj' at top-level, 'tmp' for nested assignments.
+	tmp := base
+
 	data := map[string]any{
 		"SourceTypeRefs": sourceTypeRefs,
 		"SourceTypes":    srcUnion.Values,
@@ -481,6 +488,7 @@ func transformUnion(source, target *expr.AttributeExpr, sourceVar, targetVar str
 		"TypeRef":        ta.TargetCtx.Scope.Ref(target, ta.TargetCtx.Pkg(target)),
 		"TargetTypeName": ta.TargetCtx.Scope.Name(target, ta.TargetCtx.Pkg(target), ta.TargetCtx.Pointer, ta.TargetCtx.UseDefault),
 		"TransformAttrs": ta,
+		"TempVarName":    tmp,
 	}
 	var buf bytes.Buffer
 	if err := transformGoUnionT.Execute(&buf, data); err != nil {

--- a/codegen/templates/transform_go_union.go.tpl
+++ b/codegen/templates/transform_go_union.go.tpl
@@ -2,7 +2,7 @@
 {{ end }}switch actual := {{ .SourceVar }}.(type) {
 	{{- range $i, $ref := .SourceTypeRefs }}
 	case {{ $ref }}:
-		{{ transformAttribute (index $.SourceTypes $i).Attribute (index $.TargetTypes $i).Attribute "actual" "obj" true $.TransformAttrs -}}
-		{{ $.TargetVar }} = obj
+		{{ transformAttribute (index $.SourceTypes $i).Attribute (index $.TargetTypes $i).Attribute "actual" $.TempVarName true $.TransformAttrs -}}
+		{{ $.TargetVar }} = {{ $.TempVarName }}
 	{{- end }}
 }


### PR DESCRIPTION
Avoid raw fmt.Fprintf with %[1]s and raw backtick blocks when example text includes percent signs; use Fprint + Fprintf to prevent format parsing errors in generated CLI.