### PR TITLE
codegen/cli: escape CLI examples to avoid raw backticks and fmt % artifacts

### DIFF
--- a/codegen/cli/templates/command_usage.go.tpl
+++ b/codegen/cli/templates/command_usage.go.tpl
@@ -29,9 +29,8 @@ func {{ .FullName }}Usage() {
 	fmt.Fprintln(os.Stderr, `    -{{ .Name }} {{ .Type }}: {{ .Description }}`)
 {{- end }}
 
-	// Example block: pass example as parameter to avoid format parsing of % characters
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], `{{ .Example }}`)
+        fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], {{ printf "%q" .Example }})
 }
 {{ end }}

--- a/codegen/cli/templates/usage_examples.go.tpl
+++ b/codegen/cli/templates/usage_examples.go.tpl
@@ -1,5 +1,5 @@
 // UsageExamples produces an example of a valid invocation of the CLI tool.
 func UsageExamples() string {
-	return {{ range . }}os.Args[0] + ` {{ . }}` + "\n" +
+	return {{ range . }}os.Args[0] + " " + {{ printf "%q" . }} + "\n" +
 	{{ end }}""
 }

--- a/grpc/codegen/testdata/endpoint-endpoint-with-interceptors.golden
+++ b/grpc/codegen/testdata/endpoint-endpoint-with-interceptors.golden
@@ -27,9 +27,7 @@ func UsageCommands() []string {
 
 // UsageExamples produces an example of a valid invocation of the CLI tool.
 func UsageExamples() string {
-	return os.Args[0] + ` service-with-interceptors method-a --message '{
-      "field": "Sapiente est."
-   }'` + "\n" +
+	return os.Args[0] + " " + "service-with-interceptors method-a --message '{\n      \"field\": \"Sapiente est.\"\n   }'" + "\n" +
 		""
 }
 
@@ -161,12 +159,9 @@ func serviceWithInterceptorsMethodAUsage() {
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -message JSON: `)
 
-	// Example block: pass example as parameter to avoid format parsing of % characters
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], `service-with-interceptors method-a --message '{
-      "field": "Sapiente est."
-   }'`)
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "service-with-interceptors method-a --message '{\n      \"field\": \"Sapiente est.\"\n   }'")
 }
 
 func serviceWithInterceptorsMethodBUsage() {
@@ -182,10 +177,7 @@ func serviceWithInterceptorsMethodBUsage() {
 	// Flags list
 	fmt.Fprintln(os.Stderr, `    -message JSON: `)
 
-	// Example block: pass example as parameter to avoid format parsing of % characters
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Example:")
-	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], `service-with-interceptors method-b --message '{
-      "field": 3141052981090487272
-   }'`)
+	fmt.Fprintf(os.Stderr, "    %s %s\n", os.Args[0], "service-with-interceptors method-b --message '{\n      \"field\": 3141052981090487272\n   }'")
 }


### PR DESCRIPTION
Fix CLI templates to emit examples using quoted strings:
- usage_examples.go.tpl: emit examples via printf %q
- command_usage.go.tpl: emit examples via printf %q

This prevents raw backtick conflicts and fmt 'MISSING' artifacts when examples contain backticks or % characters.

Updated affected golden files and verified with 'make test'.