### PR TITLE
http/codegen(sse): format SSE data via response body types and primitive-friendly encoding

### DIFF
--- a/http/codegen/sse.go
+++ b/http/codegen/sse.go
@@ -57,6 +57,8 @@ type (
 		RequestIDField string
 		// RequestIDPointer indicates whether the RequestIDField is a pointer (i.e., optional primitive).
 		RequestIDPointer bool
+		// HasResponseBody indicates whether an HTTP response body converter exists for this endpoint.
+		HasResponseBody bool
 	}
 )
 
@@ -134,6 +136,15 @@ func initSSEData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData) {
 		RequestIDField:      e.SSE.RequestIDField,
 		RequestIDPointer:    ridPtr,
 	}
+
+	if ed.Result != nil {
+		for _, resp := range ed.Result.Responses {
+			if len(resp.ServerBody) > 0 {
+				ed.SSE.HasResponseBody = true
+				break
+			}
+		}
+	}
 }
 
 // sseServerFile returns the file implementing the SSE server
@@ -186,22 +197,23 @@ func sseTemplateSections(data *ServiceData) []*codegen.SectionTemplate {
 			continue
 		}
 		// Create a map of template functions needed for the SSE template
-		funcs := map[string]any{
-			"dict": func(values ...any) (map[string]any, error) {
-				if len(values)%2 != 0 {
-					return nil, fmt.Errorf("odd number of arguments")
+	funcs := map[string]any{
+		"dict": func(values ...any) (map[string]any, error) {
+			if len(values)%2 != 0 {
+				return nil, fmt.Errorf("odd number of arguments")
+			}
+			dict := make(map[string]any, len(values)/2)
+			for i := 0; i < len(values); i += 2 {
+				key, ok := values[i].(string)
+				if !ok {
+					return nil, fmt.Errorf("dict keys must be strings")
 				}
-				dict := make(map[string]any, len(values)/2)
-				for i := 0; i < len(values); i += 2 {
-					key, ok := values[i].(string)
-					if !ok {
-						return nil, fmt.Errorf("dict keys must be strings")
-					}
-					dict[key] = values[i+1]
-				}
-				return dict, nil
-			},
-		}
+				dict[key] = values[i+1]
+			}
+			return dict, nil
+		},
+		"goify": codegen.Goify,
+	}
 		sections = append(sections, &codegen.SectionTemplate{
 			Name:    "server-sse",
 			Source:  httpTemplates.Read(serverSseT, sseFormatP),

--- a/http/codegen/templates/server_sse.go.tpl
+++ b/http/codegen/templates/server_sse.go.tpl
@@ -58,12 +58,65 @@ func (s *{{ .SSE.StructName }}) {{ .SSE.SendWithContextName }}(ctx context.Conte
 	{{- end }}
 
 	var data string
-	{{- if .SSE.DataField }}
-		dataField := res.{{ .SSE.DataField }}
-		{{- template "partial_sse_format" dict "TypeRef" .SSE.DataFieldTypeRef "VarName" "dataField" }}
+	var payload any
+	{{- if .SSE.HasResponseBody }}
+	body := New{{ goify .Method.Name true }}ResponseBody(res)
+		{{- if .SSE.DataField }}
+	payload = body.{{ .SSE.DataField }}
+		{{- else }}
+	payload = body
+		{{- end }}
 	{{- else }}
-		{{- template "partial_sse_format" dict "TypeRef" .SSE.EventTypeRef "VarName" "res" }}
+		{{- if .SSE.DataField }}
+	payload = res.{{ .SSE.DataField }}
+		{{- else }}
+	payload = res
+		{{- end }}
 	{{- end }}
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
+	}
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()

--- a/http/codegen/testdata/golden/sse-all-fields.golden
+++ b/http/codegen/testdata/golden/sse-all-fields.golden
@@ -47,12 +47,53 @@ func (s *SSEAllFieldsMethodServerStream) SendWithContext(ctx context.Context, v 
 	}
 
 	var data string
-	dataField := res.Data
-	byts, err := json.Marshal(dataField)
-	if err != nil {
-		return err
+	var payload any
+	body := NewSSEAllFieldsMethodResponseBody(res)
+	payload = body.Data
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
 	}
-	data = string(byts)
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()

--- a/http/codegen/testdata/golden/sse-bool.golden
+++ b/http/codegen/testdata/golden/sse-bool.golden
@@ -34,11 +34,53 @@ func (s *SSEBoolMethodServerStream) SendWithContext(ctx context.Context, v bool)
 	res := v
 
 	var data string
-	byts, err := json.Marshal(res)
-	if err != nil {
-		return err
+	var payload any
+	body := NewSSEBoolMethodResponseBody(res)
+	payload = body
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
 	}
-	data = string(byts)
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()

--- a/http/codegen/testdata/golden/sse-data-field.golden
+++ b/http/codegen/testdata/golden/sse-data-field.golden
@@ -37,8 +37,53 @@ func (s *SSEDataFieldMethodServerStream) SendWithContext(ctx context.Context, v 
 	res := v
 
 	var data string
-	dataField := res.Data
-	data = dataField
+	var payload any
+	body := NewSSEDataFieldMethodResponseBody(res)
+	payload = body.Data
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
+	}
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()

--- a/http/codegen/testdata/golden/sse-data-id-field.golden
+++ b/http/codegen/testdata/golden/sse-data-id-field.golden
@@ -41,8 +41,53 @@ func (s *SSEDataIDFieldMethodServerStream) SendWithContext(ctx context.Context, 
 	}
 
 	var data string
-	dataField := res.Data
-	data = dataField
+	var payload any
+	body := NewSSEDataIDFieldMethodResponseBody(res)
+	payload = body.Data
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
+	}
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()

--- a/http/codegen/testdata/golden/sse-int.golden
+++ b/http/codegen/testdata/golden/sse-int.golden
@@ -34,7 +34,53 @@ func (s *SSEIntMethodServerStream) SendWithContext(ctx context.Context, v int) e
 	res := v
 
 	var data string
-	data = fmt.Sprintf("%d", res)
+	var payload any
+	body := NewSSEIntMethodResponseBody(res)
+	payload = body
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
+	}
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()

--- a/http/codegen/testdata/golden/sse-object.golden
+++ b/http/codegen/testdata/golden/sse-object.golden
@@ -36,11 +36,53 @@ func (s *SSEObjectMethodServerStream) SendWithContext(ctx context.Context, v *ss
 	res := v
 
 	var data string
-	byts, err := json.Marshal(res)
-	if err != nil {
-		return err
+	var payload any
+	body := NewSSEObjectMethodResponseBody(res)
+	payload = body
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
 	}
-	data = string(byts)
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()

--- a/http/codegen/testdata/golden/sse-request-id.golden
+++ b/http/codegen/testdata/golden/sse-request-id.golden
@@ -35,7 +35,53 @@ func (s *SSERequestIDMethodServerStream) SendWithContext(ctx context.Context, v 
 	res := v
 
 	var data string
-	data = res
+	var payload any
+	body := NewSSERequestIDMethodResponseBody(res)
+	payload = body
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
+	}
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()

--- a/http/codegen/testdata/golden/sse-string.golden
+++ b/http/codegen/testdata/golden/sse-string.golden
@@ -35,7 +35,53 @@ func (s *SSEStringMethodServerStream) SendWithContext(ctx context.Context, v str
 	res := v
 
 	var data string
-	data = res
+	var payload any
+	body := NewSSEStringMethodResponseBody(res)
+	payload = body
+	switch v := payload.(type) {
+	case nil:
+		data = "null"
+	case string:
+		data = v
+	case []byte:
+		data = string(v)
+	case bool:
+		if v {
+			data = "true"
+		} else {
+			data = "false"
+		}
+	case int:
+		data = fmt.Sprintf("%d", v)
+	case int8:
+		data = fmt.Sprintf("%d", v)
+	case int16:
+		data = fmt.Sprintf("%d", v)
+	case int32:
+		data = fmt.Sprintf("%d", v)
+	case int64:
+		data = fmt.Sprintf("%d", v)
+	case uint:
+		data = fmt.Sprintf("%d", v)
+	case uint8:
+		data = fmt.Sprintf("%d", v)
+	case uint16:
+		data = fmt.Sprintf("%d", v)
+	case uint32:
+		data = fmt.Sprintf("%d", v)
+	case uint64:
+		data = fmt.Sprintf("%d", v)
+	case float32:
+		data = fmt.Sprintf("%g", v)
+	case float64:
+		data = fmt.Sprintf("%g", v)
+	default:
+		byts, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		data = string(byts)
+	}
 	fmt.Fprintf(s.w, "data: %s\n\n", data)
 
 	http.NewResponseController(s.w).Flush()


### PR DESCRIPTION
This PR refines SSE server generation to format event data more accurately and efficiently.

- Add  to SSE data to determine when to build the event payload from the generated HTTP response body type.
- Use the generated response body () for SSE payloads when present, ensuring parity with normal HTTP responses.
- Encode primitives directly (string/bytes/bool/numbers), fall back to  only for complex values.
- Expose  to the SSE template funcs.
- Update SSE golden files accordingly.

Rationale:
- Aligns SSE data shape with existing response body converters, avoiding divergence between streaming and non-streaming endpoints.
- Avoids unnecessary JSON for primitives, improving readability and performance for clients.

Tests:
- ok  	goa.design/goa/v3/http/codegen	1.145s passes locally; goldens updated.