### PR TITLE
grpc: fix validation helper naming for proto messages

### DIFF
--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -760,7 +760,10 @@ func addValidation(att *expr.AttributeExpr, attName string, sd *ServiceData, req
 	removeMeta(att)
 	if def := codegen.ValidationCode(att, ut, vtx, true, expr.IsAlias(att.Type), false, attName); def != "" {
 		v := &ValidationData{
-			Name:    "Validate" + name,
+			// Validation function names must match the identifiers used by
+			// validation templates (which Goify the type name). Use Goify here
+			// as well so helpers like ValidateMessage line up with calls.
+			Name:    "Validate" + codegen.Goify(name, true),
 			Def:     def,
 			ArgName: attName,
 			SrcName: name,
@@ -818,7 +821,9 @@ func collectValidationsR(att *expr.AttributeExpr, attName string, req bool, sd *
 		}
 		if def != "" {
 			sd.validations = append(sd.validations, &ValidationData{
-				Name:    "Validate" + name,
+				// Match helper function identifiers with validation template
+				// calls (Validate{{ Goify(name) }}).
+				Name:    "Validate" + codegen.Goify(name, true),
 				Def:     def,
 				ArgName: gattName,
 				SrcName: name,


### PR DESCRIPTION
This PR fixes a gRPC codegen bug where validation helpers for protobuf messages could be emitted with a different identifier than the one used at call sites.

### Problem
- For protobuf user types (e.g. `Message_`), `grpc/codegen/service_data.go` used **two different name sources**:
  - Helper definitions used `protoBufGoTypeName` (Go type name derived from the compiled `.pb.go`), e.g. `Message_` → `ValidateMessage_`.
  - Validation _calls_ (via `validation/user.go.tpl`) Goify the proto message name and call `Validate{{ Goify(name, true) }}`, e.g. `Message_` → `ValidateMessage`.
- In some cases this mismatch produced helpers like `ValidateMessage_` while generated code called `ValidateMessage`, causing `undefined: ValidateMessage` build errors in downstream gRPC clients/servers (observed in an `inference_engine` service).

### Fix
- In `grpc/codegen/service_data.go`, both validation paths now derive the helper name via `Goify(name, true)`:
  - `addValidation`: `Name` is now `"Validate" + codegen.Goify(name, true)`.
  - `collectValidationsR`: same change when appending `ValidationData`.
- `name` is the proto message identifier computed by `protoBufMessageName`, so helpers and the validation template now agree on the exact function symbol (e.g. `ValidateMessage`).

### Impact / Verification
- `go test ./...` passes in the `goa` repo.
- Regenerating a downstream service (AURA) with the updated `goa` binary:
  - Re-ran `goa gen`.
  - `go test ./...` under its generated `gen/` tree now passes without `ValidateMessage` / `ValidateMessage_` issues.

This keeps all naming decisions localized in the existing `protoBufMessageName` + `Goify` pipeline, and does not change any public APIs.
