### PR TITLE
eval: fix error location for module cache paths

### DIFF
--- a/eval/error.go
+++ b/eval/error.go
@@ -46,29 +46,49 @@ func (e *Error) Error() string {
 	return ""
 }
 
+// normalizeFileForPackageMatch strips @version segments from module cache paths
+// so that package matching works regardless of where the module is cached.
+// For example: ".../goa/v3@v3.23.2/dsl/..." becomes ".../goa/v3/dsl/...".
+func normalizeFileForPackageMatch(file string) string {
+	file = filepath.ToSlash(file)
+	parts := strings.Split(file, "/")
+	for i, p := range parts {
+		if at := strings.IndexByte(p, '@'); at >= 0 {
+			parts[i] = p[:at]
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
 // computeErrorLocation implements a heuristic to find the location in the user
 // code where the error occurred. It walks back the callstack until the file
 // doesn't match "/goa/design/*.go" or one of the DSL package paths.
 // When successful it returns the file name and line number, empty string and
 // 0 otherwise.
 func computeErrorLocation() (file string, line int) {
-	skipFunc := func(file string) bool {
+	skipFunc := func(pc uintptr, file string) bool {
 		if strings.HasSuffix(file, "_test.go") { // Be nice with tests
 			return false
 		}
 		file = filepath.ToSlash(file)
+		fn := runtime.FuncForPC(pc)
+		var name string
+		if fn != nil {
+			name = fn.Name()
+		}
+		normalized := normalizeFileForPackageMatch(file)
 		for _, pkg := range Context.dslPackages {
-			if strings.Contains(file, pkg) {
+			if strings.Contains(file, pkg) || strings.Contains(normalized, pkg) || strings.Contains(name, pkg) {
 				return true
 			}
 		}
 		return false
 	}
 	depth := 3
-	_, file, line, _ = runtime.Caller(depth)
-	for skipFunc(file) {
+	pc, file, line, _ := runtime.Caller(depth)
+	for skipFunc(pc, file) {
 		depth++
-		_, file, line, _ = runtime.Caller(depth)
+		pc, file, line, _ = runtime.Caller(depth)
 	}
 	wd, err := os.Getwd()
 	if err != nil {

--- a/eval/error_internal_test.go
+++ b/eval/error_internal_test.go
@@ -1,0 +1,33 @@
+package eval
+
+import "testing"
+
+func TestNormalizeFileForPackageMatch(t *testing.T) {
+	cases := map[string]struct {
+		in   string
+		want string
+	}{
+		"no version": {
+			in:   "/home/me/src/goa/eval/error.go",
+			want: "/home/me/src/goa/eval/error.go",
+		},
+		"module cache version": {
+			in:   "/home/me/go/pkg/mod/goa.design/goa/v3@v3.23.2/dsl/result_type.go",
+			want: "/home/me/go/pkg/mod/goa.design/goa/v3/dsl/result_type.go",
+		},
+		"multiple @ segments": {
+			in:   "/home/me/go/pkg/mod/example.com/foo@v1.2.3/bar@v0.1.0/baz.go",
+			want: "/home/me/go/pkg/mod/example.com/foo/bar/baz.go",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := normalizeFileForPackageMatch(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+

--- a/eval/incompatible_dsl_context_test.go
+++ b/eval/incompatible_dsl_context_test.go
@@ -1,0 +1,29 @@
+package eval_test
+
+import (
+	"strings"
+	"testing"
+
+	. "goa.design/goa/v3/dsl"
+	"goa.design/goa/v3/expr"
+)
+
+func TestIncompatibleDSLIncludesTypeContext(t *testing.T) {
+	dsl := func() {
+		Type("SomeType", func() {
+			Attribute("attr")
+			View("default", func() {
+				Attribute("attr")
+			})
+		})
+	}
+
+	err := expr.RunInvalidDSL(t, dsl)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "in type \"SomeType\"") {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+}
+

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -223,7 +223,12 @@ func walkAttribute(att *AttributeExpr, it func(name string, a *AttributeExpr) er
 }
 
 // EvalName returns the name used by the DSL evaluation.
-func (*AttributeExpr) EvalName() string {
+func (a *AttributeExpr) EvalName() string {
+	if a != nil {
+		if n, ok := a.Meta["openapi:typename"]; ok && len(n) > 0 {
+			return fmt.Sprintf("type %#v", n[0])
+		}
+	}
 	return "attribute"
 }
 


### PR DESCRIPTION
When Goa is consumed from the Go module cache, file paths contain `@version` segments (e.g., `goa/v3@v3.23.2/dsl/...`). The error location heuristic was failing to recognize these as DSL frames, causing errors to point at internal DSL files rather than the user's design.

## Changes

- Added `normalizeFileForPackageMatch()` to strip `@version` segments from paths
- Also check function names (which are stable regardless of path) as a fallback
- Made `AttributeExpr.EvalName()` report `type "X"` when the attribute belongs to a top-level `Type()` definition (via `openapi:typename` meta)

## Before

```
[.../go/pkg/mod/goa.design/goa/v3@v3.23.2/dsl/result_type.go:215] invalid use of View in attribute
```

## After

```
[design.go:5] invalid use of View in type "SomeType"
```

Fixes #3855