### PR TITLE
gRPC: Avoid synthetic wrappers for user-type OneOfs; add regression test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `dsl/`: Public design language definitions (uses dot imports intentionally).
+- `expr/`: Internal AST and validation for the DSL.
+- `codegen/`: Generators for transports, types, and docs.
+- `http/`, `grpc/`, `jsonrpc/`: Transport-specific runtime and codegen helpers.
+- `middleware/`: Built-in interceptors and middleware.
+- `pkg/`: Core runtime (endpoints, errors, version, helpers).
+- `cmd/goa/`: Goa CLI source. Install locally to try changes.
+- `docs/`, `security/`, `eval/`: Documentation assets, security notes, evaluation code.
+
+## Build, Test, and Development Commands
+- `make lint` — Run linters per `.golangci.yml` across `./...`.
+- `make test` — Run unit and integration tests; writes coverage to `cover.out`.
+- `cd cmd/goa && go install .` — Build/install the Goa CLI from source.
+
+## Coding Style & Naming Conventions
+- Go 1.24+. Format with `go fmt ./...`; keep imports grouped.
+- Files: `lower_snake_case.go`; packages: lowercase, short, meaningful.
+- Exported identifiers require GoDoc comments; avoid stutter.
+- Errors: wrap with `%w`; prefer `errors.Is/As` (enforced by `errorlint`).
+
+## Code File Organization
+- Declarations order:
+  1) Types (public first, then private) in a single `type (...)` block when practical
+  2) Constants (public, then private)
+  3) Variables (public, then private)
+  4) Public functions
+  5) Public methods
+  6) Private functions
+  7) Private methods
+- No commented‑out code; remove dead code instead of commenting.
+- Keep imports grouped; stdlib separated from external. Let `gofmt` manage ordering.
+
+## Repro Protocol
+To reproduce a code generation issue from a specific design, follow this protocol:
+1. Create a new directory under ~/src/repros: ~/src/repros/<issue>. Choose a meaningful short name, for example ~/src/repros/customtype.
+2. Create a design subdirectory and write the design file in ~/src/repros/<issue>/design/design.go.
+3. Run `go mod init <issue>` in the issue directory where <issue> is the same short name, for example `go mod init customtype`.
+4. Run `goa gen <issue>/design` in the issue directory, this will create a 'gen' directory.
+5. Run `go mod tidy` to download all dependencies.
+6. Run `go mod edit -replace goa.design/goa/v3=$HOME/src/goa`
+7. Run `goa gen <issue>/design` in the issue directory a second time, this time it will use the development version of goa.
+8. [OPTIONAL] if needed also generate the example command line tools with `goa example <issue>/design`
+You are now ready to troubleshoot goa by making changes in ~/src/goa and
+running the `goa gen` and/or `goa example` commands as per the above.
+
+## Code Generation Behavior
+- After modifying goa source code, you do not need to manually rebuild the goa
+CLI. The `goa gen` and `goa example` commands automatically compile and use a
+temporary binary that includes your latest changes.
+- The `goa gen` command deletes and recreates the entire `gen` directory each
+time it runs, removing any previously generated files. In contrast, the `goa
+example` command generates example service code but does not overwrite existing
+files in the `cmd` directory or any top-level service files; it only creates new
+files if they do not already exist.
+
+## General Principles
+- Fail fast: do not mask invariant violations with defensive nil checks in hot paths; surface precise errors.
+- Keep code tidy: no commented‑out code blocks; keep PRs focused.
+
+## Additional Style Details
+- Prefer `any` over `interface{}` in new code.
+- Use multi‑line `if` blocks; target ~80‑column lines when practical.
+- Struct/composite literals: break long/named fields onto one field per line with trailing commas; close brace on its own line.
+
+## Testing Guidelines
+- Write table‑driven tests in `*_test.go` using `testing` (optionally `testify`).
+- Name tests `TestXxx`; keep unit tests fast and deterministic.
+- Run `make test` locally and ensure coverage does not regress.
+
+## Commit & Pull Request Guidelines
+- Commit style mirrors history: `scope(subscope): concise summary`.
+  Example: `http/codegen: fix SSE Last-Event-ID handling (#1234)`.
+- Reference issues using `Fixes #NNNN` in PRs. Include rationale, tests, and docs updates when behavior/design changes.
+- Keep PRs focused and small; ensure `make lint` and `make test` pass.
+- If changing generators or DSL, run the CLI against examples to validate.
+
+## Agent‑Specific Notes
+- Avoid release automation (`make release*`). Keep patches minimal and scoped.
+- Do not run `git` commands in this environment; maintainers handle tagging and releases.

--- a/grpc/codegen/oneof_anonymous_user_union_test.go
+++ b/grpc/codegen/oneof_anonymous_user_union_test.go
@@ -1,0 +1,65 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"goa.design/goa/v3/codegen"
+	. "goa.design/goa/v3/dsl"
+	"goa.design/goa/v3/expr"
+)
+
+// Repro for anonymous (embedded) oneof of user types nested in an array.
+// The transform from protobuf -> Go should NOT introduce per-branch
+// wrappers like DetailsAlpha(...)/DetailsBeta(...) when the union members
+// are user types and the union is embedded in an object (unionPkg == "").
+func TestAnonymousUserUnionArray_NoWrappersFromProto(t *testing.T) {
+	root := codegen.RunDSL(t, func() {
+		// Two distinct user types
+		Alpha := func() {
+			// Force a concrete package location to simulate cross-package members
+			Meta("struct:pkg:path", "types")
+			Attribute("a", Int)
+		}
+		Beta := func() {
+			Meta("struct:pkg:path", "types")
+			Attribute("b", Int)
+		}
+		Type("Alpha", Alpha)
+		Type("Beta", Beta)
+
+		// Event with embedded oneof named "Details" of user types only
+		Type("Event", func() {
+			Attribute("id", String)
+			OneOf("Details", func() {
+				Attribute("alpha", "Alpha")
+				Attribute("beta", "Beta")
+			})
+		})
+
+		// Container with array of events
+		Type("Container", func() {
+			Attribute("events", ArrayOf("Event"))
+		})
+	})
+
+	sd := &ServiceData{Name: "Svc", Scope: codegen.NewNameScope()}
+	svcCtx := serviceTypeContext("proto", sd.Scope)
+	pbCtx := protoBufTypeContext("proto", sd.Scope, true)
+
+	// Transform protobuf -> Go for Container
+	target := &expr.AttributeExpr{Type: root.UserType("Container")}
+	source := makeProtoBufMessage(expr.DupAtt(target), target.Type.Name(), sd)
+
+	code, _, err := protoBufTransform(source, target, "source", "target", pbCtx, svcCtx, false, true)
+	require.NoError(t, err)
+	out := codegen.FormatTestCode(t, "package foo\nfunc transform(){\n"+code+"}")
+
+	// Ensure no per-branch wrapper casts (e.g., types.DetailsAlpha(...)).
+	require.NotContains(t, out, "types.Details")
+	require.NotContains(t, out, "Details(")
+	// Sanity check: union switch on Details field exists.
+	require.True(t, strings.Contains(out, "switch") && strings.Contains(out, ".Details"))
+}

--- a/grpc/codegen/protobuf_transform.go
+++ b/grpc/codegen/protobuf_transform.go
@@ -680,10 +680,10 @@ func transformUnionData(source, target *expr.AttributeExpr, ta *transformAttrs) 
 	sourceValueTypeRefs := make([]string, len(src.Values))
 	targetWrapperRefs := make([]string, len(src.Values))
 	if ta.proto {
-		// Go -> protobuf: switch on Go union member types. Use per-branch wrappers
-		// when needed (duplicate underlying types or cross-package members).
+		// Go -> protobuf: when union members are user types, switch on the
+		// actual user type rather than synthetic wrapper types. Only non-user
+		// types (primitives, maps, arrays) require per-branch wrapper types.
 		unionPkg := ta.SourceCtx.Pkg(source)
-		// Prefer a common member package if all member user types share one (e.g., shared unions).
 		samePkg := true
 		commonPkg := ""
 		for _, v := range src.Values {
@@ -704,41 +704,21 @@ func transformUnionData(source, target *expr.AttributeExpr, ta *transformAttrs) 
 				break
 			}
 		}
-		counts := make(map[string]int)
-		for _, v := range src.Values {
-			ref := ta.SourceCtx.Scope.Ref(v.Attribute, ta.SourceCtx.Pkg(v.Attribute))
-			counts[ref]++
-		}
 		for i, v := range src.Values {
-			baseRef := ta.SourceCtx.Scope.Ref(v.Attribute, ta.SourceCtx.Pkg(v.Attribute))
-			useWrapper := counts[baseRef] > 1
-			memberPkg := ""
-			if ut, ok := v.Attribute.Type.(expr.UserType); ok {
-				if loc := codegen.UserTypeLocation(ut); loc != nil {
-					memberPkg = loc.PackageName()
-					if memberPkg != unionPkg {
-						useWrapper = true
-					}
-				}
-			} else {
-				// Non-user types are represented via per-branch defined types.
-				useWrapper = true
+			if _, ok := v.Attribute.Type.(expr.UserType); ok {
+				sourceValueTypeRefs[i] = ta.SourceCtx.Scope.Ref(v.Attribute, ta.SourceCtx.Pkg(v.Attribute))
+				continue
 			}
-			if useWrapper {
-				w := codegen.Goify(src.Name(), true) + codegen.Goify(v.Name, true)
-				pkg := unionPkg
-				if samePkg && commonPkg != "" {
-					pkg = commonPkg
-				} else if pkg == "" {
-					pkg = memberPkg
-				}
-				if pkg != "" {
-					sourceValueTypeRefs[i] = pkg + "." + w
-				} else {
-					sourceValueTypeRefs[i] = w
-				}
+			// Non-user types are represented via per-branch defined wrapper types.
+			w := codegen.Goify(src.Name(), true) + codegen.Goify(v.Name, true)
+			pkg := unionPkg
+			if samePkg && commonPkg != "" {
+				pkg = commonPkg
+			}
+			if pkg != "" {
+				sourceValueTypeRefs[i] = pkg + "." + w
 			} else {
-				sourceValueTypeRefs[i] = baseRef
+				sourceValueTypeRefs[i] = w
 			}
 		}
 	} else {
@@ -748,6 +728,11 @@ func transformUnionData(source, target *expr.AttributeExpr, ta *transformAttrs) 
 			fieldName := ta.SourceCtx.Scope.Field(v.Attribute, v.Name, true)
 			sourceValueTypeRefs[i] = ta.message + "_" + fieldName
 		}
+		// Determine the union package for the target side. For anonymous
+		// unions embedded in objects the package may be empty. In that case
+		// we must not force per-branch wrappers solely based on package
+		// comparison; instead rely on duplicate-type detection and whether
+		// the member is a non-user type.
 		unionPkg := ta.TargetCtx.Pkg(target)
 		// Prefer a common member package for wrappers if all target values share it (e.g., shared user-type unions).
 		samePkg := true
@@ -770,19 +755,15 @@ func transformUnionData(source, target *expr.AttributeExpr, ta *transformAttrs) 
 				break
 			}
 		}
-		counts := make(map[string]int)
-		for _, tv := range tgt.Values {
-			r := ta.TargetCtx.Scope.Ref(tv.Attribute, ta.TargetCtx.Pkg(tv.Attribute))
-			counts[r]++
-		}
+		// For protobuf -> Go transforms, when union members are user types,
+		// prefer assigning the converted user type directly to the union
+		// interface. This avoids generating synthetic per-branch wrapper
+		// types (e.g., DetailsFoo) which do not exist in the target package
+		// unless transport-agnostic codegen created them. Only non-user types
+		// require wrappers.
 		for i, tv := range tgt.Values {
-			baseRef := ta.TargetCtx.Scope.Ref(tv.Attribute, ta.TargetCtx.Pkg(tv.Attribute))
-			useWrapper := counts[baseRef] > 1
-			if ut, ok := tv.Attribute.Type.(expr.UserType); ok {
-				if loc := codegen.UserTypeLocation(ut); loc != nil && loc.PackageName() != unionPkg {
-					useWrapper = true
-				}
-			} else {
+			useWrapper := false
+			if _, ok := tv.Attribute.Type.(expr.UserType); !ok {
 				useWrapper = true
 			}
 			if useWrapper {


### PR DESCRIPTION
## Summary
Fix gRPC code generation for OneOf (union) members that are user types. Previous logic sometimes generated synthetic per-branch wrapper types (e.g., `types.DetailsFoo`) and casted to them, which do not exist in transport-agnostic output. This caused undefined identifier errors downstream.

## Background & Root Cause
- OneOfs are handled in both core codegen and gRPC codegen. The two paths build on shared data but diverged in wrapper handling.
- In `grpc/codegen/protobuf_transform.go`, `transformUnionData` produced wrapper type refs for all branches in some cases (e.g., anonymous embedded unions, cross-package members, or duplicate underlying types).
- When members were user types, generated client/server transforms referenced wrapper names that are never declared (e.g., `types.DetailsInferenceRequest`), breaking builds.

## What Changed
- Update union wrapper selection in `grpc/codegen/protobuf_transform.go`:
  - Only generate per-branch wrapper types for non-user types (primitives, maps, arrays) or when duplicates require it.
  - For user-type members, assign the converted value directly to the union interface (no synthetic wrapper).
  - Avoid forcing wrappers when the union package is anonymous/empty (embedded unions inside objects).
- Add a regression test `grpc/codegen/oneof_anonymous_user_union_test.go` that reproduces an array-of-objects with an embedded OneOf of user types and asserts no wrapper casts are emitted.

## Why It’s Tricky
- The transport-agnostic path and the gRPC path transform unions differently and both rely on shared structures. Wrapper decisions must stay compatible in both directions (Go → protobuf, protobuf → Go), and across edge cases:
  - Anonymous embedded unions
  - Cross-package union members
  - Duplicate underlying types
  - Non-user-type members

## Validation
- `make` passes: lint, unit tests, and JSON‑RPC integration tests.
- New unit test passes.
- Manual downstream validation:
  - `go install ./cmd/goa`
  - Previously failing gRPC session packages now build without undefined wrapper identifiers.

## Impact
- No public API changes. Generated code shape changes to remove synthetic wrapper references for user-type unions.
- Non-user-type OneOf members and duplicate-type cases remain wrapped as needed.

## Files
- `grpc/codegen/protobuf_transform.go`: wrapper selection logic for unions
- `grpc/codegen/oneof_anonymous_user_union_test.go`: regression test

