### PR TITLE
fix: skip example generation for agent-only designs

### DIFF
--- a/codegen/example/example_client.go
+++ b/codegen/example/example_client.go
@@ -26,6 +26,11 @@ func CLIFiles(genpkg string, root *expr.RootExpr) []*codegen.File {
 func exampleCLIMain(_ string, root *expr.RootExpr, svr *expr.ServerExpr) *codegen.File {
 	svrdata := Servers.Get(svr, root)
 
+	// Skip CLI generation for servers with no transports (e.g., agent-only services)
+	if svrdata.DefaultTransport() == nil {
+		return nil
+	}
+
 	path := filepath.Join("cmd", svrdata.Dir+"-cli", "main.go")
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return nil // file already exists, skip it.

--- a/codegen/example/example_server.go
+++ b/codegen/example/example_server.go
@@ -96,6 +96,7 @@ func exampleSvrMain(genpkg string, root *expr.RootExpr, svr *expr.ServerExpr, se
 			Source: exampleTemplates.Read(serverLoggerT),
 			Data: map[string]any{
 				"APIPkg": apiPkg,
+				"Server": svrdata,
 			},
 		}, {
 			Name:   "server-main-services",

--- a/codegen/example/templates/server_logger.go.tpl
+++ b/codegen/example/templates/server_logger.go.tpl
@@ -10,4 +10,6 @@
 		ctx = log.Context(ctx, log.WithDebug())
 		log.Debugf(ctx, "debug logs enabled")
 	}
+{{- if .Server.Transports }}
 	log.Print(ctx, log.KV{K: "http-port", V: *httpPortF})
+{{- end }}


### PR DESCRIPTION
## Summary

This fixes two issues with `goa example` for services that only define agents (no HTTP/gRPC transports):

### Issue 1: CLI file generation crash
`exampleCLIMain()` crashed with nil pointer when `DefaultTransport()` is nil. Added nil check to skip CLI file generation for transport-less servers.

### Issue 2: Undefined `httpPortF` in logger
`server_logger.go.tpl` unconditionally referenced `httpPortF` even when no HTTP transport was defined, causing undefined variable errors. Added conditional to only log port when `Server.Transports` is non-empty.

## Context

These fixes are needed for goa-ai's agent-only designs to work with `goa example`. Agent-only services don't define HTTP/gRPC transports, so the example generator needs to handle this case gracefully.

## Changes

- `codegen/example/example_client.go`: Skip CLI generation when `DefaultTransport()` is nil
- `codegen/example/example_server.go`: Pass `Server` data to logger template
- `codegen/example/templates/server_logger.go.tpl`: Conditionally log port when transports exist