### PR TITLE
grpc/codegen: use google.protobuf.Value instead of Any for Goa's Any …

### DIFF
--- a/dsl/types.go
+++ b/dsl/types.go
@@ -37,9 +37,9 @@ const (
 	Bytes = expr.Bytes
 
 	// Any is the type for an arbitrary JSON value (any in Go).
-	// In gRPC, Any is mapped to google.protobuf.Any using JSON encoding/decoding.
-	// The value is JSON-marshaled when converting from Go to protobuf, and
-	// JSON-unmarshaled when converting from protobuf to Go.
+	// In gRPC, Any is mapped to google.protobuf.Value which natively supports
+	// dynamic JSON-like values. Conversion uses structpb.NewValue() for Go to
+	// protobuf and AsInterface() for protobuf to Go.
 	Any = expr.Any
 )
 

--- a/grpc/codegen/client_cli.go
+++ b/grpc/codegen/client_cli.go
@@ -61,7 +61,7 @@ func endpointParser(genpkg string, services *ServicesData, svr *expr.ServerExpr,
 		codegen.GoaNamedImport("grpc", "goagrpc"),
 		{Path: "google.golang.org/grpc", Name: "grpc"},
 	}
-	// Add anypb and structpb imports if Any type is used
+	// Add structpb import if Any type is used
 	needsAnyPb := false
 	for _, svc := range services.Root.API.GRPC.Services {
 		for _, e := range svc.GRPCEndpoints {
@@ -76,8 +76,6 @@ func endpointParser(genpkg string, services *ServicesData, svr *expr.ServerExpr,
 	}
 	if needsAnyPb {
 		specs = append(specs,
-			&codegen.ImportSpec{Path: "encoding/json"},
-			&codegen.ImportSpec{Path: "google.golang.org/protobuf/types/known/anypb", Name: "anypb"},
 			&codegen.ImportSpec{Path: "google.golang.org/protobuf/types/known/structpb", Name: "structpb"},
 		)
 	}
@@ -137,7 +135,7 @@ func payloadBuilders(genpkg string, svc *expr.GRPCServiceExpr, data *cli.Command
 		{Path: path.Join(genpkg, svcName), Name: sd.Service.PkgName},
 		{Path: path.Join(genpkg, "grpc", svcName, pbPkgName), Name: sd.PkgName},
 	}
-	// Add anypb and structpb imports if Any type is used
+	// Add structpb import if Any type is used
 	needsAnyPb := false
 	for _, e := range svc.GRPCEndpoints {
 		if hasAnyType(e.MethodExpr.Payload) || hasAnyType(e.MethodExpr.Result) {
@@ -147,7 +145,6 @@ func payloadBuilders(genpkg string, svc *expr.GRPCServiceExpr, data *cli.Command
 	}
 	if needsAnyPb {
 		specs = append(specs,
-			&codegen.ImportSpec{Path: "google.golang.org/protobuf/types/known/anypb", Name: "anypb"},
 			&codegen.ImportSpec{Path: "google.golang.org/protobuf/types/known/structpb", Name: "structpb"},
 		)
 	}

--- a/grpc/codegen/client_types.go
+++ b/grpc/codegen/client_types.go
@@ -93,8 +93,7 @@ func clientType(genpkg string, svc *expr.GRPCServiceExpr, services *ServicesData
 			}
 		}
 		if needsAnyTypeImports {
-			imports = append(imports, &codegen.ImportSpec{Path: "google.golang.org/protobuf/types/known/anypb", Name: "anypb"})
-			imports = append(imports, &codegen.ImportSpec{Path: "encoding/json"})
+			imports = append(imports, &codegen.ImportSpec{Path: "fmt"})
 			imports = append(imports, &codegen.ImportSpec{Path: "google.golang.org/protobuf/types/known/structpb", Name: "structpb"})
 		}
 		imports = append(imports, sd.Service.ProtoImports...)

--- a/grpc/codegen/protobuf.go
+++ b/grpc/codegen/protobuf.go
@@ -453,7 +453,7 @@ func protoNativeType(t expr.DataType) string {
 	case expr.BytesKind:
 		return "bytes"
 	case expr.AnyKind:
-		return "google.protobuf.Any"
+		return "google.protobuf.Value"
 	default:
 		panic(fmt.Sprintf("cannot compute native protocol buffer type for %T", t)) // bug
 	}
@@ -487,7 +487,7 @@ func protoBufNativeGoTypeName(t expr.DataType) string {
 	case expr.BytesKind:
 		return "[]byte"
 	case expr.AnyKind:
-		return "*anypb.Any"
+		return "*structpb.Value"
 	default:
 		panic(fmt.Sprintf("cannot compute native protocol buffer type for %T %v", t, t)) // bug
 	}

--- a/grpc/codegen/protobuf_test.go
+++ b/grpc/codegen/protobuf_test.go
@@ -82,7 +82,7 @@ func TestProtoNativeType(t *testing.T) {
 	}, {
 		"Bytes", expr.Bytes, "bytes",
 	}, {
-		"Any", expr.Any, "google.protobuf.Any",
+		"Any", expr.Any, "google.protobuf.Value",
 	}}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestProtoBufNativeGoTypeName(t *testing.T) {
 	}, {
 		"Bytes", expr.Bytes, "[]byte",
 	}, {
-		"Any", expr.Any, "*anypb.Any",
+		"Any", expr.Any, "*structpb.Value",
 	}}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/grpc/codegen/protobuf_transform.go
+++ b/grpc/codegen/protobuf_transform.go
@@ -679,32 +679,22 @@ func convertType(src, tgt *expr.AttributeExpr, srcPtr bool, tgtPtr bool, srcVar 
 	return convertPrimitiveFromProto(src, tgt, srcPtr, tgtPtr, srcVar, ta)
 }
 
-const convertGoAnyToProtobufAnyFunc = `func() *anypb.Any {
+const convertGoAnyToProtobufValueFunc = `func() *structpb.Value {
+	// Convert Go any to protobuf Value directly
 	if %s == nil {
-		return nil
+		return structpb.NewNullValue()
 	}
-	// Convert Go any to protobuf Any using JSON marshaling
-	if jsonData, err := json.Marshal(%s); err == nil {
-		if data, err := anypb.New(&structpb.Value{
-			Kind: &structpb.Value_StringValue{StringValue: string(jsonData)},
-		}); err == nil {
-			return data
-		}
+	value, err := structpb.NewValue(%s)
+	if err != nil {
+		panic(fmt.Sprintf("failed to convert value to structpb.Value: %%v", err))
 	}
-	return nil
+	return value
 }()`
 
-const convertProtobufAnyToGoAnyFunc = `func() any {
+const convertProtobufValueToGoAnyFunc = `func() any {
+	// Convert protobuf Value to Go any directly
 	if %s != nil {
-		var value structpb.Value
-		if err := %s.UnmarshalTo(&value); err == nil {
-			if str := value.GetStringValue(); str != "" {
-				var result any
-				if err := json.Unmarshal([]byte(str), &result); err == nil {
-					return result
-				}
-			}
-		}
+		return %s.AsInterface()
 	}
 	return nil
 }()`
@@ -714,13 +704,13 @@ const convertProtobufAnyToGoAnyFunc = `func() any {
 // NOTE: For Int and UInt kinds, protocol buffer Go compiler generates
 // int32 and uint32 respectively whereas Goa generates int and uint.
 func convertPrimitiveToProto(_, tgt *expr.AttributeExpr, srcPtr, _ bool, srcVar string, _ *transformAttrs) string {
-	// Special handling for Any type conversion to google.protobuf.Any
+	// Special handling for Any type conversion to google.protobuf.Value
 	if tgt.Type.Kind() == expr.AnyKind {
 		if srcPtr {
 			srcVar = "*" + srcVar
 		}
 
-		return fmt.Sprintf(convertGoAnyToProtobufAnyFunc, srcVar, srcVar)
+		return fmt.Sprintf(convertGoAnyToProtobufValueFunc, srcVar, srcVar)
 	}
 
 	tgtType := protoBufNativeGoTypeName(tgt.Type)
@@ -731,13 +721,13 @@ func convertPrimitiveToProto(_, tgt *expr.AttributeExpr, srcPtr, _ bool, srcVar 
 }
 
 func convertPrimitiveFromProto(_, tgt *expr.AttributeExpr, srcPtr, _ bool, srcVar string, ta *transformAttrs) string {
-	// Special handling for Any type conversion from google.protobuf.Any
+	// Special handling for Any type conversion from google.protobuf.Value
 	if tgt.Type.Kind() == expr.AnyKind {
 		if srcPtr {
 			srcVar = "*" + srcVar
 		}
 
-		return fmt.Sprintf(convertProtobufAnyToGoAnyFunc, srcVar, srcVar)
+		return fmt.Sprintf(convertProtobufValueToGoAnyFunc, srcVar, srcVar)
 	}
 
 	tgtType, _ := codegen.GetMetaType(tgt)

--- a/grpc/codegen/protobuf_transform_test.go
+++ b/grpc/codegen/protobuf_transform_test.go
@@ -220,7 +220,7 @@ func TestProtoBufTransformAnyType(t *testing.T) {
 
 			// Check if transformation contains Any type conversion logic
 			if c.ToProto {
-				require.Contains(t, code, "func() *anypb.Any", "To proto conversion should generate Any type conversion function")
+				require.Contains(t, code, "func() *structpb.Value", "To proto conversion should generate Value type conversion function")
 			} else {
 				require.Contains(t, code, "func() any", "From proto conversion should generate any type conversion function")
 			}

--- a/grpc/codegen/server_types.go
+++ b/grpc/codegen/server_types.go
@@ -88,8 +88,7 @@ func serverType(genpkg string, svc *expr.GRPCServiceExpr, services *ServicesData
 			}
 		}
 		if needsAnyTypeImports {
-			imports = append(imports, &codegen.ImportSpec{Path: "google.golang.org/protobuf/types/known/anypb", Name: "anypb"})
-			imports = append(imports, &codegen.ImportSpec{Path: "encoding/json"})
+			imports = append(imports, &codegen.ImportSpec{Path: "fmt"})
 			imports = append(imports, &codegen.ImportSpec{Path: "google.golang.org/protobuf/types/known/structpb", Name: "structpb"})
 		}
 		imports = append(imports, sd.Service.ProtoImports...)

--- a/grpc/codegen/service_data.go
+++ b/grpc/codegen/service_data.go
@@ -662,17 +662,17 @@ func collectMessages(at *expr.AttributeExpr, sd *ServiceData, seen map[string]st
 		}
 	}
 	if expr.IsPrimitive(at.Type) {
-		// Add google.protobuf.Any import when Any type is used
+		// Add google.protobuf.Value import when Any type is used
 		if at.Type.Kind() == expr.AnyKind {
 			found := false
 			for _, imp := range imports {
-				if imp == "google/protobuf/any.proto" {
+				if imp == "google/protobuf/struct.proto" {
 					found = true
 					break
 				}
 			}
 			if !found {
-				imports = append(imports, "google/protobuf/any.proto")
+				imports = append(imports, "google/protobuf/struct.proto")
 			}
 		}
 		return data, imports

--- a/grpc/codegen/testdata/golden/protobuf_type_encode_to-protobuf-type_optional-to-optional.go.golden
+++ b/grpc/codegen/testdata/golden/protobuf_type_encode_to-protobuf-type_optional-to-optional.go.golden
@@ -3,19 +3,16 @@ func transform() {
 		Float_:  source.Float,
 		String_: source.String,
 		Bytes_:  source.Bytes,
-		Any: func() *anypb.Any {
+		Any: func() *structpb.Value {
+			// Convert Go any to protobuf Value directly
 			if source.Any == nil {
-				return nil
+				return structpb.NewNullValue()
 			}
-			// Convert Go any to protobuf Any using JSON marshaling
-			if jsonData, err := json.Marshal(source.Any); err == nil {
-				if data, err := anypb.New(&structpb.Value{
-					Kind: &structpb.Value_StringValue{StringValue: string(jsonData)},
-				}); err == nil {
-					return data
-				}
+			value, err := structpb.NewValue(source.Any)
+			if err != nil {
+				panic(fmt.Sprintf("failed to convert value to structpb.Value: %v", err))
 			}
-			return nil
+			return value
 		}(),
 	}
 	if source.Int != nil {

--- a/grpc/codegen/testdata/golden/protobuf_type_encode_to-service-type_optional-to-optional.go.golden
+++ b/grpc/codegen/testdata/golden/protobuf_type_encode_to-service-type_optional-to-optional.go.golden
@@ -4,16 +4,9 @@ func transform() {
 		String: source.String_,
 		Bytes:  source.Bytes_,
 		Any: func() any {
+			// Convert protobuf Value to Go any directly
 			if source.Any != nil {
-				var value structpb.Value
-				if err := source.Any.UnmarshalTo(&value); err == nil {
-					if str := value.GetStringValue(); str != "" {
-						var result any
-						if err := json.Unmarshal([]byte(str), &result); err == nil {
-							return result
-						}
-					}
-				}
+				return source.Any.AsInterface()
 			}
 			return nil
 		}(),

--- a/grpc/docs/FAQ.md
+++ b/grpc/docs/FAQ.md
@@ -52,12 +52,12 @@ type ArrayOfBool struct {
 
 # How does goa handle the Any type in gRPC?
 
-Goa supports the `Any` type in gRPC by mapping it to `google.protobuf.Any`. The conversion between Go's `any` type and protobuf's `Any` is done using JSON marshaling/unmarshaling.
+Goa supports the `Any` type in gRPC by mapping it to `google.protobuf.Value`, which is specifically designed to represent dynamic JSON-like values. This is simpler and more efficient than using `google.protobuf.Any`.
 
 ## Conversion Process
 
-- **Go to Protobuf**: When converting from Go `any` to `*anypb.Any`, the value is JSON-marshaled and wrapped in a `structpb.Value`.
-- **Protobuf to Go**: When converting from `*anypb.Any` to Go `any`, the value is unwrapped and JSON-unmarshaled.
+- **Go to Protobuf**: When converting from Go `any` to `*structpb.Value`, Goa uses `structpb.NewValue()` which directly converts Go types to protobuf Value.
+- **Protobuf to Go**: When converting from `*structpb.Value` to Go `any`, Goa uses the `AsInterface()` method which returns the corresponding Go value.
 
 ## Example Usage
 
@@ -78,14 +78,14 @@ Method("echo", func() {
 
 This generates the following protobuf:
 ```proto
-import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
 
 message EchoRequest {
-    optional google.protobuf.Any data = 1;
+    optional google.protobuf.Value data = 1;
 }
 
 message EchoResponse {
-    optional google.protobuf.Any data = 1;
+    optional google.protobuf.Value data = 1;
 }
 ```
 
@@ -96,8 +96,18 @@ message EchoResponse {
 - Arrays of Any: `ArrayOf(Any)`
 - Nested structures containing Any
 
+## Supported Value Types
+
+The `google.protobuf.Value` type natively supports:
+- Null values
+- Numbers (integer and floating point)
+- Strings
+- Booleans
+- Structs (maps)
+- Lists (arrays)
+
 ## Limitations
 
-- The JSON conversion means that complex Go types may not roundtrip perfectly
-- Only JSON-serializable values are supported
-- Type information is lost during conversion
+- Complex Go types (channels, functions, custom structs) need to be JSON-serializable
+- Type information is abstracted to basic JSON types
+- Precision may be lost for very large integers (uses float64 internally)


### PR DESCRIPTION
## Summary

Changes the gRPC transport mapping for Goa's `Any` type from `google.protobuf.Any` (with JSON marshaling) to `google.protobuf.Value` (direct conversion via `structpb.NewValue()`).

## Motivation

The previous implementation was semantically incorrect and inefficient:
- `google.protobuf.Any` is designed for wrapping typed messages with type URLs
- Required JSON marshaling/unmarshaling for dynamic values
- `google.protobuf.Value` is purpose-built for JSON-like dynamic values (null, number, string, bool, struct, list)

## Changes

**Code Generation:**
- protobuf.go: Map `Any` to `google.protobuf.Value` / `*structpb.Value`
- protobuf_transform.go: Use `structpb.NewValue()` for Go→Proto, `AsInterface()` for Proto→Go
- service_data.go: Import `google/protobuf/struct.proto`
- client_types.go, server_types.go: Auto-add `fmt` and `structpb` imports

**Behavior:**
- Go `nil` → `structpb.NewNullValue()` (protobuf null)
- Conversion errors trigger panic (indicates unsupported type bug)

**Documentation:**
- types.go: Updated `Any` type comment
- FAQ.md: Rewritten Any type section

## Benefits

- **Semantic correctness**: Using the right protobuf type for dynamic values
- **Better performance**: No JSON marshaling overhead
- **Simpler code**: Direct conversion instead of wrapper logic
- **Clear error handling**: Panics on programming errors

## Testing

- Updated unit tests in `grpc/codegen/*_test.go`
- Updated golden files to match new generated code
- All tests pass: `make`, `make test`, `make integration-test`