### PR TITLE
openapi: update JSON Schema to draft 2020-12

### DIFF
--- a/http/codegen/openapi/json_schema.go
+++ b/http/codegen/openapi/json_schema.go
@@ -20,7 +20,7 @@ type (
 		Type         Type               `json:"type,omitempty" yaml:"type,omitempty"`
 		Items        *Schema            `json:"items,omitempty" yaml:"items,omitempty"`
 		Properties   map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
-		Definitions  map[string]*Schema `json:"definitions,omitempty" yaml:"definitions,omitempty"`
+		Defs         map[string]*Schema `json:"$defs,omitempty" yaml:"$defs,omitempty"`
 		Description  string             `json:"description,omitempty" yaml:"description,omitempty"`
 		DefaultValue any                `json:"default,omitempty" yaml:"default,omitempty"`
 		Example      any                `json:"example,omitempty" yaml:"example,omitempty"`
@@ -99,8 +99,8 @@ const (
 	File = "file"
 )
 
-// SchemaRef is the JSON Hyper-schema standard href.
-const SchemaRef = "http://json-schema.org/draft-04/hyper-schema"
+// SchemaRef is the JSON Schema draft 2020-12 meta-schema identifier.
+const SchemaRef = "https://json-schema.org/draft/2020-12/schema"
 
 var (
 	// Definitions contains the generated JSON schema definitions
@@ -115,8 +115,8 @@ func init() {
 // NewSchema instantiates a new JSON schema.
 func NewSchema() *Schema {
 	js := Schema{
-		Properties:  make(map[string]*Schema),
-		Definitions: make(map[string]*Schema),
+		Properties: make(map[string]*Schema),
+		Defs:       make(map[string]*Schema),
 	}
 	return &js
 }
@@ -156,8 +156,8 @@ func APISchema(api *expr.APIExpr, r *expr.RootExpr) *Schema {
 		Title:       api.Title,
 		Description: api.Description,
 		Type:        Object,
-		Definitions: Definitions,
-		Properties:  propertiesFromDefs(Definitions, "#/definitions/"),
+		Defs:        Definitions,
+		Properties:  propertiesFromDefs(Definitions, "#/$defs/"),
 		Links:       links,
 	}
 	return &s
@@ -250,7 +250,7 @@ func ResultTypeRefWithPrefix(api *expr.APIExpr, mt *expr.ResultTypeExpr, view, p
 		}
 		GenerateResultTypeDefinition(api, projected, expr.DefaultView)
 	}
-	return fmt.Sprintf("#/definitions/%s", projected.TypeName)
+	return fmt.Sprintf("#/$defs/%s", projected.TypeName)
 }
 
 // TypeRef produces the JSON reference to the type definition.
@@ -271,7 +271,7 @@ func TypeRefWithPrefix(api *expr.APIExpr, ut *expr.UserTypeExpr, prefix string) 
 	if _, ok := Definitions[typeName]; !ok {
 		GenerateTypeDefinitionWithName(api, ut, typeName)
 	}
-	return fmt.Sprintf("#/definitions/%s", typeName)
+	return fmt.Sprintf("#/$defs/%s", typeName)
 }
 
 // GenerateResultTypeDefinition produces the JSON schema corresponding to the
@@ -469,8 +469,8 @@ func (s *Schema) Dup() *Schema {
 	if s.Items != nil {
 		js.Items = s.Items.Dup()
 	}
-	for n, d := range s.Definitions {
-		js.Definitions[n] = d.Dup()
+	for n, d := range s.Defs {
+		js.Defs[n] = d.Dup()
 	}
 	return &js
 }

--- a/http/codegen/openapi/merge.go
+++ b/http/codegen/openapi/merge.go
@@ -26,9 +26,9 @@ func (s *Schema) Merge(other *Schema) {
 		}
 	}
 
-	for n, d := range other.Definitions {
-		if _, ok := s.Definitions[n]; !ok {
-			s.Definitions[n] = d
+	for n, d := range other.Defs {
+		if _, ok := s.Defs[n]; !ok {
+			s.Defs[n] = d
 		}
 	}
 


### PR DESCRIPTION
Update JSON Schema from draft-04 to draft 2020-12:

- Change 'definitions' to '$defs' (draft 2020-12 format)
- Update schema reference to draft 2020-12 meta-schema
- Update all reference paths from #/definitions/ to #/$defs/
- Add conversion functions in v2/builder.go to convert references back to Swagger 2.0 format (#/definitions/) for backward compatibility

This modernizes the JSON Schema format while maintaining backward compatibility for Swagger 2.0 output.