### PR TITLE
codegen(generator): merge files by path; add union+merge tests

### DIFF
--- a/codegen/cli/templates/command_usage.go.tpl
+++ b/codegen/cli/templates/command_usage.go.tpl
@@ -1,30 +1,37 @@
 {{ printf "%sUsage displays the usage of the %s command and its subcommands." .VarName .Name | comment }}
 func {{ .VarName }}Usage() {
-	fmt.Fprintf(os.Stderr, `{{ printDescription .Description }}
-Usage:
-    %[1]s [globalflags] {{ .Name }} COMMAND [flags]
-
-COMMAND:
-    {{- range .Subcommands }}
-    {{ .Name }}: {{ printDescription .Description }}
-    {{- end }}
-
-Additional help:
-    %[1]s {{ .Name }} COMMAND --help
-`, os.Args[0])
+	fmt.Fprintln(os.Stderr, `{{ printDescription .Description }}`)
+	fmt.Fprintf(os.Stderr, "Usage:\n    %s [globalflags] {{ .Name }} COMMAND [flags]\n\n", os.Args[0])
+	fmt.Fprintln(os.Stderr, "COMMAND:")
+{{- range .Subcommands }}
+	fmt.Fprintln(os.Stderr, `    {{ .Name }}: {{ printDescription .Description }}`)
+{{- end }}
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Additional help:")
+	fmt.Fprintf(os.Stderr, "    %s {{ .Name }} COMMAND --help\n", os.Args[0])
 }
 
 {{- range .Subcommands }}
 func {{ .FullName }}Usage() {
-	fmt.Fprintf(os.Stderr, `%[1]s [flags] {{ $.Name }} {{ .Name }}{{range .Flags }} -{{ .Name }} {{ .Type }}{{ end }}
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] {{ $.Name }} {{ .Name }}", os.Args[0])
+{{- range .Flags }}
+	fmt.Fprint(os.Stderr, " -{{ .Name }} {{ .Type }}")
+{{- end }}
+	fmt.Fprintln(os.Stderr)
 
-{{ printDescription .Description}}
-	{{- range .Flags }}
-    -{{ .Name }} {{ .Type }}: {{ .Description }}
-	{{- end }}
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `{{ printDescription .Description}}`)
 
-Example:
-    %[1]s {{ .Example }}
-`, os.Args[0])
+	// Flags list
+{{- range .Flags }}
+	fmt.Fprintln(os.Stderr, `    -{{ .Name }} {{ .Type }}: {{ .Description }}`)
+{{- end }}
+
+	// Example block: pass example as parameter to avoid format parsing of % characters
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], `{{ .Example }}`)
 }
 {{ end }}

--- a/codegen/generator/generate.go
+++ b/codegen/generator/generate.go
@@ -56,7 +56,15 @@ func Generate(dir, cmd string) (outputs []string, err1 error) {
 		if err != nil {
 			return nil, err
 		}
-		genpkg = pkgs[0].PkgPath
+		// In temporary workspaces (e.g., tests) and on Windows, PkgPath may resolve
+		// to an absolute filesystem path which is not a valid Go import path and
+		// would produce invalid imports (e.g., backslashes). Fall back to the
+		// relative generated package import path in that case.
+		if filepath.IsAbs(pkgs[0].PkgPath) {
+			genpkg = codegen.Gendir
+		} else {
+			genpkg = pkgs[0].PkgPath
+		}
 	}
 
 	// 3. Retrieve goa generators for given command.

--- a/codegen/generator/generate.go
+++ b/codegen/generator/generate.go
@@ -91,7 +91,11 @@ func Generate(dir, cmd string) (outputs []string, err1 error) {
 		return nil, err
 	}
 
-	// 7. Write the files.
+	// 7. Merge files that target the same path to avoid overwriting content when
+	// multiple generators (or services) emit sections for the same file.
+	genfiles = mergeFilesByPath(genfiles)
+
+	// 8. Write the files.
 	written := make(map[string]struct{})
 	for _, f := range genfiles {
 		filename, err := f.Render(dir)
@@ -103,7 +107,7 @@ func Generate(dir, cmd string) (outputs []string, err1 error) {
 		}
 	}
 
-	// 8. Compute all output filenames.
+	// 9. Compute all output filenames.
 	{
 		outputs = make([]string, len(written))
 		cwd, err := os.Getwd()
@@ -123,4 +127,119 @@ func Generate(dir, cmd string) (outputs []string, err1 error) {
 	sort.Strings(outputs)
 
 	return outputs, nil
+}
+
+// mergeFilesByPath coalesces files that share the same output path by
+// concatenating their non-header sections and merging header imports. This
+// prevents later renders from truncating earlier content when multiple
+// services contribute sections to the same file (e.g., shared user types with
+// union value methods).
+func mergeFilesByPath(files []*codegen.File) []*codegen.File {
+	if len(files) <= 1 {
+		return files
+	}
+
+	byPath := make(map[string]*codegen.File)
+	namesByPath := make(map[string]map[string]struct{})
+
+	// First pass: build merged file per path
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		path := f.Path
+		if existing, ok := byPath[path]; ok {
+			// Merge headers (index 0) imports
+			if len(existing.SectionTemplates) > 0 && len(f.SectionTemplates) > 0 {
+				mergeHeaderImports(existing.SectionTemplates[0], f.SectionTemplates[0])
+			}
+			// Initialize seen section names for this path
+			if namesByPath[path] == nil {
+				namesByPath[path] = make(map[string]struct{})
+				for _, st := range existing.SectionTemplates {
+					namesByPath[path][st.Name] = struct{}{}
+				}
+			}
+			// Append unique sections (skip header at index 0)
+			for i, st := range f.SectionTemplates {
+				if i == 0 {
+					continue
+				}
+				if _, seen := namesByPath[path][st.Name]; seen {
+					continue
+				}
+				existing.SectionTemplates = append(existing.SectionTemplates, st)
+				namesByPath[path][st.Name] = struct{}{}
+			}
+			// Preserve a finalize function if destination does not have one
+			if existing.FinalizeFunc == nil && f.FinalizeFunc != nil {
+				existing.FinalizeFunc = f.FinalizeFunc
+			}
+			// Skip adding a duplicate File entry
+			continue
+		}
+
+		// New path: record and initialize seen names
+		byPath[path] = f
+		m := make(map[string]struct{})
+		for _, st := range f.SectionTemplates {
+			m[st.Name] = struct{}{}
+		}
+		namesByPath[path] = m
+	}
+
+	// Second pass: preserve original order by first occurrence of each path
+	merged := make([]*codegen.File, 0, len(byPath))
+	seenPaths := make(map[string]struct{})
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		if _, ok := seenPaths[f.Path]; ok {
+			continue
+		}
+		if mf, ok := byPath[f.Path]; ok {
+			merged = append(merged, mf)
+			seenPaths[f.Path] = struct{}{}
+		}
+	}
+	return merged
+}
+
+// mergeHeaderImports merges the import specs from src header into dst header,
+// deduplicating by (Name, Path). If either section is not a header produced by
+// codegen.Header, this function is a no-op.
+func mergeHeaderImports(dst, src *codegen.SectionTemplate) {
+	if dst == nil || src == nil {
+		return
+	}
+	dmap, dok := dst.Data.(map[string]any)
+	smap, sok := src.Data.(map[string]any)
+	if !dok || !sok {
+		return
+	}
+	dlist, _ := dmap["Imports"].([]*codegen.ImportSpec)
+	slist, _ := smap["Imports"].([]*codegen.ImportSpec)
+	if len(slist) == 0 {
+		return
+	}
+	seen := make(map[string]struct{}, len(dlist))
+	for _, imp := range dlist {
+		if imp == nil {
+			continue
+		}
+		seen[imp.Name+"|"+imp.Path] = struct{}{}
+	}
+	for _, imp := range slist {
+		if imp == nil {
+			continue
+		}
+		key := imp.Name + "|" + imp.Path
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		dlist = append(dlist, imp)
+		seen[key] = struct{}{}
+	}
+	dmap["Imports"] = dlist
 }

--- a/codegen/generator/generate_merge_test.go
+++ b/codegen/generator/generate_merge_test.go
@@ -1,0 +1,70 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/eval"
+)
+
+// TestGenerateMergesSamePathFiles verifies that when two generators emit content
+// targeting the same output path, Generate merges the sections into a single
+// file rather than overwriting earlier content. This is a regression test for
+// an issue where only a later section (e.g., a union value method) remained and
+// the earlier struct definition was lost.
+func TestGenerateMergesSamePathFiles(t *testing.T) {
+	t.Cleanup(func() { Generators = generators })
+
+	// Fake generators emit two files with identical Path, one containing a
+	// type definition and the other containing a method. Without merging, the
+	// second write would overwrite the first.
+	Generators = func(cmd string) ([]Genfunc, error) {
+		return []Genfunc{
+			func(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
+				f := &codegen.File{Path: filepath.Join(codegen.Gendir, "types", "merge_test.go")}
+				f.SectionTemplates = []*codegen.SectionTemplate{
+					codegen.Header("User types", "types", nil),
+					{ // struct definition
+						Name:   "struct-type",
+						Source: "type MergeTest struct{}\n",
+					},
+				}
+				return []*codegen.File{f}, nil
+			},
+			func(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
+				f := &codegen.File{Path: filepath.Join(codegen.Gendir, "types", "merge_test.go")}
+				f.SectionTemplates = []*codegen.SectionTemplate{
+					codegen.Header("User types", "types", nil),
+					{ // method on MergeTest
+						Name:   "method",
+						Source: "func (*MergeTest) Marker() {}\n",
+					},
+				}
+				return []*codegen.File{f}, nil
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	_, err := Generate(dir, "gen")
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+	// Read the merged output directly from the temp dir regardless of how
+	// outputs are relativized by Generate.
+	outpath := filepath.Join(dir, codegen.Gendir, "types", "merge_test.go")
+	bs, err := os.ReadFile(outpath)
+	if err != nil {
+		t.Fatalf("failed reading merged file: %v", err)
+	}
+	content := string(bs)
+	if !strings.Contains(content, "type MergeTest struct{}") {
+		t.Fatalf("merged file missing struct definition:\n%s", content)
+	}
+	if !strings.Contains(content, "func (*MergeTest) Marker() {}") {
+		t.Fatalf("merged file missing method definition:\n%s", content)
+	}
+}

--- a/codegen/generator/generate_union_merge_integration_test.go
+++ b/codegen/generator/generate_union_merge_integration_test.go
@@ -1,0 +1,74 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cg "goa.design/goa/v3/codegen"
+	d "goa.design/goa/v3/dsl"
+)
+
+// TestGenerateUnionUserTypeSamePathMerged exercises the real service codegen path
+// for unions and user types across two services targeting the same user type
+// file. It asserts the generated file contains both the struct definition and
+// the union marker method for the union branch type. This mirrors the original
+// failure mode where only the union method remained and the struct was lost.
+func TestGenerateUnionUserTypeSamePathMerged(t *testing.T) {
+	t.Cleanup(func() { Generators = generators })
+	Generators = func(cmd string) ([]Genfunc, error) { return []Genfunc{Service, Transport, OpenAPI}, nil }
+
+	dsl := func() {
+		d.API("test", func() {})
+
+		var Summary = d.Type("Summary", func() {
+			d.Meta("struct:pkg:path", "types")
+			d.Attribute("message", d.String)
+		})
+
+		var MyUnion = d.Type("MyUnion", func() {
+			d.OneOf("MyUnion", func() {
+				d.Attribute("sum", Summary)
+			})
+		})
+
+		var Container = d.Type("Container", func() {
+			d.Meta("struct:pkg:path", "types")
+			d.Attribute("u", MyUnion)
+		})
+
+		d.Service("S1", func() {
+			d.Method("M", func() {
+				d.Payload(Container)
+			})
+		})
+
+		d.Service("S2", func() {
+			d.Method("M", func() {
+				d.Payload(Container)
+			})
+		})
+	}
+
+	_ = cg.RunDSL(t, dsl)
+
+	dir := t.TempDir()
+	if _, err := Generate(dir, "gen"); err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Verify generated types/summary.go contains both struct and union marker.
+	p := filepath.Join(dir, cg.Gendir, "types", cg.SnakeCase("Summary")+".go")
+	bs, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("failed reading generated file: %v", err)
+	}
+	content := string(bs)
+	if !strings.Contains(content, "type Summary struct") {
+		t.Fatalf("missing struct definition in %s:\n%s", p, content)
+	}
+	if !strings.Contains(content, "myUnionVal()") {
+		t.Fatalf("missing union marker method in %s:\n%s", p, content)
+	}
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -6,6 +6,7 @@ cloud.google.com/go/compute/metadata v0.6.0/go.mod h1:FjyFAW1MW0C203CEOMDTu3Dk1F
 cloud.google.com/go/compute/metadata v0.7.0/go.mod h1:j5MvL9PprKL39t166CoB1uVHfQMs4tFQZZcKwksXUjo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 h1:ErKg/3iS1AKcTkf3yixlZ54f9U1rljCkQyEXWUnIUxc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0/go.mod h1:yAZHSGnqScoU556rBOVkwLze6WP5N+U11RHuWaGVxwY=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0/go.mod h1:Cz6ft6Dkn3Et6l2v2a9/RpN7epQ1GtDlO6lj8bEcOvw=
 github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f h1:C5bqEmzEPLsHm9Mv73lSE9e9bKV23aB1vxOsmZrkl3k=
 github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
@@ -19,6 +20,7 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/go-jose/go-jose/v4 v4.0.5 h1:M6T8+mKZl/+fNNuFHvGIzDz7BTLQPIounk/b9dw3AaE=
 github.com/go-jose/go-jose/v4 v4.0.5/go.mod h1:s3P1lRrkT8igV8D9OjyL4WRyHvjB6a4JSllnOrmmBOA=
+github.com/go-jose/go-jose/v4 v4.1.1/go.mod h1:BdsZGqgdO3b6tTc6LSE56wcDbMMLuPsw5d4ZD5f94kA=
 github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
@@ -61,3 +63,4 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/genproto/googleapis/api v0.0.0-20250324211829-b45e905df463 h1:hE3bRWtU6uceqlh4fhrSnUyjKHMKB9KrTLLG+bc0ddM=
 google.golang.org/genproto/googleapis/api v0.0.0-20250324211829-b45e905df463/go.mod h1:U90ffi8eUL9MwPcrJylN5+Mk2v3vuPDptd5yyNUiRR8=
 google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a/go.mod h1:a77HrdMjoeKbnd2jmgcWdaS++ZLZAEq3orIOAEIKiVw=
+google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7/go.mod h1:kXqgZtrWaf6qS3jZOCnCH7WYfrvFjkC51bM8fz3RsCA=

--- a/grpc/codegen/testdata/endpoint-endpoint-with-interceptors.golden
+++ b/grpc/codegen/testdata/endpoint-endpoint-with-interceptors.golden
@@ -20,9 +20,9 @@ import (
 //
 //	command (subcommand1|subcommand2|...)
 func UsageCommands() []string {
-    return []string{
-        "service-with-interceptors (method-a|method-b)",
-    }
+	return []string{
+		"service-with-interceptors (method-a|method-b)",
+	}
 }
 
 // UsageExamples produces an example of a valid invocation of the CLI tool.
@@ -139,40 +139,53 @@ func ParseEndpoint(
 // serviceWithInterceptorsUsage displays the usage of the
 // service-with-interceptors command and its subcommands.
 func serviceWithInterceptorsUsage() {
-	fmt.Fprintf(os.Stderr, `Service is the ServiceWithInterceptors service interface.
-Usage:
-    %[1]s [globalflags] service-with-interceptors COMMAND [flags]
-
-COMMAND:
-    method-a: MethodA implements MethodA.
-    method-b: MethodB implements MethodB.
-
-Additional help:
-    %[1]s service-with-interceptors COMMAND --help
-`, os.Args[0])
+	fmt.Fprintln(os.Stderr, `Service is the ServiceWithInterceptors service interface.`)
+	fmt.Fprintf(os.Stderr, "Usage:\n    %s [globalflags] service-with-interceptors COMMAND [flags]\n\n", os.Args[0])
+	fmt.Fprintln(os.Stderr, "COMMAND:")
+	fmt.Fprintln(os.Stderr, `    method-a: MethodA implements MethodA.`)
+	fmt.Fprintln(os.Stderr, `    method-b: MethodB implements MethodB.`)
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Additional help:")
+	fmt.Fprintf(os.Stderr, "    %s service-with-interceptors COMMAND --help\n", os.Args[0])
 }
 func serviceWithInterceptorsMethodAUsage() {
-	fmt.Fprintf(os.Stderr, `%[1]s [flags] service-with-interceptors method-a -message JSON
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] service-with-interceptors method-a", os.Args[0])
+	fmt.Fprint(os.Stderr, " -message JSON")
+	fmt.Fprintln(os.Stderr)
 
-MethodA implements MethodA.
-    -message JSON:
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `MethodA implements MethodA.`)
 
-Example:
-    %[1]s service-with-interceptors method-a --message '{
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -message JSON: `)
+
+	// Example block: pass example as parameter to avoid format parsing of % characters
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], `service-with-interceptors method-a --message '{
       "field": "Sapiente est."
-   }'
-`, os.Args[0])
+   }'`)
 }
 
 func serviceWithInterceptorsMethodBUsage() {
-	fmt.Fprintf(os.Stderr, `%[1]s [flags] service-with-interceptors method-b -message JSON
+	// Header with flags
+	fmt.Fprintf(os.Stderr, "%s [flags] service-with-interceptors method-b", os.Args[0])
+	fmt.Fprint(os.Stderr, " -message JSON")
+	fmt.Fprintln(os.Stderr)
 
-MethodB implements MethodB.
-    -message JSON:
+	// Description
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, `MethodB implements MethodB.`)
 
-Example:
-    %[1]s service-with-interceptors method-b --message '{
+	// Flags list
+	fmt.Fprintln(os.Stderr, `    -message JSON: `)
+
+	// Example block: pass example as parameter to avoid format parsing of % characters
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Example:")
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], `service-with-interceptors method-b --message '{
       "field": 3141052981090487272
-   }'
-`, os.Args[0])
+   }'`)
 }


### PR DESCRIPTION
Summary
- Prevent same-path generation overwriting (struct + union marker).

Problem
- In designs that:
  - put a user type into a shared package via Meta("struct:pkg:path", "types"), and
  - include that user type as a branch of a union, and
  - reference that user type from more than one service,
  generation could produce multiple files targeting the same output path (e.g., gen/types/summary.go). The later render overwrote the earlier one, leaving only the union "marker" method and dropping the struct definition.

When it shows up
- After `goa gen`, you might see files like gen/types/<type>.go contain only:
  func (*Type) <union>Val() {}
- Build errors such as: undefined: <Type> in code that references the struct.

Root cause
- Generator wrote files sequentially without coalescing sections that shared the same path.

Fix
- New merge-by-path step in generator.Generate: for each output path, merge headers (imports) and non-header sections, skipping duplicates, then render once. This ensures the struct and union marker end up in the same file.

Tests
- generate_merge_test.go: minimal same-path merge unit test (struct + method).
- generate_union_merge_integration_test.go: small DSL with user type in types/, union including that type, and two services referencing it; asserts both struct and union marker are present in gen/types/summary.go.
- All repo tests + JSON-RPC integration tests pass.

Notes
- Also simplified CLI usage template to avoid fmt parsing pitfalls when examples contain %.