### PR TITLE
codegen/service: fix primitive OneOf alias emission with struct:pkg:path

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -457,6 +457,12 @@ type (
 		FieldName string
 		// FieldType is the Go type used in the union struct field and public API.
 		FieldType string
+		// EmitPrimitiveAlias is true when the branch uses a generated primitive alias
+		// that must be declared in the same file as the union type.
+		EmitPrimitiveAlias bool
+		// PrimitiveAliasType is the underlying Go type used by the generated branch
+		// alias (for example "string" or "float64").
+		PrimitiveAliasType string
 		// TypeTag is the JSON "type" discriminator value for this branch.
 		TypeTag string
 	}
@@ -746,7 +752,7 @@ func (d *ServicesData) analyze(service *expr.ServiceExpr) *Data {
 
 	// A function to collect user types from an error expression
 	recordError := func(er *expr.ErrorExpr) {
-		errTypes = append(errTypes, collectTypes(er.AttributeExpr, scope, seen)...)
+		errTypes = append(errTypes, collectTypes(er.AttributeExpr, scope, seen, nil)...)
 		if er.Type == expr.ErrorResult {
 			if _, ok := seenErrors[er.Name]; ok {
 				return
@@ -764,10 +770,12 @@ func (d *ServicesData) analyze(service *expr.ServiceExpr) *Data {
 		if att == nil {
 			return
 		}
+		var loc *codegen.Location
 		if ut, ok := att.Type.(expr.UserType); ok {
+			loc = codegen.UserTypeLocation(ut)
 			att = ut.Attribute()
 		}
-		types = append(types, collectTypes(att, scope, seen)...)
+		types = append(types, collectTypes(att, scope, seen, loc)...)
 	}
 	for _, m := range service.Methods {
 		// collect inner user types
@@ -829,12 +837,12 @@ func (d *ServicesData) analyze(service *expr.ServiceExpr) *Data {
 		if len(svcs) > 0 {
 			// Force generate type only in the specified services
 			if slices.Contains(svcs, service.Name) {
-				types = append(types, collectTypes(att, scope, seen)...)
+				types = append(types, collectTypes(att, scope, seen, nil)...)
 			}
 			continue
 		}
 		// Force generate type in all the services
-		types = append(types, collectTypes(att, scope, seen)...)
+		types = append(types, collectTypes(att, scope, seen, nil)...)
 	}
 
 	var (
@@ -1006,15 +1014,21 @@ func projectedTypeContext(pkg string, ptr bool, scope *codegen.NameScope) *codeg
 
 // collectTypes recurses through the attribute to gather all user types and
 // records them in userTypes.
-func collectTypes(at *expr.AttributeExpr, scope *codegen.NameScope, seen map[string]struct{}) (data []*UserTypeData) {
+func collectTypes(at *expr.AttributeExpr, scope *codegen.NameScope, seen map[string]struct{}, loc *codegen.Location) (data []*UserTypeData) {
 	if at == nil || at.Type == expr.Empty {
 		return data
 	}
-	collect := func(at *expr.AttributeExpr) []*UserTypeData { return collectTypes(at, scope, seen) }
+	collect := func(at *expr.AttributeExpr, loc *codegen.Location) []*UserTypeData {
+		return collectTypes(at, scope, seen, loc)
+	}
 	switch dt := at.Type.(type) {
 	case expr.UserType:
 		if _, ok := seen[dt.ID()]; ok {
 			return nil
+		}
+		typeLoc := codegen.UserTypeLocation(dt)
+		if typeLoc == nil {
+			typeLoc = loc
 		}
 		data = append(data, &UserTypeData{
 			Name:        dt.Name(),
@@ -1022,23 +1036,23 @@ func collectTypes(at *expr.AttributeExpr, scope *codegen.NameScope, seen map[str
 			Description: dt.Attribute().Description,
 			Def:         scope.GoTypeDef(dt.Attribute(), false, true),
 			Ref:         scope.GoTypeRef(at),
-			Loc:         codegen.UserTypeLocation(dt),
+			Loc:         typeLoc,
 			Type:        dt,
 		})
 		seen[dt.ID()] = struct{}{}
-		data = append(data, collect(dt.Attribute())...)
+		data = append(data, collect(dt.Attribute(), typeLoc)...)
 	case *expr.Object:
 		for _, nat := range *dt {
-			data = append(data, collect(nat.Attribute)...)
+			data = append(data, collect(nat.Attribute, loc)...)
 		}
 	case *expr.Array:
-		data = append(data, collect(dt.ElemType)...)
+		data = append(data, collect(dt.ElemType, loc)...)
 	case *expr.Map:
-		data = append(data, collect(dt.KeyType)...)
-		data = append(data, collect(dt.ElemType)...)
+		data = append(data, collect(dt.KeyType, loc)...)
+		data = append(data, collect(dt.ElemType, loc)...)
 	case *expr.Union:
 		for _, nat := range dt.Values {
-			data = append(data, collect(nat.Attribute)...)
+			data = append(data, collect(nat.Attribute, loc)...)
 		}
 	}
 	return data
@@ -1097,13 +1111,18 @@ func buildUnionTypeData(u *expr.Union, scope *codegen.NameScope, loc *codegen.Lo
 			}
 		}
 		fieldType := scope.GoFullTypeRef(nat.Attribute, pkg)
+		primitiveAliasType, hasPrimitiveAlias := primitiveAliasGoType(nat.Attribute.Type)
+		_, isUserType := nat.Attribute.Type.(expr.UserType)
+		emitPrimitiveAlias := hasPrimitiveAlias && !isUserType && pkg == ""
 		kindConst := kindName + codegen.Goify(nat.Name, true)
 		fields[i] = &UnionFieldData{
-			Name:      nat.Name,
-			KindConst: kindConst,
-			FieldName: fieldName,
-			FieldType: fieldType,
-			TypeTag:   nat.Name,
+			Name:               nat.Name,
+			KindConst:          kindConst,
+			FieldName:          fieldName,
+			FieldType:          fieldType,
+			EmitPrimitiveAlias: emitPrimitiveAlias,
+			PrimitiveAliasType: primitiveAliasType,
+			TypeTag:            nat.Name,
 		}
 	}
 
@@ -1164,13 +1183,18 @@ func buildViewUnionTypeData(u *expr.Union, scope *codegen.NameScope, loc *codege
 	for i, nat := range u.Values {
 		fieldName := codegen.Goify(nat.Name, true)
 		fieldType := scope.GoTypeRef(nat.Attribute)
+		primitiveAliasType, hasPrimitiveAlias := primitiveAliasGoType(nat.Attribute.Type)
+		_, isUserType := nat.Attribute.Type.(expr.UserType)
+		emitPrimitiveAlias := hasPrimitiveAlias && !isUserType
 		kindConst := kindName + codegen.Goify(nat.Name, true)
 		fields[i] = &UnionFieldData{
-			Name:      nat.Name,
-			KindConst: kindConst,
-			FieldName: fieldName,
-			FieldType: fieldType,
-			TypeTag:   nat.Name,
+			Name:               nat.Name,
+			KindConst:          kindConst,
+			FieldName:          fieldName,
+			FieldType:          fieldType,
+			EmitPrimitiveAlias: emitPrimitiveAlias,
+			PrimitiveAliasType: primitiveAliasType,
+			TypeTag:            nat.Name,
 		}
 	}
 
@@ -1181,6 +1205,21 @@ func buildViewUnionTypeData(u *expr.Union, scope *codegen.NameScope, loc *codege
 		Loc:      loc,
 		TypeKey:  u.GetTypeKey(),
 		ValueKey: u.GetValueKey(),
+	}
+}
+
+// primitiveAliasGoType resolves the native Go type for a primitive alias branch.
+// It uses expr.IsPrimitive to enforce the type contract and then unwraps aliases.
+func primitiveAliasGoType(dt expr.DataType) (string, bool) {
+	if !expr.IsPrimitive(dt) {
+		return "", false
+	}
+	for {
+		ut, ok := dt.(expr.UserType)
+		if !ok {
+			return codegen.GoNativeTypeName(dt), true
+		}
+		dt = ut.Attribute().Type
 	}
 }
 

--- a/codegen/service/service_test.go
+++ b/codegen/service/service_test.go
@@ -173,3 +173,42 @@ func TestStructPkgPath_UnionImportsJSON(t *testing.T) {
 	code := buf.String()
 	require.Contains(t, code, "\"encoding/json\"", "expected encoding/json import in generated file:\n%s", code)
 }
+
+func TestStructPkgPath_UnionJSONFieldBranchesGenerateAliases(t *testing.T) {
+	root := codegen.RunDSL(t, testdata.PkgPathUnionJSONFieldDSL)
+	services := NewServicesData(root)
+	require.Len(t, root.Services, 1)
+
+	files := Files("goa.design/goa/example", root.Services[0], services, make(map[string][]string))
+	require.GreaterOrEqual(t, len(files), 2, "expected at least service.go + one struct:pkg:path file")
+
+	var typeFile *codegen.File
+	for _, f := range files {
+		if strings.HasSuffix(f.Path, filepath.Join("gen", "types", "type_with_json_field_union.go")) {
+			typeFile = f
+			break
+		}
+	}
+	require.NotNil(t, typeFile, "expected generated type file for struct:pkg:path type_with_json_field_union")
+
+	buf := new(bytes.Buffer)
+	for _, s := range typeFile.SectionTemplates {
+		require.NoError(t, s.Write(buf))
+	}
+	code := buf.String()
+	hasInlineAliases := strings.Contains(code, "type ValuesA string") && strings.Contains(code, "type ValuesB int")
+	if hasInlineAliases {
+		return
+	}
+
+	var hasValuesAFile, hasValuesBFile bool
+	for _, f := range files {
+		if strings.HasSuffix(f.Path, filepath.Join("gen", "types", "values_a.go")) {
+			hasValuesAFile = true
+		}
+		if strings.HasSuffix(f.Path, filepath.Join("gen", "types", "values_b.go")) {
+			hasValuesBFile = true
+		}
+	}
+	require.True(t, hasValuesAFile && hasValuesBFile, "expected generated aliases for JSONField union branches")
+}

--- a/codegen/service/service_test.go
+++ b/codegen/service/service_test.go
@@ -196,10 +196,8 @@ func TestStructPkgPath_UnionJSONFieldBranchesGenerateAliases(t *testing.T) {
 		require.NoError(t, s.Write(buf))
 	}
 	code := buf.String()
-	hasInlineAliases := strings.Contains(code, "type ValuesA string") && strings.Contains(code, "type ValuesB int")
-	if hasInlineAliases {
-		return
-	}
+	require.Contains(t, code, "A ValuesA", "expected union field A to use generated alias type:\n%s", code)
+	require.Contains(t, code, "B ValuesB", "expected union field B to use generated alias type:\n%s", code)
 
 	var hasValuesAFile, hasValuesBFile bool
 	for _, f := range files {
@@ -210,5 +208,6 @@ func TestStructPkgPath_UnionJSONFieldBranchesGenerateAliases(t *testing.T) {
 			hasValuesBFile = true
 		}
 	}
-	require.True(t, hasValuesAFile && hasValuesBFile, "expected generated aliases for JSONField union branches")
+	require.True(t, hasValuesAFile, "expected generated alias file in struct:pkg:path package: gen/types/values_a.go")
+	require.True(t, hasValuesBFile, "expected generated alias file in struct:pkg:path package: gen/types/values_b.go")
 }

--- a/codegen/service/templates/union_type.go.tpl
+++ b/codegen/service/templates/union_type.go.tpl
@@ -1,4 +1,10 @@
 {{- /* Union sum-type definition and helpers. */ -}}
+{{- range .Fields }}
+{{- if .EmitPrimitiveAlias }}
+type {{ .FieldType }} {{ .PrimitiveAliasType }}
+
+{{- end }}
+{{- end }}
 // {{ .Name }} is a sum-type union.
 type {{ .Name }} struct {
 	kind {{ .KindName }}

--- a/codegen/service/testdata/service_dsls.go
+++ b/codegen/service/testdata/service_dsls.go
@@ -158,6 +158,27 @@ var PkgPathUnionDSL = func() {
 	})
 }
 
+// PkgPathUnionJSONFieldDSL tests OneOf branches declared with JSONField in a
+// struct:pkg:path type.
+var PkgPathUnionJSONFieldDSL = func() {
+	var TypeWithJSONFieldUnion = Type("TypeWithJSONFieldUnion", func() {
+		Meta("struct:pkg:path", "types")
+		OneOf("Values", func() {
+			Field(1, "A", String, func() {
+				Meta("struct:tag:json", "a")
+			})
+			Field(2, "B", Int, func() {
+				Meta("struct:tag:json", "b")
+			})
+		})
+	})
+	Service("PkgPathUnionJSONField", func() {
+		Method("M", func() {
+			Payload(TypeWithJSONFieldUnion)
+		})
+	})
+}
+
 var WithDefaultDSL = func() {
 	Service("WithDefault", func() {
 		Method("A", func() {


### PR DESCRIPTION
## Summary
- Fix `collectTypes` location propagation so nested user types inside `struct:pkg:path` contexts keep the correct output package path.
- Emit primitive OneOf branch aliases inline in union files when the branch resolves to a local primitive alias that would otherwise be unresolved.
- Add regression coverage for `struct:pkg:path` + OneOf primitive branch generation (including JSON-tagged field variants).

Closes #3899.

## Test plan
- [x] `go test ./codegen/service`
- [x] `go test ./codegen/generator -run "TestGenerateMergesSamePathFiles|TestGenerateUnionUserTypeSamePathMerged"`
- [x] Reproduced generation success in a scheduling-style design where `v3.25.1` previously produced `undefined: Value*` compile errors