### PR TITLE
revert response body key to data.Name in client_types.go

### DIFF
--- a/http/codegen/client_types.go
+++ b/http/codegen/client_types.go
@@ -125,10 +125,10 @@ func clientType(genpkg string, svc *expr.HTTPServiceExpr, seen map[string]struct
 		adata := data.Endpoint(a.Name())
 		for _, resp := range adata.Result.Responses {
 			if data := resp.ClientBody; data != nil {
-				if _, ok := seen[data.Ref]; ok {
+				if _, ok := seen[data.Name]; ok {
 					continue
 				}
-				seen[data.Ref] = struct{}{}
+				seen[data.Name] = struct{}{}
 				if data.Def != "" {
 					sections = append(sections, &codegen.SectionTemplate{
 						Name:   "client-response-body",


### PR DESCRIPTION
PR #3879 fixed a bug where multiple ArrayOf request body types collided because data.Name was always "array". 
The fix changed the dedup key to data.Ref across all body types. 
However, for response bodies, data.Name is already unique per endpoint. This causes endpoints with Result(ArrayOf(SameType)) to collide, generating only the first type alias in types.go while encode_decode.go references all of them.

This PR reverts the response body dedup key back to data.Name.

### Reproduction

```
var Item = Type("Item", func() {
      Attribute("id", String)
      Attribute("name", String)
      Required("id", "name")
  })

  Service("example", func() {
      Method("list_a", func() {
          Result(ArrayOf(Item))
          HTTP(func() { GET("/a") })
      })
      Method("list_b", func() {
          Result(ArrayOf(Item))
          HTTP(func() { GET("/b") })
      })
  })
```

  list_a generates ListAResponseBody in types.go. list_b does not generate ListBResponseBody, but encode_decode.go references it, causing a compile error.
