### PR TITLE
Performance: optimise file writes

### DIFF
--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"goa.design/goa/v3/codegen"
 	"golang.org/x/tools/go/packages"
@@ -44,7 +45,7 @@ type Generator struct {
 }
 
 // NewGenerator creates a Generator.
-func NewGenerator(cmd, path, output string) *Generator {
+func NewGenerator(cmd, path, output string, debug bool) *Generator {
 	bin := "goa"
 	if runtime.GOOS == "windows" {
 		bin += ".exe"
@@ -55,7 +56,11 @@ func NewGenerator(cmd, path, output string) *Generator {
 	{
 		version = 2
 		matched := false
+		startPkgLoad := time.Now()
 		pkgs, _ := packages.Load(&packages.Config{Mode: packages.NeedFiles | packages.NeedModule}, path)
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]   packages.Load (design files) took %v\n", time.Since(startPkgLoad))
+		}
 		fset := token.NewFileSet()
 		p := regexp.MustCompile(`goa.design/goa/v(\d+)/dsl`)
 		for _, pkg := range pkgs {
@@ -132,6 +137,7 @@ func (g *Generator) Write(_ bool) error {
 			codegen.SimpleImport("sort"),
 			codegen.SimpleImport("strconv"),
 			codegen.SimpleImport("strings"),
+			codegen.SimpleImport("time"),
 			codegen.SimpleImport("goa.design/goa/" + ver + "codegen"),
 			codegen.SimpleImport("goa.design/goa/" + ver + "codegen/generator"),
 			codegen.SimpleImport("goa.design/goa/" + ver + "eval"),
@@ -154,9 +160,10 @@ func (g *Generator) Write(_ bool) error {
 }
 
 // Compile compiles the generator.
-func (g *Generator) Compile() error {
+func (g *Generator) Compile(debug bool) error {
 	// We first need to go get the generated package to make sure that all
 	// dependencies are added to go.sum prior to compiling.
+	startLoad := time.Now()
 	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, fmt.Sprintf(".%c%s", filepath.Separator, g.tmpDir))
 	if err != nil {
 		return err
@@ -164,13 +171,25 @@ func (g *Generator) Compile() error {
 	if len(pkgs) != 1 {
 		return fmt.Errorf("expected to find one package in %s", g.tmpDir)
 	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   packages.Load (temp dir) took %v\n", time.Since(startLoad))
+	}
+
 	if !g.hasVendorDirectory {
+		startGet := time.Now()
 		if err := g.runGoCmd("get", pkgs[0].PkgPath); err != nil {
 			return err
 		}
+		if debug {
+			fmt.Fprintf(os.Stderr, "[TIMING]   go get took %v\n", time.Since(startGet))
+		}
 	}
 
+	startBuild := time.Now()
 	err = g.runGoCmd("build", "-o", g.bin)
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   go build took %v\n", time.Since(startBuild))
+	}
 
 	// If we're in vendor context we check the error string to see if it's an issue of unsatisfied dependencies
 	if err != nil && g.hasVendorDirectory {
@@ -183,7 +202,7 @@ func (g *Generator) Compile() error {
 }
 
 // Run runs the compiled binary and return the output lines.
-func (g *Generator) Run() ([]string, error) {
+func (g *Generator) Run(debug bool) ([]string, error) {
 	var cmdl string
 	{
 		args := make([]string, len(os.Args)-1)
@@ -210,7 +229,7 @@ func (g *Generator) Run() ([]string, error) {
 		cmdl = fmt.Sprintf("$ %s%s", rawcmd, cmdl)
 	}
 
-	args := []string{"--version=" + strconv.Itoa(g.DesignVersion), "--output=" + g.Output, "--cmd=" + cmdl}
+	args := []string{"--version=" + strconv.Itoa(g.DesignVersion), "--output=" + g.Output, "--cmd=" + cmdl, "--debug=" + strconv.FormatBool(debug)}
 	cmd := exec.Command(filepath.Join(g.tmpDir, g.bin), args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -291,6 +310,7 @@ const mainT = `func main() {
 		out     = flag.String("output", "", "")
 		version = flag.String("version", "", "")
 		cmdl    = flag.String("cmd", "", "")
+		debug   = flag.Bool("debug", false, "")
 		ver int
 	)
 	{
@@ -311,15 +331,31 @@ const mainT = `func main() {
 		ver = v
 	}
 
+	startBinary := time.Now()
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] Starting generated binary execution\n")
+	}
+
 	if ver > goa.Major {
 		fail("cannot run goa %s on design using goa v%s\n", goa.Version(), *version)
 	}
+
+	startCheckErrors := time.Now()
 	if err := eval.Context.Errors; err != nil {
 		fail(err.Error())
 	}
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] Check eval.Context.Errors took %v\n", time.Since(startCheckErrors))
+	}
+
+	startRunDSL := time.Now()
 	if err := eval.RunDSL(); err != nil {
 		fail(err.Error())
 	}
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] eval.RunDSL() took %v\n", time.Since(startRunDSL))
+	}
+
 {{- range .CleanupDirs }}
 	if err := os.RemoveAll({{ printf "%q" . }}); err != nil {
 		fail(err.Error())
@@ -328,11 +364,16 @@ const mainT = `func main() {
 {{- if gt .DesignVersion 2 }}
 	codegen.DesignVersion = ver
 {{- end }}
-	outputs, err := generator.Generate(*out, {{ printf "%q" .Command }})
+
+	startGenerate := time.Now()
+	outputs, err := generator.Generate(*out, {{ printf "%q" .Command }}, *debug)
 	if err != nil {
 		fail(err.Error())
 	}
-
+	if *debug {
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] generator.Generate() took %v\n", time.Since(startGenerate))
+		fmt.Fprintf(os.Stderr, "[TIMING]   [binary] Total binary execution took %v\n", time.Since(startBinary))
+	}
 	fmt.Println(strings.Join(outputs, "\n"))
 }
 

--- a/cmd/goa/main.go
+++ b/cmd/goa/main.go
@@ -5,6 +5,7 @@ import (
 	"go/build"
 	"os"
 	"strings"
+	"time"
 
 	"flag"
 
@@ -77,29 +78,55 @@ var (
 
 func generate(cmd, path, output string, debug bool) error {
 	var (
-		files []string
-		err   error
-		tmp   *Generator
+		files                                                            []string
+		err                                                              error
+		tmp                                                              *Generator
+		startTotal, startImport, startNewGen, startWrite, startCompile, startRun time.Time
 	)
 
+	startTotal = time.Now()
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] Starting goa generation\n")
+	}
+
+	startImport = time.Now()
 	if _, err = build.Import(path, ".", 0); err != nil {
 		goto fail
 	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] build.Import took %v\n", time.Since(startImport))
+	}
 
-	tmp = NewGenerator(cmd, path, output)
+	startNewGen = time.Now()
+	tmp = NewGenerator(cmd, path, output, debug)
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] NewGenerator took %v\n", time.Since(startNewGen))
+	}
 
+	startWrite = time.Now()
 	if err = tmp.Write(debug); err != nil {
 		goto fail
 	}
-
-	if err = tmp.Compile(); err != nil {
-		goto fail
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] Write (generate main.go) took %v\n", time.Since(startWrite))
 	}
 
-	if files, err = tmp.Run(); err != nil {
+	startCompile = time.Now()
+	if err = tmp.Compile(debug); err != nil {
 		goto fail
 	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] Compile (go get + go build) took %v\n", time.Since(startCompile))
+	}
 
+	startRun = time.Now()
+	if files, err = tmp.Run(debug); err != nil {
+		goto fail
+	}
+	if debug {
+		fmt.Fprintf(os.Stderr, "[TIMING] Run (execute binary) took %v\n", time.Since(startRun))
+		fmt.Fprintf(os.Stderr, "[TIMING] Total generation time: %v\n", time.Since(startTotal))
+	}
 	fmt.Println(strings.Join(files, "\n"))
 	if !debug {
 		tmp.Remove()

--- a/codegen/file.go
+++ b/codegen/file.go
@@ -85,28 +85,26 @@ func (f *File) Render(dir string) (string, error) {
 		return "", err
 	}
 
-	file, err := os.OpenFile(
-		path,
-		os.O_CREATE|os.O_TRUNC|os.O_WRONLY,
-		0600,
-	)
-	if err != nil {
-		return "", err
-	}
+	// Render all sections to a buffer instead of directly to file
+	var buf bytes.Buffer
 	for _, s := range f.SectionTemplates {
-		if err := s.Write(file); err != nil {
+		if err := s.Write(&buf); err != nil {
 			return "", err
 		}
-	}
-	if err := file.Close(); err != nil {
-		return "", err
 	}
 
-	// Format Go source files
+	// For Go files, process everything in memory
+	content := buf.Bytes()
 	if filepath.Ext(path) == ".go" {
-		if err := finalizeGoSource(path); err != nil {
+		content, err = finalizeGoSource(path, content)
+		if err != nil {
 			return "", err
 		}
+	}
+
+	// Write the final content exactly once
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		return "", err
 	}
 
 	// Run finalizer if any
@@ -127,17 +125,15 @@ func (s *SectionTemplate) Write(w io.Writer) error {
 	return tmpl.Execute(w, s.Data)
 }
 
-// finalizeGoSource removes unneeded imports from the given Go source file and
-// runs go fmt on it.
-func finalizeGoSource(path string) error {
-	// Make sure file parses and print content if it does not.
+// finalizeGoSource processes Go source entirely in memory without file I/O
+func finalizeGoSource(path string, content []byte) ([]byte, error) {
+	// Parse the content
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	file, err := parser.ParseFile(fset, path, content, parser.ParseComments)
 	if err != nil {
-		content, _ := os.ReadFile(path)
 		var buf bytes.Buffer
 		scanner.PrintError(&buf, err)
-		return fmt.Errorf("%s\n========\nContent:\n%s", buf.String(), content)
+		return nil, fmt.Errorf("%s\n========\nContent:\n%s", buf.String(), content)
 	}
 
 	// Clean unused imports using optimized single-pass detection
@@ -145,29 +141,22 @@ func finalizeGoSource(path string) error {
 	detectUsedImports(file, impMap)
 	removeUnusedImports(fset, file, impMap)
 	ast.SortImports(fset, file)
-	w, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	if err := format.Node(w, fset, file); err != nil {
-		return err
-	}
-	if err := w.Close(); err != nil {
-		return err
+
+	// Format the AST back to bytes
+	var formatted bytes.Buffer
+	if err := format.Node(&formatted, fset, file); err != nil {
+		return nil, err
 	}
 
-	// Format code using goimport standard
-	bs, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
+	// Apply goimports formatting
 	opt := imports.Options{
 		Comments:   true,
 		FormatOnly: true,
 	}
-	bs, err = imports.Process(path, bs, &opt)
+	result, err := imports.Process(path, formatted.Bytes(), &opt)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return os.WriteFile(path, bs, os.ModePerm)
+
+	return result, nil
 }

--- a/codegen/generator/generate_merge_test.go
+++ b/codegen/generator/generate_merge_test.go
@@ -49,7 +49,7 @@ func TestGenerateMergesSamePathFiles(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	_, err := Generate(dir, "gen")
+	_, err := Generate(dir, "gen", false)
 	if err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}

--- a/codegen/generator/generate_merge_test.go
+++ b/codegen/generator/generate_merge_test.go
@@ -68,3 +68,218 @@ func TestGenerateMergesSamePathFiles(t *testing.T) {
 		t.Fatalf("merged file missing method definition:\n%s", content)
 	}
 }
+
+// TestGenerateParallelManyFiles verifies that parallel file writing correctly
+// handles multiple files (more than runtime.NumCPU()) to exercise the worker
+// pool distribution. This ensures all workers process files and all files are
+// written correctly.
+func TestGenerateParallelManyFiles(t *testing.T) {
+	t.Cleanup(func() { Generators = generators })
+
+	// Generate 20 files to ensure we exceed typical CPU counts and exercise
+	// the worker pool's work distribution.
+	const numFiles = 20
+	Generators = func(cmd string) ([]Genfunc, error) {
+		return []Genfunc{
+			func(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
+				files := make([]*codegen.File, numFiles)
+				for i := 0; i < numFiles; i++ {
+					f := &codegen.File{
+						Path: filepath.Join(codegen.Gendir, "types", filepath.Join("parallel", filepath.Join("file"+string(rune('a'+i%26)), "test"+string(rune('0'+i/26))+".go"))),
+					}
+					f.SectionTemplates = []*codegen.SectionTemplate{
+						codegen.Header("Types", "types", nil),
+						{
+							Name:   "type-def",
+							Source: "type Test" + string(rune('A'+i)) + " struct{ ID int }\n",
+						},
+					}
+					files[i] = f
+				}
+				return files, nil
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	outputs, err := Generate(dir, "gen", false)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Verify all files were written
+	if len(outputs) != numFiles {
+		t.Fatalf("expected %d output files, got %d", numFiles, len(outputs))
+	}
+
+	// Verify each file exists and has correct content
+	for i := 0; i < numFiles; i++ {
+		outpath := filepath.Join(dir, codegen.Gendir, "types", filepath.Join("parallel", filepath.Join("file"+string(rune('a'+i%26)), "test"+string(rune('0'+i/26))+".go")))
+		bs, err := os.ReadFile(outpath)
+		if err != nil {
+			t.Fatalf("failed reading file %d: %v", i, err)
+		}
+		content := string(bs)
+		expected := "type Test" + string(rune('A'+i)) + " struct"
+		if !strings.Contains(content, expected) {
+			t.Fatalf("file %d missing expected content %q:\n%s", i, expected, content)
+		}
+	}
+}
+
+// TestGenerateParallelWithMerge verifies that parallel file writing correctly
+// handles file merging when multiple generators target the same path. This
+// tests the interaction between mergeFilesByPath and parallel rendering.
+func TestGenerateParallelWithMerge(t *testing.T) {
+	t.Cleanup(func() { Generators = generators })
+
+	// Three generators: first two merge to same path, third is separate.
+	// This exercises both merging and parallel writing with NumCPU workers.
+	Generators = func(cmd string) ([]Genfunc, error) {
+		return []Genfunc{
+			func(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
+				f1 := &codegen.File{Path: filepath.Join(codegen.Gendir, "types", "merged.go")}
+				f1.SectionTemplates = []*codegen.SectionTemplate{
+					codegen.Header("Types", "types", nil),
+					{Name: "type1", Source: "type Type1 struct{}\n"},
+				}
+				return []*codegen.File{f1}, nil
+			},
+			func(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
+				f2 := &codegen.File{Path: filepath.Join(codegen.Gendir, "types", "merged.go")}
+				f2.SectionTemplates = []*codegen.SectionTemplate{
+					codegen.Header("Types", "types", nil),
+					{Name: "type2", Source: "type Type2 struct{}\n"},
+				}
+				return []*codegen.File{f2}, nil
+			},
+			func(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
+				f3 := &codegen.File{Path: filepath.Join(codegen.Gendir, "types", "separate.go")}
+				f3.SectionTemplates = []*codegen.SectionTemplate{
+					codegen.Header("Types", "types", nil),
+					{Name: "type3", Source: "type Type3 struct{}\n"},
+				}
+				return []*codegen.File{f3}, nil
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	outputs, err := Generate(dir, "gen", false)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	if len(outputs) != 2 {
+		t.Fatalf("expected 2 output files, got %d", len(outputs))
+	}
+
+	// Verify merged file contains both types
+	mergedPath := filepath.Join(dir, codegen.Gendir, "types", "merged.go")
+	bs, err := os.ReadFile(mergedPath)
+	if err != nil {
+		t.Fatalf("failed reading merged file: %v", err)
+	}
+	content := string(bs)
+	if !strings.Contains(content, "type Type1 struct{}") {
+		t.Fatalf("merged file missing Type1:\n%s", content)
+	}
+	if !strings.Contains(content, "type Type2 struct{}") {
+		t.Fatalf("merged file missing Type2:\n%s", content)
+	}
+
+	// Verify separate file
+	separatePath := filepath.Join(dir, codegen.Gendir, "types", "separate.go")
+	bs, err = os.ReadFile(separatePath)
+	if err != nil {
+		t.Fatalf("failed reading separate file: %v", err)
+	}
+	content = string(bs)
+	if !strings.Contains(content, "type Type3 struct{}") {
+		t.Fatalf("separate file missing Type3:\n%s", content)
+	}
+}
+
+// TestGenerateParallelErrorHandling verifies that when file rendering fails
+// in the parallel worker pool, the first error is captured and returned while
+// other workers continue processing.
+func TestGenerateParallelErrorHandling(t *testing.T) {
+	t.Cleanup(func() { Generators = generators })
+
+	// Create multiple files where some will fail to render due to invalid paths.
+	// Worker pool should capture first error but continue processing other files.
+	Generators = func(cmd string) ([]Genfunc, error) {
+		return []Genfunc{
+			func(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
+				files := make([]*codegen.File, 5)
+				for i := 0; i < 5; i++ {
+					f := &codegen.File{
+						Path: filepath.Join(codegen.Gendir, "types", "file"+string(rune('0'+i))+".go"),
+					}
+					f.SectionTemplates = []*codegen.SectionTemplate{
+						codegen.Header("Types", "types", nil),
+						{Name: "type", Source: "type T" + string(rune('0'+i)) + " struct{}\n"},
+					}
+					// Make file 2 fail by adding an invalid path character after writing starts
+					if i == 2 {
+						// Use a FinalizeFunc that returns an error
+						f.FinalizeFunc = func(fp string) error {
+							return os.ErrInvalid
+						}
+					}
+					files[i] = f
+				}
+				return files, nil
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	_, err := Generate(dir, "gen", false)
+	if err == nil {
+		t.Fatal("expected error from parallel generation, got nil")
+	}
+	// Verify we got an error (the first one encountered)
+	if !strings.Contains(err.Error(), "invalid") && !strings.Contains(err.Error(), "finalize") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestGenerateParallelSingleFile verifies that parallel file writing works
+// correctly with just a single file (minimal parallelism edge case).
+func TestGenerateParallelSingleFile(t *testing.T) {
+	t.Cleanup(func() { Generators = generators })
+
+	Generators = func(cmd string) ([]Genfunc, error) {
+		return []Genfunc{
+			func(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
+				f := &codegen.File{Path: filepath.Join(codegen.Gendir, "types", "single.go")}
+				f.SectionTemplates = []*codegen.SectionTemplate{
+					codegen.Header("Types", "types", nil),
+					{Name: "type", Source: "type Single struct{}\n"},
+				}
+				return []*codegen.File{f}, nil
+			},
+		}, nil
+	}
+
+	dir := t.TempDir()
+	outputs, err := Generate(dir, "gen", false)
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	if len(outputs) != 1 {
+		t.Fatalf("expected 1 output file, got %d", len(outputs))
+	}
+
+	outpath := filepath.Join(dir, codegen.Gendir, "types", "single.go")
+	bs, err := os.ReadFile(outpath)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	content := string(bs)
+	if !strings.Contains(content, "type Single struct{}") {
+		t.Fatalf("file missing expected content:\n%s", content)
+	}
+}

--- a/codegen/generator/generate_union_merge_integration_test.go
+++ b/codegen/generator/generate_union_merge_integration_test.go
@@ -54,7 +54,7 @@ func TestGenerateUnionUserTypeSamePathMerged(t *testing.T) {
 	_ = cg.RunDSL(t, dsl)
 
 	dir := t.TempDir()
-	if _, err := Generate(dir, "gen"); err != nil {
+	if _, err := Generate(dir, "gen", false); err != nil {
 		t.Fatalf("Generate failed: %v", err)
 	}
 

--- a/codegen/testing.go
+++ b/codegen/testing.go
@@ -65,12 +65,10 @@ func sectionCodeWithPrefix(t *testing.T, section *SectionTemplate, prefix string
 // content of a valid Go source file (i.e. start with "package")
 func FormatTestCode(t *testing.T, code string) string {
 	t.Helper()
-	tmp := CreateTempFile(t, code)
-	defer func() { _ = os.Remove(tmp) }()
-	require.NoError(t, finalizeGoSource(tmp))
-	content, err := os.ReadFile(tmp)
+	// Process the code in memory without creating a temp file
+	formatted, err := finalizeGoSource("test.go", []byte(code))
 	require.NoError(t, err)
-	return strings.Join(strings.Split(string(content), "\n")[2:], "\n")
+	return strings.Join(strings.Split(string(formatted), "\n")[2:], "\n")
 }
 
 // CreateTempFile creates a temporary file and writes the given content.

--- a/expr/random.go
+++ b/expr/random.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"net"
 	"strings"
+	"sync"
 
 	"github.com/manveru/faker"
 )
@@ -69,10 +70,13 @@ func NewRandom(seed string) *ExampleGenerator {
 type ExampleGenerator struct {
 	Randomizer
 	seen map[string]*any
+	mu   sync.RWMutex
 }
 
 // PreviouslySeen returns the previously seen value for a given ID
 func (r *ExampleGenerator) PreviouslySeen(typeID string) (*any, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	if r.seen == nil {
 		return nil, false
 	}
@@ -82,6 +86,8 @@ func (r *ExampleGenerator) PreviouslySeen(typeID string) (*any, bool) {
 
 // HaveSeen stores the seen value in the randomizer, for reuse later
 func (r *ExampleGenerator) HaveSeen(typeID string, val *any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.seen == nil {
 		r.seen = make(map[string]*any)
 	}


### PR DESCRIPTION
tl;dr: make codegen much faster through parallel writing of files, and writing each file's contents once.

We have a very large API design, with over 100 services, which generates almost 3k files with goa generate. As our API has grown, running goa gen has got really slow.

There's three changes in this PR:

Emit [TIMING] logs when --debug is passed - this makes finding bottlenecks much easier
Use a worker pool to write files: parallelising this makes it significantly faster (~3x)
Only write files once they are finalized - i.e. tidying up imports with an in-memory copy of the file, before persisting it at the end.
This cut the time on that stage for us from ~52s to ~10s 🎉

Thank you @isaacseymour !