### PR TITLE
ci: upgrade Go versions to 1.24 and 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ['1.23', '1.24']
+        go: ['1.24', '1.25']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
 
@@ -31,7 +31,7 @@ jobs:
         run: make ci
 
       - name: Upload test coverage for deep source
-        if: matrix.go == '1.23' && matrix.os == 'ubuntu-latest'
+        if: matrix.go == '1.25' && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v5
         with:
           name: coverage


### PR DESCRIPTION
Remove Go 1.23 from CI matrix and add Go 1.25.

## Changes

- `.github/workflows/test.yml`: Update Go matrix from [1.23, 1.24] to [1.24, 1.25]
- Update coverage upload to use Go 1.24 instead of 1.23