### PR TITLE
grpc: fix validation helper naming to match call sites

### DIFF
--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -761,9 +761,9 @@ func addValidation(att *expr.AttributeExpr, attName string, sd *ServiceData, req
 	if def := codegen.ValidationCode(att, ut, vtx, true, expr.IsAlias(att.Type), false, attName); def != "" {
 		v := &ValidationData{
 			// Validation function names must match the identifiers used by
-			// validation templates (which Goify the type name). Use Goify here
-			// as well so helpers like ValidateMessage line up with calls.
-			Name:    "Validate" + codegen.Goify(name, true),
+			// validation templates. The template uses the scoped type name
+			// directly (no Goify) to preserve proto-reserved names like Message_.
+			Name:    "Validate" + name,
 			Def:     def,
 			ArgName: attName,
 			SrcName: name,
@@ -822,8 +822,9 @@ func collectValidationsR(att *expr.AttributeExpr, attName string, req bool, sd *
 		if def != "" {
 			sd.validations = append(sd.validations, &ValidationData{
 				// Match helper function identifiers with validation template
-				// calls (Validate{{ Goify(name) }}).
-				Name:    "Validate" + codegen.Goify(name, true),
+				// calls. The template uses the scoped type name directly (no
+				// Goify) to preserve proto-reserved names like Message_.
+				Name:    "Validate" + name,
 				Def:     def,
 				ArgName: gattName,
 				SrcName: name,


### PR DESCRIPTION
## Problem

PR #3844 introduced a regression where validation function names for proto messages with trailing underscores (e.g., `Message_`) were incorrectly generated.

The function definition used `Goify(name)` which strips underscores:
```go
Name: "Validate" + codegen.Goify(name, true)  // → ValidateMessage
```

But the call site template (`codegen/templates/validation/user.go.tpl`) uses the raw name:
```go
if err2 := Validate{{ .name }}({{ .target }}); err2 != nil {  // → ValidateMessage_
```

This caused `undefined: ValidateMessage` build errors in downstream gRPC services.

## Fix

Remove `Goify` from the function name generation in `grpc/codegen/service_data.go` to match the template behavior. Both now use the raw scoped type name, preserving proto-reserved identifiers like `Message_`.

## Verification

- `go test ./grpc/codegen/...` passes
- Regenerating a downstream service with proto messages using reserved names (e.g., `Message_`) now produces matching function names
- Lint passes in downstream projects