### PR TITLE
dsl/meta: make Meta extensible via expr.MetaAdder

### DIFF
--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -314,42 +314,11 @@ const DefaultProtoc = expr.DefaultProtoc
 //	    Meta("openapi:typename", "Bar")
 //	})
 func Meta(name string, value ...string) {
-	appendMeta := func(meta expr.MetaExpr, name string, value ...string) expr.MetaExpr {
-		if meta == nil {
-			meta = make(map[string][]string)
-		}
-		meta[name] = append(meta[name], value...)
-		return meta
-	}
-
 	switch e := eval.Current().(type) {
-	case *expr.APIExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.ServerExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.HostExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.AttributeExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.ResultTypeExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.MethodExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.ServiceExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.HTTPServiceExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.HTTPEndpointExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.RouteExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.HTTPFileServerExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
-	case *expr.HTTPResponseExpr:
-		e.Meta = appendMeta(e.Meta, name, value...)
 	case expr.CompositeExpr:
-		att := e.Attribute()
-		att.Meta = appendMeta(att.Meta, name, value...)
+		e.Attribute().AddMeta(name, value...)
+	case expr.MetaAdder:
+		e.AddMeta(name, value...)
 	default:
 		eval.IncompatibleDSL()
 	}
@@ -362,33 +331,10 @@ func Meta(name string, value ...string) {
 // RemoveMeta takes a single argument, the name of the meta key to remove.
 func RemoveMeta(name string) {
 	switch e := eval.Current().(type) {
-	case *expr.APIExpr:
-		delete(e.Meta, name)
-	case *expr.ServerExpr:
-		delete(e.Meta, name)
-	case *expr.HostExpr:
-		delete(e.Meta, name)
-	case *expr.AttributeExpr:
-		delete(e.Meta, name)
-	case *expr.ResultTypeExpr:
-		delete(e.Meta, name)
-	case *expr.MethodExpr:
-		delete(e.Meta, name)
-	case *expr.ServiceExpr:
-		delete(e.Meta, name)
-	case *expr.HTTPServiceExpr:
-		delete(e.Meta, name)
-	case *expr.HTTPEndpointExpr:
-		delete(e.Meta, name)
-	case *expr.RouteExpr:
-		delete(e.Meta, name)
-	case *expr.HTTPFileServerExpr:
-		delete(e.Meta, name)
-	case *expr.HTTPResponseExpr:
-		delete(e.Meta, name)
 	case expr.CompositeExpr:
-		att := e.Attribute()
-		delete(att.Meta, name)
+		e.Attribute().DeleteMeta(name)
+	case expr.MetaDeleter:
+		e.DeleteMeta(name)
 	default:
 		eval.IncompatibleDSL()
 	}

--- a/dsl/meta.go
+++ b/dsl/meta.go
@@ -315,10 +315,10 @@ const DefaultProtoc = expr.DefaultProtoc
 //	})
 func Meta(name string, value ...string) {
 	switch e := eval.Current().(type) {
-	case expr.CompositeExpr:
-		e.Attribute().AddMeta(name, value...)
 	case expr.MetaAdder:
 		e.AddMeta(name, value...)
+	case expr.CompositeExpr:
+		e.Attribute().AddMeta(name, value...)
 	default:
 		eval.IncompatibleDSL()
 	}
@@ -331,10 +331,10 @@ func Meta(name string, value ...string) {
 // RemoveMeta takes a single argument, the name of the meta key to remove.
 func RemoveMeta(name string) {
 	switch e := eval.Current().(type) {
-	case expr.CompositeExpr:
-		e.Attribute().DeleteMeta(name)
 	case expr.MetaDeleter:
 		e.DeleteMeta(name)
+	case expr.CompositeExpr:
+		e.Attribute().DeleteMeta(name)
 	default:
 		eval.IncompatibleDSL()
 	}

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -646,6 +646,11 @@ func (a *AttributeExpr) AddMeta(name string, vals ...string) {
 	a.Meta[name] = append(a.Meta[name], vals...)
 }
 
+// DeleteMeta removes the metadata entry with the given name.
+func (a *AttributeExpr) DeleteMeta(name string) {
+	delete(a.Meta, name)
+}
+
 // ExtractUserExamples return the examples defined in the design directly on the
 // attribute or on its type.
 func (a *AttributeExpr) ExtractUserExamples() []*ExampleExpr {

--- a/expr/meta.go
+++ b/expr/meta.go
@@ -1,0 +1,32 @@
+package expr
+
+// MetaAdder is implemented by expressions that can receive design-time metadata.
+//
+// Goa's standard DSL helper `Meta(name, value...)` attaches metadata to the
+// current expression. Most Goa core expressions store metadata directly in a
+// `MetaExpr` field. Third-party DSLs (and plugins) may add new expression types
+// that also want to support `Meta` without Goa needing to know about those
+// concrete types.
+//
+// An expression that implements MetaAdder opts into Goa's `Meta` DSL by
+// providing an AddMeta implementation that:
+//   - appends values to the existing entry for the given name, and
+//   - preserves existing metadata for other names.
+//
+// Callers should treat metadata keys and values as opaque strings; their
+// interpretation is application-specific.
+type MetaAdder interface {
+	// AddMeta appends the given values to the metadata entry identified by name.
+	AddMeta(name string, value ...string)
+}
+
+// MetaDeleter is implemented by expressions that can remove design-time metadata.
+//
+// Goa's standard DSL helper `RemoveMeta(name)` removes the metadata entry with
+// the given name from the current expression.
+//
+// Implementations should be a no-op when no metadata is present.
+type MetaDeleter interface {
+	// DeleteMeta removes the metadata entry identified by name.
+	DeleteMeta(name string)
+}

--- a/expr/meta_methods.go
+++ b/expr/meta_methods.go
@@ -1,0 +1,116 @@
+// This file wires Goa's core expressions into the Meta DSL extension points.
+//
+// The `dsl.Meta` and `dsl.RemoveMeta` helpers operate on the expression returned
+// by `eval.Current()`. Most expressions that accept metadata store it in a
+// `MetaExpr` field. By implementing the `MetaAdder` / `MetaDeleter` interfaces
+// on those expressions, the DSL implementation stays small and does not need to
+// enumerate all supported expression types.
+package expr
+
+func appendMeta(meta MetaExpr, name string, vals ...string) MetaExpr {
+	if meta == nil {
+		meta = make(MetaExpr)
+	}
+	meta[name] = append(meta[name], vals...)
+	return meta
+}
+
+// AddMeta appends metadata values to the API expression.
+func (a *APIExpr) AddMeta(name string, value ...string) {
+	a.Meta = appendMeta(a.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the API expression.
+func (a *APIExpr) DeleteMeta(name string) {
+	delete(a.Meta, name)
+}
+
+// AddMeta appends metadata values to the server expression.
+func (s *ServerExpr) AddMeta(name string, value ...string) {
+	s.Meta = appendMeta(s.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the server expression.
+func (s *ServerExpr) DeleteMeta(name string) {
+	delete(s.Meta, name)
+}
+
+// AddMeta appends metadata values to the host expression.
+func (h *HostExpr) AddMeta(name string, value ...string) {
+	h.Meta = appendMeta(h.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the host expression.
+func (h *HostExpr) DeleteMeta(name string) {
+	delete(h.Meta, name)
+}
+
+// AddMeta appends metadata values to the service expression.
+func (s *ServiceExpr) AddMeta(name string, value ...string) {
+	s.Meta = appendMeta(s.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the service expression.
+func (s *ServiceExpr) DeleteMeta(name string) {
+	delete(s.Meta, name)
+}
+
+// AddMeta appends metadata values to the method expression.
+func (m *MethodExpr) AddMeta(name string, value ...string) {
+	m.Meta = appendMeta(m.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the method expression.
+func (m *MethodExpr) DeleteMeta(name string) {
+	delete(m.Meta, name)
+}
+
+// AddMeta appends metadata values to the HTTP service expression.
+func (s *HTTPServiceExpr) AddMeta(name string, value ...string) {
+	s.Meta = appendMeta(s.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the HTTP service expression.
+func (s *HTTPServiceExpr) DeleteMeta(name string) {
+	delete(s.Meta, name)
+}
+
+// AddMeta appends metadata values to the HTTP endpoint expression.
+func (e *HTTPEndpointExpr) AddMeta(name string, value ...string) {
+	e.Meta = appendMeta(e.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the HTTP endpoint expression.
+func (e *HTTPEndpointExpr) DeleteMeta(name string) {
+	delete(e.Meta, name)
+}
+
+// AddMeta appends metadata values to the route expression.
+func (r *RouteExpr) AddMeta(name string, value ...string) {
+	r.Meta = appendMeta(r.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the route expression.
+func (r *RouteExpr) DeleteMeta(name string) {
+	delete(r.Meta, name)
+}
+
+// AddMeta appends metadata values to the HTTP file server expression.
+func (f *HTTPFileServerExpr) AddMeta(name string, value ...string) {
+	f.Meta = appendMeta(f.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the HTTP file server expression.
+func (f *HTTPFileServerExpr) DeleteMeta(name string) {
+	delete(f.Meta, name)
+}
+
+// AddMeta appends metadata values to the HTTP response expression.
+func (r *HTTPResponseExpr) AddMeta(name string, value ...string) {
+	r.Meta = appendMeta(r.Meta, name, value...)
+}
+
+// DeleteMeta removes a metadata entry from the HTTP response expression.
+func (r *HTTPResponseExpr) DeleteMeta(name string) {
+	delete(r.Meta, name)
+}


### PR DESCRIPTION
## Summary
- Introduces a documented extension point for design-time metadata via `expr.MetaAdder` and `expr.MetaDeleter`.
- Implements these interfaces on Goa core expressions that carry a `Meta` field.
- Simplifies `dsl.Meta` / `dsl.RemoveMeta` to interface dispatch (keeping `expr.CompositeExpr` behavior by delegating to the underlying attribute).

## Rationale
`dsl.Meta` and `dsl.RemoveMeta` previously enumerated every expression type that supports metadata. That makes it easy to miss new expression types and forces changes in Goa's DSL internals whenever new meta-bearing expressions are introduced (including in external DSLs/plugins).

With `expr.MetaAdder`/`expr.MetaDeleter`, any expression can opt into `Meta(...)` / `RemoveMeta(...)` by implementing a small, well-documented interface.

## Behavior
- No behavioral change for existing designs: metadata values are appended per key and removed by key.
- `expr.CompositeExpr` continues to attach/remove metadata on its underlying attribute.

## Testing
- Regenerated a downstream repo using goa-ai agent DSL metadata (`Meta(...)` inside tool expressions) successfully.
