### PR TITLE
codegen: use helper transforms for union object branches

### DIFF
--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -490,6 +490,12 @@ func transformUnion(source, target *expr.AttributeExpr, sourceVar, targetVar str
 		if castPkg == ta.TargetCtx.DefaultPkg && unionPkg != "" && unionPkg != ta.TargetCtx.DefaultPkg {
 			castPkg = unionPkg
 		}
+		useHelper := false
+		if _, ok := st.Attribute.Type.(expr.UserType); ok && expr.IsObject(st.Attribute.Type) {
+			if _, ok := tt.Attribute.Type.(expr.UserType); ok && expr.IsObject(tt.Attribute.Type) {
+				useHelper = true
+			}
+		}
 		cases = append(cases, map[string]any{
 			"CaseName":        st.Name,
 			"SourceFieldName": Goify(st.Name, true),
@@ -497,6 +503,8 @@ func transformUnion(source, target *expr.AttributeExpr, sourceVar, targetVar str
 			"SourceAttr":      st.Attribute,
 			"TargetAttr":      tt.Attribute,
 			"TargetCastType":  ta.TargetCtx.Scope.Ref(tt.Attribute, castPkg),
+			"UseHelper":       useHelper,
+			"HelperName":      transformHelperName(st.Attribute, tt.Attribute, ta),
 		})
 	}
 

--- a/codegen/go_transform_union_test.go
+++ b/codegen/go_transform_union_test.go
@@ -20,6 +20,8 @@ func TestGoTransformUnion(t *testing.T) {
 		unionString2    = root.UserType("Container").Attribute().Find("UnionString2").Find("UnionString2")
 		unionStringInt  = root.UserType("Container").Attribute().Find("UnionStringInt").Find("UnionStringInt")
 		unionStringInt2 = root.UserType("Container").Attribute().Find("UnionStringInt2").Find("UnionStringInt2")
+		unionSomeType   = root.UserType("Container").Attribute().Find("UnionSomeType").Find("UnionSomeType")
+		unionSomeType2  = root.UserType("Container").Attribute().Find("UnionSomeType2").Find("UnionSomeType2")
 		defaultCtx      = NewAttributeContext(false, false, true, "", scope)
 	)
 	tc := []struct {
@@ -29,6 +31,7 @@ func TestGoTransformUnion(t *testing.T) {
 	}{
 		{"UnionString to UnionString2", unionString, unionString2},
 		{"UnionStringInt to UnionStringInt2", unionStringInt, unionStringInt2},
+		{"UnionSomeType to UnionSomeType2", unionSomeType, unionSomeType2},
 	}
 	for _, c := range tc {
 		t.Run(c.Name, func(t *testing.T) {

--- a/codegen/service/testdata/golden/service_service-result-with-one-of-type.go.golden
+++ b/codegen/service/testdata/golden/service_service-result-with-one-of-type.go.golden
@@ -200,20 +200,13 @@ func newResultOneof(vres *resultwithoneoftypeviews.ResultOneofView) *ResultOneof
 		switch string(vres.Result.Kind()) {
 		case "t":
 			actual, _ := vres.Result.AsT()
-			obj := &T{
-				Message: actual.Message,
-			}
-
+			obj := transformResultwithoneoftypeviewsTViewToT(actual)
 			u := res.Result
 			u.SetT((*T)(obj))
 			res.Result = u
 		case "u":
 			actual, _ := vres.Result.AsU()
-			obj := &U{}
-			if actual.Item != nil {
-				obj.Item = transformResultwithoneoftypeviewsItemViewToItem(actual.Item)
-			}
-
+			obj := transformResultwithoneoftypeviewsUViewToU(actual)
 			u := res.Result
 			u.SetU((*U)(obj))
 			res.Result = u
@@ -230,20 +223,13 @@ func newResultOneofView(res *ResultOneof) *resultwithoneoftypeviews.ResultOneofV
 		switch string(res.Result.Kind()) {
 		case "t":
 			actual, _ := res.Result.AsT()
-			obj := &resultwithoneoftypeviews.TView{
-				Message: actual.Message,
-			}
-
+			obj := transformTToResultwithoneoftypeviewsTView(actual)
 			u := vres.Result
 			u.SetT((*resultwithoneoftypeviews.TView)(obj))
 			vres.Result = u
 		case "u":
 			actual, _ := res.Result.AsU()
-			obj := &resultwithoneoftypeviews.UView{}
-			if actual.Item != nil {
-				obj.Item = transformItemToResultwithoneoftypeviewsItemView(actual.Item)
-			}
-
+			obj := transformUToResultwithoneoftypeviewsUView(actual)
 			u := vres.Result
 			u.SetU((*resultwithoneoftypeviews.UView)(obj))
 			vres.Result = u

--- a/codegen/templates/transform_go_union.go.tpl
+++ b/codegen/templates/transform_go_union.go.tpl
@@ -4,7 +4,11 @@ switch string({{ .SourceVar }}.Kind()) {
 {{- range .Cases }}
 case {{ printf "%q" .CaseName }}:
 	actual, _ := {{ $.SourceVar }}.As{{ .SourceFieldName }}()
+	{{- if .UseHelper }}
+	{{ $.TempVarName }} := {{ .HelperName }}(actual)
+	{{- else }}
 	{{ transformAttribute .SourceAttr .TargetAttr "actual" $.TempVarName true $.TransformAttrs -}}
+	{{- end }}
 	{{- if $.NewVar }}
 	var u {{ $.ValueTypeRef }}
 	u.Set{{ .TargetFieldName }}(({{ .TargetCastType }})({{ $.TempVarName }}))

--- a/codegen/testdata/golden/go_transform_union_UnionSomeType to UnionSomeType2.go.golden
+++ b/codegen/testdata/golden/go_transform_union_UnionSomeType to UnionSomeType2.go.golden
@@ -1,0 +1,11 @@
+func transform() {
+	var target *UnionSomeType2
+	switch string(source.Kind()) {
+	case "SomeType":
+		actual, _ := source.AsSomeType()
+		obj := transformSomeTypeToSomeType(actual)
+		var u UnionSomeType2
+		u.SetSomeType((*SomeType)(obj))
+		target = &u
+	}
+}

--- a/codegen/testdata/union_dsls.go
+++ b/codegen/testdata/union_dsls.go
@@ -37,6 +37,11 @@ var TestUnionDSL = func() {
 				Attribute("SomeType", SomeType)
 			})
 		})
+		UnionSomeType2 = Type("UnionSomeType2", func() {
+			OneOf("UnionSomeType2", func() {
+				Attribute("SomeType", SomeType)
+			})
+		})
 
 		_ = Type("Container", func() {
 			Attribute("UnionString", UnionString)
@@ -44,6 +49,7 @@ var TestUnionDSL = func() {
 			Attribute("UnionStringInt", UnionStringInt)
 			Attribute("UnionStringInt2", UnionStringInt2)
 			Attribute("UnionSomeType", UnionSomeType)
+			Attribute("UnionSomeType2", UnionSomeType2)
 		})
 
 		_ = Type("UnionUserType", func() {


### PR DESCRIPTION
## Summary
- Generate union-to-union transforms that call the existing per-type transform helper for **object** union branches, instead of inlining the full attribute transform in the union switch.

## Rationale
Inlining object-branch transforms inside the union switch can produce branch-local conversion code that diverges from the canonical helper-based transform path (e.g., differences around nested map key casting / scoped type references). Using the helper keeps transforms consistent and avoids emitting invalid or mismatched conversions.

## Test plan
- `go test ./...`