### PR TITLE
feat: added oneof:type:field and oneof:value:field support to OneOf union

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -430,6 +430,10 @@ type (
 		// Loc defines the file and Go package of the union type if overridden via
 		// Meta. When nil the type is generated in the default service file.
 		Loc *codegen.Location
+		// TypeKey is the discriminator field name for JSON marshaling (defaults to "type").
+		TypeKey string
+		// ValueKey is the value field name for JSON marshaling (defaults to "value").
+		ValueKey string
 	}
 
 	// UnionFieldData describes a single branch of a union.
@@ -1094,6 +1098,8 @@ func buildUnionTypeData(u *expr.Union, scope *codegen.NameScope, loc *codegen.Lo
 		KindName: kindName,
 		Fields:   fields,
 		Loc:      loc,
+		TypeKey:  u.GetTypeKey(),
+		ValueKey: u.GetValueKey(),
 	}
 }
 

--- a/codegen/service/templates/union_type.go.tpl
+++ b/codegen/service/templates/union_type.go.tpl
@@ -50,7 +50,7 @@ func (u *{{ $.Name }}) Set{{ .FieldName }}(v {{ .FieldType }}) {
 func (u {{ .Name }}) Validate() error {
 	switch u.kind {
 	case "":
-		return goa.InvalidEnumValueError("type", "", []any{
+		return goa.InvalidEnumValueError({{ printf "%q" .TypeKey }}, "", []any{
 			{{- range .Fields }}
 			string({{ .KindConst }}),
 			{{- end }}
@@ -60,7 +60,7 @@ func (u {{ .Name }}) Validate() error {
 		return nil
 	{{- end }}
 	default:
-		return goa.InvalidEnumValueError("type", u.kind, []any{
+		return goa.InvalidEnumValueError({{ printf "%q" $.TypeKey }}, u.kind, []any{
 			{{- range .Fields }}
 			string({{ .KindConst }}),
 			{{- end }}
@@ -85,8 +85,8 @@ func (u {{ .Name }}) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("unexpected {{ .Name }} discriminant %q", u.kind)
 	}
 	return json.Marshal(struct {
-		Type  string {{ printf "`json:\"type\"`" }}
-		Value any    {{ printf "`json:\"value\"`" }}
+		Type  string {{ printf "`json:\"%s\"`" .TypeKey }}
+		Value any    {{ printf "`json:\"%s\"`" .ValueKey }}
 	}{
 		Type:  string(u.kind),
 		Value: value,
@@ -96,8 +96,8 @@ func (u {{ .Name }}) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals the union from the canonical {type,value} JSON shape.
 func (u *{{ .Name }}) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Type  string          {{ printf "`json:\"type\"`" }}
-		Value json.RawMessage {{ printf "`json:\"value\"`" }}
+		Type  string          {{ printf "`json:\"%s\"`" .TypeKey }}
+		Value json.RawMessage {{ printf "`json:\"%s\"`" .ValueKey }}
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err

--- a/codegen/service/testdata/service_dsls.go
+++ b/codegen/service/testdata/service_dsls.go
@@ -1054,3 +1054,61 @@ var MixedAndMultipleAPIKeySecurityDSL = func() {
 		})
 	})
 }
+
+// UnionCustomKeysDSL tests union with custom type and value keys via Meta tags.
+var UnionCustomKeysDSL = func() {
+	var CustomUnion = Type("CustomUnion", func() {
+		OneOf("Values", func() {
+			Meta("oneof:type:field", "kind")
+			Meta("oneof:value:field", "data")
+			Attribute("Int", Int)
+			Attribute("String", String)
+		})
+	})
+	Service("CustomKeysService", func() {
+		Method("CustomUnion", func() {
+			Payload(CustomUnion)
+			Result(CustomUnion)
+		})
+	})
+}
+
+// UnionCustomKeysMultiTypeDSL tests union with custom keys and user-defined types.
+var UnionCustomKeysMultiTypeDSL = func() {
+	var TypeA = Type("TypeA", func() {
+		Attribute("a", Int)
+	})
+	var TypeB = Type("TypeB", func() {
+		Attribute("b", String)
+	})
+	var PaymentMethod = Type("PaymentMethod", func() {
+		OneOf("method", func() {
+			Meta("oneof:type:field", "paymentType")
+			Meta("oneof:value:field", "details")
+			Attribute("credit_card", TypeA)
+			Attribute("paypal", TypeB)
+		})
+	})
+	Service("PaymentService", func() {
+		Method("ProcessPayment", func() {
+			Payload(PaymentMethod)
+			Result(PaymentMethod)
+		})
+	})
+}
+
+// UnionDefaultKeysDSL tests that unions without custom Meta tags still use "type" and "value".
+var UnionDefaultKeysDSL = func() {
+	var DefaultUnion = Type("DefaultUnion", func() {
+		OneOf("Values", func() {
+			Attribute("Int", Int)
+			Attribute("String", String)
+		})
+	})
+	Service("DefaultKeysService", func() {
+		Method("DefaultUnion", func() {
+			Payload(DefaultUnion)
+			Result(DefaultUnion)
+		})
+	})
+}

--- a/codegen/testdata/union_dsls.go
+++ b/codegen/testdata/union_dsls.go
@@ -51,5 +51,30 @@ var TestUnionDSL = func() {
 			Attribute("Value", String)
 			Required("Type", "Value")
 		})
+
+		// Union with custom type and value keys
+		UnionCustomKeys = Type("UnionCustomKeys", func() {
+			OneOf("UnionCustomKeys", func() {
+				Meta("oneof:type:field", "kind")
+				Meta("oneof:value:field", "data")
+				Attribute("String", String)
+				Attribute("Int", Int)
+			})
+		})
+
+		// Union with different custom keys for testing
+		UnionPaymentMethod = Type("UnionPaymentMethod", func() {
+			OneOf("UnionPaymentMethod", func() {
+				Meta("oneof:type:field", "paymentType")
+				Meta("oneof:value:field", "details")
+				Attribute("CreditCard", SomeType)
+				Attribute("PayPal", String)
+			})
+		})
+
+		_ = Type("CustomKeysContainer", func() {
+			Attribute("UnionCustomKeys", UnionCustomKeys)
+			Attribute("UnionPaymentMethod", UnionPaymentMethod)
+		})
 	)
 }

--- a/dsl/oneof_test.go
+++ b/dsl/oneof_test.go
@@ -1,0 +1,128 @@
+package dsl_test
+
+import (
+	"testing"
+
+	. "goa.design/goa/v3/dsl"
+	"goa.design/goa/v3/eval"
+	"goa.design/goa/v3/expr"
+)
+
+func TestOneOfCustomKeys(t *testing.T) {
+	cases := []struct {
+		name           string
+		typeKey        string
+		valueKey       string
+		expectedType   string
+		expectedValue  string
+		expectError    bool
+		errorSubstring string
+	}{
+		{
+			name:          "custom type and value keys",
+			typeKey:       "kind",
+			valueKey:      "data",
+			expectedType:  "kind",
+			expectedValue: "data",
+		},
+		{
+			name:          "default keys when not specified",
+			typeKey:       "",
+			valueKey:      "",
+			expectedType:  "type",
+			expectedValue: "value",
+		},
+		{
+			name:          "custom type key only",
+			typeKey:       "discriminator",
+			valueKey:      "",
+			expectedType:  "discriminator",
+			expectedValue: "value",
+		},
+		{
+			name:          "custom value key only",
+			typeKey:       "",
+			valueKey:      "payload",
+			expectedType:  "type",
+			expectedValue: "payload",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eval.Context = &eval.DSLContext{}
+
+			ut := &expr.UserTypeExpr{
+				AttributeExpr: &expr.AttributeExpr{
+					Type: &expr.Object{},
+				},
+				TypeName: "TestType",
+			}
+
+			eval.Execute(func() {
+				OneOf("Shape", func() {
+					if tc.typeKey != "" {
+						Meta("oneof:type:field", tc.typeKey)
+					}
+					if tc.valueKey != "" {
+						Meta("oneof:value:field", tc.valueKey)
+					}
+					Attribute("Circle", Int)
+					Attribute("Square", String)
+				})
+			}, ut)
+
+			if tc.expectError {
+				if eval.Context.Errors == nil {
+					t.Fatal("expected DSL error, got none")
+				}
+				return
+			}
+
+			if eval.Context.Errors != nil {
+				t.Fatalf("unexpected DSL errors: %v", eval.Context.Errors)
+			}
+
+			obj := ut.Attribute().Type.(*expr.Object)
+			shapeAttr := obj.Attribute("Shape")
+			if shapeAttr == nil {
+				t.Fatal("Shape attribute not found")
+			}
+
+			union, ok := shapeAttr.Type.(*expr.Union)
+			if !ok {
+				t.Fatalf("expected Union type, got %T", shapeAttr.Type)
+			}
+
+			if union.GetTypeKey() != tc.expectedType {
+				t.Errorf("expected GetTypeKey() %q, got %q", tc.expectedType, union.GetTypeKey())
+			}
+			if union.GetValueKey() != tc.expectedValue {
+				t.Errorf("expected GetValueKey() %q, got %q", tc.expectedValue, union.GetValueKey())
+			}
+		})
+	}
+}
+
+func TestOneOfCustomKeysSameKeyError(t *testing.T) {
+	eval.Context = &eval.DSLContext{}
+
+	ut := &expr.UserTypeExpr{
+		AttributeExpr: &expr.AttributeExpr{
+			Type: &expr.Object{},
+		},
+		TypeName: "TestType",
+	}
+
+	eval.Execute(func() {
+		OneOf("Shape", func() {
+			Meta("oneof:type:field", "same")
+			Meta("oneof:value:field", "same")
+			Attribute("Circle", Int)
+		})
+	}, ut)
+
+	if eval.Context.Errors == nil {
+		t.Fatal("expected DSL error for same type and value keys, got none")
+	}
+}

--- a/expr/dup.go
+++ b/expr/dup.go
@@ -87,7 +87,12 @@ func (d *dupper) DupType(t DataType) DataType {
 			ElemType: d.DupAttribute(actual.ElemType),
 		}
 	case *Union:
-		dp := Union{TypeName: actual.TypeName, Values: make([]*NamedAttributeExpr, len(actual.Values))}
+		dp := Union{
+			TypeName: actual.TypeName,
+			Values:   make([]*NamedAttributeExpr, len(actual.Values)),
+			TypeKey:  actual.TypeKey,
+			ValueKey: actual.ValueKey,
+		}
 		for i, nat := range actual.Values {
 			dp.Values[i] = &NamedAttributeExpr{Name: nat.Name, Attribute: d.DupAttribute(nat.Attribute)}
 		}

--- a/expr/http_body_types.go
+++ b/expr/http_body_types.go
@@ -9,16 +9,21 @@ import (
 )
 
 // UnionToObject returns an object adequate to serialize the given union type in
-// HTTP requests and responses. The object has two fields: "Type" and "Value".
-// The "Type" field is a string that indicates the name of the union type. The
-// "Value" field is a string that contains the JSON encoded union value.
+// HTTP requests and responses. The object has two fields for the discriminator
+// and value, with names determined by the union's Meta tags (defaulting to
+// "Type" and "Value"). The discriminator field indicates the name of the union
+// type, and the value field contains the JSON encoded union value.
 func UnionToObject(att *AttributeExpr) *AttributeExpr {
 	example := att.Example(Root.API.ExampleGenerator)
 	js, err := json.Marshal(example)
 	if err != nil {
 		js = []byte("null")
 	}
-	values := AsUnion(att.Type).Values
+	union := AsUnion(att.Type)
+	values := union.Values
+	typeKey := union.GetTypeKey()
+	valueKey := union.GetValueKey()
+
 	names := make([]any, len(values))
 	vals := make([]string, len(values))
 	bases := make([]DataType, len(values))
@@ -28,32 +33,32 @@ func UnionToObject(att *AttributeExpr) *AttributeExpr {
 		bases[i] = nat.Attribute.Type
 	}
 	obj := Object([]*NamedAttributeExpr{
-		{Name: "Type", Attribute: &AttributeExpr{
+		{Name: typeKey, Attribute: &AttributeExpr{
 			Type:        String,
 			Description: "Union type name, one of:\n" + strings.Join(vals, "\n"),
 			Validation:  &ValidationExpr{Values: names},
 			Meta: MetaExpr{
-				"struct:tag:form": {"Type"},
-				"struct:tag:json": {"Type"},
-				"struct:tag:xml":  {"Type"},
+				"struct:tag:form": {typeKey},
+				"struct:tag:json": {typeKey},
+				"struct:tag:xml":  {typeKey},
 			},
 		}},
-		{Name: "Value", Attribute: &AttributeExpr{
+		{Name: valueKey, Attribute: &AttributeExpr{
 			Type:         String,
 			Description:  "JSON encoded union value",
 			UserExamples: []*ExampleExpr{{Value: string(js)}},
 			Bases:        bases, // For OpenAPI generation
 			Meta: MetaExpr{
-				"struct:tag:form": {"Value"},
-				"struct:tag:json": {"Value"},
-				"struct:tag:xml":  {"Value"},
+				"struct:tag:form": {valueKey},
+				"struct:tag:json": {valueKey},
+				"struct:tag:xml":  {valueKey},
 			},
 		}},
 	})
 	return &AttributeExpr{
 		Type:        &obj,
 		Description: att.Description,
-		Validation:  &ValidationExpr{Required: []string{"Type", "Value"}},
+		Validation:  &ValidationExpr{Required: []string{typeKey, valueKey}},
 	}
 }
 

--- a/expr/types.go
+++ b/expr/types.go
@@ -59,6 +59,10 @@ type (
 	Union struct {
 		TypeName string
 		Values   []*NamedAttributeExpr
+		// TypeKey is the discriminator field name for JSON marshaling (defaults to "type")
+		TypeKey string
+		// ValueKey is the value field name for JSON marshaling (defaults to "value")
+		ValueKey string
 	}
 
 	// UserType is the interface implemented by all user type
@@ -649,6 +653,24 @@ func (u *Union) Example(r *ExampleGenerator) any {
 		return nil
 	}
 	return u.Values[r.Int()%len(u.Values)].Attribute.Example(r)
+}
+
+// GetTypeKey returns the discriminator field name for JSON marshaling.
+// Defaults to "type" if not explicitly set via Meta("oneof:type:field").
+func (u *Union) GetTypeKey() string {
+	if u.TypeKey != "" {
+		return u.TypeKey
+	}
+	return "type"
+}
+
+// GetValueKey returns the value field name for JSON marshaling.
+// Defaults to "value" if not explicitly set via Meta("oneof:value:field").
+func (u *Union) GetValueKey() string {
+	if u.ValueKey != "" {
+		return u.ValueKey
+	}
+	return "value"
 }
 
 // QualifiedTypeName returns the qualified type name for the given data type.

--- a/expr/types_test.go
+++ b/expr/types_test.go
@@ -876,6 +876,106 @@ func TestMapIsCompatible(t *testing.T) {
 	}
 }
 
+func TestUnionGetTypeKey(t *testing.T) {
+	cases := map[string]struct {
+		typeKey  string
+		expected string
+	}{
+		"default": {
+			typeKey:  "",
+			expected: "type",
+		},
+		"custom": {
+			typeKey:  "kind",
+			expected: "kind",
+		},
+		"discriminator": {
+			typeKey:  "discriminator",
+			expected: "discriminator",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			union := &Union{
+				TypeName: "TestUnion",
+				TypeKey:  tc.typeKey,
+			}
+			if actual := union.GetTypeKey(); actual != tc.expected {
+				t.Errorf("got %q, expected %q", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestUnionGetValueKey(t *testing.T) {
+	cases := map[string]struct {
+		valueKey string
+		expected string
+	}{
+		"default": {
+			valueKey: "",
+			expected: "value",
+		},
+		"custom": {
+			valueKey: "data",
+			expected: "data",
+		},
+		"payload": {
+			valueKey: "payload",
+			expected: "payload",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			union := &Union{
+				TypeName: "TestUnion",
+				ValueKey: tc.valueKey,
+			}
+			if actual := union.GetValueKey(); actual != tc.expected {
+				t.Errorf("got %q, expected %q", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestUnionDupPreservesCustomKeys(t *testing.T) {
+	original := &Union{
+		TypeName: "TestUnion",
+		TypeKey:  "kind",
+		ValueKey: "data",
+		Values: []*NamedAttributeExpr{
+			{
+				Name: "String",
+				Attribute: &AttributeExpr{
+					Type: String,
+				},
+			},
+		},
+	}
+
+	duplicated := Dup(original)
+
+	dup, ok := duplicated.(*Union)
+	if !ok {
+		t.Fatalf("expected *Union, got %T", duplicated)
+	}
+
+	if dup.TypeKey != original.TypeKey {
+		t.Errorf("TypeKey: got %q, expected %q", dup.TypeKey, original.TypeKey)
+	}
+	if dup.ValueKey != original.ValueKey {
+		t.Errorf("ValueKey: got %q, expected %q", dup.ValueKey, original.ValueKey)
+	}
+	if dup.GetTypeKey() != original.GetTypeKey() {
+		t.Errorf("GetTypeKey(): got %q, expected %q", dup.GetTypeKey(), original.GetTypeKey())
+	}
+	if dup.GetValueKey() != original.GetValueKey() {
+		t.Errorf("GetValueKey(): got %q, expected %q", dup.GetValueKey(), original.GetValueKey())
+	}
+}
+
 func TestQualifiedTypeName(t *testing.T) {
 	var (
 		array = &Array{

--- a/http/codegen/openapi/json_schema.go
+++ b/http/codegen/openapi/json_schema.go
@@ -365,27 +365,30 @@ func TypeSchemaWithPrefix(api *expr.APIExpr, t expr.DataType, prefix string) *Sc
 			s.AdditionalProperties = true
 		}
 	case *expr.Union:
-		// Unions are represented as an object with a discriminated value:
-		// { "type": <branch>, "value": <branch schema> }.
+		// Unions are represented as an object with a discriminated value.
+		// The field names are configurable via Meta tags (defaults: "type" and "value").
+		typeKey := actual.GetTypeKey()
+		valueKey := actual.GetValueKey()
+
 		s.Type = Object
 		if s.Properties == nil {
 			s.Properties = make(map[string]*Schema)
 		}
-		// Discriminator "type" with enum of branch names.
+		// Discriminator with enum of branch names.
 		typeSchema := NewSchema()
 		typeSchema.Type = String
 		typeSchema.Enum = make([]any, len(actual.Values))
 		for i, val := range actual.Values {
 			typeSchema.Enum[i] = val.Name
 		}
-		// "value" can be any of the branch schemas.
+		// Value can be any of the branch schemas.
 		valueSchema := NewSchema()
 		for _, val := range actual.Values {
 			valueSchema.AnyOf = append(valueSchema.AnyOf, AttributeTypeSchemaWithPrefix(api, val.Attribute, prefix))
 		}
-		s.Properties["type"] = typeSchema
-		s.Properties["value"] = valueSchema
-		s.Required = append(s.Required, "type", "value")
+		s.Properties[typeKey] = typeSchema
+		s.Properties[valueKey] = valueSchema
+		s.Required = append(s.Required, typeKey, valueKey)
 	case *expr.UserTypeExpr:
 		s.Ref = TypeRefWithPrefix(api, actual, prefix)
 	case *expr.ResultTypeExpr:

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -211,8 +211,11 @@ func (sf *schemafier) schemafy(attr *expr.AttributeExpr, noref ...bool) *openapi
 			s.AdditionalProperties = sf.schemafy(t.ElemType)
 		}
 	case *expr.Union:
-		// Represent unions as an object {type, value} where "type" is a discriminator
-		// and "value" holds one of the branch schemas.
+		// Represent unions as an object with discriminator and value fields.
+		// The field names are configurable via Meta tags (defaults: "type" and "value").
+		typeKey := t.GetTypeKey()
+		valueKey := t.GetValueKey()
+
 		s.Type = openapi.Object
 		if s.Properties == nil {
 			s.Properties = make(map[string]*openapi.Schema)
@@ -226,9 +229,9 @@ func (sf *schemafier) schemafy(attr *expr.AttributeExpr, noref ...bool) *openapi
 		for _, val := range t.Values {
 			valueSchema.AnyOf = append(valueSchema.AnyOf, sf.schemafy(val.Attribute))
 		}
-		s.Properties["type"] = typeSchema
-		s.Properties["value"] = valueSchema
-		s.Required = append(s.Required, "type", "value")
+		s.Properties[typeKey] = typeSchema
+		s.Properties[valueKey] = valueSchema
+		s.Required = append(s.Required, typeKey, valueKey)
 	case expr.UserType:
 		if expr.IsAlias(t) {
 			return sf.schemafy(t.Attribute())

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -2732,6 +2732,8 @@ func buildHTTPUnionTypeData(u *expr.Union, scope *codegen.NameScope) *service.Un
 		Name:     name,
 		KindName: kindName,
 		Fields:   fields,
+		TypeKey:  u.GetTypeKey(),
+		ValueKey: u.GetValueKey(),
 	}
 }
 

--- a/http/codegen/templates/union_type.go.tpl
+++ b/http/codegen/templates/union_type.go.tpl
@@ -50,7 +50,7 @@ func (u *{{ $.Name }}) Set{{ .FieldName }}(v {{ .FieldType }}) {
 func (u {{ .Name }}) Validate() error {
 	switch u.kind {
 	case "":
-		return goa.InvalidEnumValueError("type", "", []any{
+		return goa.InvalidEnumValueError({{ printf "%q" .TypeKey }}, "", []any{
 			{{- range .Fields }}
 			string({{ .KindConst }}),
 			{{- end }}
@@ -60,7 +60,7 @@ func (u {{ .Name }}) Validate() error {
 		return nil
 	{{- end }}
 	default:
-		return goa.InvalidEnumValueError("type", u.kind, []any{
+		return goa.InvalidEnumValueError({{ printf "%q" $.TypeKey }}, u.kind, []any{
 			{{- range .Fields }}
 			string({{ .KindConst }}),
 			{{- end }}
@@ -85,8 +85,8 @@ func (u {{ .Name }}) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("unexpected {{ .Name }} discriminant %q", u.kind)
 	}
 	return json.Marshal(struct {
-		Type  string {{ printf "`json:\"type\"`" }}
-		Value any    {{ printf "`json:\"value\"`" }}
+		Type  string {{ printf "`json:\"%s\"`" .TypeKey }}
+		Value any    {{ printf "`json:\"%s\"`" .ValueKey }}
 	}{
 		Type:  string(u.kind),
 		Value: value,
@@ -96,8 +96,8 @@ func (u {{ .Name }}) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals the union from the canonical {type,value} JSON shape.
 func (u *{{ .Name }}) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Type  string          {{ printf "`json:\"type\"`" }}
-		Value json.RawMessage {{ printf "`json:\"value\"`" }}
+		Type  string          {{ printf "`json:\"%s\"`" .TypeKey }}
+		Value json.RawMessage {{ printf "`json:\"%s\"`" .ValueKey }}
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -3666,3 +3666,44 @@ var PayloadWithValidatedAliasDSL = func() {
 		})
 	})
 }
+
+var PayloadBodyUnionCustomKeysDSL = func() {
+	var CustomUnion = Type("CustomUnion", func() {
+		OneOf("Values", func() {
+			Meta("oneof:type:field", "kind")
+			Meta("oneof:value:field", "data")
+			Attribute("String", String)
+			Attribute("Int", Int)
+		})
+	})
+	Service("ServiceBodyUnionCustomKeys", func() {
+		Method("MethodBodyUnionCustomKeys", func() {
+			Payload(CustomUnion)
+			HTTP(func() {
+				POST("/")
+			})
+		})
+	})
+}
+
+var PayloadBodyUnionCustomKeysValidateDSL = func() {
+	var PaymentMethod = Type("PaymentMethod", func() {
+		OneOf("method", func() {
+			Meta("oneof:type:field", "paymentType")
+			Meta("oneof:value:field", "details")
+			Attribute("CreditCard", String)
+			Attribute("PayPal", String)
+		})
+	})
+	Service("ServiceBodyUnionCustomKeysValidate", func() {
+		Method("MethodBodyUnionCustomKeysValidate", func() {
+			Payload(func() {
+				Attribute("payment", PaymentMethod)
+				Required("payment")
+			})
+			HTTP(func() {
+				POST("/")
+			})
+		})
+	})
+}

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -1596,3 +1596,47 @@ var ValidateErrorResponseTypeDSL = func() {
 		})
 	})
 }
+
+var ResultBodyUnionCustomKeysDSL = func() {
+	var CustomUnion = Type("CustomUnion", func() {
+		OneOf("Values", func() {
+			Meta("oneof:type:field", "kind")
+			Meta("oneof:value:field", "data")
+			Attribute("String", String)
+			Attribute("Int", Int)
+		})
+	})
+	Service("ServiceResultUnionCustomKeys", func() {
+		Method("MethodResultUnionCustomKeys", func() {
+			Result(CustomUnion)
+			HTTP(func() {
+				GET("/")
+			})
+		})
+	})
+}
+
+var ResultBodyUnionCustomKeysMultiDSL = func() {
+	var TypeA = Type("TypeA", func() {
+		Attribute("a", Int)
+	})
+	var TypeB = Type("TypeB", func() {
+		Attribute("b", String)
+	})
+	var PaymentResponse = Type("PaymentResponse", func() {
+		OneOf("status", func() {
+			Meta("oneof:type:field", "statusType")
+			Meta("oneof:value:field", "statusDetails")
+			Attribute("success", TypeA)
+			Attribute("failure", TypeB)
+		})
+	})
+	Service("ServiceResultUnionCustomKeysMulti", func() {
+		Method("MethodResultUnionCustomKeysMulti", func() {
+			Result(PaymentResponse)
+			HTTP(func() {
+				GET("/")
+			})
+		})
+	})
+}


### PR DESCRIPTION
## Context

This PR implements to customize the keys for the  new oneOf union change for goa. Previously the keys were hardcoded as `type` and `value`. 

Example
```json
{ "type": "sql-database", "value":  {  } }
```

But the problem with this is - some APIs may not be following this same exact format. Example
```json
{ "kind": "", "payload": {} }
```

This PR will allow customization of these keys and also if not provided will keep the default keys as `type` and `value`.

Example
```go
OneOf("Shape", func() {
    Meta("oneof:type:field", "kinda")
    Meta("oneof:value:field", "payload")
    Attribute("Circle", Int)
})
```
