### PR TITLE
Fix example JSON-RPC handler call order

### DIFF
--- a/codegen/example/server_data_test.go
+++ b/codegen/example/server_data_test.go
@@ -1,0 +1,67 @@
+package example
+
+import (
+	"testing"
+
+	"goa.design/goa/v3/expr"
+)
+
+func TestComputeHandlerArgsForURI_JSONRPCOrdering(t *testing.T) {
+	method := &expr.MethodExpr{Name: "Run"}
+	httpSvc := &expr.HTTPServiceExpr{
+		ServiceExpr: &expr.ServiceExpr{
+			Name:    "orchestrator",
+			Methods: []*expr.MethodExpr{method},
+		},
+		HTTPEndpoints: []*expr.HTTPEndpointExpr{{MethodExpr: method}},
+	}
+	mcpMethod := &expr.MethodExpr{Name: "ListTools"}
+	jsonrpcOrchestrator := &expr.HTTPServiceExpr{ServiceExpr: &expr.ServiceExpr{Name: "orchestrator"}}
+	jsonrpcMCPAssistant := &expr.HTTPServiceExpr{
+		ServiceExpr: &expr.ServiceExpr{
+			Name:    "mcp_assistant",
+			Methods: []*expr.MethodExpr{mcpMethod},
+		},
+		HTTPEndpoints: []*expr.HTTPEndpointExpr{{MethodExpr: mcpMethod}},
+	}
+	root := &expr.RootExpr{
+		API: &expr.APIExpr{
+			HTTP: &expr.HTTPExpr{
+				Services: []*expr.HTTPServiceExpr{httpSvc},
+			},
+			JSONRPC: &expr.JSONRPCExpr{
+				HTTPExpr: expr.HTTPExpr{
+					Services: []*expr.HTTPServiceExpr{jsonrpcOrchestrator, jsonrpcMCPAssistant},
+				},
+			},
+		},
+		Services: []*expr.ServiceExpr{
+			{Name: "orchestrator", Methods: []*expr.MethodExpr{method}},
+			{Name: "mcp_assistant", Methods: []*expr.MethodExpr{mcpMethod}},
+		},
+	}
+	server := &Data{
+		Services: []string{"orchestrator", "mcp_assistant"},
+		Transports: []*TransportData{
+			{Type: TransportHTTP, Services: []string{"orchestrator", "mcp_assistant"}},
+		},
+	}
+	uri := &URIData{Transport: &TransportData{Type: TransportHTTP}}
+
+	args := computeHandlerArgsForURI(uri, server, root)
+
+	want := []HandlerArg{
+		{Endpoint: "orchestratorEndpoints"},
+		{Service: "orchestratorSvc"},
+		{Service: "mcpAssistantSvc"},
+		{Endpoint: "mcpAssistantEndpoints"},
+	}
+	if len(args) != len(want) {
+		t.Fatalf("expected %d handler args, got %d (%v)", len(want), len(args), args)
+	}
+	for i, arg := range want {
+		if args[i] != arg {
+			t.Fatalf("handler arg %d: expected %+v, got %+v", i, arg, args[i])
+		}
+	}
+}


### PR DESCRIPTION
## Problem

When a Goa server hosts both HTTP and JSON-RPC services, the generated example code fails to compile with errors like:

```
cannot use mcpAssistantEndpoints (*mcpassistant.Endpoints) as orchestrator.Service
cannot use orchestratorSvc (orchestrator.Service) as mcpassistant.Service
```

This happens because there's a mismatch between:
- The argument order in `main.go` (generated using `HandlerArgs` from `computeHandlerArgsForURI`)
- The function signature in `http.go` (generated from the JSON-RPC template)

## Root Cause

The `computeHandlerArgsForURI` function in `codegen/example/server_data.go` wasn't matching the order that the JSON-RPC `handleHTTPServer` template generates.

The template data `$.Services` contains:
- Only HTTP services when HTTP services exist  
- ALL JSON-RPC services when NO HTTP services exist (JSON-RPC-only scenario)

## Solution

Updated `computeHandlerArgsForURI` to match the template's behavior:

1. **Step 1**: Add endpoint pointers for services with HTTP transport
2. **Step 2**: For each JSON-RPC service, add service interface followed immediately by endpoint (if not already added)

This produces the correct patterns for both scenarios:

**Mixed HTTP/JSON-RPC** (e.g., orchestrator has HTTP, mcp_assistant is JSON-RPC-only):
```
orchestratorEndpoints, orchestratorSvc, mcpAssistantSvc, mcpAssistantEndpoints
```

**JSON-RPC-only** (all services are JSON-RPC):
```
testEndpoints, testsseEndpoints, testwsEndpoints, testSvc, testsseSvc, testwsSvc
```

## Testing

- ✅ All Goa core tests pass (`make`)
- ✅ JSON-RPC integration tests pass
- ✅ New unit test `TestComputeHandlerArgsForURI_JSONRPCOrdering` validates the ordering
- ✅ goa-ai example builds and tests pass

## Files Changed

- `codegen/example/server_data.go` - Fixed `computeHandlerArgsForURI` logic
- `codegen/example/server_data_test.go` - Added test for JSON-RPC ordering