### PR TITLE
http: preserve Content-Type parameters set in DSL (fixes #3843)

### DIFF
--- a/http/encoding.go
+++ b/http/encoding.go
@@ -150,7 +150,7 @@ func ResponseEncoder(ctx context.Context, w http.ResponseWriter) Encoder {
 					enc = json.NewEncoder(w)
 				}
 			}
-			SetContentType(w, mt)
+			SetContentType(w, ct)
 			return enc
 		}
 		// If Accept header exists in the request, infer the response encoder

--- a/http/encoding_test.go
+++ b/http/encoding_test.go
@@ -182,6 +182,17 @@ func TestResponseEncoder(t *testing.T) {
 	}
 }
 
+func TestResponseEncoder_ContentTypeHeaderPreservesCharset(t *testing.T) {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ContentTypeKey, "application/json; charset=utf-8")
+	w := httptest.NewRecorder()
+
+	encoder := ResponseEncoder(ctx, w)
+
+	require.Equal(t, "*json.Encoder", fmt.Sprintf("%T", encoder))
+	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+}
+
 func TestResponseEncoder_Encode_ErrorResponse(t *testing.T) {
 	var (
 		serviceError              = goa.NewServiceError(errors.New("foo"), "foo", false, false, false)


### PR DESCRIPTION
Fixes #3843.

When `ContentType(...)` is explicitly set in the DSL, `ResponseEncoder` parsed it to infer the encoder, but then overwrote the response header with the parsed media type, dropping parameters like `charset`.

This change keeps using the parsed media type for encoder selection, but sets the header using the original DSL value, preserving parameters.

Added a unit test asserting the `charset` parameter is preserved.