### PR TITLE
grpc/codegen: allow overriding proto json_name

### DIFF
--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -130,6 +130,15 @@ const DefaultProtoc = expr.DefaultProtoc
 //	    })
 //	})
 //
+// - "proto:tag:json" sets the JSON name emitted in the generated protobuf
+//   field option. Applicable to attributes only.
+//
+//	var MyType = Type("MyType", func() {
+//	    Field(1, "id", String, func() {
+//	        Meta("proto:tag:json", "identifier")
+//	    })
+//	})
+//
 // - "protoc:cmd" provides an alternate command to execute for protoc with
 // optional arguments. Applicable to API and service definitions only. If used
 // on an API definition the include paths are used for all services, unless

--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -294,7 +294,8 @@ func protoBufMessageDef(att *expr.AttributeExpr, sd *ServiceData) string {
 			if d := nat.Attribute.Description; d != "" {
 				desc = codegen.Comment(d) + "\n\t"
 			}
-			def += fmt.Sprintf("\n\t\t%s%s %s = %d;", desc, typ, fn, fnum)
+			opt := protoJSONOption(nat.Attribute)
+			def += fmt.Sprintf("\n\t\t%s%s %s = %d%s;", desc, typ, fn, fnum, opt)
 		}
 		def += "\n\t}"
 		return def
@@ -336,13 +337,24 @@ func protoBufMessageDef(att *expr.AttributeExpr, sd *ServiceData) string {
 					desc = codegen.Comment(nat.Attribute.Description) + "\n\t"
 				}
 			}
-			ss = append(ss, fmt.Sprintf("\t%s%s%s %s = %d;", desc, opt, typ, fn, fnum))
+			optJSON := protoJSONOption(nat.Attribute)
+			ss = append(ss, fmt.Sprintf("\t%s%s%s %s = %d%s;", desc, opt, typ, fn, fnum, optJSON))
 		}
 		ss = append(ss, "}")
 		return strings.Join(ss, "\n")
 	default:
 		panic(fmt.Sprintf("unknown data type %T", actual)) // bug
 	}
+}
+
+func protoJSONOption(att *expr.AttributeExpr) string {
+	if att == nil || att.Meta == nil {
+		return ""
+	}
+	if names := att.Meta["proto:tag:json"]; len(names) > 0 && names[0] != "" {
+		return fmt.Sprintf(" [json_name = %q]", names[0])
+	}
+	return ""
 }
 
 // protoBufGoFullTypeRef returns the Go code qualified with package name that

--- a/grpc/codegen/protobuf_test.go
+++ b/grpc/codegen/protobuf_test.go
@@ -1,8 +1,10 @@
 package codegen
 
 import (
+	"strings"
 	"testing"
 
+	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/expr"
 )
 
@@ -176,5 +178,52 @@ func TestHasAnyType(t *testing.T) {
 				t.Errorf("got %t, expected %t", got, c.Expected)
 			}
 		})
+	}
+}
+
+func TestProtoBufMessageDefJSONNameOption(t *testing.T) {
+	attr := &expr.AttributeExpr{
+		Type: &expr.Object{
+			&expr.NamedAttributeExpr{
+				Name: "value",
+				Attribute: &expr.AttributeExpr{
+					Type: expr.String,
+					Meta: expr.MetaExpr{
+						"rpc:tag":        []string{"1"},
+						"proto:tag:json": []string{"customValue"},
+					},
+				},
+			},
+		},
+	}
+	sd := &ServiceData{Scope: codegen.NewNameScope()}
+	def := protoBufMessageDef(attr, sd)
+	if !strings.Contains(def, `json_name = "customValue"`) {
+		t.Fatalf("expected json_name option, got %q", def)
+	}
+}
+
+func TestProtoBufMessageDefJSONNameOptionOneOf(t *testing.T) {
+	attr := &expr.AttributeExpr{
+		Type: &expr.Union{
+			TypeName: "Animal",
+			Values: []*expr.NamedAttributeExpr{
+				{
+					Name: "Cat",
+					Attribute: &expr.AttributeExpr{
+						Type: expr.String,
+						Meta: expr.MetaExpr{
+							"rpc:tag":        []string{"1"},
+							"proto:tag:json": []string{"cat"},
+						},
+					},
+				},
+			},
+		},
+	}
+	sd := &ServiceData{Scope: codegen.NewNameScope()}
+	def := protoBufMessageDef(attr, sd)
+	if !strings.Contains(def, `json_name = "cat"`) {
+		t.Fatalf("expected json_name option in oneof, got %q", def)
 	}
 }


### PR DESCRIPTION
## Summary
- extend the DSL with `Meta("proto:tag:json", ...)` so designers can override the `json_name` emitted in generated protobuf definitions
- plumb the metadata through `grpc/codegen/protobuf.go`, emitting `[json_name = "..."]` on both regular fields and oneof members when present
- update the DSL documentation to mention the new metadata key and add unit tests that cover the option for structs and oneofs

## Motivation
Some downstream consumers rely on protobuf JSON descriptors whose field names must diverge from the default lower_snake_case. Prior to this change there was no way to control the descriptor in Goa-generated protos without patching the generated files. The new metadata brings parity with the existing struct-tag overrides and keeps designs self-contained.

## Example
DSL:
```go
var Item = Type("Item", func() {
    Field(1, "ID", String, func() {
        Meta("proto:tag:json", "identifier")
    })
})
```

Generated `.proto` fragment
```proto
message Item {
    string id = 1 [json_name = "identifier"];
}
```

Generated Go struct (`.pb.go`)
```go
type Item struct {
    Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"identifier,omitempty"`
}
```