### PR TITLE
codegen: support mixed unary + SSE results

### DIFF
--- a/codegen/service/client_test.go
+++ b/codegen/service/client_test.go
@@ -25,6 +25,7 @@ func TestClient(t *testing.T) {
 		{"client-no-payload", testdata.NoPayloadEndpointDSL, testdata.NoPayloadMethodsClient},
 		{"client-with-result", testdata.WithResultEndpointDSL, testdata.WithResultMethodClient},
 		{"client-streaming-result", testdata.StreamingResultMethodDSL, testdata.StreamingResultMethodClient},
+		{"client-mixed-results", testdata.MixedResultsEndpointDSL, testdata.MixedResultsMethodClient},
 		{"client-streaming-result-no-payload", testdata.StreamingResultNoPayloadMethodDSL, testdata.StreamingResultNoPayloadMethodClient},
 		{"client-streaming-payload", testdata.StreamingPayloadMethodDSL, testdata.StreamingPayloadMethodClient},
 		{"client-streaming-payload-no-payload", testdata.StreamingPayloadNoPayloadMethodDSL, testdata.StreamingPayloadNoPayloadMethodClient},

--- a/codegen/service/endpoint.go
+++ b/codegen/service/endpoint.go
@@ -44,6 +44,11 @@ type (
 		// ArgName is the name of the argument used to initialize the client
 		// struct method field.
 		ArgName string
+		// StreamArgName is the name of the argument used to initialize the client
+		// struct stream endpoint field when the method defines mixed results.
+		//
+		// It is only set when HasMixedResults is true.
+		StreamArgName string
 		// ClientVarName is the corresponding client struct field name.
 		ClientVarName string
 		// ServiceName is the name of the owner service.
@@ -142,16 +147,24 @@ func EndpointFile(genpkg string, service *expr.ServiceExpr, services *ServicesDa
 
 func endpointData(svc *Data) *EndpointsData {
 	methods := make([]*EndpointMethodData, len(svc.Methods))
-	names := make([]string, len(svc.Methods))
+	argScope := codegen.NewNameScope()
+	var names []string
 	for i, m := range svc.Methods {
+		argName := argScope.Unique(codegen.Goify(m.VarName, false), "")
+		names = append(names, argName)
+		streamArgName := ""
+		if m.HasMixedResults {
+			streamArgName = argScope.Unique(argName+"Stream", "")
+			names = append(names, streamArgName)
+		}
 		methods[i] = &EndpointMethodData{
 			MethodData:     m,
-			ArgName:        codegen.Goify(m.VarName, false),
+			ArgName:        argName,
+			StreamArgName:  streamArgName,
 			ServiceName:    svc.Name,
 			ServiceVarName: serviceInterfaceName,
 			ClientVarName:  clientStructName,
 		}
-		names[i] = codegen.Goify(m.VarName, false)
 	}
 	desc := fmt.Sprintf("%s wraps the %q service endpoints.", endpointsStructName, svc.Name)
 	return &EndpointsData{

--- a/codegen/service/endpoint_test.go
+++ b/codegen/service/endpoint_test.go
@@ -26,6 +26,7 @@ func TestEndpoint(t *testing.T) {
 		{"endpoint-with-result", testdata.WithResultEndpointDSL, testdata.WithResultEndpoint},
 		{"endpoint-with-result-multiple-views", testdata.WithResultMultipleViewsEndpointDSL, testdata.WithResultMultipleViewsEndpoint},
 		{"endpoint-streaming-result", testdata.StreamingResultEndpointDSL, testdata.StreamingResultMethodEndpoint},
+		{"endpoint-mixed-results", testdata.MixedResultsEndpointDSL, testdata.MixedResultsMethodEndpoint},
 		{"endpoint-streaming-result-no-payload", testdata.StreamingResultNoPayloadEndpointDSL, testdata.StreamingResultNoPayloadMethodEndpoint},
 		{"endpoint-streaming-result-with-views", testdata.StreamingResultWithViewsMethodDSL, testdata.StreamingResultWithViewsMethodEndpoint},
 		{"endpoint-streaming-payload", testdata.StreamingPayloadEndpointDSL, testdata.StreamingPayloadMethodEndpoint},

--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -188,6 +188,10 @@ type (
 		// StreamKind is the kind of the stream (payload or result or
 		// bidirectional).
 		StreamKind expr.StreamKind
+		// HasMixedResults indicates whether the method defines both Result and
+		// StreamingResult with different types, enabling content negotiation at
+		// the transport layer (e.g. JSON vs SSE over HTTP).
+		HasMixedResults bool
 		// SkipRequestBodyEncodeDecode is true if the method payload includes
 		// the raw HTTP request body reader.
 		SkipRequestBodyEncodeDecode bool
@@ -206,6 +210,13 @@ type (
 		// struct to store the goa.Endpoint for this method. It is computed with a
 		// scope that includes method names to avoid field/method name collisions.
 		EndpointField string
+		// StreamEndpointField is the unique field name used in the generated client
+		// struct to store the "streaming mode" goa.Endpoint for mixed results. The
+		// transport endpoint forces server streaming (e.g. sets "Accept:
+		// text/event-stream") and returns the client stream interface.
+		//
+		// It is only set when HasMixedResults is true.
+		StreamEndpointField string
 	}
 
 	// StreamData is the data used to generate client and server interfaces that
@@ -871,6 +882,9 @@ func (d *ServicesData) analyze(service *expr.ServiceExpr) *Data {
 	// existing method names.
 	for _, m := range methods {
 		m.EndpointField = scope.Unique(m.VarName+"Endpoint", "")
+		if m.HasMixedResults {
+			m.StreamEndpointField = scope.Unique(m.VarName+"StreamEndpoint", "")
+		}
 	}
 
 	// Collect union sum-type definitions for the service.
@@ -1263,6 +1277,7 @@ func (d *ServicesData) buildMethodData(m *expr.MethodExpr, scope *codegen.NameSc
 		Requirements:                 reqs,
 		Schemes:                      schemes,
 		StreamKind:                   m.Stream,
+		HasMixedResults:              m.HasMixedResults(),
 		SkipRequestBodyEncodeDecode:  skipRequestBodyEncodeDecode,
 		SkipResponseBodyEncodeDecode: skipResponseBodyEncodeDecode,
 		RequestStruct:                vname + "RequestData",

--- a/codegen/service/service_test.go
+++ b/codegen/service/service_test.go
@@ -43,6 +43,7 @@ func TestService(t *testing.T) {
 		{"service-force-generate-type", testdata.ForceGenerateTypeDSL},
 		{"service-force-generate-type-explicit", testdata.ForceGenerateTypeExplicitDSL},
 		{"service-streaming-result", testdata.StreamingResultMethodDSL},
+		{"service-mixed-results", testdata.MixedResultsEndpointDSL},
 		{"service-streaming-result-with-views", testdata.StreamingResultWithViewsMethodDSL},
 		{"service-streaming-result-with-explicit-view", testdata.StreamingResultWithExplicitViewMethodDSL},
 		{"service-streaming-result-no-payload", testdata.StreamingResultNoPayloadMethodDSL},

--- a/codegen/service/templates/service.go.tpl
+++ b/codegen/service/templates/service.go.tpl
@@ -25,6 +25,10 @@ type Service interface {
 	{{- if .ServerStream }}
 		{{- if and .IsJSONRPC (not .IsJSONRPCSSE) (eq .ServerStream.Kind 2) }}
 			{{ .VarName }}(context.Context{{ if .Payload }}, {{ .PayloadRef }}{{ end }}) ({{ if .Result }}res {{ .ResultRef }}, {{ end }}err error)
+		{{- else if .HasMixedResults }}
+			{{- /* Mixed results: the method may be invoked in a unary (JSON) or streaming (SSE) mode.
+			     The server stream is non-nil only when the transport negotiates streaming. */}}
+			{{ .VarName }}(context.Context{{ if .Payload }}, {{ .PayloadRef }}{{ end }}, {{ .ServerStream.Interface }}) ({{ if .Result }}res {{ .ResultRef }}, {{ end }}{{ if .ViewedResult }}{{ if not .ViewedResult.ViewName }}view string, {{ end }}{{ end }}err error)
 		{{- else }}
 			{{- if and .IsJSONRPC (not .IsJSONRPCSSE) (eq .ServerStream.Kind 3) .PayloadRef }}
 				{{- /* JSON-RPC WebSocket server streaming with non-streaming payload */ -}}

--- a/codegen/service/templates/service_client.go.tpl
+++ b/codegen/service/templates/service_client.go.tpl
@@ -2,5 +2,8 @@
 type {{ .ClientVarName }} struct {
 {{- range .Methods}}
 	{{ .EndpointField }} goa.Endpoint
+	{{- if .HasMixedResults }}
+	{{ .StreamEndpointField }} goa.Endpoint
+	{{- end }}
 {{- end }}
 }

--- a/codegen/service/templates/service_client_init.go.tpl
+++ b/codegen/service/templates/service_client_init.go.tpl
@@ -3,6 +3,9 @@ func New{{ .ClientVarName }}({{ .ClientInitArgs }} goa.Endpoint{{ if .HasClientI
     return &{{ .ClientVarName }}{
     {{- range .Methods }}
         {{ .EndpointField }}: {{ if .ClientInterceptors }}Wrap{{ .VarName }}ClientEndpoint({{ end }}{{ .ArgName }}{{ if .ClientInterceptors }}, ci){{ end }},
+		{{- if .HasMixedResults }}
+        {{ .StreamEndpointField }}: {{ if .ClientInterceptors }}Wrap{{ .VarName }}ClientEndpoint({{ end }}{{ .StreamArgName }}{{ if .ClientInterceptors }}, ci){{ end }},
+		{{- end }}
     {{- end }}
     }
 }

--- a/codegen/service/templates/service_client_method.go.tpl
+++ b/codegen/service/templates/service_client_method.go.tpl
@@ -7,6 +7,38 @@
 	{{- end }}
 //	- error: internal error
 {{- end }}
+{{- if .HasMixedResults }}
+{{- $unaryResultType := .ResultRef }}
+func (c *{{ .ClientVarName }}) {{ .VarName }}(ctx context.Context{{ if .PayloadRef }}, p {{ .PayloadRef }}{{ end }}{{ if .MethodData.SkipRequestBodyEncodeDecode}}, req io.ReadCloser{{ end }}) ({{ if $unaryResultType }}res {{ $unaryResultType }}, {{ end }}{{ if .MethodData.SkipResponseBodyEncodeDecode }}resp io.ReadCloser, {{ end }}err error) {
+	{{- if or $unaryResultType .MethodData.SkipResponseBodyEncodeDecode }}
+	var ires any
+	{{- end }}
+	{{ if or $unaryResultType .MethodData.SkipResponseBodyEncodeDecode }}ires{{ else }}_{{ end }}, err = c.{{ .EndpointField }}(ctx, {{ if .MethodData.SkipRequestBodyEncodeDecode }}&{{ .RequestStruct }}{ {{ if .PayloadRef }}Payload: p, {{ end }}Body: req }{{ else if .PayloadRef }}p{{ else }}nil{{ end }})
+	{{- if not (or $unaryResultType .MethodData.SkipResponseBodyEncodeDecode) }}
+	return
+	{{- else }}
+	if err != nil {
+		return
+	}
+		{{- if .MethodData.SkipResponseBodyEncodeDecode }}
+	o := ires.(*{{ .MethodData.ResponseStruct }})
+	return {{ if .ResultRef }}o.Result, {{ end }}o.Body, nil
+		{{- else }}
+	return ires.({{ $unaryResultType }}), nil
+		{{- end }}
+	{{- end }}
+}
+
+{{ printf "%sStream calls the %q endpoint of the %q service with server streaming enabled." .VarName .Name .ServiceName | comment }}
+func (c *{{ .ClientVarName }}) {{ .VarName }}Stream(ctx context.Context{{ if .PayloadRef }}, p {{ .PayloadRef }}{{ end }}{{ if .MethodData.SkipRequestBodyEncodeDecode}}, req io.ReadCloser{{ end }}) (res {{ .ClientStream.Interface }}, err error) {
+	var ires any
+	ires, err = c.{{ .StreamEndpointField }}(ctx, {{ if .MethodData.SkipRequestBodyEncodeDecode }}&{{ .RequestStruct }}{ {{ if .PayloadRef }}Payload: p, {{ end }}Body: req }{{ else if .PayloadRef }}p{{ else }}nil{{ end }})
+	if err != nil {
+		return
+	}
+	return ires.({{ .ClientStream.Interface }}), nil
+}
+{{- else }}
 {{- $resultType := .ResultRef }}
 {{- if .ClientStream }}
 	{{- /* When a client stream exists, always return it from the client method. */ -}}
@@ -31,3 +63,4 @@ func (c *{{ .ClientVarName }}) {{ .VarName }}(ctx context.Context{{ if .PayloadR
 		{{- end }}
 	{{- end }}
 }
+{{- end }}

--- a/codegen/service/templates/service_endpoint_method.go.tpl
+++ b/codegen/service/templates/service_endpoint_method.go.tpl
@@ -120,7 +120,24 @@ func New{{ .VarName }}Endpoint(s {{ .ServiceVarName }}{{ range .Schemes.DedupeBy
 
 {{- if .ServerStream }}
 	{{- if .ServerStream.EndpointStruct }}
+		{{- if .HasMixedResults }}
+		res, {{ if .ViewedResult }}{{ if not .ViewedResult.ViewName }}view, {{ end }}{{ end }}err := s.{{ .VarName }}(ctx, {{ if .PayloadRef }}{{ $payload }}, {{ end }}ep.Stream)
+		if err != nil {
+			return nil, err
+		}
+			{{- if .ViewedResult }}
+				{{- if .ViewedResult.ViewName }}
+		vres := {{ $.ViewedResult.Init.Name }}(res, {{ printf "%q" .ViewedResult.ViewName }})
+				{{- else }}
+		vres := {{ $.ViewedResult.Init.Name }}(res, view)
+				{{- end }}
+		return vres, nil
+			{{- else }}
+		return res, nil
+			{{- end }}
+		{{- else }}
 		return nil, s.{{ .VarName }}(ctx, {{ if .PayloadRef }}{{ $payload }}, {{ end }}ep.Stream)
+		{{- end }}
 	{{- else }}
 		{{- /* JSON-RPC WebSocket client streaming: no stream parameter, just payload */ -}}
 		{{- if .PayloadRef }}

--- a/codegen/service/testdata/client_code.go
+++ b/codegen/service/testdata/client_code.go
@@ -133,6 +133,44 @@ func (c *Client) StreamingResultMethod(ctx context.Context, p *APayload) (res St
 }
 `
 
+const MixedResultsMethodClient = `// Client is the "MixedResultsEndpoint" service client.
+type Client struct {
+	MixedResultsMethodEndpoint       goa.Endpoint
+	MixedResultsMethodStreamEndpoint goa.Endpoint
+}
+
+// NewClient initializes a "MixedResultsEndpoint" service client given the
+// endpoints.
+func NewClient(mixedResultsMethod, mixedResultsMethodStream goa.Endpoint) *Client {
+	return &Client{
+		MixedResultsMethodEndpoint:       mixedResultsMethod,
+		MixedResultsMethodStreamEndpoint: mixedResultsMethodStream,
+	}
+}
+
+// MixedResultsMethod calls the "MixedResultsMethod" endpoint of the
+// "MixedResultsEndpoint" service.
+func (c *Client) MixedResultsMethod(ctx context.Context, p *Payload) (res *ResultType, err error) {
+	var ires any
+	ires, err = c.MixedResultsMethodEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(*ResultType), nil
+}
+
+// MixedResultsMethodStream calls the "MixedResultsMethod" endpoint of the
+// "MixedResultsEndpoint" service with server streaming enabled.
+func (c *Client) MixedResultsMethodStream(ctx context.Context, p *Payload) (res MixedResultsMethodClientStream, err error) {
+	var ires any
+	ires, err = c.MixedResultsMethodStreamEndpoint(ctx, p)
+	if err != nil {
+		return
+	}
+	return ires.(MixedResultsMethodClientStream), nil
+}
+`
+
 const StreamingResultNoPayloadMethodClient = `// Client is the "StreamingResultNoPayloadService" service client.
 type Client struct {
 	StreamingResultNoPayloadMethodEndpoint goa.Endpoint

--- a/codegen/service/testdata/endpoint_code.go
+++ b/codegen/service/testdata/endpoint_code.go
@@ -242,6 +242,49 @@ func NewStreamingResultMethodEndpoint(s Service) goa.Endpoint {
 }
 `
 
+const MixedResultsMethodEndpoint = `// Endpoints wraps the "MixedResultsEndpoint" service endpoints.
+type Endpoints struct {
+	MixedResultsMethod goa.Endpoint
+}
+
+// MixedResultsMethodEndpointInput holds both the payload and the server stream
+// of the "MixedResultsMethod" method.
+type MixedResultsMethodEndpointInput struct {
+	// Payload is the method payload.
+	Payload *Payload
+	// Stream is the server stream used by the "MixedResultsMethod" method to send
+	// data.
+	Stream MixedResultsMethodServerStream
+}
+
+// NewEndpoints wraps the methods of the "MixedResultsEndpoint" service with
+// endpoints.
+func NewEndpoints(s Service) *Endpoints {
+	return &Endpoints{
+		MixedResultsMethod: NewMixedResultsMethodEndpoint(s),
+	}
+}
+
+// Use applies the given middleware to all the "MixedResultsEndpoint" service
+// endpoints.
+func (e *Endpoints) Use(m func(goa.Endpoint) goa.Endpoint) {
+	e.MixedResultsMethod = m(e.MixedResultsMethod)
+}
+
+// NewMixedResultsMethodEndpoint returns an endpoint function that calls the
+// method "MixedResultsMethod" of service "MixedResultsEndpoint".
+func NewMixedResultsMethodEndpoint(s Service) goa.Endpoint {
+	return func(ctx context.Context, req any) (any, error) {
+		ep := req.(*MixedResultsMethodEndpointInput)
+		res, err := s.MixedResultsMethod(ctx, ep.Payload, ep.Stream)
+		if err != nil {
+			return nil, err
+		}
+		return res, nil
+	}
+}
+`
+
 const StreamingResultNoPayloadMethodEndpoint = `// Endpoints wraps the "StreamingResultNoPayloadEndpoint" service endpoints.
 type Endpoints struct {
 	StreamingResultNoPayloadMethod goa.Endpoint

--- a/codegen/service/testdata/endpoint_dsls.go
+++ b/codegen/service/testdata/endpoint_dsls.go
@@ -116,6 +116,28 @@ var StreamingResultEndpointDSL = func() {
 	})
 }
 
+var MixedResultsEndpointDSL = func() {
+	var PayloadType = Type("Payload", func() {
+		Attribute("id", String)
+		Required("id")
+	})
+	var ResultType = Type("ResultType", func() {
+		Attribute("ok", Boolean)
+		Required("ok")
+	})
+	var EventType = Type("EventType", func() {
+		Attribute("message", String)
+		Required("message")
+	})
+	Service("MixedResultsEndpoint", func() {
+		Method("MixedResultsMethod", func() {
+			Payload(PayloadType)
+			Result(ResultType)
+			StreamingResult(EventType)
+		})
+	})
+}
+
 var StreamingPayloadEndpointDSL = func() {
 	var AType = Type("AType", func() {
 		Attribute("a", String)

--- a/codegen/service/testdata/golden/service_service-mixed-results.go.golden
+++ b/codegen/service/testdata/golden/service_service-mixed-results.go.golden
@@ -1,0 +1,60 @@
+
+// Service is the MixedResultsEndpoint service interface.
+type Service interface {
+	// MixedResultsMethod implements MixedResultsMethod.
+	MixedResultsMethod(context.Context, *Payload, MixedResultsMethodServerStream) (res *ResultType, err error)
+}
+
+// APIName is the name of the API as defined in the design.
+const APIName = "test api"
+
+// APIVersion is the version of the API as defined in the design.
+const APIVersion = "0.0.1"
+
+// ServiceName is the name of the service as defined in the design. This is the
+// same value that is set in the endpoint request contexts under the ServiceKey
+// key.
+const ServiceName = "MixedResultsEndpoint"
+
+// MethodNames lists the service method names as defined in the design. These
+// are the same values that are set in the endpoint request contexts under the
+// MethodKey key.
+var MethodNames = [1]string{"MixedResultsMethod"}
+
+// MixedResultsMethodServerStream allows streaming instances of *EventType to
+// the client.
+type MixedResultsMethodServerStream interface {
+	// Send streams instances of "EventType".
+	Send(*EventType) error
+	// SendWithContext streams instances of "EventType" with context.
+	SendWithContext(context.Context, *EventType) error
+	// Close closes the stream.
+	Close() error
+}
+
+// MixedResultsMethodClientStream allows streaming instances of *EventType to
+// the client.
+type MixedResultsMethodClientStream interface {
+	// Recv reads instances of "EventType" from the stream.
+	Recv() (*EventType, error)
+	// RecvWithContext reads instances of "EventType" from the stream with context.
+	RecvWithContext(context.Context) (*EventType, error)
+}
+
+// EventType is the streaming result type of the MixedResultsEndpoint service
+// MixedResultsMethod method.
+type EventType struct {
+	Message string
+}
+
+// Payload is the payload type of the MixedResultsEndpoint service
+// MixedResultsMethod method.
+type Payload struct {
+	ID string
+}
+
+// ResultType is the result type of the MixedResultsEndpoint service
+// MixedResultsMethod method.
+type ResultType struct {
+	OK bool
+}

--- a/http/codegen/sse.go
+++ b/http/codegen/sse.go
@@ -137,6 +137,14 @@ func initSSEData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData) {
 		RequestIDPointer:    ridPtr,
 	}
 
+	// Mixed results SSE uses the streaming result type for events, not the unary
+	// HTTP response body type. Disable HTTP response body conversion in the SSE
+	// stream implementation and marshal the event value directly.
+	if ed.HasMixedResults {
+		ed.SSE.HasResponseBody = false
+		return
+	}
+
 	if ed.Result != nil {
 		for _, resp := range ed.Result.Responses {
 			if len(resp.ServerBody) > 0 {

--- a/http/codegen/sse_client.go
+++ b/http/codegen/sse_client.go
@@ -3,6 +3,7 @@ package codegen
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/expr"
@@ -76,6 +77,9 @@ func sseClientTemplateSections(data *ServiceData) []*codegen.SectionTemplate {
 					dict[key] = values[i+1]
 				}
 				return dict, nil
+			},
+			"deref": func(ref string) string {
+				return strings.TrimPrefix(ref, "*")
 			},
 		}
 		sections = append(sections, &codegen.SectionTemplate{

--- a/http/codegen/sse_mixed_results_test.go
+++ b/http/codegen/sse_mixed_results_test.go
@@ -1,0 +1,55 @@
+package codegen
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/http/codegen/testdata"
+)
+
+func TestSSE_MixedResults(t *testing.T) {
+	root := RunHTTPDSL(t, testdata.MixedResultsDSL)
+	services := CreateHTTPServices(root)
+
+	t.Run("server", func(t *testing.T) {
+		files := ServerFiles("", services)
+		var sseFile *codegen.File
+		for _, f := range files {
+			if strings.HasSuffix(f.Path, filepath.Join("server", "sse.go")) {
+				sseFile = f
+				break
+			}
+		}
+		require.NotNil(t, sseFile)
+
+		sections := sseFile.Section("server-sse")
+		require.NotEmpty(t, sections)
+		code := codegen.SectionCode(t, sections[0])
+
+		require.Contains(t, code, "payload = res")
+		require.NotContains(t, code, "NewCreateResponseBody")
+	})
+
+	t.Run("client", func(t *testing.T) {
+		files := ClientFiles("", services)
+		var sseFile *codegen.File
+		for _, f := range files {
+			if strings.HasSuffix(f.Path, filepath.Join("client", "sse.go")) {
+				sseFile = f
+				break
+			}
+		}
+		require.NotNil(t, sseFile)
+
+		sections := sseFile.Section("client-sse")
+		require.NotEmpty(t, sections)
+		code := codegen.SectionCode(t, sections[0])
+
+		require.Contains(t, code, "event = new(")
+	})
+}
+

--- a/http/codegen/streaming_test.go
+++ b/http/codegen/streaming_test.go
@@ -39,6 +39,9 @@ func TestServerStreaming(t *testing.T) {
 		}},
 
 		// streaming result
+		{"mixed-results", testdata.MixedResultsDSL, []*sectionExpectation{
+			{"server-handler-init", &testdata.MixedResultsServerHandlerInitCode},
+		}},
 		{"streaming-result", testdata.StreamingResultDSL, []*sectionExpectation{
 			{"server-handler-init", &testdata.StreamingResultServerHandlerInitCode},
 			{"server-websocket-send", &testdata.StreamingResultServerStreamSendCode},

--- a/http/codegen/templates/client_sse.go.tpl
+++ b/http/codegen/templates/client_sse.go.tpl
@@ -183,7 +183,7 @@ func (s *{{ .Method.VarName }}StreamImpl) Close() error {
 // processEvent processes a raw SSE event into the expected type
 func (s *{{ .Method.VarName }}StreamImpl) processEvent(eventData []byte) (event {{ .SSE.EventTypeRef }}, err error) {
         {{- if .SSE.EventIsStruct }}
-        event = &{{ .SSE.EventTypeName }}{}
+        event = new({{ deref .SSE.EventTypeRef }})
         {{- end }}
         var dataLines []string
         for _, line := range bytes.Split(eventData, []byte("\n")) {

--- a/http/codegen/templates/server_handler_init.go.tpl
+++ b/http/codegen/templates/server_handler_init.go.tpl
@@ -94,7 +94,16 @@ func {{ .HandlerInit }}(
 			data := &{{ .ServicePkgName }}.{{ .Method.RequestStruct }}{ {{ if .Payload.Ref }}Payload: payload, {{ end }}Body: r.Body }
 			res, err := endpoint(ctx, data)
 		{{- else }}
-			res, err := endpoint(ctx, {{ if .Payload.Ref }}payload{{ else }}nil{{ end }})
+			// Mixed results endpoints always use the generated endpoint input struct.
+			// In the standard (non-SSE) mode, Stream discards events and the service
+			// must return the synchronous result.
+			v := &{{ .ServicePkgName }}.{{ .Method.ServerStream.EndpointStruct }}{
+				Stream: &discard{{ .Method.VarName }}ServerStream{},
+			{{- if .Payload.Ref }}
+				Payload: payload,
+			{{- end }}
+			}
+			res, err := endpoint(ctx, v)
 		{{- end }}
 			if err != nil {
 				if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
@@ -289,3 +298,27 @@ func {{ .HandlerInit }}(
 	{{- end }}{{/* end of not .HasMixedResults */}}
 	})
 }
+
+{{- if .HasMixedResults }}
+
+// discard{{ .Method.VarName }}ServerStream implements the {{ .SSE.Interface }}
+// interface and drops all events. It is used for mixed results endpoints in
+// unary (non-SSE) mode so service implementations can use the stream parameter
+// without nil checks.
+type discard{{ .Method.VarName }}ServerStream struct{}
+
+// {{ .SSE.SendName }} discards the event.
+func (s *discard{{ .Method.VarName }}ServerStream) {{ .SSE.SendName }}(v {{ .SSE.EventTypeRef }}) error {
+	return nil
+}
+
+// {{ .SSE.SendWithContextName }} discards the event.
+func (s *discard{{ .Method.VarName }}ServerStream) {{ .SSE.SendWithContextName }}(ctx context.Context, v {{ .SSE.EventTypeRef }}) error {
+	return nil
+}
+
+// Close is a no-op.
+func (s *discard{{ .Method.VarName }}ServerStream) Close() error {
+	return nil
+}
+{{- end }}

--- a/http/codegen/testdata/streaming_code.go
+++ b/http/codegen/testdata/streaming_code.go
@@ -80,6 +80,104 @@ func NewStreamingResultMethodHandler(
 }
 `
 
+var MixedResultsServerHandlerInitCode = `// NewCreateHandler creates a HTTP handler which loads the HTTP request and
+// calls the "MixedResultsService" service "Create" endpoint.
+func NewCreateHandler(
+	endpoint goa.Endpoint,
+	mux goahttp.Muxer,
+	decoder func(*http.Request) goahttp.Decoder,
+	encoder func(context.Context, http.ResponseWriter) goahttp.Encoder,
+	errhandler func(context.Context, http.ResponseWriter, error),
+	formatter func(ctx context.Context, err error) goahttp.Statuser,
+) http.Handler {
+	var (
+		decodeRequest  = DecodeCreateRequest(mux, decoder)
+		encodeResponse = EncodeCreateResponse(encoder)
+		encodeError    = goahttp.ErrorEncoder(encoder, formatter)
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), goahttp.AcceptTypeKey, r.Header.Get("Accept"))
+		ctx = context.WithValue(ctx, goa.MethodKey, "Create")
+		ctx = context.WithValue(ctx, goa.ServiceKey, "MixedResultsService")
+
+		// Content negotiation for mixed results (standard HTTP vs SSE)
+		acceptHeader := r.Header.Get("Accept")
+		if strings.Contains(acceptHeader, "text/event-stream") {
+			// Handle SSE request
+			payload, err := decodeRequest(r)
+			if err != nil {
+				if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+					errhandler(ctx, w, err)
+				}
+				return
+			}
+			v := &mixedresultsservice.CreateEndpointInput{
+				Stream: &CreateServerStream{
+					w: w,
+					r: r,
+				},
+				Payload: payload,
+			}
+			_, err = endpoint(ctx, v)
+			if err != nil {
+				if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+					errhandler(ctx, w, err)
+				}
+			}
+		} else {
+			// Handle standard HTTP request
+			payload, err := decodeRequest(r)
+			if err != nil {
+				if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+					errhandler(ctx, w, err)
+				}
+				return
+			}
+			// Mixed results endpoints always use the generated endpoint input struct.
+			// In the standard (non-SSE) mode, Stream discards events and the service
+			// must return the synchronous result.
+			v := &mixedresultsservice.CreateEndpointInput{
+				Stream:  &discardCreateServerStream{},
+				Payload: payload,
+			}
+			res, err := endpoint(ctx, v)
+			if err != nil {
+				if err := encodeError(ctx, w, err); err != nil && errhandler != nil {
+					errhandler(ctx, w, err)
+				}
+				return
+			}
+			if err := encodeResponse(ctx, w, res); err != nil {
+				if errhandler != nil {
+					errhandler(ctx, w, err)
+				}
+			}
+		}
+	})
+}
+
+// discardCreateServerStream implements the mixedresultsservice.CreateServerStream
+// interface and drops all events. It is used for mixed results endpoints in
+// unary (non-SSE) mode so service implementations can use the stream parameter
+// without nil checks.
+type discardCreateServerStream struct{}
+
+// Send discards the event.
+func (s *discardCreateServerStream) Send(v *mixedresultsservice.Event) error {
+	return nil
+}
+
+// SendWithContext discards the event.
+func (s *discardCreateServerStream) SendWithContext(ctx context.Context, v *mixedresultsservice.Event) error {
+	return nil
+}
+
+// Close is a no-op.
+func (s *discardCreateServerStream) Close() error {
+	return nil
+}
+`
+
 var StreamingResultServerStreamSendCode = `// Send streams instances of "streamingresultservice.UserType" to the
 // "StreamingResultMethod" endpoint websocket connection.
 func (s *StreamingResultMethodServerStream) Send(v *streamingresultservice.UserType) error {

--- a/http/codegen/testdata/streaming_dsls.go
+++ b/http/codegen/testdata/streaming_dsls.go
@@ -74,6 +74,33 @@ var StreamingResultDSL = func() {
 	})
 }
 
+var MixedResultsDSL = func() {
+	var PayloadType = Type("Payload", func() {
+		Attribute("x", String)
+		Required("x")
+	})
+	var ResultType = Type("Result", func() {
+		Attribute("id", String)
+		Required("id")
+	})
+	var EventType = Type("Event", func() {
+		Attribute("message", String)
+		Required("message")
+	})
+	Service("MixedResultsService", func() {
+		Method("Create", func() {
+			Payload(PayloadType)
+			Result(ResultType)
+			StreamingResult(EventType)
+			HTTP(func() {
+				POST("/jobs")
+				ServerSentEvents()
+				Response(StatusOK)
+			})
+		})
+	})
+}
+
 var StreamingResultWithViewsDSL = func() {
 	var Request = Type("Request", func() {
 		Attribute("x", String)


### PR DESCRIPTION
## Summary
- Support methods that define both `Result` (unary/JSON) and `StreamingResult` (SSE) with distinct types.
- Generate HTTP handler content negotiation based on `Accept` and always pass a unified endpoint input struct.
- In unary mode, pass a non-nil discard stream implementation so service implementations can use the stream parameter without nil checks.
- Generate a split client API for mixed results: unary method + `<Method>Stream` variant.

## Rationale
This matches the documented HTTP content negotiation story for SSE while fixing the runtime type-assertion panic for mixed results endpoints.

## Test plan
- `make test`