### PR TITLE
codegen: fix union-sum validation pointer semantics

### DIFF
--- a/codegen/scope.go
+++ b/codegen/scope.go
@@ -197,7 +197,14 @@ func (s *NameScope) goTypeDefWithPkgOverride(att *expr.AttributeExpr, ptr, useDe
 		} else if targetPkg != "" {
 			prefix = targetPkg + "."
 		}
-		return prefix + s.GoTypeName(att)
+		// Qualified references (pkg.Type) do not compete in the local identifier
+		// namespace. Never apply local scoping (suffixing) to the type name portion
+		// of an external reference, otherwise we can emit identifiers that do not
+		// exist in the referenced package (e.g., pkg.Foo2).
+		if prefix == "" {
+			return s.GoTypeName(att)
+		}
+		return prefix + Goify(actual.Name(), true)
 	default:
 		panic(fmt.Sprintf("unknown data type %T", actual)) // bug
 	}
@@ -279,11 +286,15 @@ func (s *NameScope) GoFullTypeName(att *expr.AttributeExpr, pkg string) string {
 		if actual == expr.ErrorResult {
 			return "goa.ServiceError"
 		}
-		n := s.HashedUnique(actual, Goify(actual.Name(), true), "")
+		// Qualified type references (pkg.Type) do not compete in the local
+		// identifier namespace. Never apply local scoping (suffixing) to the type
+		// name portion of an external reference, otherwise we can emit identifiers
+		// that do not exist in the referenced package (e.g., pkg.Foo2).
+		base := Goify(actual.Name(), true)
 		if pkg == "" {
-			return n
+			return s.HashedUnique(actual, base, "")
 		}
-		return pkg + "." + n
+		return pkg + "." + base
 	case expr.CompositeExpr:
 		return s.GoFullTypeName(actual.Attribute(), pkgWithDefault(actual.Attribute().Type, pkg))
 	default:

--- a/codegen/testdata/golden/validation_union-with-format-validation.go.golden
+++ b/codegen/testdata/golden/validation_union-with-format-validation.go.golden
@@ -2,8 +2,6 @@ func Validate() (err error) {
 	switch string(target.Response.Kind()) {
 	case "timestamp":
 		actual, _ := target.Response.AsTimestamp()
-		if actual != nil {
-			err = goa.MergeErrors(err, goa.ValidateFormat("target.response.value", string(*actual), goa.FormatDateTime))
-		}
+		err = goa.MergeErrors(err, goa.ValidateFormat("target.response.value", string(actual), goa.FormatDateTime))
 	}
 }

--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -190,7 +190,14 @@ func recurseValidationCode(att *expr.AttributeExpr, put expr.UserType, attCtx *A
 		if _, ok := attCtx.Scope.(*AttributeScope); ok {
 			cases := make([]map[string]any, 0, len(u.Values))
 			for _, v := range u.Values {
-				val := validateAttribute(attCtx, v.Attribute, put, "actual", context+".value", true, view, seen)
+				// Sum-type unions (struct-based, with Kind/AsX accessors) store each
+				// branch as either a value (primitives, arrays, maps) or a pointer
+				// (object user types). The union validation template binds the branch
+				// value to a local named "actual"; the pointer semantics must match
+				// that local, not the enclosing field context.
+				unionCtx := attCtx.Dup()
+				unionCtx.Pointer = expr.IsObject(v.Attribute.Type)
+				val := validateAttribute(unionCtx, v.Attribute, put, "actual", context+".value", true, view, seen)
 				if val == "" {
 					continue
 				}

--- a/expr/attribute.go
+++ b/expr/attribute.go
@@ -277,11 +277,6 @@ func (a *AttributeExpr) Validate(ctx string, parent eval.Expression) *eval.Valid
 	} else if u := AsUnion(a.Type); u != nil {
 		for _, ut := range u.Values {
 			verr.Merge(ut.Attribute.Validate(ctx, parent))
-			if IsArray(ut.Attribute.Type) {
-				verr.Add(parent, "union type %s has array elements, not supported by gRPC", u.Name())
-			} else if IsMap(ut.Attribute.Type) {
-				verr.Add(parent, "union type %s has map elements, not supported by gRPC", u.Name())
-			}
 		}
 	}
 

--- a/expr/grpc_endpoint.go
+++ b/expr/grpc_endpoint.go
@@ -152,6 +152,16 @@ func (e *GRPCEndpointExpr) Validate() error {
 		verr.Add(e, "Endpoint name cannot be empty")
 	}
 
+	seenUnions := make(map[*Union]struct{})
+	seenAttrs := make(map[*AttributeExpr]struct{})
+	validateGRPCUnionShapes(e.MethodExpr.Payload, e.MethodExpr, verr, seenUnions, seenAttrs)
+	validateGRPCUnionShapes(e.MethodExpr.StreamingPayload, e.MethodExpr, verr, seenUnions, seenAttrs)
+	validateGRPCUnionShapes(e.MethodExpr.Result, e.MethodExpr, verr, seenUnions, seenAttrs)
+	validateGRPCUnionShapes(e.MethodExpr.StreamingResult, e.MethodExpr, verr, seenUnions, seenAttrs)
+	for _, er := range e.MethodExpr.Errors {
+		validateGRPCUnionShapes(er.AttributeExpr, e.MethodExpr, verr, seenUnions, seenAttrs)
+	}
+
 	var hasMessage, hasMetadata bool
 	// Validate request
 	if e.Request.Type != Empty {
@@ -214,6 +224,51 @@ func (e *GRPCEndpointExpr) Validate() error {
 		verr.Merge(er.Validate())
 	}
 	return verr
+}
+
+func validateGRPCUnionShapes(att *AttributeExpr, parent eval.Expression, verr *eval.ValidationErrors, seenUnions map[*Union]struct{}, seenAttrs map[*AttributeExpr]struct{}) {
+	if att == nil || att.Type == nil {
+		return
+	}
+	if _, ok := seenAttrs[att]; ok {
+		return
+	}
+	seenAttrs[att] = struct{}{}
+
+	if u := AsUnion(att.Type); u != nil {
+		if _, ok := seenUnions[u]; ok {
+			return
+		}
+		seenUnions[u] = struct{}{}
+		for _, ut := range u.Values {
+			switch {
+			case IsArray(ut.Attribute.Type):
+				verr.Add(parent, "union type %s has array elements, not supported by gRPC", u.Name())
+			case IsMap(ut.Attribute.Type):
+				verr.Add(parent, "union type %s has map elements, not supported by gRPC", u.Name())
+			}
+			validateGRPCUnionShapes(ut.Attribute, parent, verr, seenUnions, seenAttrs)
+		}
+		return
+	}
+
+	if o := AsObject(att.Type); o != nil {
+		for _, nat := range *o {
+			validateGRPCUnionShapes(nat.Attribute, parent, verr, seenUnions, seenAttrs)
+		}
+		return
+	}
+
+	if ar := AsArray(att.Type); ar != nil {
+		validateGRPCUnionShapes(ar.ElemType, parent, verr, seenUnions, seenAttrs)
+		return
+	}
+
+	if m := AsMap(att.Type); m != nil {
+		validateGRPCUnionShapes(m.KeyType, parent, verr, seenUnions, seenAttrs)
+		validateGRPCUnionShapes(m.ElemType, parent, verr, seenUnions, seenAttrs)
+		return
+	}
 }
 
 // Finalize ensures the request and response attributes are initialized.


### PR DESCRIPTION
## Summary
- Fix sum-type union validation generation so branch-local variable semantics match the union storage model (value for primitives/arrays/maps, pointer for object branches).
- Prevent NameScope from suffixing *qualified* user type references (pkg.Type), avoiding generation of non-existent identifiers like `pkg.Foo2`.
- Move gRPC union member shape restrictions (no array/map union members) from `AttributeExpr.Validate` to gRPC endpoint validation with recursion guards.

## Rationale
Two independent correctness issues could produce uncompilable or invalid generated code:

1) **Union-sum validation for non-object branches**: the union-sum validation template binds the selected branch value to a local `actual` variable. Goa sum-type unions store primitives/arrays/maps as values, but object branches as pointers. When the enclosing validation context uses pointer primitives (common in HTTP/server-body validation), validations were incorrectly generated as if `actual` were a pointer even for value branches, yielding invalid `actual != nil` / `*actual` code.

2) **Qualified user type refs must not be scoped**: local NameScope uniquing is only valid for identifiers in the current package. For `pkg.Type` references, the `Type` segment must remain the canonical type name; suffixing can produce references that do not exist in the imported package.

The gRPC union-shape check is preserved but moved to the gRPC-specific validation surface and made cycle-safe so it doesn’t leak transport constraints into generic attribute validation.

## Test plan
- `make test`