### PR TITLE
expr/interceptor: consider Extend in interceptor attribute validation

### DIFF
--- a/expr/interceptor.go
+++ b/expr/interceptor.go
@@ -58,10 +58,10 @@ func (i *InterceptorExpr) validate(m *MethodExpr) *eval.ValidationErrors {
 				}
 			}
 			if i.ReadPayload != nil {
-				i.validateAttributeAccess(m, "read payload", verr, AsObject(payload.Type), i.ReadPayload)
+				i.validateAttributeAccess(m, "read payload", verr, payload, i.ReadPayload)
 			}
 			if i.WritePayload != nil {
-				i.validateAttributeAccess(m, "write payload", verr, AsObject(payload.Type), i.WritePayload)
+				i.validateAttributeAccess(m, "write payload", verr, payload, i.WritePayload)
 			}
 		}
 	}
@@ -82,10 +82,10 @@ func (i *InterceptorExpr) validate(m *MethodExpr) *eval.ValidationErrors {
 				}
 			}
 			if i.ReadResult != nil {
-				i.validateAttributeAccess(m, "read result", verr, AsObject(result.Type), i.ReadResult)
+				i.validateAttributeAccess(m, "read result", verr, result, i.ReadResult)
 			}
 			if i.WriteResult != nil {
-				i.validateAttributeAccess(m, "write result", verr, AsObject(result.Type), i.WriteResult)
+				i.validateAttributeAccess(m, "write result", verr, result, i.WriteResult)
 			}
 		}
 	}
@@ -106,10 +106,10 @@ func (i *InterceptorExpr) validate(m *MethodExpr) *eval.ValidationErrors {
 					}
 				}
 				if i.ReadStreamingPayload != nil {
-					i.validateAttributeAccess(m, "read streaming payload", verr, AsObject(payload.Type), i.ReadStreamingPayload)
+					i.validateAttributeAccess(m, "read streaming payload", verr, payload, i.ReadStreamingPayload)
 				}
 				if i.WriteStreamingPayload != nil {
-					i.validateAttributeAccess(m, "write streaming payload", verr, AsObject(payload.Type), i.WriteStreamingPayload)
+					i.validateAttributeAccess(m, "write streaming payload", verr, payload, i.WriteStreamingPayload)
 				}
 			}
 		}
@@ -131,10 +131,10 @@ func (i *InterceptorExpr) validate(m *MethodExpr) *eval.ValidationErrors {
 					}
 				}
 				if i.ReadStreamingResult != nil {
-					i.validateAttributeAccess(m, "read streaming result", verr, AsObject(result.Type), i.ReadStreamingResult)
+					i.validateAttributeAccess(m, "read streaming result", verr, result, i.ReadStreamingResult)
 				}
 				if i.WriteStreamingResult != nil {
-					i.validateAttributeAccess(m, "write streaming result", verr, AsObject(result.Type), i.WriteStreamingResult)
+					i.validateAttributeAccess(m, "write streaming result", verr, result, i.WriteStreamingResult)
 				}
 			}
 		}
@@ -144,14 +144,14 @@ func (i *InterceptorExpr) validate(m *MethodExpr) *eval.ValidationErrors {
 }
 
 // validateAttributeAccess validates that all attributes in attr exist in obj
-func (i *InterceptorExpr) validateAttributeAccess(m *MethodExpr, source string, verr *eval.ValidationErrors, obj *Object, attr *AttributeExpr) {
+func (i *InterceptorExpr) validateAttributeAccess(m *MethodExpr, source string, verr *eval.ValidationErrors, target *AttributeExpr, attr *AttributeExpr) {
 	attrObj := AsObject(attr.Type)
 	if attrObj == nil {
 		verr.Add(m, "interceptor %q %s attribute is not an object", i.Name, source)
 		return
 	}
 	for _, att := range *attrObj {
-		if obj.Attribute(att.Name) == nil {
+		if target.Find(att.Name) == nil {
 			verr.Add(m, "interceptor %q cannot %s attribute %q: attribute does not exist", i.Name, source, att.Name)
 		}
 	}

--- a/expr/interceptor_test.go
+++ b/expr/interceptor_test.go
@@ -40,6 +40,36 @@ func TestInterceptorExpr_Validate(t *testing.T) {
 				}),
 			),
 		},
+		"payload-with-user-type-extend": {
+			intercept: makeInterceptor(t, withReadPayload(t, namedAttr(t, "frombase"))),
+			method: makeMethod(t, func(m *MethodExpr) {
+				// Base user type providing attribute via Extend
+				base := &UserTypeExpr{AttributeExpr: &AttributeExpr{Type: &Object{namedAttr(t, "frombase")}}, TypeName: "Base"}
+				// Payload is a user type that extends base
+				ut := &UserTypeExpr{AttributeExpr: &AttributeExpr{Type: &Object{namedAttr(t, "own")}}, TypeName: "PayloadUT"}
+				ut.AttributeExpr.Bases = []DataType{base}
+				m.Payload = &AttributeExpr{Type: ut}
+			}),
+		},
+		"result-with-user-type-extend": {
+			intercept: makeInterceptor(t, withReadResult(t, namedAttr(t, "frombase"))),
+			method: makeMethod(t, func(m *MethodExpr) {
+				base := &UserTypeExpr{AttributeExpr: &AttributeExpr{Type: &Object{namedAttr(t, "frombase")}}, TypeName: "RBase"}
+				ut := &UserTypeExpr{AttributeExpr: &AttributeExpr{Type: &Object{namedAttr(t, "ownr")}}, TypeName: "ResultUT"}
+				ut.AttributeExpr.Bases = []DataType{base}
+				m.Result = &AttributeExpr{Type: ut}
+			}),
+		},
+		"streaming-payload-with-user-type-extend": {
+			intercept: makeInterceptor(t, withReadStreamingPayload(t, namedAttr(t, "frombase"))),
+			method: makeMethod(t, func(m *MethodExpr) {
+				m.Stream = ClientStreamKind
+				base := &UserTypeExpr{AttributeExpr: &AttributeExpr{Type: &Object{namedAttr(t, "frombase")}}, TypeName: "SPBase"}
+				ut := &UserTypeExpr{AttributeExpr: &AttributeExpr{Type: &Object{namedAttr(t, "ownsp")}}, TypeName: "SPUT"}
+				ut.AttributeExpr.Bases = []DataType{base}
+				m.StreamingPayload = &AttributeExpr{Type: ut}
+			}),
+		},
 		"invalid-payload-not-object": {
 			intercept: makeInterceptor(t, withReadPayload(t, namedAttr(t, "foo"))),
 			method: makeMethod(t, func(m *MethodExpr) {


### PR DESCRIPTION
Fix a bug where interceptor validation ignores attributes introduced via Extend on payload/result user types. Interceptors now correctly validate access to attributes merged from Bases.

Changes:
- Update validateAttributeAccess to accept the target *AttributeExpr and use target.Find(name) so inherited attributes (Extend/References/UserType) are recognized.
- Adjust all call sites to pass duplicated payload/result/streaming attributes.

Tests:
- Add cases in expr/interceptor_test.go for payload/result/streaming payload when user types Extend base types providing the accessed attribute.
- All new tests pass; they would fail prior to this change.

Compatibility:
- No public API changes; internal method signature changed only.

Notes:
- Validation runs pre-finalization; switching to Find ensures we traverse Bases and References consistently with other validations.
- Lint and full test suite (including JSON-RPC integration tests) pass locally.
