### PR TITLE
Fixed http client code generator

### DIFF
--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -2,12 +2,12 @@ package codegen
 
 import (
 	"bytes"
-	"goa.design/goa/v3/codegen/testutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/codegen/testutil"
 	"goa.design/goa/v3/http/codegen/testdata"
 )
 
@@ -72,6 +72,7 @@ func TestClientTypes(t *testing.T) {
 	}{
 		{"client-mixed-payload-attrs", testdata.MixedPayloadInBodyDSL},
 		{"client-multiple-methods", testdata.MultipleMethodsDSL},
+		{"client-multiple-methods-with-array-type-payloads", testdata.MultipleMethodsWithArrayTypePayloadsDSL},
 		{"client-payload-extend-validate", testdata.PayloadExtendedValidateDSL},
 		{"client-result-type-validate", testdata.ResultTypeValidateDSL},
 		{"client-with-result-collection", testdata.ResultWithResultCollectionDSL},

--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -70,10 +70,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 	for _, a := range svc.HTTPEndpoints {
 		adata := data.Endpoint(a.Name())
 		if data := adata.Payload.Request.ClientBody; data != nil {
-			if _, ok := seen[data.Name]; ok {
+			if _, ok := seen[data.Ref]; ok {
 				continue
 			}
-			seen[data.Name] = struct{}{}
+			seen[data.Ref] = struct{}{}
 			if data.Def != "" {
 				sections = append(sections, &codegen.SectionTemplate{
 					Name:   "client-request-body",
@@ -96,10 +96,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 		}
 		if adata.ClientWebSocket != nil {
 			if data := adata.ClientWebSocket.Payload; data != nil {
-				if _, ok := seen[data.Name]; ok {
+				if _, ok := seen[data.Ref]; ok {
 					continue
 				}
-				seen[data.Name] = struct{}{}
+				seen[data.Ref] = struct{}{}
 				if data.Def != "" {
 					sections = append(sections, &codegen.SectionTemplate{
 						Name:   "client-request-body",
@@ -125,10 +125,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 		adata := data.Endpoint(a.Name())
 		for _, resp := range adata.Result.Responses {
 			if data := resp.ClientBody; data != nil {
-				if _, ok := seen[data.Name]; ok {
+				if _, ok := seen[data.Ref]; ok {
 					continue
 				}
-				seen[data.Name] = struct{}{}
+				seen[data.Ref] = struct{}{}
 				if data.Def != "" {
 					sections = append(sections, &codegen.SectionTemplate{
 						Name:   "client-response-body",
@@ -152,10 +152,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 		for _, gerr := range adata.Errors {
 			for _, herr := range gerr.Errors {
 				if data := herr.Response.ClientBody; data != nil {
-					if _, ok := seen[data.Name]; ok {
+					if _, ok := seen[data.Ref]; ok {
 						continue
 					}
-					seen[data.Name] = struct{}{}
+					seen[data.Ref] = struct{}{}
 					if data.Def != "" {
 						sections = append(sections, &codegen.SectionTemplate{
 							Name:   "client-error-body",
@@ -176,10 +176,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 
 	for _, data := range data.ClientBodyAttributeTypes {
 		// Check if this type has already been added to avoid duplicates
-		if _, ok := seen[data.Name]; ok {
+		if _, ok := seen[data.Ref]; ok {
 			continue
 		}
-		seen[data.Name] = struct{}{}
+		seen[data.Ref] = struct{}{}
 
 		if data.Def != "" {
 			sections = append(sections, &codegen.SectionTemplate{

--- a/http/codegen/testdata/golden/client_types_client-multiple-methods-with-array-type-payloads.go.golden
+++ b/http/codegen/testdata/golden/client_types_client-multiple-methods-with-array-type-payloads.go.golden
@@ -1,0 +1,55 @@
+// PayloadARequestBody is used to define fields on request body types.
+type PayloadARequestBody struct {
+	A *string `form:"a,omitempty" json:"a,omitempty" xml:"a,omitempty"`
+}
+
+// PayloadBRequestBody is used to define fields on request body types.
+type PayloadBRequestBody struct {
+	A string `form:"a" json:"a" xml:"a"`
+	B string `form:"b" json:"b" xml:"b"`
+}
+
+// NewPayloadARequestBody builds the HTTP request body from the payload of the
+// "MethodA" endpoint of the "ServiceMultipleMethods" service.
+func NewPayloadARequestBody(p []*servicemultiplemethods.PayloadA) []*PayloadARequestBody {
+	body := make([]*PayloadARequestBody, len(p))
+	for i, val := range p {
+		if val == nil {
+			body[i] = nil
+			continue
+		}
+		body[i] = marshalServicemultiplemethodsPayloadAToPayloadARequestBody(val)
+	}
+	return body
+}
+
+// NewPayloadBRequestBody builds the HTTP request body from the payload of the
+// "MethodB" endpoint of the "ServiceMultipleMethods" service.
+func NewPayloadBRequestBody(p []*servicemultiplemethods.PayloadB) []*PayloadBRequestBody {
+	body := make([]*PayloadBRequestBody, len(p))
+	for i, val := range p {
+		if val == nil {
+			body[i] = nil
+			continue
+		}
+		body[i] = marshalServicemultiplemethodsPayloadBToPayloadBRequestBody(val)
+	}
+	return body
+}
+
+// ValidatePayloadARequestBody runs the validations defined on
+// PayloadARequestBody
+func ValidatePayloadARequestBody(body *PayloadARequestBody) (err error) {
+	if body.A != nil {
+		err = goa.MergeErrors(err, goa.ValidatePattern("body.a", *body.A, "patterna"))
+	}
+	return
+}
+
+// ValidatePayloadBRequestBody runs the validations defined on
+// PayloadBRequestBody
+func ValidatePayloadBRequestBody(body *PayloadBRequestBody) (err error) {
+	err = goa.MergeErrors(err, goa.ValidatePattern("body.a", body.A, "patterna"))
+	err = goa.MergeErrors(err, goa.ValidatePattern("body.b", body.B, "patternb"))
+	return
+}

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -3160,6 +3160,37 @@ var MultipleMethodsDSL = func() {
 	})
 }
 
+var MultipleMethodsWithArrayTypePayloadsDSL = func() {
+	var PayloadA = Type("PayloadA", func() {
+		Attribute("a", String, func() {
+			Pattern("patterna")
+		})
+	})
+	var PayloadB = Type("PayloadB", func() {
+		Attribute("a", String, func() {
+			Pattern("patterna")
+		})
+		Attribute("b", String, func() {
+			Pattern("patternb")
+		})
+		Required("a", "b")
+	})
+	Service("ServiceMultipleMethods", func() {
+		Method("MethodA", func() {
+			Payload(ArrayOf(PayloadA))
+			HTTP(func() {
+				POST("/")
+			})
+		})
+		Method("MethodB", func() {
+			Payload(ArrayOf(PayloadB))
+			HTTP(func() {
+				PUT("/")
+			})
+		})
+	})
+}
+
 var MixedPayloadInBodyDSL = func() {
 	var BPayload = Type("BPayload", func() {
 		Attribute("int", Int)


### PR DESCRIPTION
This PR fixes a bug we have hit within http client code generator.

In case two or more Methods using `Payload(ArrayOf(...))` are defined, generator generates _HTTP request body builder_ function for the first of defined Method only _(client/types.go file)_.

Bug can be reproduced using new added unit test.

**Goa design code:**
```go
       var PayloadA = Type("PayloadA", func() {
               Attribute("a", String, func() {
                       Pattern("patterna")
               })
       })
       var PayloadB = Type("PayloadB", func() {
               Attribute("a", String, func() {
                       Pattern("patterna")
               })  
               Attribute("b", String, func() {
                       Pattern("patternb")
               })  
               Required("a", "b")
       })  
       Service("ServiceMultipleMethods", func() {
               Method("MethodA", func() {
                       Payload(ArrayOf(PayloadA))
                       HTTP(func() {
                               POST("/")
                       })
               })
               Method("MethodB", func() {
                       Payload(ArrayOf(PayloadB))
                       HTTP(func() {
                               PUT("/")
                       })
               })
       })
```

**Bug is located in `http/codegen/client_types.go: func clientType`:**
In this function there is incorrectly used `data.Name` attribute for already seen payload types. Attribute is always set to `"array"` value regardless of real payload type.

**Fix:**
Using of `data.Ref` attribute instead, the problem is solved. Since its value corresponds to the real type of Payload `"[]*PayloadARequestBody"` resp. `"[]*PayloadBRequestBody"`. The code for the both `func NewPayloadARequestBody()` and `func NewPayloadBRequestBody()` is properly generated.
