### PR TITLE
http/codegen: decode composite client responses without wrappers

### DIFF
--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -1666,7 +1666,7 @@ func (sds *ServicesData) buildResponses(e *expr.HTTPEndpointExpr, result *expr.A
 					}
 					clientBodyData = sds.buildResponseBodyType(resp.Body, result, md.ResultLoc, e, false, nil, sd)
 				}
-				if clientBodyData != nil {
+				if clientBodyData != nil && clientBodyData.Def != "" {
 					sd.ClientTypeNames[clientBodyData.Name] = false
 				}
 				for _, h := range headersData {
@@ -1993,7 +1993,9 @@ func (sds *ServicesData) buildErrorsData(e *expr.HTTPEndpointExpr, sd *ServiceDa
 				}
 				clientBodyData = sds.buildResponseBodyType(v.Response.Body, v.AttributeExpr, errorLoc, e, false, nil, sd)
 				if clientBodyData != nil {
-					sd.ClientTypeNames[clientBodyData.Name] = false
+					if clientBodyData.Def != "" {
+						sd.ClientTypeNames[clientBodyData.Name] = false
+					}
 					clientBodyData.Description = fmt.Sprintf("%s is the type of the %q service %q endpoint HTTP response body for the %q error.",
 						clientBodyData.VarName, svc.Name, e.Name(), v.Name)
 					serverBodyData[0].Description = fmt.Sprintf("%s is the type of the %q service %q endpoint HTTP response body for the %q error.",
@@ -2274,12 +2276,27 @@ func (sds *ServicesData) buildResponseBodyType(body, att *expr.AttributeExpr, lo
 			}
 		}
 	} else if !expr.IsPrimitive(body.Type) && mustInit {
-		// response body is an array or map type.
-		name = codegen.Goify(e.Name(), true) + "ResponseBody"
-		varname = name
-		desc = fmt.Sprintf("%s is the type of the %q service %q endpoint HTTP response body.",
-			varname, svc.Name, e.Name())
-		def = goTypeDef(sd.Scope, body, !svr, svr)
+		// Response body is an array or map type.
+		//
+		// Server-side code needs a named wrapper (scoped to the endpoint) so the
+		// generator can produce stable constructor identifiers (e.g.
+		// New<Endpoint>ResponseBody) for element-wise transforms and projections.
+		//
+		// Client-side code decodes directly into the concrete composite type (e.g.
+		// []T, map[K]V) and validates/transforms the value in-place. This avoids
+		// generating endpoint-named alias types that are structurally identical and
+		// may be deduplicated away in client/types.go.
+		if svr {
+			name = codegen.Goify(e.Name(), true) + "ResponseBody"
+			varname = name
+			desc = fmt.Sprintf("%s is the type of the %q service %q endpoint HTTP response body.",
+				varname, svc.Name, e.Name())
+			def = goTypeDef(sd.Scope, body, !svr, svr)
+		} else {
+			varname = sd.Scope.GoTypeRef(body)
+			desc = body.Description
+			def = ""
+		}
 		validateRef = codegen.ValidationCode(body, nil, httpctx, true, expr.IsAlias(body.Type), false, "body")
 	} else {
 		// response body is a primitive type. They are used as non-pointers when
@@ -2376,7 +2393,7 @@ func (sds *ServicesData) buildResponseBodyType(body, att *expr.AttributeExpr, lo
 			ServerArgs:          []*InitArgData{&arg},
 		}
 	}
-	return &TypeData{
+	td := &TypeData{
 		Name:        name,
 		VarName:     varname,
 		Description: desc,
@@ -2388,6 +2405,7 @@ func (sds *ServicesData) buildResponseBodyType(body, att *expr.AttributeExpr, lo
 		Example:     body.Example(sds.Root.API.ExampleGenerator),
 		View:        viewName,
 	}
+	return td
 }
 
 func (sds *ServicesData) extractPathParams(a *expr.MappedAttributeExpr, service *expr.AttributeExpr, scope *codegen.NameScope) []*ParamData {

--- a/http/codegen/testdata/streaming_code.go
+++ b/http/codegen/testdata/streaming_code.go
@@ -1040,7 +1040,7 @@ var StreamingResultUserTypeArrayClientStreamRecvCode = `// Recv reads instances 
 func (s *StreamingResultUserTypeArrayMethodClientStream) Recv() ([]*streamingresultusertypearrayservice.UserType, error) {
 	var (
 		rv   []*streamingresultusertypearrayservice.UserType
-		body StreamingResultUserTypeArrayMethodResponseBody
+		body []*UserTypeResponse
 		err  error
 	)
 	err = s.conn.ReadJSON(&body)
@@ -1107,7 +1107,7 @@ var StreamingResultUserTypeMapClientStreamRecvCode = `// Recv reads instances of
 func (s *StreamingResultUserTypeMapMethodClientStream) Recv() (map[string]*streamingresultusertypemapservice.UserType, error) {
 	var (
 		rv   map[string]*streamingresultusertypemapservice.UserType
-		body StreamingResultUserTypeMapMethodResponseBody
+		body map[string]*UserTypeResponse
 		err  error
 	)
 	err = s.conn.ReadJSON(&body)
@@ -4128,7 +4128,7 @@ var BidirectionalStreamingUserTypeArrayClientStreamRecvCode = `// Recv reads ins
 func (s *BidirectionalStreamingUserTypeArrayMethodClientStream) Recv() ([]*bidirectionalstreamingusertypearrayservice.ResultType, error) {
 	var (
 		rv   []*bidirectionalstreamingusertypearrayservice.ResultType
-		body BidirectionalStreamingUserTypeArrayMethodResponseBody
+		body []*ResultTypeResponse
 		err  error
 	)
 	err = s.conn.ReadJSON(&body)
@@ -4256,7 +4256,7 @@ var BidirectionalStreamingUserTypeMapClientStreamRecvCode = `// Recv reads insta
 func (s *BidirectionalStreamingUserTypeMapMethodClientStream) Recv() (map[string]*bidirectionalstreamingusertypemapservice.ResultType, error) {
 	var (
 		rv   map[string]*bidirectionalstreamingusertypemapservice.ResultType
-		body BidirectionalStreamingUserTypeMapMethodResponseBody
+		body map[string]*ResultTypeResponse
 		err  error
 	)
 	err = s.conn.ReadJSON(&body)


### PR DESCRIPTION
## Summary
- Stop generating endpoint-scoped `*ResponseBody` wrapper aliases for unnamed array/map HTTP **client** response bodies.
- Client decode paths now decode directly into the concrete composite wire type (e.g. `[]T`, `map[K]V`).
- Update HTTP websocket streaming codegen expectations accordingly.

## Rationale
Recent HTTP client codegen deduplicates body type declarations by structural type (`Ref`). For unnamed composite response bodies, the generator previously used endpoint-derived wrapper names (e.g. `ListStarredSessionsResponseBody`) in decode sites, but `client/types.go` could emit only one declaration for the shared `Ref`, causing undefined type build failures.

This change removes the mismatch at the source by making client composite response bodies *never* depend on endpoint-named wrappers. Server-side wrappers remain unchanged because they are used for stable constructor identifiers and server projection semantics.

## Test plan
- `make`
  - runs lint (`0 issues.`)
  - runs `go test ./... --coverprofile=cover.out`
  - runs JSON-RPC integration tests (`jsonrpc/integration_tests`)