### PR TITLE
codegen: reuse scoped names for qualified refs

### DIFF
--- a/codegen/scope.go
+++ b/codegen/scope.go
@@ -287,12 +287,26 @@ func (s *NameScope) GoFullTypeName(att *expr.AttributeExpr, pkg string) string {
 			return "goa.ServiceError"
 		}
 		// Qualified type references (pkg.Type) do not compete in the local
-		// identifier namespace. Never apply local scoping (suffixing) to the type
-		// name portion of an external reference, otherwise we can emit identifiers
-		// that do not exist in the referenced package (e.g., pkg.Foo2).
+		// identifier namespace.
+		//
+		// When generating qualified references, we must not blindly apply local
+		// scoping (suffixing) to the referenced type name, otherwise we can emit
+		// identifiers that do not exist in the referenced package (e.g., pkg.Foo2).
+		//
+		// However, when the scope already assigned a unique name to the referenced
+		// type (i.e., the type is defined in this scope and got suffixed due to a
+		// collision), qualified references must use that assigned name to stay
+		// consistent across packages. This is critical for transport packages that
+		// refer to types defined in the service package (e.g., grpc referencing a
+		// payload type defined as Request2).
 		base := Goify(actual.Name(), true)
 		if pkg == "" {
 			return s.HashedUnique(actual, base, "")
+		}
+		if UserTypeLocation(actual) == nil {
+			if n, ok := s.names[actual.Hash()]; ok {
+				return pkg + "." + n
+			}
 		}
 		return pkg + "." + base
 	case expr.CompositeExpr:

--- a/codegen/scope_test.go
+++ b/codegen/scope_test.go
@@ -2,6 +2,8 @@ package codegen
 
 import (
 	"testing"
+
+	"goa.design/goa/v3/expr"
 )
 
 func TestNameScope_Unique(t *testing.T) {
@@ -34,5 +36,32 @@ func TestNameScope_Unique(t *testing.T) {
 		if got := scope.Unique(v.Input, v.Suffix...); v.Expected != got {
 			t.Errorf("#%v, expected %v, got %v", i, v.Expected, got)
 		}
+	}
+}
+
+func TestNameScope_GoFullTypeName_UsesScopedNameWhenQualified(t *testing.T) {
+	scope := NewNameScope()
+
+	// Simulate the service generator reserving/using "Request" for a different
+	// identifier before naming a user type that also wants to be "Request".
+	scope.Unique("Request")
+
+	ut := &expr.UserTypeExpr{
+		AttributeExpr: &expr.AttributeExpr{Type: expr.String},
+		TypeName:      "Request",
+		UID:           "t",
+	}
+	att := &expr.AttributeExpr{Type: ut}
+
+	if got, want := scope.GoTypeName(att), "Request2"; got != want {
+		t.Fatalf("expected scoped type name %q, got %q", want, got)
+	}
+	if got, want := scope.GoFullTypeName(att, "svc"), "svc.Request2"; got != want {
+		t.Fatalf("expected qualified scoped name %q, got %q", want, got)
+	}
+
+	fresh := NewNameScope()
+	if got, want := fresh.GoFullTypeName(att, "svc"), "svc.Request"; got != want {
+		t.Fatalf("expected qualified base name %q with fresh scope, got %q", want, got)
 	}
 }


### PR DESCRIPTION
## Summary
- Fix Goa codegen emitting qualified references to non-existent identifiers when a user type is suffixed due to a local name collision (e.g. `Request2`).
- Ensure qualified references reuse the already-scoped name when the scope owns the type.
- Add a focused regression test for the qualified-reference path.

## Why
Transport packages (gRPC/HTTP/JSON-RPC) frequently reference types defined in the service package. If the service scope suffixes a type name to avoid collisions, qualified references must match that scoped name; otherwise generated code fails to compile.

## Test plan
- `make`