### PR TITLE
http: set r.Pattern on dispatched requests for automatic route tagging

### DIFF
--- a/http/mux.go
+++ b/http/mux.go
@@ -94,6 +94,10 @@ func NewMuxer() ResolverMuxer {
 var wildPath = regexp.MustCompile(`/{\*([a-zA-Z0-9_]+)}`)
 
 // Handle registers the handler function for the given method and pattern.
+// It sets r.Pattern on every matched request to "METHOD /path" (matching the
+// Go 1.22+ convention used by http.ServeMux), enabling observability
+// middleware such as otelhttp to automatically tag spans and metrics with
+// the matched route.
 func (m *mux) Handle(method, pattern string, handler http.HandlerFunc) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -109,6 +113,9 @@ func (m *mux) Handle(method, pattern string, handler http.HandlerFunc) {
 		}))
 		m.middlewares = nil
 	}
+	// Capture the registered pattern before wildcard rewriting so we can
+	// populate r.Pattern for downstream consumers.
+	reqPattern := method + " " + pattern
 	if wildcards := wildPath.FindStringSubmatch(pattern); len(wildcards) > 0 {
 		if len(wildcards) > 2 {
 			panic("too many wildcards")
@@ -116,7 +123,10 @@ func (m *mux) Handle(method, pattern string, handler http.HandlerFunc) {
 		pattern = wildPath.ReplaceAllString(pattern, "/*")
 		m.wildcards[method+"::"+pattern] = wildcards[1]
 	}
-	m.Method(method, pattern, handler)
+	m.Method(method, pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Pattern = reqPattern
+		handler(w, r)
+	}))
 }
 
 // Vars extracts the path variables from the request context.

--- a/http/mux_test.go
+++ b/http/mux_test.go
@@ -146,6 +146,53 @@ func TestVars(t *testing.T) {
 	}
 }
 
+func TestRequestPattern(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Method   string
+		Pattern  string
+		URL      string
+		Expected string
+	}{
+		{
+			Name:     "simple",
+			Method:   "GET",
+			Pattern:  "/users",
+			URL:      "/users",
+			Expected: "GET /users",
+		},
+		{
+			Name:     "with segment",
+			Method:   "POST",
+			Pattern:  "/users/{id}",
+			URL:      "/users/123",
+			Expected: "POST /users/{id}",
+		},
+		{
+			Name:     "with wildcard",
+			Method:   "GET",
+			Pattern:  "/files/{*path}",
+			URL:      "/files/a/b/c",
+			Expected: "GET /files/{*path}",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			var called bool
+			mux := NewMuxer()
+			mux.Handle(c.Method, c.Pattern, func(_ http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, c.Expected, r.Pattern)
+				called = true
+			})
+			req, _ := http.NewRequest(c.Method, c.URL, nil)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			assert.True(t, called)
+		})
+	}
+}
+
 func TestResolvePattern(t *testing.T) {
 	cases := []struct {
 		Name     string


### PR DESCRIPTION
## Summary

The default HTTP muxer now populates `r.Pattern` with `"METHOD /path"` on every dispatched request, following the [Go 1.22+ convention](https://pkg.go.dev/net/http#Request) established by `http.ServeMux`.

This enables observability middleware such as `otelhttp` (v0.65.0+) to **automatically** tag spans and metrics with the matched route — no per-handler wrapping required.

## Problem

The `otelhttp` package removed [`WithRouteTag`](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/8268) in v0.65.0, breaking the [otel plugin](https://github.com/goadesign/plugins/tree/v3/otel) which generated calls to that function. The upstream replacement is `r.Pattern` — otelhttp now reads it automatically after handler dispatch.

Since Goa uses a Chi-based muxer (not `http.ServeMux`), `r.Pattern` was never set, so otelhttp couldn't pick up the route.

## Solution

A single change in `mux.Handle`: capture the original Goa pattern before Chi's wildcard rewriting and set `r.Pattern` inside the handler wrapper:

```go
reqPattern := method + " " + pattern
// ... wildcard rewriting ...
m.Method(method, pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
    r.Pattern = reqPattern
    handler(w, r)
}))
```

Benefits over the old plugin approach:
- **One place** instead of N per-handler wrappers
- **Covers all handlers** uniformly — endpoints and file servers alike (the plugin only covered endpoints)
- **No fragile template string surgery** in a plugin
- **Zero otelhttp dependency** in generated or framework code — pure Go stdlib `r.Pattern`

The otel plugin has been deprecated in [goadesign/plugins#242](https://github.com/goadesign/plugins/pull/242).

Fixes #3896

## Test plan

- [x] New `TestRequestPattern` — verifies `r.Pattern` is set correctly for simple paths, parameterized segments (`/users/{id}`), and wildcards (`/files/{*path}`)
- [x] All existing mux tests pass (`TestMiddlewares`, `TestVars`, `TestResolvePattern`)
- [x] `go test ./http/` green