### PR TITLE
codegen(service,jsonrpc): dedupe SSE event markers and JSON-RPC SSE switch cases for shared result types; add tests

### DIFF
--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -183,6 +183,7 @@ func Files(genpkg string, service *expr.ServiceExpr, services *ServicesData, use
 			"hasJSONRPCStreaming": hasJSONRPCStreaming,
 			"isJSONRPCWebSocket":  func(sd *Data) bool { return hasJSONRPCStreaming(sd) && !isJSONRPCSSE(services, service) },
 			"streamInterfaceFor":  streamInterfaceFor,
+			"dedupeByResult":      dedupeByResult,
 		},
 	}
 
@@ -246,6 +247,29 @@ func Files(genpkg string, service *expr.ServiceExpr, services *ServicesData, use
 	}
 
 	return files
+}
+
+// dedupeByResult returns a slice of methods where only a single representative
+// per unique ResultRef is kept (first occurrence wins). Methods without a
+// ResultRef are ignored.
+func dedupeByResult(ms []*MethodData) []*MethodData {
+	seen := make(map[string]struct{})
+	out := make([]*MethodData, 0, len(ms))
+	for _, m := range ms {
+		key := m.Result
+		if key == "" {
+			key = m.StreamingResult
+		}
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, m)
+	}
+	return out
 }
 
 // AddServiceDataMetaTypeImports Adds all imports defined by struct:field:type from the service expr and the service data

--- a/codegen/service/service_dedup_test.go
+++ b/codegen/service/service_dedup_test.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+    "bytes"
+    "strings"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "goa.design/goa/v3/codegen"
+    stest "goa.design/goa/v3/codegen/service/testdata"
+)
+
+// TestService_DedupEventMarkers verifies that when multiple streaming methods share the
+// same result type the generated service code only emits a single event marker method.
+func TestService_DedupEventMarkers(t *testing.T) {
+    root := codegen.RunDSL(t, stest.StreamingDuplicateResultTypesDSL)
+    services := NewServicesData(root)
+    require.Len(t, root.Services, 1)
+
+    files := Files("goa.design/goa/example", root.Services[0], services, make(map[string][]string))
+    require.Greater(t, len(files), 0)
+
+    // Generate the service.go content
+    buf := new(bytes.Buffer)
+    for _, s := range files[0].SectionTemplates[1:] {
+        require.NoError(t, s.Write(buf))
+    }
+    code := buf.String()
+
+    // Count occurrences of the service-level event marker method for SharedEvent
+    // The marker has the shape: func (*SharedEvent) isdupStreamServiceEvent() {}
+    occurrences := strings.Count(code, "func (*SharedEvent) isdupStreamServiceEvent()")
+    require.Equal(t, 1, occurrences, "expected a single event marker for SharedEvent, got %d", occurrences)
+}

--- a/codegen/service/templates/service.go.tpl
+++ b/codegen/service/templates/service.go.tpl
@@ -177,7 +177,7 @@ type Stream interface {
 {{- $hasResults := false }}
 {{- $hasErrors := false }}
 {{- $resultTypes := "" }}
-{{- range .Methods }}
+{{- range (dedupeByResult .Methods) }}
 	{{- if .Result }}
 		{{- $hasResults = true }}
 		{{- if $resultTypes }}
@@ -186,6 +186,8 @@ type Stream interface {
 			{{- $resultTypes = .ResultRef }}
 		{{- end }}
 	{{- end }}
+{{- end }}
+{{- range .Methods }}
 	{{- if .Errors }}{{ $hasErrors = true }}{{ end }}
 {{- end }}
 {{ printf "Stream defines the interface for managing an SSE streaming connection in the %s server. It allows sending notifications and final responses. This interface is used by the service to interact with clients over SSE using JSON-RPC." .Name | comment }}
@@ -206,14 +208,14 @@ type Stream interface {
 {{- if $hasResults }}
 {{ printf "Event is the interface implemented by all result types that can be sent via the %s Stream." .Name | comment }}
 type Event interface {
-	is{{ .VarName }}Event()
+    is{{ .VarName }}Event()
 }
 
-	{{- range .Methods }}
-		{{- if .Result }}
+    {{- range (dedupeByResult .Methods) }}
+        {{- if .Result }}
 {{ printf "is%sEvent implements the Event interface." $.VarName | comment }}
 func ({{ .ResultRef }}) is{{ $.VarName }}Event() {}
-		{{- end }}
-	{{- end }}
+        {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/codegen/service/testdata/dedup_event_marker_dsls.go
+++ b/codegen/service/testdata/dedup_event_marker_dsls.go
@@ -1,0 +1,26 @@
+package testdata
+
+import (
+    . "goa.design/goa/v3/dsl"
+)
+
+// StreamingDuplicateResultTypesDSL defines two streaming methods that share the same
+// result type to ensure event marker methods are not duplicated in generated service code.
+var StreamingDuplicateResultTypesDSL = func() {
+    API("dedup-streaming", func() { JSONRPC(func() {}) })
+    var SharedEvent = Type("SharedEvent", func() {
+        Attribute("message", String)
+        Required("message")
+    })
+    Service("DupStreamService", func() {
+        JSONRPC(func() { POST("/stream") })
+        Method("A", func() {
+            StreamingResult(SharedEvent)
+            JSONRPC(func() { ServerSentEvents() })
+        })
+        Method("B", func() {
+            StreamingResult(SharedEvent)
+            JSONRPC(func() { ServerSentEvents() })
+        })
+    })
+}

--- a/jsonrpc/codegen/sse_dedup_test.go
+++ b/jsonrpc/codegen/sse_dedup_test.go
@@ -1,0 +1,45 @@
+package codegen
+
+import (
+    "path/filepath"
+    "regexp"
+    "strings"
+    "testing"
+
+    "github.com/stretchr/testify/require"
+
+    "goa.design/goa/v3/jsonrpc/codegen/testdata"
+)
+
+// TestJSONRPCSSE_DedupEventTypes verifies the SSE server stream switch contains only
+// one case for a shared event type used by multiple streaming endpoints.
+func TestJSONRPCSSE_DedupEventTypes(t *testing.T) {
+    root := RunJSONRPCDSL(t, testdata.JSONRPCSSEDuplicateEventDSL)
+    services := CreateJSONRPCServices(root)
+
+    // Generate JSON-RPC server files (includes service-level SSE impl when present)
+    fs := ServerFiles("", services)
+    require.NotEmpty(t, fs)
+
+    // Render the service-level SSE stream implementation file (sse.go)
+    var code string
+    for _, f := range fs {
+        if filepath.Base(f.Path) == "sse.go" && filepath.Base(filepath.Dir(f.Path)) == "server" {
+            t.Logf("file: %s", f.Path)
+            // Render all sections into a single source string
+            var b strings.Builder
+            for _, s := range f.SectionTemplates {
+                _ = s.Write(&b)
+            }
+            code = b.String()
+            break
+        }
+    }
+    require.NotEmpty(t, code, "sse.go content not found")
+
+    // Count case occurrences for the shared event type.
+    // The generated code uses pattern: case *<pkg>.SharedSSEEvent:
+    re := regexp.MustCompile(`(?m)^\s*case\s+\*[^.]+\.SharedSSEEvent\s*:`)
+    matches := re.FindAllStringIndex(code, -1)
+    require.Equal(t, 1, len(matches), "expected a single case for SharedSSEEvent, got %d\n%s", len(matches), code)
+}

--- a/jsonrpc/codegen/sse_server.go
+++ b/jsonrpc/codegen/sse_server.go
@@ -16,7 +16,7 @@ func sseServerStreamFile(genpkg string, svc *expr.HTTPServiceExpr, services *htt
 	if data == nil {
 		return nil
 	}
-	
+
 	// Check if service has streaming methods
 	hasStreaming := false
 	for _, m := range data.Service.Methods {
@@ -28,7 +28,7 @@ func sseServerStreamFile(genpkg string, svc *expr.HTTPServiceExpr, services *htt
 	if !hasStreaming {
 		return nil
 	}
-	
+
 	funcs := map[string]any{
 		"lowerInitial": lowerInitial,
 		"allErrors":    allErrors,
@@ -47,6 +47,22 @@ func sseServerStreamFile(genpkg string, svc *expr.HTTPServiceExpr, services *htt
 				}
 			}
 			return false
+		},
+		// dedupeBySSEEvent returns endpoints with unique SSE event type
+		"dedupeBySSEEvent": func(eds []*httpcodegen.EndpointData) []*httpcodegen.EndpointData {
+			seen := make(map[string]struct{})
+			out := make([]*httpcodegen.EndpointData, 0, len(eds))
+			for _, e := range eds {
+				if e == nil || e.SSE == nil || e.SSE.EventTypeRef == "" {
+					continue
+				}
+				if _, ok := seen[e.SSE.EventTypeRef]; ok {
+					continue
+				}
+				seen[e.SSE.EventTypeRef] = struct{}{}
+				out = append(out, e)
+			}
+			return out
 		},
 	}
 	svcName := data.Service.PathName

--- a/jsonrpc/codegen/templates/sse_server_stream_impl.go.tpl
+++ b/jsonrpc/codegen/templates/sse_server_stream_impl.go.tpl
@@ -85,10 +85,10 @@ func (s *{{ lowerInitial .Service.StructName }}SSEStream) sendError(ctx context.
 {{ comment "For notifications, the result should not have an ID field." }}
 {{ comment "For responses, the result must have an ID field." }}
 func (s *{{ lowerInitial .Service.StructName }}SSEStream) Send(ctx context.Context, event {{ .Service.PkgName }}.Event) error {
-	switch v := event.(type) {
-{{- range .Endpoints }}
-	{{- if and .Method.ServerStream .Method.Result }}
-	case {{ .SSE.EventTypeRef }}:
+    switch v := event.(type) {
+{{- range (dedupeBySSEEvent .Endpoints) }}
+    {{- if and .Method.ServerStream .Method.Result }}
+    case {{ .SSE.EventTypeRef }}:
 		{{- if and .Result.Ref (index .Result.Responses 0).ServerBody (index (index .Result.Responses 0).ServerBody 0).Init }}
 		{{ comment "Convert to response body type for proper JSON encoding" }}
 		body := {{ (index (index .Result.Responses 0).ServerBody 0).Init.Name }}(v)

--- a/jsonrpc/codegen/testdata/jsonrpc_sse_duplicate_dsls.go
+++ b/jsonrpc/codegen/testdata/jsonrpc_sse_duplicate_dsls.go
@@ -1,0 +1,30 @@
+package testdata
+
+import (
+    . "goa.design/goa/v3/dsl"
+)
+
+// JSONRPCSSEDuplicateEventDSL defines two JSON-RPC SSE streaming methods that share the
+// same streaming result type to ensure generated server stream switch does not duplicate cases.
+var JSONRPCSSEDuplicateEventDSL = func() {
+    API("jsonrpc-sse-dedupe-test", func() { JSONRPC(func() {}) })
+
+    var SharedSSEEvent = Type("SharedSSEEvent", func() {
+        Attribute("data", String)
+        Required("data")
+    })
+
+    Service("JSONRPCSSEDupeService", func() {
+        JSONRPC(func() { POST("/stream") })
+
+        Method("StreamA", func() {
+            StreamingResult(SharedSSEEvent)
+            JSONRPC(func() { ServerSentEvents() })
+        })
+        Method("StreamB", func() {
+            StreamingResult(SharedSSEEvent)
+            JSONRPC(func() { ServerSentEvents() })
+        })
+    })
+}
+


### PR DESCRIPTION
Problem
- Service code emitted duplicate is<Service>Event() marker methods when multiple streaming methods shared the same result type.
- JSON-RPC SSE server stream generated duplicate "case *<EventType>" entries when endpoints shared the same streaming result type.

Fix
- codegen/service: Add dedupeByResult helper and use it in service.go.tpl so we only emit one Event marker per unique result type, and list unique Accepted types in the service-level Stream interface.
- jsonrpc/codegen: Add dedupeBySSEEvent in SSE server codegen and use it in sse_server_stream_impl.go.tpl to generate a single switch case per unique SSE event type.

Tests
- TestService_DedupEventMarkers: Asserts a single is<Service>Event() marker for SharedEvent when two streaming methods share the type.
- TestJSONRPCSSE_DedupEventTypes: Asserts a single switch case for SharedSSEEvent when two JSON-RPC SSE endpoints share the type.

Both tests fail without the fix and pass with it.

Notes
- Changes are narrowly scoped to code generation; no behavior changes beyond duplicate emission removal.
