### PR TITLE
codegen: guard nil elements in array transforms to prevent panic (#3828)

### DIFF
--- a/codegen/templates/transform_go_array.go.tpl
+++ b/codegen/templates/transform_go_array.go.tpl
@@ -1,6 +1,10 @@
 {{ .TargetVar }} {{ if .NewVar }}:={{ else }}={{ end }} make({{ if .TypeAliasName }}{{ .TypeAliasName }}{{ else }}[]{{ .ElemTypeRef }}{{ end }}, len({{ .SourceVar }}))
 for {{ .LoopVar }}, val := range {{ .SourceVar }} {
 {{ if .IsStruct -}}
+	if val == nil {
+		{{ .TargetVar }}[{{ .LoopVar }}] = nil
+		continue
+	}
 	{{ .TargetVar }}[{{ .LoopVar }}] = {{ transformHelperName .SourceElem .TargetElem .TransformAttrs }}(val)
 {{ else -}}
 	{{ transformAttribute .SourceElem .TargetElem "val" (printf "%s[%s]" .TargetVar .LoopVar) false .TransformAttrs -}}

--- a/codegen/testdata/golden/go_transform_source-target-type-use-default_recursive-array-to-recursive-array.go.golden
+++ b/codegen/testdata/golden/go_transform_source-target-type-use-default_recursive-array-to-recursive-array.go.golden
@@ -5,6 +5,10 @@ func transform() {
 	if source.Recursive != nil {
 		target.Recursive = make([]*RecursiveArray, len(source.Recursive))
 		for i, val := range source.Recursive {
+			if val == nil {
+				target.Recursive[i] = nil
+				continue
+			}
 			target.Recursive[i] = transformRecursiveArrayToRecursiveArray(val)
 		}
 	}

--- a/codegen/testdata/golden/go_transform_source-target-type-use-default_result-type-collection-to-result-type-collection.go.golden
+++ b/codegen/testdata/golden/go_transform_source-target-type-use-default_result-type-collection-to-result-type-collection.go.golden
@@ -3,6 +3,10 @@ func transform() {
 	if source.Collection != nil {
 		target.Collection = make([]*ResultType, len(source.Collection))
 		for i, val := range source.Collection {
+			if val == nil {
+				target.Collection[i] = nil
+				continue
+			}
 			target.Collection[i] = transformResultTypeToResultType(val)
 		}
 	}

--- a/codegen/testdata/golden/go_transform_source-target-type-use-default_type-array-to-type-array.go.golden
+++ b/codegen/testdata/golden/go_transform_source-target-type-use-default_type-array-to-type-array.go.golden
@@ -3,6 +3,10 @@ func transform() {
 	if source.TypeArray != nil {
 		target.TypeArray = make([]*SimpleArray, len(source.TypeArray))
 		for i, val := range source.TypeArray {
+			if val == nil {
+				target.TypeArray[i] = nil
+				continue
+			}
 			target.TypeArray[i] = transformSimpleArrayToSimpleArray(val)
 		}
 	}

--- a/http/codegen/testdata/golden/client_body_type_init_body-primitive-array-user-validate.go.golden
+++ b/http/codegen/testdata/golden/client_body_type_init_body-primitive-array-user-validate.go.golden
@@ -4,6 +4,10 @@
 func NewPayloadTypeRequestBody(p []*servicebodyprimitivearrayuservalidate.PayloadType) []*PayloadTypeRequestBody {
 	body := make([]*PayloadTypeRequestBody, len(p))
 	for i, val := range p {
+		if val == nil {
+			body[i] = nil
+			continue
+		}
 		body[i] = marshalServicebodyprimitivearrayuservalidatePayloadTypeToPayloadTypeRequestBody(val)
 	}
 	return body

--- a/http/codegen/testdata/golden/client_cli_payload-array-user-type.go.golden
+++ b/http/codegen/testdata/golden/client_cli_payload-array-user-type.go.golden
@@ -11,6 +11,10 @@ func BuildMethodBodyInlineArrayUserPayload(serviceBodyInlineArrayUserMethodBodyI
 	}
 	v := make([]*servicebodyinlinearrayuser.ElemType, len(body))
 	for i, val := range body {
+		if val == nil {
+			v[i] = nil
+			continue
+		}
 		v[i] = marshalElemTypeRequestBodyToServicebodyinlinearrayuserElemType(val)
 	}
 	return v, nil

--- a/http/codegen/testdata/golden/server_payload_types_body-inline-array-user.go.golden
+++ b/http/codegen/testdata/golden/server_payload_types_body-inline-array-user.go.golden
@@ -3,6 +3,10 @@
 func NewMethodBodyInlineArrayUserElemType(body []*ElemTypeRequestBody) []*servicebodyinlinearrayuser.ElemType {
 	v := make([]*servicebodyinlinearrayuser.ElemType, len(body))
 	for i, val := range body {
+		if val == nil {
+			v[i] = nil
+			continue
+		}
 		v[i] = unmarshalElemTypeRequestBodyToServicebodyinlinearrayuserElemType(val)
 	}
 	return v


### PR DESCRIPTION
Fixes #3828.

- Add nil guard in array transform template for struct element pointers to avoid deref panic when JSON includes nulls in arrays.
- Update goldens in codegen and http/codegen.
- All tests pass: `go test ./...`.

Repro in issue: Sending a required array with a null element would panic in generated `unmarshal...` transform. This change returns a nil element instead of crashing; separate follow-up PR will add DSL validation to disallow null elements when desired.
