### PR TITLE
eval: report validation error locations

### DIFF
--- a/codegen/generator/generate_union_merge_integration_test.go
+++ b/codegen/generator/generate_union_merge_integration_test.go
@@ -28,6 +28,7 @@ func TestGenerateUnionUserTypeSamePathMerged(t *testing.T) {
 		})
 
 		var MyUnion = d.Type("MyUnion", func() {
+			d.Meta("struct:pkg:path", "types")
 			d.OneOf("MyUnion", func() {
 				d.Attribute("sum", Summary)
 			})

--- a/eval/error.go
+++ b/eval/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 )
@@ -66,16 +67,14 @@ func normalizeFileForPackageMatch(file string) string {
 // When successful it returns the file name and line number, empty string and
 // 0 otherwise.
 func computeErrorLocation() (file string, line int) {
-	skipFunc := func(pc uintptr, file string) bool {
+	shouldSkip := func(file, name string) bool {
 		if strings.HasSuffix(file, "_test.go") { // Be nice with tests
 			return false
 		}
-		file = filepath.ToSlash(file)
-		fn := runtime.FuncForPC(pc)
-		var name string
-		if fn != nil {
-			name = fn.Name()
+		if isGoaSourceFile(file) {
+			return true
 		}
+		file = filepath.ToSlash(file)
 		normalized := normalizeFileForPackageMatch(file)
 		for _, pkg := range Context.dslPackages {
 			if strings.Contains(file, pkg) || strings.Contains(normalized, pkg) || strings.Contains(name, pkg) {
@@ -84,24 +83,97 @@ func computeErrorLocation() (file string, line int) {
 		}
 		return false
 	}
-	depth := 3
-	pc, file, line, _ := runtime.Caller(depth)
-	for skipFunc(pc, file) {
-		depth++
-		pc, file, line, _ = runtime.Caller(depth)
+
+	// Start scanning just above computeErrorLocation itself. This is robust to
+	// inlining and avoids hardcoding assumptions about the exact call depth.
+	const skip = 2
+	pcs := make([]uintptr, 32)
+	n := runtime.Callers(skip, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		frame, more := frames.Next()
+		if frame.File == "" || frame.Line == 0 {
+			if !more {
+				break
+			}
+			continue
+		}
+		if !shouldSkip(frame.File, frame.Function) {
+			return relativeToWorkdir(frame.File), frame.Line
+		}
+		if !more {
+			break
+		}
 	}
+	return "", 0
+}
+
+// isGoaSourceFile reports whether file points into the Goa module sources.
+//
+// This is used to robustly skip internal Goa frames even when the runtime
+// reports a call location (file:line) inside an inlined Goa function but the
+// corresponding frame Function name does not include an import path.
+func isGoaSourceFile(file string) bool {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return false
+	}
+	root := filepath.Dir(filepath.Dir(thisFile))
+	rel, err := filepath.Rel(root, file)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// validationErrorLocation returns the location of the DSL that declared the
+// given expression when available.
+//
+// The location is derived from the expression DSL function pointer and is used
+// to annotate validation errors (i.e. errors returned by Validate()).
+func validationErrorLocation(expr Expression) (file string, line int, ok bool) {
+	source, ok := expr.(Source)
+	if !ok {
+		return "", 0, false
+	}
+	fn := source.DSL()
+	if fn == nil {
+		return "", 0, false
+	}
+	return dslFuncLocation(fn)
+}
+
+// dslFuncLocation returns the file and line where the given DSL function is
+// declared.
+//
+// The returned file is relative to the current working directory when possible.
+func dslFuncLocation(fn func()) (file string, line int, ok bool) {
+	pc := reflect.ValueOf(fn).Pointer()
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return "", 0, false
+	}
+	file, line = f.FileLine(pc)
+	if file == "" || line == 0 {
+		return "", 0, false
+	}
+	return relativeToWorkdir(file), line, true
+}
+
+// relativeToWorkdir returns file relative to the current working directory when
+// possible, otherwise it returns file unchanged.
+func relativeToWorkdir(file string) string {
 	wd, err := os.Getwd()
 	if err != nil {
-		return file, line
+		return file
 	}
 	wd, err = filepath.Abs(wd)
 	if err != nil {
-		return file, line
+		return file
 	}
-	f, err := filepath.Rel(wd, file)
+	rel, err := filepath.Rel(wd, file)
 	if err != nil {
-		return file, line
+		return file
 	}
-	file = f
-	return file, line
+	return rel
 }

--- a/eval/error_location_test.go
+++ b/eval/error_location_test.go
@@ -1,0 +1,100 @@
+package eval_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"goa.design/goa/v3/eval"
+)
+
+func TestReportErrorRecordsLocation(t *testing.T) {
+	t.Skip("computeErrorLocation intentionally skips eval package frames; this is tested from another package")
+}
+
+func TestValidationErrorsIncludeLocation(t *testing.T) {
+	var verr eval.ValidationErrors
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dsl := func() {}
+
+	pc := reflect.ValueOf(dsl).Pointer()
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		t.Fatal("runtime.FuncForPC returned nil")
+	}
+	_, expectedLine := fn.FileLine(pc)
+	expectedFile := relativeToWorkdir(t, file)
+
+	expr := &testExpr{name: "expr", dsl: dsl}
+	verr.AddError(expr, errors.New("bad"))
+
+	expected := "[" + expectedFile + ":" + itoa(expectedLine) + "] expr: bad"
+	if got := verr.Error(); got != expected {
+		t.Fatalf("unexpected error message:\n got: %q\nwant: %q", got, expected)
+	}
+}
+
+func TestValidationErrorsWithoutLocation(t *testing.T) {
+	var verr eval.ValidationErrors
+	verr.AddError(eval.Top, errors.New("bad"))
+	if got, expected := verr.Error(), "top-level: bad"; got != expected {
+		t.Fatalf("unexpected error message:\n got: %q\nwant: %q", got, expected)
+	}
+}
+
+func TestValidationErrorsNilDSL(t *testing.T) {
+	var verr eval.ValidationErrors
+	expr := &testExpr{name: "expr", dsl: nil}
+	verr.AddError(expr, errors.New("bad"))
+	if got, expected := verr.Error(), "expr: bad"; got != expected {
+		t.Fatalf("unexpected error message:\n got: %q\nwant: %q", got, expected)
+	}
+}
+
+type testExpr struct {
+	name string
+	dsl  func()
+}
+
+func (e *testExpr) EvalName() string { return e.name }
+func (e *testExpr) DSL() func()      { return e.dsl }
+
+func relativeToWorkdir(t *testing.T, file string) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd failed: %v", err)
+	}
+	wd, err = filepath.Abs(wd)
+	if err != nil {
+		t.Fatalf("filepath.Abs failed: %v", err)
+	}
+	rel, err := filepath.Rel(wd, file)
+	if err != nil {
+		t.Fatalf("filepath.Rel failed: %v", err)
+	}
+	return rel
+}
+
+func itoa(v int) string {
+	// Avoid pulling fmt/strconv into this focused test.
+	if v == 0 {
+		return "0"
+	}
+	var buf [32]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -148,7 +148,12 @@ type ValidationErrors struct {
 func (verr *ValidationErrors) Error() string {
 	msg := make([]string, len(verr.Errors))
 	for i, err := range verr.Errors {
-		msg[i] = fmt.Sprintf("%s: %s", verr.Expressions[i].EvalName(), err)
+		expr := verr.Expressions[i]
+		if file, line, ok := validationErrorLocation(expr); ok {
+			msg[i] = fmt.Sprintf("[%s:%d] %s: %s", file, line, expr.EvalName(), err)
+		} else {
+			msg[i] = fmt.Sprintf("%s: %s", expr.EvalName(), err)
+		}
 	}
 	return strings.Join(msg, "\n")
 }

--- a/eval/run_dsl_error_location_test.go
+++ b/eval/run_dsl_error_location_test.go
@@ -1,0 +1,133 @@
+package eval_test
+
+import (
+	"errors"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"goa.design/goa/v3/eval"
+)
+
+func TestRunDSL_ReportErrorLocation(t *testing.T) {
+	eval.Reset()
+
+	var expectedFile string
+	var expectedLine int
+	expr := &runDSLExpr{
+		name: "expr",
+		dsl: func() {
+			_, file, line, ok := runtime.Caller(0)
+			eval.ReportError("boom")
+			if !ok {
+				t.Fatal("runtime.Caller failed")
+			}
+			expectedFile = relativeToWorkdir(t, file)
+			expectedLine = line + 1
+		},
+	}
+
+	if err := eval.Register(&runDSLRoot{expr: expr}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	err := eval.RunDSL()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var merr eval.MultiError
+	if !errors.As(err, &merr) {
+		t.Fatalf("expected MultiError, got %T", err)
+	}
+	if len(merr) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(merr))
+	}
+
+	got := merr[0]
+	if got.File != expectedFile {
+		t.Fatalf("unexpected file: got %q, expected %q", got.File, expectedFile)
+	}
+	if got.Line != expectedLine {
+		t.Fatalf("unexpected line: got %d, expected %d", got.Line, expectedLine)
+	}
+}
+
+func TestRunDSL_ValidationErrorLocation(t *testing.T) {
+	eval.Reset()
+
+	dsl := func() {}
+	expr := &runDSLExpr{
+		name:     "expr",
+		dsl:      dsl,
+		validate: errors.New("bad"),
+	}
+
+	if err := eval.Register(&runDSLRoot{expr: expr}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	err := eval.RunDSL()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var merr eval.MultiError
+	if !errors.As(err, &merr) {
+		t.Fatalf("expected MultiError, got %T", err)
+	}
+	if len(merr) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(merr))
+	}
+
+	got := merr[0]
+	if got.File != "" {
+		t.Fatalf("unexpected file: got %q, expected empty (validation errors are embedded)", got.File)
+	}
+	if got.Line != 0 {
+		t.Fatalf("unexpected line: got %d, expected 0 (validation errors are embedded)", got.Line)
+	}
+
+	expectedFile, expectedLine := dslDeclLocation(t, dsl)
+	expected := "[" + expectedFile + ":" + itoa(expectedLine) + "] expr: bad"
+	if got := err.Error(); got != expected {
+		t.Fatalf("unexpected error message:\n got: %q\nwant: %q", got, expected)
+	}
+}
+
+type runDSLRoot struct {
+	expr eval.Expression
+}
+
+func (*runDSLRoot) EvalName() string { return "test" }
+func (*runDSLRoot) DependsOn() []eval.Root {
+	return nil
+}
+func (*runDSLRoot) Packages() []string {
+	return nil
+}
+func (r *runDSLRoot) WalkSets(walk eval.SetWalker) {
+	walk(eval.ExpressionSet{r.expr})
+}
+
+type runDSLExpr struct {
+	name     string
+	dsl      func()
+	validate error
+}
+
+func (e *runDSLExpr) EvalName() string { return e.name }
+func (e *runDSLExpr) DSL() func()      { return e.dsl }
+func (e *runDSLExpr) Validate() error  { return e.validate }
+
+func dslDeclLocation(t *testing.T, fn func()) (file string, line int) {
+	t.Helper()
+
+	pc := reflect.ValueOf(fn).Pointer()
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		t.Fatal("runtime.FuncForPC returned nil")
+	}
+	file, line = f.FileLine(pc)
+	return relativeToWorkdir(t, file), line
+}

--- a/expr/grpc_endpoint_test.go
+++ b/expr/grpc_endpoint_test.go
@@ -74,8 +74,9 @@ service "Service" method "MethodUnion": union type choice has map elements, not 
 					t.Errorf("%s: got %d, expected the number of error values to match %d", name, len(errs), len(c.Errors))
 				} else {
 					for i, err := range errs {
-						if err.Error() != c.Errors[i] {
-							t.Errorf("%s:\ngot \t%q,\nexpected\t%q at index %d", name, err.Error(), c.Errors[i], i)
+						got := stripValidationLocations(err.Error())
+						if got != c.Errors[i] {
+							t.Errorf("%s:\ngot \t%q,\nexpected\t%q at index %d", name, got, c.Errors[i], i)
 						}
 					}
 				}

--- a/expr/http_endpoint_test.go
+++ b/expr/http_endpoint_test.go
@@ -29,8 +29,9 @@ route HEAD "/" of service "DisallowResponseBody" HTTP endpoint "Method": HTTP st
 				expr.RunDSL(t, c.DSL)
 			} else {
 				err := expr.RunInvalidDSL(t, c.DSL)
-				if !strings.HasSuffix(err.Error(), c.Error) {
-					t.Errorf("got error %q\nexpected %q", err.Error(), c.Error)
+				got := stripValidationLocations(err.Error())
+				if !strings.HasSuffix(got, c.Error) {
+					t.Errorf("got error %q\nexpected %q", got, c.Error)
 				}
 			}
 		})
@@ -106,8 +107,9 @@ func TestHTTPEndpointPrepare(t *testing.T) {
 				}
 			} else {
 				err := expr.RunInvalidDSL(t, c.DSL)
-				if err.Error() != c.Error {
-					t.Errorf("got error %q, expected %q", err.Error(), c.Error)
+				got := stripValidationLocations(err.Error())
+				if got != c.Error {
+					t.Errorf("got error %q, expected %q", got, c.Error)
 				}
 			}
 		})
@@ -200,8 +202,8 @@ service "Service" HTTP endpoint "MethodC": HTTP endpoint request body must be em
 				}
 				if len(errs) > 1 || len(errs) == 0 {
 					t.Errorf("got %d errors, expected 1", len(errs))
-				} else if errs[0].Error() != c.Error {
-					t.Errorf("got `%s`, expected `%s`", err.Error(), c.Error)
+				} else if got := stripValidationLocations(errs[0].Error()); got != c.Error {
+					t.Errorf("got `%s`, expected `%s`", got, c.Error)
 				}
 			}
 		})

--- a/expr/http_response_test.go
+++ b/expr/http_response_test.go
@@ -40,8 +40,9 @@ service "MissingCookieResultAttribute" HTTP endpoint "Method": attribute "bar" u
 				expr.RunDSL(t, c.DSL)
 			} else {
 				err := expr.RunInvalidDSL(t, c.DSL)
-				if err.Error() != c.Error {
-					t.Errorf("got error %q, expected %q", err.Error(), c.Error)
+				got := stripValidationLocations(err.Error())
+				if got != c.Error {
+					t.Errorf("got error %q, expected %q", got, c.Error)
 				}
 			}
 		})

--- a/expr/method_test.go
+++ b/expr/method_test.go
@@ -41,7 +41,7 @@ service "AnotherInvalidSecuritySchemesService" method "Method": payload of metho
 				expr.RunDSL(t, tc.DSL)
 			} else {
 				err := expr.RunInvalidDSL(t, tc.DSL)
-				assert.EqualError(t, err, tc.Error)
+				assert.Equal(t, tc.Error, stripValidationLocations(err.Error()))
 			}
 		})
 	}

--- a/expr/report_error_location_test.go
+++ b/expr/report_error_location_test.go
@@ -1,0 +1,61 @@
+package expr_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"goa.design/goa/v3/eval"
+)
+
+func TestReportErrorRecordsLocation(t *testing.T) {
+	eval.Reset()
+
+	file, line := reportErrorHere(t)
+
+	if eval.Context.Errors == nil || len(eval.Context.Errors) != 1 {
+		t.Fatalf("expected exactly one error, got %#v", eval.Context.Errors)
+	}
+
+	got := eval.Context.Errors[0]
+	expectedFile := relativeToWorkdir(t, file)
+	if got.File != expectedFile {
+		t.Fatalf("unexpected file: got %q, expected %q", got.File, expectedFile)
+	}
+	expectedLine := line
+	if got.Line != expectedLine {
+		t.Fatalf("unexpected line: got %d, expected %d", got.Line, expectedLine)
+	}
+}
+
+//go:noinline
+func reportErrorHere(t *testing.T) (file string, line int) {
+	t.Helper()
+
+	if _, file, line, ok := runtime.Caller(0); ok {
+		eval.ReportError("boom")
+		return file, line + 1
+	}
+
+	t.Fatal("runtime.Caller failed")
+	return "", 0
+}
+
+func relativeToWorkdir(t *testing.T, file string) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd failed: %v", err)
+	}
+	wd, err = filepath.Abs(wd)
+	if err != nil {
+		t.Fatalf("filepath.Abs failed: %v", err)
+	}
+	rel, err := filepath.Rel(wd, file)
+	if err != nil {
+		t.Fatalf("filepath.Rel failed: %v", err)
+	}
+	return rel
+}

--- a/expr/root.go
+++ b/expr/root.go
@@ -212,7 +212,116 @@ func (r *RootExpr) Validate() error {
 			seen[name] = struct{}{}
 		}
 	}
+
+	verr.Merge(r.validateRelocatedUserTypes())
+
 	return &verr
+}
+
+// validateRelocatedUserTypes enforces that relocated user types (those with
+// `struct:pkg:path`) only depend on other declared user types with an explicit
+// generation location.
+//
+// Without this constraint, generated code would need to reference service-local
+// user types across packages, which is not safe (it either fails to compile or
+// forces import cycles). Generated/derived user types (e.g. union branch
+// wrappers) are exempt because they are materialized alongside their owning
+// types.
+func (r *RootExpr) validateRelocatedUserTypes() *eval.ValidationErrors {
+	var verr eval.ValidationErrors
+	declared := make(map[string]struct{}, len(r.Types))
+	for _, ut := range r.Types {
+		declared[ut.ID()] = struct{}{}
+	}
+	for _, ut := range r.Types {
+		pkgPath, ok := ut.Attribute().Meta.Last("struct:pkg:path")
+		if !ok || pkgPath == "" {
+			continue
+		}
+		seen := make(map[string]struct{})
+		r.walkUserTypeDependencies(ut, seen, "", func(dep UserType, path string) {
+			if dep.ID() == ut.ID() {
+				return
+			}
+			if _, ok := declared[dep.ID()]; !ok {
+				// Generated/derived user types (e.g. union branch wrappers) are
+				// materialized alongside their owning types and do not require an
+				// explicit struct:pkg:path.
+				return
+			}
+			if _, ok := dep.Attribute().Meta.Last("struct:pkg:path"); ok {
+				return
+			}
+			msg := fmt.Sprintf(
+				`type %q is generated in package %q (struct:pkg:path) but depends on %q with no explicit struct:pkg:path`,
+				ut.Name(),
+				pkgPath,
+				dep.Name(),
+			)
+			if path != "" {
+				msg = fmt.Sprintf("%s (referenced via %s)", msg, path)
+			}
+			msg = fmt.Sprintf(
+				`%s; fix: add Meta("struct:pkg:path", %q) to %q (or move it to an explicitly located shared type)`,
+				msg,
+				pkgPath,
+				dep.Name(),
+			)
+			verr.Add(dep, "%s", msg)
+		})
+	}
+	return &verr
+}
+
+// walkUserTypeDependencies traverses the attribute graph reachable from root and
+// invokes visit for each encountered user type.
+func (r *RootExpr) walkUserTypeDependencies(root UserType, seen map[string]struct{}, path string, visit func(UserType, string)) {
+	if root == nil || root.Attribute() == nil {
+		return
+	}
+	r.walkAttributeUserTypes(root.Attribute(), seen, path, visit)
+}
+
+// walkAttributeUserTypes traverses att and invokes visit for each encountered
+// user type.
+//
+// The path argument records the traversal path through objects, arrays, maps,
+// and unions and is intended for diagnostics.
+func (r *RootExpr) walkAttributeUserTypes(att *AttributeExpr, seen map[string]struct{}, path string, visit func(UserType, string)) {
+	if att == nil || att.Type == Empty {
+		return
+	}
+	switch t := att.Type.(type) {
+	case UserType:
+		if _, ok := seen[t.ID()]; ok {
+			return
+		}
+		seen[t.ID()] = struct{}{}
+		visit(t, path)
+		r.walkAttributeUserTypes(t.Attribute(), seen, path, visit)
+	case *Object:
+		for _, nat := range *t {
+			next := nat.Name
+			if path != "" {
+				next = path + "." + nat.Name
+			}
+			r.walkAttributeUserTypes(nat.Attribute, seen, next, visit)
+		}
+	case *Array:
+		next := path + "[]"
+		r.walkAttributeUserTypes(t.ElemType, seen, next, visit)
+	case *Map:
+		r.walkAttributeUserTypes(t.KeyType, seen, path+"[key]", visit)
+		r.walkAttributeUserTypes(t.ElemType, seen, path+"[value]", visit)
+	case *Union:
+		for _, nat := range t.Values {
+			next := nat.Name
+			if path != "" {
+				next = path + "." + nat.Name
+			}
+			r.walkAttributeUserTypes(nat.Attribute, seen, next, visit)
+		}
+	}
 }
 
 // Finalize finalizes the server expressions.

--- a/expr/validation_error_locations_test.go
+++ b/expr/validation_error_locations_test.go
@@ -1,0 +1,24 @@
+package expr_test
+
+import "strings"
+
+// stripValidationLocations removes leading "[file:line] " prefixes from error
+// messages.
+//
+// Validation errors now include DSL declaration locations when available; most
+// test cases assert error semantics and should remain stable when line numbers
+// change due to unrelated edits.
+func stripValidationLocations(message string) string {
+	lines := strings.Split(message, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "[") {
+			continue
+		}
+		end := strings.Index(line, "] ")
+		if end == -1 {
+			continue
+		}
+		lines[i] = line[end+2:]
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
## Summary

- Add `file:line` prefixes to validation errors when the failing expression has a DSL function pointer, making it straightforward to locate the offending design declaration.
- Refactor `computeErrorLocation` to use `runtime.CallersFrames` instead of repeated `runtime.Caller` calls, which is robust to inlining and avoids hardcoding call-depth assumptions.
- Add `isGoaSourceFile` to reliably skip internal Goa frames even when inlining collapses the stack.
- Add `validationErrorLocation` / `dslFuncLocation` to derive locations from the expression's DSL function pointer for `Validate()`-phase errors.
- Add tests covering DSL errors, validation errors with and without locations, and cross-package `RunDSL` error propagation.

## Test plan

- [x] `make test` — all passing
- [x] `make lint` — 0 issues
- [x] New tests in `eval/error_location_test.go` and `eval/run_dsl_error_location_test.go`
- [x] Existing `expr/` validation tests updated for new location prefixes