### PR TITLE
Fix HTTP request decoders for primitive payloads

### DIFF
--- a/http/codegen/server_decode_test.go
+++ b/http/codegen/server_decode_test.go
@@ -113,6 +113,7 @@ func TestDecode(t *testing.T) {
 		{"decode-path-array-string-validate", testdata.PayloadPathArrayStringValidateDSL},
 
 		{"decode-path-primitive-string-validate", testdata.PayloadPathPrimitiveStringValidateDSL},
+		{"decode-path-primitive-string-formatip-validate", testdata.PayloadPathPrimitiveStringFormatIPValidateDSL},
 		{"decode-path-primitive-bool-validate", testdata.PayloadPathPrimitiveBoolValidateDSL},
 		{"decode-path-primitive-array-string-validate", testdata.PayloadPathPrimitiveArrayStringValidateDSL},
 		{"decode-path-primitive-array-bool-validate", testdata.PayloadPathPrimitiveArrayBoolValidateDSL},
@@ -225,6 +226,7 @@ func TestDecode(t *testing.T) {
 			sections := fs[1].SectionTemplates
 			require.Greater(t, len(sections), 2)
 			code := codegen.SectionCode(t, sections[2])
+			require.NotContains(t, code, "return nil,")
 			testutil.AssertGo(t, "testdata/golden/server_decode_"+c.Name+".go.golden", code)
 		})
 	}

--- a/http/codegen/templates/request_decoder.go.tpl
+++ b/http/codegen/templates/request_decoder.go.tpl
@@ -1,14 +1,14 @@
 {{ printf "%s returns a decoder for requests sent to the %s %s endpoint." .RequestDecoder .ServiceName .Method.Name | comment }}
 func {{ .RequestDecoder }}(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ({{ .Payload.Ref }}, error) {
 	return func(r *http.Request) ({{ .Payload.Ref }}, error) {
-{{- if .MultipartRequestDecoder }}
 		var payload {{ .Payload.Ref }}
+{{- if .MultipartRequestDecoder }}
 		if err := decoder(r).Decode(&payload); err != nil {
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 {{- else if .Payload.Request.ServerBody }}
 		var (
@@ -19,7 +19,7 @@ func {{ .RequestDecoder }}(mux goahttp.Muxer, decoder func(*http.Request) goahtt
 		if err != nil {
 	{{- if .Payload.Request.MustHaveBody }}
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 	{{- else }}
 			if errors.Is(err, io.EOF) {
@@ -28,9 +28,9 @@ func {{ .RequestDecoder }}(mux goahttp.Muxer, decoder func(*http.Request) goahtt
 	{{- end }}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 	{{- if not .Payload.Request.MustHaveBody }}
 			}
 	{{- end }}
@@ -38,7 +38,7 @@ func {{ .RequestDecoder }}(mux goahttp.Muxer, decoder func(*http.Request) goahtt
 	{{- if .Payload.Request.ServerBody.ValidateRef }}
 		{{ .Payload.Request.ServerBody.ValidateRef }}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 	{{- end }}
 {{- end }}
@@ -46,22 +46,22 @@ func {{ .RequestDecoder }}(mux goahttp.Muxer, decoder func(*http.Request) goahtt
 	{{- template "partial_request_elements" .Payload.Request }}
 	{{- if .Payload.Request.MustValidate }}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 	{{- end }}
 	{{- if .Payload.Request.PayloadInit }}
-	payload := {{ .Payload.Request.PayloadInit.Name }}({{ range .Payload.Request.PayloadInit.ServerArgs }}{{ .Ref }}, {{ end }})
+	payload = {{ .Payload.Request.PayloadInit.Name }}({{ range .Payload.Request.PayloadInit.ServerArgs }}{{ .Ref }}, {{ end }})
 	{{- else if .Payload.DecoderReturnValue }}
-	payload := {{ .Payload.DecoderReturnValue }}
+	payload = {{ .Payload.DecoderReturnValue }}
 	{{- else }}
-	payload := body
+	payload = body
 	{{- end }}
 {{- end }}
 {{- if .BasicScheme }}{{ with .BasicScheme }}
 	user, pass, {{ if or .UsernameRequired .PasswordRequired }}ok{{ else }}_{{ end }} := r.BasicAuth()
 		{{- if or .UsernameRequired .PasswordRequired}}
 	if !ok {
-		return nil, goa.MissingFieldError("Authorization", "header")
+		return payload, goa.MissingFieldError("Authorization", "header")
 	}
 		{{- end }}
 	payload.{{ .UsernameField }} = {{ if .UsernamePointer }}&{{ end }}user

--- a/http/codegen/testdata/golden/server_decode_decode-body-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodBodyArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyarraystringvalidate.MethodBodyArrayStringValidatePayload, error) {
 	return func(r *http.Request) (*servicebodyarraystringvalidate.MethodBodyArrayStringValidatePayload, error) {
+		var payload *servicebodyarraystringvalidate.MethodBodyArrayStringValidatePayload
 		var (
 			body MethodBodyArrayStringValidateRequestBody
 			err  error
@@ -10,19 +11,19 @@ func DecodeMethodBodyArrayStringValidateRequest(mux goahttp.Muxer, decoder func(
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyArrayStringValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyArrayStringValidatePayload(&body)
+		payload = NewMethodBodyArrayStringValidatePayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-array-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-array-string.go.golden
@@ -2,6 +2,7 @@
 // the ServiceBodyArrayString MethodBodyArrayString endpoint.
 func DecodeMethodBodyArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyarraystring.MethodBodyArrayStringPayload, error) {
 	return func(r *http.Request) (*servicebodyarraystring.MethodBodyArrayStringPayload, error) {
+		var payload *servicebodyarraystring.MethodBodyArrayStringPayload
 		var (
 			body MethodBodyArrayStringRequestBody
 			err  error
@@ -9,15 +10,15 @@ func DecodeMethodBodyArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Re
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
-		payload := NewMethodBodyArrayStringPayload(&body)
+		payload = NewMethodBodyArrayStringPayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-array-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-array-user-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceBodyArrayUserValidate MethodBodyArrayUserValidate endpoint.
 func DecodeMethodBodyArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyarrayuservalidate.MethodBodyArrayUserValidatePayload, error) {
 	return func(r *http.Request) (*servicebodyarrayuservalidate.MethodBodyArrayUserValidatePayload, error) {
+		var payload *servicebodyarrayuservalidate.MethodBodyArrayUserValidatePayload
 		var (
 			body MethodBodyArrayUserValidateRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyArrayUserValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyArrayUserValidatePayload(&body)
+		payload = NewMethodBodyArrayUserValidatePayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-array-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-array-user.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyArrayUser MethodBodyArrayUser endpoint.
 func DecodeMethodBodyArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyarrayuser.MethodBodyArrayUserPayload, error) {
 	return func(r *http.Request) (*servicebodyarrayuser.MethodBodyArrayUserPayload, error) {
+		var payload *servicebodyarrayuser.MethodBodyArrayUserPayload
 		var (
 			body MethodBodyArrayUserRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Requ
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyArrayUserRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyArrayUserPayload(&body)
+		payload = NewMethodBodyArrayUserPayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-custom-name.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-custom-name.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyCustomName MethodBodyCustomName endpoint.
 func DecodeMethodBodyCustomNameRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodycustomname.MethodBodyCustomNamePayload, error) {
 	return func(r *http.Request) (*servicebodycustomname.MethodBodyCustomNamePayload, error) {
+		var payload *servicebodycustomname.MethodBodyCustomNamePayload
 		var (
 			body MethodBodyCustomNameRequestBody
 			err  error
@@ -9,15 +10,15 @@ func DecodeMethodBodyCustomNameRequest(mux goahttp.Muxer, decoder func(*http.Req
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
-		payload := NewMethodBodyCustomNamePayload(&body)
+		payload = NewMethodBodyCustomNamePayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-extend-primitive-field-array-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-extend-primitive-field-array-user.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyprimitivearrayuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyprimitivearrayuser.PayloadType, error) {
+		var payload *servicebodyprimitivearrayuser.PayloadType
 		var (
 			body []string
 			err  error
@@ -14,12 +15,12 @@ func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*
 			} else {
 				var gerr *goa.ServiceError
 				if errors.As(err, &gerr) {
-					return nil, gerr
+					return payload, gerr
 				}
-				return nil, goa.DecodePayloadError(err.Error())
+				return payload, goa.DecodePayloadError(err.Error())
 			}
 		}
-		payload := NewMethodBodyPrimitiveArrayUserPayloadType(body)
+		payload = NewMethodBodyPrimitiveArrayUserPayloadType(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-extend-primitive-field-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-extend-primitive-field-string.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyprimitivearrayuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyprimitivearrayuser.PayloadType, error) {
+		var payload *servicebodyprimitivearrayuser.PayloadType
 		var (
 			body string
 			err  error
@@ -14,12 +15,12 @@ func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*
 			} else {
 				var gerr *goa.ServiceError
 				if errors.As(err, &gerr) {
-					return nil, gerr
+					return payload, gerr
 				}
-				return nil, goa.DecodePayloadError(err.Error())
+				return payload, goa.DecodePayloadError(err.Error())
 			}
 		}
-		payload := NewMethodBodyPrimitiveArrayUserPayloadType(body)
+		payload = NewMethodBodyPrimitiveArrayUserPayloadType(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-map-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-map-string-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceBodyMapStringValidate MethodBodyMapStringValidate endpoint.
 func DecodeMethodBodyMapStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodymapstringvalidate.MethodBodyMapStringValidatePayload, error) {
 	return func(r *http.Request) (*servicebodymapstringvalidate.MethodBodyMapStringValidatePayload, error) {
+		var payload *servicebodymapstringvalidate.MethodBodyMapStringValidatePayload
 		var (
 			body MethodBodyMapStringValidateRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyMapStringValidateRequest(mux goahttp.Muxer, decoder func(*h
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyMapStringValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyMapStringValidatePayload(&body)
+		payload = NewMethodBodyMapStringValidatePayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-map-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-map-string.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyMapString MethodBodyMapString endpoint.
 func DecodeMethodBodyMapStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodymapstring.MethodBodyMapStringPayload, error) {
 	return func(r *http.Request) (*servicebodymapstring.MethodBodyMapStringPayload, error) {
+		var payload *servicebodymapstring.MethodBodyMapStringPayload
 		var (
 			body MethodBodyMapStringRequestBody
 			err  error
@@ -9,15 +10,15 @@ func DecodeMethodBodyMapStringRequest(mux goahttp.Muxer, decoder func(*http.Requ
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
-		payload := NewMethodBodyMapStringPayload(&body)
+		payload = NewMethodBodyMapStringPayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-map-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-map-user-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceBodyMapUserValidate MethodBodyMapUserValidate endpoint.
 func DecodeMethodBodyMapUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodymapuservalidate.MethodBodyMapUserValidatePayload, error) {
 	return func(r *http.Request) (*servicebodymapuservalidate.MethodBodyMapUserValidatePayload, error) {
+		var payload *servicebodymapuservalidate.MethodBodyMapUserValidatePayload
 		var (
 			body MethodBodyMapUserValidateRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyMapUserValidateRequest(mux goahttp.Muxer, decoder func(*htt
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyMapUserValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyMapUserValidatePayload(&body)
+		payload = NewMethodBodyMapUserValidatePayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-map-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-map-user.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyMapUser MethodBodyMapUser endpoint.
 func DecodeMethodBodyMapUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodymapuser.MethodBodyMapUserPayload, error) {
 	return func(r *http.Request) (*servicebodymapuser.MethodBodyMapUserPayload, error) {
+		var payload *servicebodymapuser.MethodBodyMapUserPayload
 		var (
 			body MethodBodyMapUserRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyMapUserRequest(mux goahttp.Muxer, decoder func(*http.Reques
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyMapUserRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyMapUserPayload(&body)
+		payload = NewMethodBodyMapUserPayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-object-required.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-object-required.go.golden
@@ -2,6 +2,7 @@
 // the ServiceBodyObjectRequired MethodBodyObjectRequired endpoint.
 func DecodeMethodBodyObjectRequiredRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyobjectrequired.MethodBodyObjectRequiredPayload, error) {
 	return func(r *http.Request) (*servicebodyobjectrequired.MethodBodyObjectRequiredPayload, error) {
+		var payload *servicebodyobjectrequired.MethodBodyObjectRequiredPayload
 		var (
 			body struct {
 				B *string `form:"b" json:"b" xml:"b"`
@@ -11,21 +12,21 @@ func DecodeMethodBodyObjectRequiredRequest(mux goahttp.Muxer, decoder func(*http
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		if body.B == nil {
 			err = goa.MergeErrors(err, goa.MissingFieldError("b", "body"))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyObjectRequiredPayload(body)
+		payload = NewMethodBodyObjectRequiredPayload(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-object-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-object-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceBodyObjectValidate MethodBodyObjectValidate endpoint.
 func DecodeMethodBodyObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyobjectvalidate.MethodBodyObjectValidatePayload, error) {
 	return func(r *http.Request) (*servicebodyobjectvalidate.MethodBodyObjectValidatePayload, error) {
+		var payload *servicebodyobjectvalidate.MethodBodyObjectValidatePayload
 		var (
 			body struct {
 				B *string `form:"b" json:"b" xml:"b"`
@@ -11,21 +12,21 @@ func DecodeMethodBodyObjectValidateRequest(mux goahttp.Muxer, decoder func(*http
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		if body.B != nil {
 			err = goa.MergeErrors(err, goa.ValidatePattern("body.b", *body.B, "pattern"))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyObjectValidatePayload(body)
+		payload = NewMethodBodyObjectValidatePayload(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-object.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-object.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyObject MethodBodyObject endpoint.
 func DecodeMethodBodyObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyobject.MethodBodyObjectPayload, error) {
 	return func(r *http.Request) (*servicebodyobject.MethodBodyObjectPayload, error) {
+		var payload *servicebodyobject.MethodBodyObjectPayload
 		var (
 			body struct {
 				B *string `form:"b" json:"b" xml:"b"`
@@ -11,15 +12,15 @@ func DecodeMethodBodyObjectRequest(mux goahttp.Muxer, decoder func(*http.Request
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
-		payload := NewMethodBodyObjectPayload(body)
+		payload = NewMethodBodyObjectPayload(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-path-object-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-path-object-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodBodyPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodypathobjectvalidate.MethodBodyPathObjectValidatePayload, error) {
 	return func(r *http.Request) (*servicebodypathobjectvalidate.MethodBodyPathObjectValidatePayload, error) {
+		var payload *servicebodypathobjectvalidate.MethodBodyPathObjectValidatePayload
 		var (
 			body MethodBodyPathObjectValidateRequestBody
 			err  error
@@ -10,17 +11,17 @@ func DecodeMethodBodyPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyPathObjectValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 
 		var (
@@ -31,9 +32,9 @@ func DecodeMethodBodyPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*
 		b = params["b"]
 		err = goa.MergeErrors(err, goa.ValidatePattern("b", b, "patternb"))
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyPathObjectValidatePayload(&body, b)
+		payload = NewMethodBodyPathObjectValidatePayload(&body, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-path-object.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-path-object.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyPathObject MethodBodyPathObject endpoint.
 func DecodeMethodBodyPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodypathobject.MethodBodyPathObjectPayload, error) {
 	return func(r *http.Request) (*servicebodypathobject.MethodBodyPathObjectPayload, error) {
+		var payload *servicebodypathobject.MethodBodyPathObjectPayload
 		var (
 			body MethodBodyPathObjectRequestBody
 			err  error
@@ -9,13 +10,13 @@ func DecodeMethodBodyPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Req
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		var (
@@ -24,7 +25,7 @@ func DecodeMethodBodyPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Req
 			params = mux.Vars(r)
 		)
 		b = params["b"]
-		payload := NewMethodBodyPathObjectPayload(&body, b)
+		payload = NewMethodBodyPathObjectPayload(&body, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-path-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-path-user-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceBodyPathUserValidate MethodUserBodyPathValidate endpoint.
 func DecodeMethodUserBodyPathValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodypathuservalidate.PayloadType, error) {
 	return func(r *http.Request) (*servicebodypathuservalidate.PayloadType, error) {
+		var payload *servicebodypathuservalidate.PayloadType
 		var (
 			body MethodUserBodyPathValidateRequestBody
 			err  error
@@ -9,17 +10,17 @@ func DecodeMethodUserBodyPathValidateRequest(mux goahttp.Muxer, decoder func(*ht
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodUserBodyPathValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 
 		var (
@@ -30,9 +31,9 @@ func DecodeMethodUserBodyPathValidateRequest(mux goahttp.Muxer, decoder func(*ht
 		b = params["b"]
 		err = goa.MergeErrors(err, goa.ValidatePattern("b", b, "patternb"))
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodUserBodyPathValidatePayloadType(&body, b)
+		payload = NewMethodUserBodyPathValidatePayloadType(&body, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-path-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-path-user.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyPathUser MethodBodyPathUser endpoint.
 func DecodeMethodBodyPathUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodypathuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodypathuser.PayloadType, error) {
+		var payload *servicebodypathuser.PayloadType
 		var (
 			body MethodBodyPathUserRequestBody
 			err  error
@@ -9,13 +10,13 @@ func DecodeMethodBodyPathUserRequest(mux goahttp.Muxer, decoder func(*http.Reque
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		var (
@@ -24,7 +25,7 @@ func DecodeMethodBodyPathUserRequest(mux goahttp.Muxer, decoder func(*http.Reque
 			params = mux.Vars(r)
 		)
 		b = params["b"]
-		payload := NewMethodBodyPathUserPayloadType(&body, b)
+		payload = NewMethodBodyPathUserPayloadType(&body, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-primitive-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-primitive-array-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodBodyPrimitiveArrayBoolValidate endpoint.
 func DecodeMethodBodyPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]bool, error) {
 	return func(r *http.Request) ([]bool, error) {
+		var payload []bool
 		var (
 			body []bool
 			err  error
@@ -10,13 +11,13 @@ func DecodeMethodBodyPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decode
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		if len(body) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body", body, len(body), 1, true))
@@ -27,9 +28,9 @@ func DecodeMethodBodyPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decode
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := body
+		payload = body
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-primitive-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-primitive-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodBodyPrimitiveArrayStringValidate endpoint.
 func DecodeMethodBodyPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]string, error) {
 	return func(r *http.Request) ([]string, error) {
+		var payload []string
 		var (
 			body []string
 			err  error
@@ -10,13 +11,13 @@ func DecodeMethodBodyPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, deco
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		if len(body) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body", body, len(body), 1, true))
@@ -27,9 +28,9 @@ func DecodeMethodBodyPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, deco
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := body
+		payload = body
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-primitive-array-user-required.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-primitive-array-user-required.go.golden
@@ -3,6 +3,7 @@
 // MethodBodyPrimitiveArrayUserRequired endpoint.
 func DecodeMethodBodyPrimitiveArrayUserRequiredRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]*servicebodyprimitivearrayuserrequired.PayloadType, error) {
 	return func(r *http.Request) ([]*servicebodyprimitivearrayuserrequired.PayloadType, error) {
+		var payload []*servicebodyprimitivearrayuserrequired.PayloadType
 		var (
 			body []*PayloadTypeRequestBody
 			err  error
@@ -10,13 +11,13 @@ func DecodeMethodBodyPrimitiveArrayUserRequiredRequest(mux goahttp.Muxer, decode
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		for _, e := range body {
 			if e != nil {
@@ -26,9 +27,9 @@ func DecodeMethodBodyPrimitiveArrayUserRequiredRequest(mux goahttp.Muxer, decode
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyPrimitiveArrayUserRequiredPayloadType(body)
+		payload = NewMethodBodyPrimitiveArrayUserRequiredPayloadType(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-primitive-array-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-primitive-array-user-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodBodyPrimitiveArrayUserValidate endpoint.
 func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]*servicebodyprimitivearrayuservalidate.PayloadType, error) {
 	return func(r *http.Request) ([]*servicebodyprimitivearrayuservalidate.PayloadType, error) {
+		var payload []*servicebodyprimitivearrayuservalidate.PayloadType
 		var (
 			body []*PayloadTypeRequestBody
 			err  error
@@ -10,13 +11,13 @@ func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decode
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		if len(body) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body", body, len(body), 1, true))
@@ -29,9 +30,9 @@ func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decode
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyPrimitiveArrayUserValidatePayloadType(body)
+		payload = NewMethodBodyPrimitiveArrayUserValidatePayloadType(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-primitive-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-primitive-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodBodyPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (bool, error) {
 	return func(r *http.Request) (bool, error) {
+		var payload bool
 		var (
 			body bool
 			err  error
@@ -10,21 +11,21 @@ func DecodeMethodBodyPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fun
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		if !(body == true) {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", body, []any{true}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := body
+		payload = body
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-primitive-field-array-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-primitive-field-array-user-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodBodyPrimitiveArrayUserValidate endpoint.
 func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyprimitivearrayuservalidate.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyprimitivearrayuservalidate.PayloadType, error) {
+		var payload *servicebodyprimitivearrayuservalidate.PayloadType
 		var (
 			body []string
 			err  error
@@ -10,13 +11,13 @@ func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decode
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		if len(body) < 1 {
 			err = goa.MergeErrors(err, goa.InvalidLengthError("body", body, len(body), 1, true))
@@ -25,9 +26,9 @@ func DecodeMethodBodyPrimitiveArrayUserValidateRequest(mux goahttp.Muxer, decode
 			err = goa.MergeErrors(err, goa.ValidatePattern("body[*]", e, "pattern"))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyPrimitiveArrayUserValidatePayloadType(body)
+		payload = NewMethodBodyPrimitiveArrayUserValidatePayloadType(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-primitive-field-array-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-primitive-field-array-user.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyprimitivearrayuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyprimitivearrayuser.PayloadType, error) {
+		var payload *servicebodyprimitivearrayuser.PayloadType
 		var (
 			body []string
 			err  error
@@ -14,12 +15,12 @@ func DecodeMethodBodyPrimitiveArrayUserRequest(mux goahttp.Muxer, decoder func(*
 			} else {
 				var gerr *goa.ServiceError
 				if errors.As(err, &gerr) {
-					return nil, gerr
+					return payload, gerr
 				}
-				return nil, goa.DecodePayloadError(err.Error())
+				return payload, goa.DecodePayloadError(err.Error())
 			}
 		}
-		payload := NewMethodBodyPrimitiveArrayUserPayloadType(body)
+		payload = NewMethodBodyPrimitiveArrayUserPayloadType(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-primitive-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-primitive-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodBodyPrimitiveStringValidate endpoint.
 func DecodeMethodBodyPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
 	return func(r *http.Request) (string, error) {
+		var payload string
 		var (
 			body string
 			err  error
@@ -10,21 +11,21 @@ func DecodeMethodBodyPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder f
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		if !(body == "val") {
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("body", body, []any{"val"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := body
+		payload = body
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-query-object-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-query-object-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodBodyQueryObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyqueryobjectvalidate.MethodBodyQueryObjectValidatePayload, error) {
 	return func(r *http.Request) (*servicebodyqueryobjectvalidate.MethodBodyQueryObjectValidatePayload, error) {
+		var payload *servicebodyqueryobjectvalidate.MethodBodyQueryObjectValidatePayload
 		var (
 			body MethodBodyQueryObjectValidateRequestBody
 			err  error
@@ -10,17 +11,17 @@ func DecodeMethodBodyQueryObjectValidateRequest(mux goahttp.Muxer, decoder func(
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyQueryObjectValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 
 		var (
@@ -32,9 +33,9 @@ func DecodeMethodBodyQueryObjectValidateRequest(mux goahttp.Muxer, decoder func(
 		}
 		err = goa.MergeErrors(err, goa.ValidatePattern("b", b, "patternb"))
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyQueryObjectValidatePayload(&body, b)
+		payload = NewMethodBodyQueryObjectValidatePayload(&body, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-query-object.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-query-object.go.golden
@@ -2,6 +2,7 @@
 // the ServiceBodyQueryObject MethodBodyQueryObject endpoint.
 func DecodeMethodBodyQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyqueryobject.MethodBodyQueryObjectPayload, error) {
 	return func(r *http.Request) (*servicebodyqueryobject.MethodBodyQueryObjectPayload, error) {
+		var payload *servicebodyqueryobject.MethodBodyQueryObjectPayload
 		var (
 			body MethodBodyQueryObjectRequestBody
 			err  error
@@ -9,13 +10,13 @@ func DecodeMethodBodyQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Re
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		var (
@@ -25,7 +26,7 @@ func DecodeMethodBodyQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Re
 		if bRaw != "" {
 			b = &bRaw
 		}
-		payload := NewMethodBodyQueryObjectPayload(&body, b)
+		payload = NewMethodBodyQueryObjectPayload(&body, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-query-path-object-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-query-path-object-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodBodyQueryPathObjectValidate endpoint.
 func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyquerypathobjectvalidate.MethodBodyQueryPathObjectValidatePayload, error) {
 	return func(r *http.Request) (*servicebodyquerypathobjectvalidate.MethodBodyQueryPathObjectValidatePayload, error) {
+		var payload *servicebodyquerypathobjectvalidate.MethodBodyQueryPathObjectValidatePayload
 		var (
 			body MethodBodyQueryPathObjectValidateRequestBody
 			err  error
@@ -10,17 +11,17 @@ func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder f
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyQueryPathObjectValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 
 		var (
@@ -37,9 +38,9 @@ func DecodeMethodBodyQueryPathObjectValidateRequest(mux goahttp.Muxer, decoder f
 		}
 		err = goa.MergeErrors(err, goa.ValidatePattern("b", b, "patternb"))
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyQueryPathObjectValidatePayload(&body, c2, b)
+		payload = NewMethodBodyQueryPathObjectValidatePayload(&body, c2, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-query-path-object.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-query-path-object.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceBodyQueryPathObject MethodBodyQueryPathObject endpoint.
 func DecodeMethodBodyQueryPathObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyquerypathobject.MethodBodyQueryPathObjectPayload, error) {
 	return func(r *http.Request) (*servicebodyquerypathobject.MethodBodyQueryPathObjectPayload, error) {
+		var payload *servicebodyquerypathobject.MethodBodyQueryPathObjectPayload
 		var (
 			body MethodBodyQueryPathObjectRequestBody
 			err  error
@@ -9,13 +10,13 @@ func DecodeMethodBodyQueryPathObjectRequest(mux goahttp.Muxer, decoder func(*htt
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		var (
@@ -29,7 +30,7 @@ func DecodeMethodBodyQueryPathObjectRequest(mux goahttp.Muxer, decoder func(*htt
 		if bRaw != "" {
 			b = &bRaw
 		}
-		payload := NewMethodBodyQueryPathObjectPayload(&body, c2, b)
+		payload = NewMethodBodyQueryPathObjectPayload(&body, c2, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-query-path-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-query-path-user-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyquerypathuservalidate.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyquerypathuservalidate.PayloadType, error) {
+		var payload *servicebodyquerypathuservalidate.PayloadType
 		var (
 			body MethodBodyQueryPathUserValidateRequestBody
 			err  error
@@ -10,17 +11,17 @@ func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder fun
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyQueryPathUserValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 
 		var (
@@ -37,9 +38,9 @@ func DecodeMethodBodyQueryPathUserValidateRequest(mux goahttp.Muxer, decoder fun
 		}
 		err = goa.MergeErrors(err, goa.ValidatePattern("b", b, "patternb"))
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyQueryPathUserValidatePayloadType(&body, c2, b)
+		payload = NewMethodBodyQueryPathUserValidatePayloadType(&body, c2, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-query-path-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-query-path-user.go.golden
@@ -2,6 +2,7 @@
 // the ServiceBodyQueryPathUser MethodBodyQueryPathUser endpoint.
 func DecodeMethodBodyQueryPathUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyquerypathuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyquerypathuser.PayloadType, error) {
+		var payload *servicebodyquerypathuser.PayloadType
 		var (
 			body MethodBodyQueryPathUserRequestBody
 			err  error
@@ -9,13 +10,13 @@ func DecodeMethodBodyQueryPathUserRequest(mux goahttp.Muxer, decoder func(*http.
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		var (
@@ -29,7 +30,7 @@ func DecodeMethodBodyQueryPathUserRequest(mux goahttp.Muxer, decoder func(*http.
 		if bRaw != "" {
 			b = &bRaw
 		}
-		payload := NewMethodBodyQueryPathUserPayloadType(&body, c2, b)
+		payload = NewMethodBodyQueryPathUserPayloadType(&body, c2, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-query-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-query-user-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceBodyQueryUserValidate MethodBodyQueryUserValidate endpoint.
 func DecodeMethodBodyQueryUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyqueryuservalidate.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyqueryuservalidate.PayloadType, error) {
+		var payload *servicebodyqueryuservalidate.PayloadType
 		var (
 			body MethodBodyQueryUserValidateRequestBody
 			err  error
@@ -9,17 +10,17 @@ func DecodeMethodBodyQueryUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyQueryUserValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 
 		var (
@@ -31,9 +32,9 @@ func DecodeMethodBodyQueryUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 		}
 		err = goa.MergeErrors(err, goa.ValidatePattern("b", b, "patternb"))
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyQueryUserValidatePayloadType(&body, b)
+		payload = NewMethodBodyQueryUserValidatePayloadType(&body, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-query-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-query-user.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyQueryUser MethodBodyQueryUser endpoint.
 func DecodeMethodBodyQueryUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyqueryuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyqueryuser.PayloadType, error) {
+		var payload *servicebodyqueryuser.PayloadType
 		var (
 			body MethodBodyQueryUserRequestBody
 			err  error
@@ -9,13 +10,13 @@ func DecodeMethodBodyQueryUserRequest(mux goahttp.Muxer, decoder func(*http.Requ
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		var (
@@ -25,7 +26,7 @@ func DecodeMethodBodyQueryUserRequest(mux goahttp.Muxer, decoder func(*http.Requ
 		if bRaw != "" {
 			b = &bRaw
 		}
-		payload := NewMethodBodyQueryUserPayloadType(&body, b)
+		payload = NewMethodBodyQueryUserPayloadType(&body, b)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-string-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceBodyStringValidate MethodBodyStringValidate endpoint.
 func DecodeMethodBodyStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodystringvalidate.MethodBodyStringValidatePayload, error) {
 	return func(r *http.Request) (*servicebodystringvalidate.MethodBodyStringValidatePayload, error) {
+		var payload *servicebodystringvalidate.MethodBodyStringValidatePayload
 		var (
 			body MethodBodyStringValidateRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyStringValidateRequest(mux goahttp.Muxer, decoder func(*http
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyStringValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyStringValidatePayload(&body)
+		payload = NewMethodBodyStringValidatePayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-string.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyString MethodBodyString endpoint.
 func DecodeMethodBodyStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodystring.MethodBodyStringPayload, error) {
 	return func(r *http.Request) (*servicebodystring.MethodBodyStringPayload, error) {
+		var payload *servicebodystring.MethodBodyStringPayload
 		var (
 			body MethodBodyStringRequestBody
 			err  error
@@ -9,15 +10,15 @@ func DecodeMethodBodyStringRequest(mux goahttp.Muxer, decoder func(*http.Request
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
-		payload := NewMethodBodyStringPayload(&body)
+		payload = NewMethodBodyStringPayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-union-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-union-user-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceBodyUnionUserValidate MethodBodyUnionUserValidate endpoint.
 func DecodeMethodBodyUnionUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyunionuservalidate.MethodBodyUnionUserValidatePayload, error) {
 	return func(r *http.Request) (*servicebodyunionuservalidate.MethodBodyUnionUserValidatePayload, error) {
+		var payload *servicebodyunionuservalidate.MethodBodyUnionUserValidatePayload
 		var (
 			body MethodBodyUnionUserValidateRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyUnionUserValidateRequest(mux goahttp.Muxer, decoder func(*h
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyUnionUserValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyUnionUserValidatePayload(&body)
+		payload = NewMethodBodyUnionUserValidatePayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-union-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-union-user.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyUnionUser MethodBodyUnionUser endpoint.
 func DecodeMethodBodyUnionUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyunionuser.UnionUser, error) {
 	return func(r *http.Request) (*servicebodyunionuser.UnionUser, error) {
+		var payload *servicebodyunionuser.UnionUser
 		var (
 			body MethodBodyUnionUserRequestBody
 			err  error
@@ -9,15 +10,15 @@ func DecodeMethodBodyUnionUserRequest(mux goahttp.Muxer, decoder func(*http.Requ
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
-		payload := NewMethodBodyUnionUserUnionUser(&body)
+		payload = NewMethodBodyUnionUserUnionUser(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-union-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-union-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceBodyUnionValidate MethodBodyUnionValidate endpoint.
 func DecodeMethodBodyUnionValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyunionvalidate.MethodBodyUnionValidatePayload, error) {
 	return func(r *http.Request) (*servicebodyunionvalidate.MethodBodyUnionValidatePayload, error) {
+		var payload *servicebodyunionvalidate.MethodBodyUnionValidatePayload
 		var (
 			body MethodBodyUnionValidateRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyUnionValidateRequest(mux goahttp.Muxer, decoder func(*http.
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyUnionValidateRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyUnionValidatePayload(&body)
+		payload = NewMethodBodyUnionValidatePayload(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-union.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-union.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyUnion MethodBodyUnion endpoint.
 func DecodeMethodBodyUnionRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyunion.Union, error) {
 	return func(r *http.Request) (*servicebodyunion.Union, error) {
+		var payload *servicebodyunion.Union
 		var (
 			body MethodBodyUnionRequestBody
 			err  error
@@ -9,15 +10,15 @@ func DecodeMethodBodyUnionRequest(mux goahttp.Muxer, decoder func(*http.Request)
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
-		payload := NewMethodBodyUnionUnion(&body)
+		payload = NewMethodBodyUnionUnion(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-user-nested.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-user-nested.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyUser MethodBodyUser endpoint.
 func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyuser.PayloadType, error) {
+		var payload *servicebodyuser.PayloadType
 		var (
 			body MethodBodyUserRequestBody
 			err  error
@@ -13,16 +14,16 @@ func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 			} else {
 				var gerr *goa.ServiceError
 				if errors.As(err, &gerr) {
-					return nil, gerr
+					return payload, gerr
 				}
-				return nil, goa.DecodePayloadError(err.Error())
+				return payload, goa.DecodePayloadError(err.Error())
 			}
 		}
 		err = ValidateMethodBodyUserRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyUserPayloadType(&body)
+		payload = NewMethodBodyUserPayloadType(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-user-required.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-user-required.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyUser MethodBodyUser endpoint.
 func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyuser.PayloadType, error) {
+		var payload *servicebodyuser.PayloadType
 		var (
 			body MethodBodyUserRequestBody
 			err  error
@@ -9,19 +10,19 @@ func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodBodyUserRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyUserPayloadType(&body)
+		payload = NewMethodBodyUserPayloadType(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-user-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-user-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceBodyUserValidate MethodBodyUserValidate endpoint.
 func DecodeMethodBodyUserValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyuservalidate.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyuservalidate.PayloadType, error) {
+		var payload *servicebodyuservalidate.PayloadType
 		var (
 			body string
 			err  error
@@ -13,16 +14,16 @@ func DecodeMethodBodyUserValidateRequest(mux goahttp.Muxer, decoder func(*http.R
 			} else {
 				var gerr *goa.ServiceError
 				if errors.As(err, &gerr) {
-					return nil, gerr
+					return payload, gerr
 				}
-				return nil, goa.DecodePayloadError(err.Error())
+				return payload, goa.DecodePayloadError(err.Error())
 			}
 		}
 		err = goa.MergeErrors(err, goa.ValidatePattern("body", body, "apattern"))
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodBodyUserValidatePayloadType(body)
+		payload = NewMethodBodyUserValidatePayloadType(body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-body-user.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-body-user.go.golden
@@ -2,6 +2,7 @@
 // ServiceBodyUser MethodBodyUser endpoint.
 func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicebodyuser.PayloadType, error) {
 	return func(r *http.Request) (*servicebodyuser.PayloadType, error) {
+		var payload *servicebodyuser.PayloadType
 		var (
 			body MethodBodyUserRequestBody
 			err  error
@@ -9,15 +10,15 @@ func DecodeMethodBodyUserRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
-		payload := NewMethodBodyUserPayloadType(&body)
+		payload = NewMethodBodyUserPayloadType(&body)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-cookie-custom-name.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-cookie-custom-name.go.golden
@@ -2,6 +2,7 @@
 // the ServiceCookieCustomName MethodCookieCustomName endpoint.
 func DecodeMethodCookieCustomNameRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicecookiecustomname.MethodCookieCustomNamePayload, error) {
 	return func(r *http.Request) (*servicecookiecustomname.MethodCookieCustomNamePayload, error) {
+		var payload *servicecookiecustomname.MethodCookieCustomNamePayload
 		var (
 			c2 *string
 			c  *http.Cookie
@@ -14,7 +15,7 @@ func DecodeMethodCookieCustomNameRequest(mux goahttp.Muxer, decoder func(*http.R
 		if c2Raw != "" {
 			c2 = &c2Raw
 		}
-		payload := NewMethodCookieCustomNamePayload(c2)
+		payload = NewMethodCookieCustomNamePayload(c2)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-cookie-primitive-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-cookie-primitive-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodCookiePrimitiveBoolValidate endpoint.
 func DecodeMethodCookiePrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (bool, error) {
 	return func(r *http.Request) (bool, error) {
+		var payload bool
 		var (
 			c2  bool
 			err error
@@ -27,9 +28,9 @@ func DecodeMethodCookiePrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder f
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c", c2, []any{true}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := c
+		payload = c
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-cookie-primitive-string-default.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-cookie-primitive-string-default.go.golden
@@ -3,6 +3,7 @@
 // MethodCookiePrimitiveStringDefault endpoint.
 func DecodeMethodCookiePrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
 	return func(r *http.Request) (string, error) {
+		var payload string
 		var (
 			c2  string
 			err error
@@ -15,9 +16,9 @@ func DecodeMethodCookiePrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder 
 			c2 = c.Value
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := c
+		payload = c
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-cookie-primitive-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-cookie-primitive-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodCookiePrimitiveStringValidate endpoint.
 func DecodeMethodCookiePrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
 	return func(r *http.Request) (string, error) {
+		var payload string
 		var (
 			c2  string
 			err error
@@ -18,9 +19,9 @@ func DecodeMethodCookiePrimitiveStringValidateRequest(mux goahttp.Muxer, decoder
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c", c2, []any{"val"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := c
+		payload = c
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-cookie-string-default-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-cookie-string-default-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodCookieStringDefaultValidate endpoint.
 func DecodeMethodCookieStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicecookiestringdefaultvalidate.MethodCookieStringDefaultValidatePayload, error) {
 	return func(r *http.Request) (*servicecookiestringdefaultvalidate.MethodCookieStringDefaultValidatePayload, error) {
+		var payload *servicecookiestringdefaultvalidate.MethodCookieStringDefaultValidatePayload
 		var (
 			c2  string
 			err error
@@ -22,9 +23,9 @@ func DecodeMethodCookieStringDefaultValidateRequest(mux goahttp.Muxer, decoder f
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("c", c2, []any{"def"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodCookieStringDefaultValidatePayload(c2)
+		payload = NewMethodCookieStringDefaultValidatePayload(c2)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-cookie-string-default.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-cookie-string-default.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceCookieStringDefault MethodCookieStringDefault endpoint.
 func DecodeMethodCookieStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicecookiestringdefault.MethodCookieStringDefaultPayload, error) {
 	return func(r *http.Request) (*servicecookiestringdefault.MethodCookieStringDefaultPayload, error) {
+		var payload *servicecookiestringdefault.MethodCookieStringDefaultPayload
 		var (
 			c2 string
 			c  *http.Cookie
@@ -16,7 +17,7 @@ func DecodeMethodCookieStringDefaultRequest(mux goahttp.Muxer, decoder func(*htt
 		} else {
 			c2 = "def"
 		}
-		payload := NewMethodCookieStringDefaultPayload(c2)
+		payload = NewMethodCookieStringDefaultPayload(c2)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-cookie-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-cookie-string-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceCookieStringValidate MethodCookieStringValidate endpoint.
 func DecodeMethodCookieStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicecookiestringvalidate.MethodCookieStringValidatePayload, error) {
 	return func(r *http.Request) (*servicecookiestringvalidate.MethodCookieStringValidatePayload, error) {
+		var payload *servicecookiestringvalidate.MethodCookieStringValidatePayload
 		var (
 			c2  *string
 			err error
@@ -19,9 +20,9 @@ func DecodeMethodCookieStringValidateRequest(mux goahttp.Muxer, decoder func(*ht
 			err = goa.MergeErrors(err, goa.ValidatePattern("c", *c2, "cookie"))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodCookieStringValidatePayload(c2)
+		payload = NewMethodCookieStringValidatePayload(c2)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-cookie-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-cookie-string.go.golden
@@ -2,6 +2,7 @@
 // ServiceCookieString MethodCookieString endpoint.
 func DecodeMethodCookieStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicecookiestring.MethodCookieStringPayload, error) {
 	return func(r *http.Request) (*servicecookiestring.MethodCookieStringPayload, error) {
+		var payload *servicecookiestring.MethodCookieStringPayload
 		var (
 			c2 *string
 			c  *http.Cookie
@@ -14,7 +15,7 @@ func DecodeMethodCookieStringRequest(mux goahttp.Muxer, decoder func(*http.Reque
 		if c2Raw != "" {
 			c2 = &c2Raw
 		}
-		payload := NewMethodCookieStringPayload(c2)
+		payload = NewMethodCookieStringPayload(c2)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodHeaderArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*serviceheaderarraystringvalidate.MethodHeaderArrayStringValidatePayload, error) {
 	return func(r *http.Request) (*serviceheaderarraystringvalidate.MethodHeaderArrayStringValidatePayload, error) {
+		var payload *serviceheaderarraystringvalidate.MethodHeaderArrayStringValidatePayload
 		var (
 			h   []string
 			err error
@@ -14,9 +15,9 @@ func DecodeMethodHeaderArrayStringValidateRequest(mux goahttp.Muxer, decoder fun
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodHeaderArrayStringValidatePayload(h)
+		payload = NewMethodHeaderArrayStringValidatePayload(h)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-array-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-array-string.go.golden
@@ -2,11 +2,12 @@
 // the ServiceHeaderArrayString MethodHeaderArrayString endpoint.
 func DecodeMethodHeaderArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*serviceheaderarraystring.MethodHeaderArrayStringPayload, error) {
 	return func(r *http.Request) (*serviceheaderarraystring.MethodHeaderArrayStringPayload, error) {
+		var payload *serviceheaderarraystring.MethodHeaderArrayStringPayload
 		var (
 			h []string
 		)
 		h = r.Header["H"]
-		payload := NewMethodHeaderArrayStringPayload(h)
+		payload = NewMethodHeaderArrayStringPayload(h)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-custom-name.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-custom-name.go.golden
@@ -2,6 +2,7 @@
 // the ServiceHeaderCustomName MethodHeaderCustomName endpoint.
 func DecodeMethodHeaderCustomNameRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*serviceheadercustomname.MethodHeaderCustomNamePayload, error) {
 	return func(r *http.Request) (*serviceheadercustomname.MethodHeaderCustomNamePayload, error) {
+		var payload *serviceheadercustomname.MethodHeaderCustomNamePayload
 		var (
 			h *string
 		)
@@ -9,7 +10,7 @@ func DecodeMethodHeaderCustomNameRequest(mux goahttp.Muxer, decoder func(*http.R
 		if hRaw != "" {
 			h = &hRaw
 		}
-		payload := NewMethodHeaderCustomNamePayload(h)
+		payload = NewMethodHeaderCustomNamePayload(h)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-int-alias.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-int-alias.go.golden
@@ -2,6 +2,7 @@
 // ServiceHeaderIntAlias MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*serviceheaderintalias.MethodAPayload, error) {
 	return func(r *http.Request) (*serviceheaderintalias.MethodAPayload, error) {
+		var payload *serviceheaderintalias.MethodAPayload
 		var (
 			int_   *int
 			int32_ *int32
@@ -41,9 +42,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(int_, int32_, int64_)
+		payload = NewMethodAPayload(int_, int32_, int64_)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-primitive-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-primitive-array-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodHeaderPrimitiveArrayBoolValidate endpoint.
 func DecodeMethodHeaderPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]bool, error) {
 	return func(r *http.Request) ([]bool, error) {
+		var payload []bool
 		var (
 			h   []bool
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodHeaderPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, deco
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := h
+		payload = h
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-primitive-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-primitive-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodHeaderPrimitiveArrayStringValidate endpoint.
 func DecodeMethodHeaderPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]string, error) {
 	return func(r *http.Request) ([]string, error) {
+		var payload []string
 		var (
 			h   []string
 			err error
@@ -18,9 +19,9 @@ func DecodeMethodHeaderPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, de
 			err = goa.MergeErrors(err, goa.ValidatePattern("h[*]", e, "val"))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := h
+		payload = h
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-primitive-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-primitive-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodHeaderPrimitiveBoolValidate endpoint.
 func DecodeMethodHeaderPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (bool, error) {
 	return func(r *http.Request) (bool, error) {
+		var payload bool
 		var (
 			h   bool
 			err error
@@ -22,9 +23,9 @@ func DecodeMethodHeaderPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder f
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []any{true}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := h
+		payload = h
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-primitive-string-default.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-primitive-string-default.go.golden
@@ -3,6 +3,7 @@
 // MethodHeaderPrimitiveStringDefault endpoint.
 func DecodeMethodHeaderPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
 	return func(r *http.Request) (string, error) {
+		var payload string
 		var (
 			h   string
 			err error
@@ -12,9 +13,9 @@ func DecodeMethodHeaderPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder 
 			err = goa.MergeErrors(err, goa.MissingFieldError("h", "header"))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := h
+		payload = h
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-primitive-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-primitive-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodHeaderPrimitiveStringValidate endpoint.
 func DecodeMethodHeaderPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
 	return func(r *http.Request) (string, error) {
+		var payload string
 		var (
 			h   string
 			err error
@@ -15,9 +16,9 @@ func DecodeMethodHeaderPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []any{"val"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := h
+		payload = h
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-string-default-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-string-default-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodHeaderStringDefaultValidate endpoint.
 func DecodeMethodHeaderStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*serviceheaderstringdefaultvalidate.MethodHeaderStringDefaultValidatePayload, error) {
 	return func(r *http.Request) (*serviceheaderstringdefaultvalidate.MethodHeaderStringDefaultValidatePayload, error) {
+		var payload *serviceheaderstringdefaultvalidate.MethodHeaderStringDefaultValidatePayload
 		var (
 			h   string
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodHeaderStringDefaultValidateRequest(mux goahttp.Muxer, decoder f
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("h", h, []any{"def"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodHeaderStringDefaultValidatePayload(h)
+		payload = NewMethodHeaderStringDefaultValidatePayload(h)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-string-default.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-string-default.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceHeaderStringDefault MethodHeaderStringDefault endpoint.
 func DecodeMethodHeaderStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*serviceheaderstringdefault.MethodHeaderStringDefaultPayload, error) {
 	return func(r *http.Request) (*serviceheaderstringdefault.MethodHeaderStringDefaultPayload, error) {
+		var payload *serviceheaderstringdefault.MethodHeaderStringDefaultPayload
 		var (
 			h string
 		)
@@ -11,7 +12,7 @@ func DecodeMethodHeaderStringDefaultRequest(mux goahttp.Muxer, decoder func(*htt
 		} else {
 			h = "def"
 		}
-		payload := NewMethodHeaderStringDefaultPayload(h)
+		payload = NewMethodHeaderStringDefaultPayload(h)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-string-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceHeaderStringValidate MethodHeaderStringValidate endpoint.
 func DecodeMethodHeaderStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*serviceheaderstringvalidate.MethodHeaderStringValidatePayload, error) {
 	return func(r *http.Request) (*serviceheaderstringvalidate.MethodHeaderStringValidatePayload, error) {
+		var payload *serviceheaderstringvalidate.MethodHeaderStringValidatePayload
 		var (
 			h   *string
 			err error
@@ -14,9 +15,9 @@ func DecodeMethodHeaderStringValidateRequest(mux goahttp.Muxer, decoder func(*ht
 			err = goa.MergeErrors(err, goa.ValidatePattern("h", *h, "header"))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodHeaderStringValidatePayload(h)
+		payload = NewMethodHeaderStringValidatePayload(h)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-header-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-header-string.go.golden
@@ -2,6 +2,7 @@
 // ServiceHeaderString MethodHeaderString endpoint.
 func DecodeMethodHeaderStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*serviceheaderstring.MethodHeaderStringPayload, error) {
 	return func(r *http.Request) (*serviceheaderstring.MethodHeaderStringPayload, error) {
+		var payload *serviceheaderstring.MethodHeaderStringPayload
 		var (
 			h *string
 		)
@@ -9,7 +10,7 @@ func DecodeMethodHeaderStringRequest(mux goahttp.Muxer, decoder func(*http.Reque
 		if hRaw != "" {
 			h = &hRaw
 		}
-		payload := NewMethodHeaderStringPayload(h)
+		payload = NewMethodHeaderStringPayload(h)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-map-query-object.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-map-query-object.go.golden
@@ -2,6 +2,7 @@
 // ServiceMapQueryObject MethodMapQueryObject endpoint.
 func DecodeMethodMapQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicemapqueryobject.PayloadType, error) {
 	return func(r *http.Request) (*servicemapqueryobject.PayloadType, error) {
+		var payload *servicemapqueryobject.PayloadType
 		var (
 			body MethodMapQueryObjectRequestBody
 			err  error
@@ -9,17 +10,17 @@ func DecodeMethodMapQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Req
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 		err = ValidateMethodMapQueryObjectRequestBody(&body)
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
 
 		var (
@@ -49,9 +50,9 @@ func DecodeMethodMapQueryObjectRequest(mux goahttp.Muxer, decoder func(*http.Req
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodMapQueryObjectPayloadType(&body, a, c)
+		payload = NewMethodMapQueryObjectPayloadType(&body, a, c)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-map-query-primitive-array.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-map-query-primitive-array.go.golden
@@ -2,6 +2,7 @@
 // the ServiceMapQueryPrimitiveArray MapQueryPrimitiveArray endpoint.
 func DecodeMapQueryPrimitiveArrayRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (map[string][]uint, error) {
 	return func(r *http.Request) (map[string][]uint, error) {
+		var payload map[string][]uint
 		var (
 			query map[string][]uint
 			err   error
@@ -42,9 +43,9 @@ func DecodeMapQueryPrimitiveArrayRequest(mux goahttp.Muxer, decoder func(*http.R
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := query
+		payload = query
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-map-query-primitive-primitive.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-map-query-primitive-primitive.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceMapQueryPrimitivePrimitive MapQueryPrimitivePrimitive endpoint.
 func DecodeMapQueryPrimitivePrimitiveRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (map[string]string, error) {
 	return func(r *http.Request) (map[string]string, error) {
+		var payload map[string]string
 		var (
 			query map[string]string
 			err   error
@@ -31,9 +32,9 @@ func DecodeMapQueryPrimitivePrimitiveRequest(mux goahttp.Muxer, decoder func(*ht
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := query
+		payload = query
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-multipart-body-array-type.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-multipart-body-array-type.go.golden
@@ -6,9 +6,9 @@ func DecodeMethodMultipartArrayTypeRequest(mux goahttp.Muxer, decoder func(*http
 		if err := decoder(r).Decode(&payload); err != nil {
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		return payload, nil

--- a/http/codegen/testdata/golden/server_decode_decode-multipart-body-map-type.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-multipart-body-map-type.go.golden
@@ -6,9 +6,9 @@ func DecodeMethodMultipartMapTypeRequest(mux goahttp.Muxer, decoder func(*http.R
 		if err := decoder(r).Decode(&payload); err != nil {
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		return payload, nil

--- a/http/codegen/testdata/golden/server_decode_decode-multipart-body-primitive.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-multipart-body-primitive.go.golden
@@ -6,9 +6,9 @@ func DecodeMethodMultipartPrimitiveRequest(mux goahttp.Muxer, decoder func(*http
 		if err := decoder(r).Decode(&payload); err != nil {
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		return payload, nil

--- a/http/codegen/testdata/golden/server_decode_decode-multipart-body-user-type.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-multipart-body-user-type.go.golden
@@ -6,9 +6,9 @@ func DecodeMethodMultipartUserTypeRequest(mux goahttp.Muxer, decoder func(*http.
 		if err := decoder(r).Decode(&payload); err != nil {
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		return payload, nil

--- a/http/codegen/testdata/golden/server_decode_decode-path-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodPathArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepatharraystringvalidate.MethodPathArrayStringValidatePayload, error) {
 	return func(r *http.Request) (*servicepatharraystringvalidate.MethodPathArrayStringValidatePayload, error) {
+		var payload *servicepatharraystringvalidate.MethodPathArrayStringValidatePayload
 		var (
 			p   []string
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodPathArrayStringValidateRequest(mux goahttp.Muxer, decoder func(
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []any{[]string{"val"}}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathArrayStringValidatePayload(p)
+		payload = NewMethodPathArrayStringValidatePayload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-array-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-array-string.go.golden
@@ -2,6 +2,7 @@
 // the ServicePathArrayString MethodPathArrayString endpoint.
 func DecodeMethodPathArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepatharraystring.MethodPathArrayStringPayload, error) {
 	return func(r *http.Request) (*servicepatharraystring.MethodPathArrayStringPayload, error) {
+		var payload *servicepatharraystring.MethodPathArrayStringPayload
 		var (
 			p []string
 
@@ -15,7 +16,7 @@ func DecodeMethodPathArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Re
 				p[i] = rv
 			}
 		}
-		payload := NewMethodPathArrayStringPayload(p)
+		payload = NewMethodPathArrayStringPayload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-float32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-float32.go.golden
@@ -2,6 +2,7 @@
 // the ServicePathCustomFloat32 MethodPathCustomFloat32 endpoint.
 func DecodeMethodPathCustomFloat32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomfloat32.MethodPathCustomFloat32Payload, error) {
 	return func(r *http.Request) (*servicepathcustomfloat32.MethodPathCustomFloat32Payload, error) {
+		var payload *servicepathcustomfloat32.MethodPathCustomFloat32Payload
 		var (
 			p   hide.Float32
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodPathCustomFloat32Request(mux goahttp.Muxer, decoder func(*http.
 			p = hide.Float32(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathCustomFloat32Payload(p)
+		payload = NewMethodPathCustomFloat32Payload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-float64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-float64.go.golden
@@ -2,6 +2,7 @@
 // the ServicePathCustomFloat64 MethodPathCustomFloat64 endpoint.
 func DecodeMethodPathCustomFloat64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomfloat64.MethodPathCustomFloat64Payload, error) {
 	return func(r *http.Request) (*servicepathcustomfloat64.MethodPathCustomFloat64Payload, error) {
+		var payload *servicepathcustomfloat64.MethodPathCustomFloat64Payload
 		var (
 			p   hide.Float64
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodPathCustomFloat64Request(mux goahttp.Muxer, decoder func(*http.
 			p = (hide.Float64)(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathCustomFloat64Payload(p)
+		payload = NewMethodPathCustomFloat64Payload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-int.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-int.go.golden
@@ -2,6 +2,7 @@
 // ServicePathCustomInt MethodPathCustomInt endpoint.
 func DecodeMethodPathCustomIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomint.MethodPathCustomIntPayload, error) {
 	return func(r *http.Request) (*servicepathcustomint.MethodPathCustomIntPayload, error) {
+		var payload *servicepathcustomint.MethodPathCustomIntPayload
 		var (
 			p   hide.Int
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodPathCustomIntRequest(mux goahttp.Muxer, decoder func(*http.Requ
 			p = hide.Int(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathCustomIntPayload(p)
+		payload = NewMethodPathCustomIntPayload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-int32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-int32.go.golden
@@ -2,6 +2,7 @@
 // the ServicePathCustomInt32 MethodPathCustomInt32 endpoint.
 func DecodeMethodPathCustomInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomint32.MethodPathCustomInt32Payload, error) {
 	return func(r *http.Request) (*servicepathcustomint32.MethodPathCustomInt32Payload, error) {
+		var payload *servicepathcustomint32.MethodPathCustomInt32Payload
 		var (
 			p   hide.Int32
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodPathCustomInt32Request(mux goahttp.Muxer, decoder func(*http.Re
 			p = hide.Int32(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathCustomInt32Payload(p)
+		payload = NewMethodPathCustomInt32Payload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-int64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-int64.go.golden
@@ -2,6 +2,7 @@
 // the ServicePathCustomInt64 MethodPathCustomInt64 endpoint.
 func DecodeMethodPathCustomInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomint64.MethodPathCustomInt64Payload, error) {
 	return func(r *http.Request) (*servicepathcustomint64.MethodPathCustomInt64Payload, error) {
+		var payload *servicepathcustomint64.MethodPathCustomInt64Payload
 		var (
 			p   hide.Int64
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodPathCustomInt64Request(mux goahttp.Muxer, decoder func(*http.Re
 			p = (hide.Int64)(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathCustomInt64Payload(p)
+		payload = NewMethodPathCustomInt64Payload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-name.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-name.go.golden
@@ -2,13 +2,14 @@
 // ServicePathCustomName MethodPathCustomName endpoint.
 func DecodeMethodPathCustomNameRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomname.MethodPathCustomNamePayload, error) {
 	return func(r *http.Request) (*servicepathcustomname.MethodPathCustomNamePayload, error) {
+		var payload *servicepathcustomname.MethodPathCustomNamePayload
 		var (
 			p string
 
 			params = mux.Vars(r)
 		)
 		p = params["p"]
-		payload := NewMethodPathCustomNamePayload(p)
+		payload = NewMethodPathCustomNamePayload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-uint.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-uint.go.golden
@@ -2,6 +2,7 @@
 // ServicePathCustomUInt MethodPathCustomUInt endpoint.
 func DecodeMethodPathCustomUIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomuint.MethodPathCustomUIntPayload, error) {
 	return func(r *http.Request) (*servicepathcustomuint.MethodPathCustomUIntPayload, error) {
+		var payload *servicepathcustomuint.MethodPathCustomUIntPayload
 		var (
 			p   hide.Uint
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodPathCustomUIntRequest(mux goahttp.Muxer, decoder func(*http.Req
 			p = hide.Uint(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathCustomUIntPayload(p)
+		payload = NewMethodPathCustomUIntPayload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-uint32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-uint32.go.golden
@@ -2,6 +2,7 @@
 // the ServicePathCustomUInt32 MethodPathCustomUInt32 endpoint.
 func DecodeMethodPathCustomUInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomuint32.MethodPathCustomUInt32Payload, error) {
 	return func(r *http.Request) (*servicepathcustomuint32.MethodPathCustomUInt32Payload, error) {
+		var payload *servicepathcustomuint32.MethodPathCustomUInt32Payload
 		var (
 			p   hide.Uint32
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodPathCustomUInt32Request(mux goahttp.Muxer, decoder func(*http.R
 			p = hide.Uint32(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathCustomUInt32Payload(p)
+		payload = NewMethodPathCustomUInt32Payload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-custom-uint64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-custom-uint64.go.golden
@@ -2,6 +2,7 @@
 // the ServicePathCustomUInt64 MethodPathCustomUInt64 endpoint.
 func DecodeMethodPathCustomUInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathcustomuint64.MethodPathCustomUInt64Payload, error) {
 	return func(r *http.Request) (*servicepathcustomuint64.MethodPathCustomUInt64Payload, error) {
+		var payload *servicepathcustomuint64.MethodPathCustomUInt64Payload
 		var (
 			p   hide.Uint64
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodPathCustomUInt64Request(mux goahttp.Muxer, decoder func(*http.R
 			p = (hide.Uint64)(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathCustomUInt64Payload(p)
+		payload = NewMethodPathCustomUInt64Payload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-int-alias.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-int-alias.go.golden
@@ -2,6 +2,7 @@
 // ServicePathIntAlias MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathintalias.MethodAPayload, error) {
 	return func(r *http.Request) (*servicepathintalias.MethodAPayload, error) {
+		var payload *servicepathintalias.MethodAPayload
 		var (
 			int_   int
 			int32_ int32
@@ -35,9 +36,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			int64_ = v
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(int_, int32_, int64_)
+		payload = NewMethodAPayload(int_, int32_, int64_)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-primitive-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-primitive-array-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodPathPrimitiveArrayBoolValidate endpoint.
 func DecodeMethodPathPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]bool, error) {
 	return func(r *http.Request) ([]bool, error) {
+		var payload []bool
 		var (
 			p   []bool
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodPathPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decode
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := p
+		payload = p
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-primitive-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-primitive-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodPathPrimitiveArrayStringValidate endpoint.
 func DecodeMethodPathPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]string, error) {
 	return func(r *http.Request) ([]string, error) {
+		var payload []string
 		var (
 			p   []string
 			err error
@@ -26,9 +27,9 @@ func DecodeMethodPathPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, deco
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := p
+		payload = p
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-primitive-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-primitive-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodPathPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (bool, error) {
 	return func(r *http.Request) (bool, error) {
+		var payload bool
 		var (
 			p   bool
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodPathPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fun
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []any{true}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := p
+		payload = p
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-primitive-string-formatip-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-primitive-string-formatip-validate.go.golden
@@ -1,0 +1,22 @@
+// DecodeMethodPathPrimitiveStringFormatIPValidateRequest returns a decoder for
+// requests sent to the ServicePathPrimitiveStringFormatIPValidate
+// MethodPathPrimitiveStringFormatIPValidate endpoint.
+func DecodeMethodPathPrimitiveStringFormatIPValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
+	return func(r *http.Request) (string, error) {
+		var payload string
+		var (
+			ip  string
+			err error
+
+			params = mux.Vars(r)
+		)
+		ip = params["ip"]
+		err = goa.MergeErrors(err, goa.ValidateFormat("ip", ip, goa.FormatIP))
+		if err != nil {
+			return payload, err
+		}
+		payload = ip
+
+		return payload, nil
+	}
+}

--- a/http/codegen/testdata/golden/server_decode_decode-path-primitive-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-primitive-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodPathPrimitiveStringValidate endpoint.
 func DecodeMethodPathPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
 	return func(r *http.Request) (string, error) {
+		var payload string
 		var (
 			p   string
 			err error
@@ -14,9 +15,9 @@ func DecodeMethodPathPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder f
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []any{"val"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := p
+		payload = p
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-string-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServicePathStringValidate MethodPathStringValidate endpoint.
 func DecodeMethodPathStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathstringvalidate.MethodPathStringValidatePayload, error) {
 	return func(r *http.Request) (*servicepathstringvalidate.MethodPathStringValidatePayload, error) {
+		var payload *servicepathstringvalidate.MethodPathStringValidatePayload
 		var (
 			p   string
 			err error
@@ -13,9 +14,9 @@ func DecodeMethodPathStringValidateRequest(mux goahttp.Muxer, decoder func(*http
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("p", p, []any{"val"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodPathStringValidatePayload(p)
+		payload = NewMethodPathStringValidatePayload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-path-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-path-string.go.golden
@@ -2,13 +2,14 @@
 // ServicePathString MethodPathString endpoint.
 func DecodeMethodPathStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicepathstring.MethodPathStringPayload, error) {
 	return func(r *http.Request) (*servicepathstring.MethodPathStringPayload, error) {
+		var payload *servicepathstring.MethodPathStringPayload
 		var (
 			p string
 
 			params = mux.Vars(r)
 		)
 		p = params["p"]
-		payload := NewMethodPathStringPayload(p)
+		payload = NewMethodPathStringPayload(p)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-any-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-any-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryAnyValidate MethodQueryAnyValidate endpoint.
 func DecodeMethodQueryAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryanyvalidate.MethodQueryAnyValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryanyvalidate.MethodQueryAnyValidatePayload, error) {
+		var payload *servicequeryanyvalidate.MethodQueryAnyValidatePayload
 		var (
 			q   any
 			err error
@@ -14,9 +15,9 @@ func DecodeMethodQueryAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.R
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"val", 1}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryAnyValidatePayload(q)
+		payload = NewMethodQueryAnyValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-any.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-any.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryAny MethodQueryAny endpoint.
 func DecodeMethodQueryAnyRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryany.MethodQueryAnyPayload, error) {
 	return func(r *http.Request) (*servicequeryany.MethodQueryAnyPayload, error) {
+		var payload *servicequeryany.MethodQueryAnyPayload
 		var (
 			q any
 		)
@@ -9,7 +10,7 @@ func DecodeMethodQueryAnyRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 		if qRaw != "" {
 			q = qRaw
 		}
-		payload := NewMethodQueryAnyPayload(q)
+		payload = NewMethodQueryAnyPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-alias-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-alias-validate.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryArrayAliasValidate MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayaliasvalidate.MethodAPayload, error) {
 	return func(r *http.Request) (*servicequeryarrayaliasvalidate.MethodAPayload, error) {
+		var payload *servicequeryarrayaliasvalidate.MethodAPayload
 		var (
 			array []uint
 			err   error
@@ -28,9 +29,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(array)
+		payload = NewMethodAPayload(array)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-alias.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-alias.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryArrayAlias MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayalias.MethodAPayload, error) {
 	return func(r *http.Request) (*servicequeryarrayalias.MethodAPayload, error) {
+		var payload *servicequeryarrayalias.MethodAPayload
 		var (
 			array []uint
 			err   error
@@ -20,9 +21,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(array)
+		payload = NewMethodAPayload(array)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-any-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-any-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryArrayAnyValidate MethodQueryArrayAnyValidate endpoint.
 func DecodeMethodQueryArrayAnyValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload, error) {
+		var payload *servicequeryarrayanyvalidate.MethodQueryArrayAnyValidatePayload
 		var (
 			q   []any
 			err error
@@ -25,9 +26,9 @@ func DecodeMethodQueryArrayAnyValidateRequest(mux goahttp.Muxer, decoder func(*h
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayAnyValidatePayload(q)
+		payload = NewMethodQueryArrayAnyValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-any.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-any.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryArrayAny MethodQueryArrayAny endpoint.
 func DecodeMethodQueryArrayAnyRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayany.MethodQueryArrayAnyPayload, error) {
 	return func(r *http.Request) (*servicequeryarrayany.MethodQueryArrayAnyPayload, error) {
+		var payload *servicequeryarrayany.MethodQueryArrayAnyPayload
 		var (
 			q []any
 		)
@@ -14,7 +15,7 @@ func DecodeMethodQueryArrayAnyRequest(mux goahttp.Muxer, decoder func(*http.Requ
 				}
 			}
 		}
-		payload := NewMethodQueryArrayAnyPayload(q)
+		payload = NewMethodQueryArrayAnyPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayboolvalidate.MethodQueryArrayBoolValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayboolvalidate.MethodQueryArrayBoolValidatePayload, error) {
+		var payload *servicequeryarrayboolvalidate.MethodQueryArrayBoolValidatePayload
 		var (
 			q   []bool
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayBoolValidatePayload(q)
+		payload = NewMethodQueryArrayBoolValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-bool.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-bool.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryArrayBool MethodQueryArrayBool endpoint.
 func DecodeMethodQueryArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarraybool.MethodQueryArrayBoolPayload, error) {
 	return func(r *http.Request) (*servicequeryarraybool.MethodQueryArrayBoolPayload, error) {
+		var payload *servicequeryarraybool.MethodQueryArrayBoolPayload
 		var (
 			q   []bool
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Req
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayBoolPayload(q)
+		payload = NewMethodQueryArrayBoolPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-bytes-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-bytes-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayBytesValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarraybytesvalidate.MethodQueryArrayBytesValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarraybytesvalidate.MethodQueryArrayBytesValidatePayload, error) {
+		var payload *servicequeryarraybytesvalidate.MethodQueryArrayBytesValidatePayload
 		var (
 			q   [][]byte
 			err error
@@ -26,9 +27,9 @@ func DecodeMethodQueryArrayBytesValidateRequest(mux goahttp.Muxer, decoder func(
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayBytesValidatePayload(q)
+		payload = NewMethodQueryArrayBytesValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-bytes.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-bytes.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryArrayBytes MethodQueryArrayBytes endpoint.
 func DecodeMethodQueryArrayBytesRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarraybytes.MethodQueryArrayBytesPayload, error) {
 	return func(r *http.Request) (*servicequeryarraybytes.MethodQueryArrayBytesPayload, error) {
+		var payload *servicequeryarraybytes.MethodQueryArrayBytesPayload
 		var (
 			q [][]byte
 		)
@@ -14,7 +15,7 @@ func DecodeMethodQueryArrayBytesRequest(mux goahttp.Muxer, decoder func(*http.Re
 				}
 			}
 		}
-		payload := NewMethodQueryArrayBytesPayload(q)
+		payload = NewMethodQueryArrayBytesPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-float32-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-float32-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayFloat32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayfloat32validate.MethodQueryArrayFloat32ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayfloat32validate.MethodQueryArrayFloat32ValidatePayload, error) {
+		var payload *servicequeryarrayfloat32validate.MethodQueryArrayFloat32ValidatePayload
 		var (
 			q   []float32
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryArrayFloat32ValidateRequest(mux goahttp.Muxer, decoder fun
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayFloat32ValidatePayload(q)
+		payload = NewMethodQueryArrayFloat32ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-float32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-float32.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryArrayFloat32 MethodQueryArrayFloat32 endpoint.
 func DecodeMethodQueryArrayFloat32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayfloat32.MethodQueryArrayFloat32Payload, error) {
 	return func(r *http.Request) (*servicequeryarrayfloat32.MethodQueryArrayFloat32Payload, error) {
+		var payload *servicequeryarrayfloat32.MethodQueryArrayFloat32Payload
 		var (
 			q   []float32
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayFloat32Request(mux goahttp.Muxer, decoder func(*http.
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayFloat32Payload(q)
+		payload = NewMethodQueryArrayFloat32Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-float64-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-float64-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayFloat64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayfloat64validate.MethodQueryArrayFloat64ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayfloat64validate.MethodQueryArrayFloat64ValidatePayload, error) {
+		var payload *servicequeryarrayfloat64validate.MethodQueryArrayFloat64ValidatePayload
 		var (
 			q   []float64
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryArrayFloat64ValidateRequest(mux goahttp.Muxer, decoder fun
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayFloat64ValidatePayload(q)
+		payload = NewMethodQueryArrayFloat64ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-float64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-float64.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryArrayFloat64 MethodQueryArrayFloat64 endpoint.
 func DecodeMethodQueryArrayFloat64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayfloat64.MethodQueryArrayFloat64Payload, error) {
 	return func(r *http.Request) (*servicequeryarrayfloat64.MethodQueryArrayFloat64Payload, error) {
+		var payload *servicequeryarrayfloat64.MethodQueryArrayFloat64Payload
 		var (
 			q   []float64
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayFloat64Request(mux goahttp.Muxer, decoder func(*http.
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayFloat64Payload(q)
+		payload = NewMethodQueryArrayFloat64Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-int-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-int-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryArrayIntValidate MethodQueryArrayIntValidate endpoint.
 func DecodeMethodQueryArrayIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayintvalidate.MethodQueryArrayIntValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayintvalidate.MethodQueryArrayIntValidatePayload, error) {
+		var payload *servicequeryarrayintvalidate.MethodQueryArrayIntValidatePayload
 		var (
 			q   []int
 			err error
@@ -29,9 +30,9 @@ func DecodeMethodQueryArrayIntValidateRequest(mux goahttp.Muxer, decoder func(*h
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayIntValidatePayload(q)
+		payload = NewMethodQueryArrayIntValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-int.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-int.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryArrayInt MethodQueryArrayInt endpoint.
 func DecodeMethodQueryArrayIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayint.MethodQueryArrayIntPayload, error) {
 	return func(r *http.Request) (*servicequeryarrayint.MethodQueryArrayIntPayload, error) {
+		var payload *servicequeryarrayint.MethodQueryArrayIntPayload
 		var (
 			q   []int
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayIntRequest(mux goahttp.Muxer, decoder func(*http.Requ
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayIntPayload(q)
+		payload = NewMethodQueryArrayIntPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-int32-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-int32-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayint32validate.MethodQueryArrayInt32ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayint32validate.MethodQueryArrayInt32ValidatePayload, error) {
+		var payload *servicequeryarrayint32validate.MethodQueryArrayInt32ValidatePayload
 		var (
 			q   []int32
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryArrayInt32ValidateRequest(mux goahttp.Muxer, decoder func(
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayInt32ValidatePayload(q)
+		payload = NewMethodQueryArrayInt32ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-int32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-int32.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryArrayInt32 MethodQueryArrayInt32 endpoint.
 func DecodeMethodQueryArrayInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayint32.MethodQueryArrayInt32Payload, error) {
 	return func(r *http.Request) (*servicequeryarrayint32.MethodQueryArrayInt32Payload, error) {
+		var payload *servicequeryarrayint32.MethodQueryArrayInt32Payload
 		var (
 			q   []int32
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayInt32Request(mux goahttp.Muxer, decoder func(*http.Re
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayInt32Payload(q)
+		payload = NewMethodQueryArrayInt32Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-int64-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-int64-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayint64validate.MethodQueryArrayInt64ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayint64validate.MethodQueryArrayInt64ValidatePayload, error) {
+		var payload *servicequeryarrayint64validate.MethodQueryArrayInt64ValidatePayload
 		var (
 			q   []int64
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryArrayInt64ValidateRequest(mux goahttp.Muxer, decoder func(
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayInt64ValidatePayload(q)
+		payload = NewMethodQueryArrayInt64ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-int64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-int64.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryArrayInt64 MethodQueryArrayInt64 endpoint.
 func DecodeMethodQueryArrayInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayint64.MethodQueryArrayInt64Payload, error) {
 	return func(r *http.Request) (*servicequeryarrayint64.MethodQueryArrayInt64Payload, error) {
+		var payload *servicequeryarrayint64.MethodQueryArrayInt64Payload
 		var (
 			q   []int64
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayInt64Request(mux goahttp.Muxer, decoder func(*http.Re
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayInt64Payload(q)
+		payload = NewMethodQueryArrayInt64Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-nested-alias-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-nested-alias-validate.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryArrayAliasValidate MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayaliasvalidate.MethodAPayload, error) {
 	return func(r *http.Request) (*servicequeryarrayaliasvalidate.MethodAPayload, error) {
+		var payload *servicequeryarrayaliasvalidate.MethodAPayload
 		var (
 			array []float64
 			err   error
@@ -25,9 +26,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(array)
+		payload = NewMethodAPayload(array)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarraystringvalidate.MethodQueryArrayStringValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarraystringvalidate.MethodQueryArrayStringValidatePayload, error) {
+		var payload *servicequeryarraystringvalidate.MethodQueryArrayStringValidatePayload
 		var (
 			q   []string
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayStringValidateRequest(mux goahttp.Muxer, decoder func
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayStringValidatePayload(q)
+		payload = NewMethodQueryArrayStringValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-string.go.golden
@@ -2,11 +2,12 @@
 // the ServiceQueryArrayString MethodQueryArrayString endpoint.
 func DecodeMethodQueryArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarraystring.MethodQueryArrayStringPayload, error) {
 	return func(r *http.Request) (*servicequeryarraystring.MethodQueryArrayStringPayload, error) {
+		var payload *servicequeryarraystring.MethodQueryArrayStringPayload
 		var (
 			q []string
 		)
 		q = r.URL.Query()["q"]
-		payload := NewMethodQueryArrayStringPayload(q)
+		payload = NewMethodQueryArrayStringPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-uint-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-uint-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayUIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayuintvalidate.MethodQueryArrayUIntValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayuintvalidate.MethodQueryArrayUIntValidatePayload, error) {
+		var payload *servicequeryarrayuintvalidate.MethodQueryArrayUIntValidatePayload
 		var (
 			q   []uint
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryArrayUIntValidateRequest(mux goahttp.Muxer, decoder func(*
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayUIntValidatePayload(q)
+		payload = NewMethodQueryArrayUIntValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-uint.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-uint.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryArrayUInt MethodQueryArrayUInt endpoint.
 func DecodeMethodQueryArrayUIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayuint.MethodQueryArrayUIntPayload, error) {
 	return func(r *http.Request) (*servicequeryarrayuint.MethodQueryArrayUIntPayload, error) {
+		var payload *servicequeryarrayuint.MethodQueryArrayUIntPayload
 		var (
 			q   []uint
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayUIntRequest(mux goahttp.Muxer, decoder func(*http.Req
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayUIntPayload(q)
+		payload = NewMethodQueryArrayUIntPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-uint32-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-uint32-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayUInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayuint32validate.MethodQueryArrayUInt32ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayuint32validate.MethodQueryArrayUInt32ValidatePayload, error) {
+		var payload *servicequeryarrayuint32validate.MethodQueryArrayUInt32ValidatePayload
 		var (
 			q   []uint32
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryArrayUInt32ValidateRequest(mux goahttp.Muxer, decoder func
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayUInt32ValidatePayload(q)
+		payload = NewMethodQueryArrayUInt32ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-uint32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-uint32.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryArrayUInt32 MethodQueryArrayUInt32 endpoint.
 func DecodeMethodQueryArrayUInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayuint32.MethodQueryArrayUInt32Payload, error) {
 	return func(r *http.Request) (*servicequeryarrayuint32.MethodQueryArrayUInt32Payload, error) {
+		var payload *servicequeryarrayuint32.MethodQueryArrayUInt32Payload
 		var (
 			q   []uint32
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayUInt32Request(mux goahttp.Muxer, decoder func(*http.R
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayUInt32Payload(q)
+		payload = NewMethodQueryArrayUInt32Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-uint64-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-uint64-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryArrayUInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayuint64validate.MethodQueryArrayUInt64ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryarrayuint64validate.MethodQueryArrayUInt64ValidatePayload, error) {
+		var payload *servicequeryarrayuint64validate.MethodQueryArrayUInt64ValidatePayload
 		var (
 			q   []uint64
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryArrayUInt64ValidateRequest(mux goahttp.Muxer, decoder func
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayUInt64ValidatePayload(q)
+		payload = NewMethodQueryArrayUInt64ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-array-uint64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-array-uint64.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryArrayUInt64 MethodQueryArrayUInt64 endpoint.
 func DecodeMethodQueryArrayUInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryarrayuint64.MethodQueryArrayUInt64Payload, error) {
 	return func(r *http.Request) (*servicequeryarrayuint64.MethodQueryArrayUInt64Payload, error) {
+		var payload *servicequeryarrayuint64.MethodQueryArrayUInt64Payload
 		var (
 			q   []uint64
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryArrayUInt64Request(mux goahttp.Muxer, decoder func(*http.R
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryArrayUInt64Payload(q)
+		payload = NewMethodQueryArrayUInt64Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-bool-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryBoolValidate MethodQueryBoolValidate endpoint.
 func DecodeMethodQueryBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryboolvalidate.MethodQueryBoolValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryboolvalidate.MethodQueryBoolValidatePayload, error) {
+		var payload *servicequeryboolvalidate.MethodQueryBoolValidatePayload
 		var (
 			q   bool
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{true}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryBoolValidatePayload(q)
+		payload = NewMethodQueryBoolValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-bool.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-bool.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryBool MethodQueryBool endpoint.
 func DecodeMethodQueryBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerybool.MethodQueryBoolPayload, error) {
 	return func(r *http.Request) (*servicequerybool.MethodQueryBoolPayload, error) {
+		var payload *servicequerybool.MethodQueryBoolPayload
 		var (
 			q   *bool
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodQueryBoolRequest(mux goahttp.Muxer, decoder func(*http.Request)
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryBoolPayload(q)
+		payload = NewMethodQueryBoolPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-bytes-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-bytes-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryBytesValidate MethodQueryBytesValidate endpoint.
 func DecodeMethodQueryBytesValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerybytesvalidate.MethodQueryBytesValidatePayload, error) {
 	return func(r *http.Request) (*servicequerybytesvalidate.MethodQueryBytesValidatePayload, error) {
+		var payload *servicequerybytesvalidate.MethodQueryBytesValidatePayload
 		var (
 			q   []byte
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodQueryBytesValidateRequest(mux goahttp.Muxer, decoder func(*http
 			err = goa.MergeErrors(err, goa.InvalidLengthError("q", q, len(q), 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryBytesValidatePayload(q)
+		payload = NewMethodQueryBytesValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-bytes.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-bytes.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryBytes MethodQueryBytes endpoint.
 func DecodeMethodQueryBytesRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerybytes.MethodQueryBytesPayload, error) {
 	return func(r *http.Request) (*servicequerybytes.MethodQueryBytesPayload, error) {
+		var payload *servicequerybytes.MethodQueryBytesPayload
 		var (
 			q []byte
 		)
@@ -11,7 +12,7 @@ func DecodeMethodQueryBytesRequest(mux goahttp.Muxer, decoder func(*http.Request
 				q = []byte(qRaw)
 			}
 		}
-		payload := NewMethodQueryBytesPayload(q)
+		payload = NewMethodQueryBytesPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-custom-name.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-custom-name.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryCustomName MethodQueryCustomName endpoint.
 func DecodeMethodQueryCustomNameRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerycustomname.MethodQueryCustomNamePayload, error) {
 	return func(r *http.Request) (*servicequerycustomname.MethodQueryCustomNamePayload, error) {
+		var payload *servicequerycustomname.MethodQueryCustomNamePayload
 		var (
 			q *string
 		)
@@ -9,7 +10,7 @@ func DecodeMethodQueryCustomNameRequest(mux goahttp.Muxer, decoder func(*http.Re
 		if qRaw != "" {
 			q = &qRaw
 		}
-		payload := NewMethodQueryCustomNamePayload(q)
+		payload = NewMethodQueryCustomNamePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-float32-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-float32-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryFloat32Validate MethodQueryFloat32Validate endpoint.
 func DecodeMethodQueryFloat32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryfloat32validate.MethodQueryFloat32ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryfloat32validate.MethodQueryFloat32ValidatePayload, error) {
+		var payload *servicequeryfloat32validate.MethodQueryFloat32ValidatePayload
 		var (
 			q   float32
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryFloat32ValidateRequest(mux goahttp.Muxer, decoder func(*ht
 			err = goa.MergeErrors(err, goa.InvalidRangeError("q", q, 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryFloat32ValidatePayload(q)
+		payload = NewMethodQueryFloat32ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-float32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-float32.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryFloat32 MethodQueryFloat32 endpoint.
 func DecodeMethodQueryFloat32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryfloat32.MethodQueryFloat32Payload, error) {
 	return func(r *http.Request) (*servicequeryfloat32.MethodQueryFloat32Payload, error) {
+		var payload *servicequeryfloat32.MethodQueryFloat32Payload
 		var (
 			q   *float32
 			err error
@@ -18,9 +19,9 @@ func DecodeMethodQueryFloat32Request(mux goahttp.Muxer, decoder func(*http.Reque
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryFloat32Payload(q)
+		payload = NewMethodQueryFloat32Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-float64-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-float64-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryFloat64Validate MethodQueryFloat64Validate endpoint.
 func DecodeMethodQueryFloat64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryfloat64validate.MethodQueryFloat64ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryfloat64validate.MethodQueryFloat64ValidatePayload, error) {
+		var payload *servicequeryfloat64validate.MethodQueryFloat64ValidatePayload
 		var (
 			q   float64
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryFloat64ValidateRequest(mux goahttp.Muxer, decoder func(*ht
 			err = goa.MergeErrors(err, goa.InvalidRangeError("q", q, 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryFloat64ValidatePayload(q)
+		payload = NewMethodQueryFloat64ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-float64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-float64.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryFloat64 MethodQueryFloat64 endpoint.
 func DecodeMethodQueryFloat64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryfloat64.MethodQueryFloat64Payload, error) {
 	return func(r *http.Request) (*servicequeryfloat64.MethodQueryFloat64Payload, error) {
+		var payload *servicequeryfloat64.MethodQueryFloat64Payload
 		var (
 			q   *float64
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodQueryFloat64Request(mux goahttp.Muxer, decoder func(*http.Reque
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryFloat64Payload(q)
+		payload = NewMethodQueryFloat64Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-int-alias-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-int-alias-validate.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryIntAliasValidate MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryintaliasvalidate.MethodAPayload, error) {
 	return func(r *http.Request) (*servicequeryintaliasvalidate.MethodAPayload, error) {
+		var payload *servicequeryintaliasvalidate.MethodAPayload
 		var (
 			int_   *int
 			int32_ *int32
@@ -57,9 +58,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(int_, int32_, int64_)
+		payload = NewMethodAPayload(int_, int32_, int64_)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-int-alias.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-int-alias.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryIntAlias MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryintalias.MethodAPayload, error) {
 	return func(r *http.Request) (*servicequeryintalias.MethodAPayload, error) {
+		var payload *servicequeryintalias.MethodAPayload
 		var (
 			int_   *int
 			int32_ *int32
@@ -42,9 +43,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(int_, int32_, int64_)
+		payload = NewMethodAPayload(int_, int32_, int64_)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-int-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-int-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryIntValidate MethodQueryIntValidate endpoint.
 func DecodeMethodQueryIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryintvalidate.MethodQueryIntValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryintvalidate.MethodQueryIntValidatePayload, error) {
+		var payload *servicequeryintvalidate.MethodQueryIntValidatePayload
 		var (
 			q   int
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryIntValidateRequest(mux goahttp.Muxer, decoder func(*http.R
 			err = goa.MergeErrors(err, goa.InvalidRangeError("q", q, 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryIntValidatePayload(q)
+		payload = NewMethodQueryIntValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-int.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-int.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryInt MethodQueryInt endpoint.
 func DecodeMethodQueryIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryint.MethodQueryIntPayload, error) {
 	return func(r *http.Request) (*servicequeryint.MethodQueryIntPayload, error) {
+		var payload *servicequeryint.MethodQueryIntPayload
 		var (
 			q   *int
 			err error
@@ -18,9 +19,9 @@ func DecodeMethodQueryIntRequest(mux goahttp.Muxer, decoder func(*http.Request) 
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryIntPayload(q)
+		payload = NewMethodQueryIntPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-int32-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-int32-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryInt32Validate MethodQueryInt32Validate endpoint.
 func DecodeMethodQueryInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryint32validate.MethodQueryInt32ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryint32validate.MethodQueryInt32ValidatePayload, error) {
+		var payload *servicequeryint32validate.MethodQueryInt32ValidatePayload
 		var (
 			q   int32
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http
 			err = goa.MergeErrors(err, goa.InvalidRangeError("q", q, 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryInt32ValidatePayload(q)
+		payload = NewMethodQueryInt32ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-int32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-int32.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryInt32 MethodQueryInt32 endpoint.
 func DecodeMethodQueryInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryint32.MethodQueryInt32Payload, error) {
 	return func(r *http.Request) (*servicequeryint32.MethodQueryInt32Payload, error) {
+		var payload *servicequeryint32.MethodQueryInt32Payload
 		var (
 			q   *int32
 			err error
@@ -18,9 +19,9 @@ func DecodeMethodQueryInt32Request(mux goahttp.Muxer, decoder func(*http.Request
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryInt32Payload(q)
+		payload = NewMethodQueryInt32Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-int64-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-int64-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryInt64Validate MethodQueryInt64Validate endpoint.
 func DecodeMethodQueryInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryint64validate.MethodQueryInt64ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryint64validate.MethodQueryInt64ValidatePayload, error) {
+		var payload *servicequeryint64validate.MethodQueryInt64ValidatePayload
 		var (
 			q   int64
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http
 			err = goa.MergeErrors(err, goa.InvalidRangeError("q", q, 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryInt64ValidatePayload(q)
+		payload = NewMethodQueryInt64ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-int64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-int64.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryInt64 MethodQueryInt64 endpoint.
 func DecodeMethodQueryInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryint64.MethodQueryInt64Payload, error) {
 	return func(r *http.Request) (*servicequeryint64.MethodQueryInt64Payload, error) {
+		var payload *servicequeryint64.MethodQueryInt64Payload
 		var (
 			q   *int64
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodQueryInt64Request(mux goahttp.Muxer, decoder func(*http.Request
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryInt64Payload(q)
+		payload = NewMethodQueryInt64Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-alias-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-alias-validate.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryMapAliasValidate MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapaliasvalidate.MethodAPayload, error) {
 	return func(r *http.Request) (*servicequerymapaliasvalidate.MethodAPayload, error) {
+		var payload *servicequerymapaliasvalidate.MethodAPayload
 		var (
 			map_ map[float32]bool
 			err  error
@@ -47,9 +48,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			err = goa.MergeErrors(err, goa.InvalidLengthError("map", map_, len(map_), 5, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(map_)
+		payload = NewMethodAPayload(map_)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-alias.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-alias.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryMapAlias MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapalias.MethodAPayload, error) {
 	return func(r *http.Request) (*servicequerymapalias.MethodAPayload, error) {
+		var payload *servicequerymapalias.MethodAPayload
 		var (
 			map_ map[float32]bool
 			err  error
@@ -44,9 +45,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(map_)
+		payload = NewMethodAPayload(map_)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-bool-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-bool-array-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapBoolArrayBoolValidate endpoint.
 func DecodeMethodQueryMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapboolarrayboolvalidate.MethodQueryMapBoolArrayBoolValidatePayload, error) {
 	return func(r *http.Request) (*servicequerymapboolarrayboolvalidate.MethodQueryMapBoolArrayBoolValidatePayload, error) {
+		var payload *servicequerymapboolarrayboolvalidate.MethodQueryMapBoolArrayBoolValidatePayload
 		var (
 			q   map[bool][]bool
 			err error
@@ -59,9 +60,9 @@ func DecodeMethodQueryMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapBoolArrayBoolValidatePayload(q)
+		payload = NewMethodQueryMapBoolArrayBoolValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-bool-array-bool.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-bool-array-bool.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryMapBoolArrayBool MethodQueryMapBoolArrayBool endpoint.
 func DecodeMethodQueryMapBoolArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapboolarraybool.MethodQueryMapBoolArrayBoolPayload, error) {
 	return func(r *http.Request) (*servicequerymapboolarraybool.MethodQueryMapBoolArrayBoolPayload, error) {
+		var payload *servicequerymapboolarraybool.MethodQueryMapBoolArrayBoolPayload
 		var (
 			q   map[bool][]bool
 			err error
@@ -46,9 +47,9 @@ func DecodeMethodQueryMapBoolArrayBoolRequest(mux goahttp.Muxer, decoder func(*h
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapBoolArrayBoolPayload(q)
+		payload = NewMethodQueryMapBoolArrayBoolPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-bool-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-bool-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapBoolArrayStringValidate endpoint.
 func DecodeMethodQueryMapBoolArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapboolarraystringvalidate.MethodQueryMapBoolArrayStringValidatePayload, error) {
 	return func(r *http.Request) (*servicequerymapboolarraystringvalidate.MethodQueryMapBoolArrayStringValidatePayload, error) {
+		var payload *servicequerymapboolarraystringvalidate.MethodQueryMapBoolArrayStringValidatePayload
 		var (
 			q   map[bool][]string
 			err error
@@ -47,9 +48,9 @@ func DecodeMethodQueryMapBoolArrayStringValidateRequest(mux goahttp.Muxer, decod
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapBoolArrayStringValidatePayload(q)
+		payload = NewMethodQueryMapBoolArrayStringValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-bool-array-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-bool-array-string.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryMapBoolArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapboolarraystring.MethodQueryMapBoolArrayStringPayload, error) {
 	return func(r *http.Request) (*servicequerymapboolarraystring.MethodQueryMapBoolArrayStringPayload, error) {
+		var payload *servicequerymapboolarraystring.MethodQueryMapBoolArrayStringPayload
 		var (
 			q   map[bool][]string
 			err error
@@ -36,9 +37,9 @@ func DecodeMethodQueryMapBoolArrayStringRequest(mux goahttp.Muxer, decoder func(
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapBoolArrayStringPayload(q)
+		payload = NewMethodQueryMapBoolArrayStringPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-bool-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-bool-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapboolboolvalidate.MethodQueryMapBoolBoolValidatePayload, error) {
 	return func(r *http.Request) (*servicequerymapboolboolvalidate.MethodQueryMapBoolBoolValidatePayload, error) {
+		var payload *servicequerymapboolboolvalidate.MethodQueryMapBoolBoolValidatePayload
 		var (
 			q   map[bool]bool
 			err error
@@ -57,9 +58,9 @@ func DecodeMethodQueryMapBoolBoolValidateRequest(mux goahttp.Muxer, decoder func
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapBoolBoolValidatePayload(q)
+		payload = NewMethodQueryMapBoolBoolValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-bool-bool.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-bool-bool.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryMapBoolBool MethodQueryMapBoolBool endpoint.
 func DecodeMethodQueryMapBoolBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapboolbool.MethodQueryMapBoolBoolPayload, error) {
 	return func(r *http.Request) (*servicequerymapboolbool.MethodQueryMapBoolBoolPayload, error) {
+		var payload *servicequerymapboolbool.MethodQueryMapBoolBoolPayload
 		var (
 			q   map[bool]bool
 			err error
@@ -44,9 +45,9 @@ func DecodeMethodQueryMapBoolBoolRequest(mux goahttp.Muxer, decoder func(*http.R
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapBoolBoolPayload(q)
+		payload = NewMethodQueryMapBoolBoolPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-bool-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-bool-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapBoolStringValidate endpoint.
 func DecodeMethodQueryMapBoolStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapboolstringvalidate.MethodQueryMapBoolStringValidatePayload, error) {
 	return func(r *http.Request) (*servicequerymapboolstringvalidate.MethodQueryMapBoolStringValidatePayload, error) {
+		var payload *servicequerymapboolstringvalidate.MethodQueryMapBoolStringValidatePayload
 		var (
 			q   map[bool]string
 			err error
@@ -48,9 +49,9 @@ func DecodeMethodQueryMapBoolStringValidateRequest(mux goahttp.Muxer, decoder fu
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapBoolStringValidatePayload(q)
+		payload = NewMethodQueryMapBoolStringValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-bool-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-bool-string.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryMapBoolString MethodQueryMapBoolString endpoint.
 func DecodeMethodQueryMapBoolStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapboolstring.MethodQueryMapBoolStringPayload, error) {
 	return func(r *http.Request) (*servicequerymapboolstring.MethodQueryMapBoolStringPayload, error) {
+		var payload *servicequerymapboolstring.MethodQueryMapBoolStringPayload
 		var (
 			q   map[bool]string
 			err error
@@ -35,9 +36,9 @@ func DecodeMethodQueryMapBoolStringRequest(mux goahttp.Muxer, decoder func(*http
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapBoolStringPayload(q)
+		payload = NewMethodQueryMapBoolStringPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-int-map-string-array-int-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-int-map-string-array-int-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapIntMapStringArrayIntValidate endpoint.
 func DecodeMethodQueryMapIntMapStringArrayIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (map[int]map[string][]int, error) {
 	return func(r *http.Request) (map[int]map[string][]int, error) {
+		var payload map[int]map[string][]int
 		var (
 			q   map[int]map[string][]int
 			err error
@@ -67,9 +68,9 @@ func DecodeMethodQueryMapIntMapStringArrayIntValidateRequest(mux goahttp.Muxer, 
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-array-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapStringArrayBoolValidate endpoint.
 func DecodeMethodQueryMapStringArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapstringarrayboolvalidate.MethodQueryMapStringArrayBoolValidatePayload, error) {
 	return func(r *http.Request) (*servicequerymapstringarrayboolvalidate.MethodQueryMapStringArrayBoolValidatePayload, error) {
+		var payload *servicequerymapstringarrayboolvalidate.MethodQueryMapStringArrayBoolValidatePayload
 		var (
 			q   map[string][]bool
 			err error
@@ -54,9 +55,9 @@ func DecodeMethodQueryMapStringArrayBoolValidateRequest(mux goahttp.Muxer, decod
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapStringArrayBoolValidatePayload(q)
+		payload = NewMethodQueryMapStringArrayBoolValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-array-bool.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-array-bool.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryMapStringArrayBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapstringarraybool.MethodQueryMapStringArrayBoolPayload, error) {
 	return func(r *http.Request) (*servicequerymapstringarraybool.MethodQueryMapStringArrayBoolPayload, error) {
+		var payload *servicequerymapstringarraybool.MethodQueryMapStringArrayBoolPayload
 		var (
 			q   map[string][]bool
 			err error
@@ -42,9 +43,9 @@ func DecodeMethodQueryMapStringArrayBoolRequest(mux goahttp.Muxer, decoder func(
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapStringArrayBoolPayload(q)
+		payload = NewMethodQueryMapStringArrayBoolPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapStringArrayStringValidate endpoint.
 func DecodeMethodQueryMapStringArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapstringarraystringvalidate.MethodQueryMapStringArrayStringValidatePayload, error) {
 	return func(r *http.Request) (*servicequerymapstringarraystringvalidate.MethodQueryMapStringArrayStringValidatePayload, error) {
+		var payload *servicequerymapstringarraystringvalidate.MethodQueryMapStringArrayStringValidatePayload
 		var (
 			q   map[string][]string
 			err error
@@ -43,9 +44,9 @@ func DecodeMethodQueryMapStringArrayStringValidateRequest(mux goahttp.Muxer, dec
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapStringArrayStringValidatePayload(q)
+		payload = NewMethodQueryMapStringArrayStringValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-array-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-array-string.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryMapStringArrayStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapstringarraystring.MethodQueryMapStringArrayStringPayload, error) {
 	return func(r *http.Request) (*servicequerymapstringarraystring.MethodQueryMapStringArrayStringPayload, error) {
+		var payload *servicequerymapstringarraystring.MethodQueryMapStringArrayStringPayload
 		var (
 			q   map[string][]string
 			err error
@@ -31,9 +32,9 @@ func DecodeMethodQueryMapStringArrayStringRequest(mux goahttp.Muxer, decoder fun
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapStringArrayStringPayload(q)
+		payload = NewMethodQueryMapStringArrayStringPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapStringBoolValidate endpoint.
 func DecodeMethodQueryMapStringBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapstringboolvalidate.MethodQueryMapStringBoolValidatePayload, error) {
 	return func(r *http.Request) (*servicequerymapstringboolvalidate.MethodQueryMapStringBoolValidatePayload, error) {
+		var payload *servicequerymapstringboolvalidate.MethodQueryMapStringBoolValidatePayload
 		var (
 			q   map[string]bool
 			err error
@@ -52,9 +53,9 @@ func DecodeMethodQueryMapStringBoolValidateRequest(mux goahttp.Muxer, decoder fu
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapStringBoolValidatePayload(q)
+		payload = NewMethodQueryMapStringBoolValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-bool.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-bool.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryMapStringBool MethodQueryMapStringBool endpoint.
 func DecodeMethodQueryMapStringBoolRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapstringbool.MethodQueryMapStringBoolPayload, error) {
 	return func(r *http.Request) (*servicequerymapstringbool.MethodQueryMapStringBoolPayload, error) {
+		var payload *servicequerymapstringbool.MethodQueryMapStringBoolPayload
 		var (
 			q   map[string]bool
 			err error
@@ -39,9 +40,9 @@ func DecodeMethodQueryMapStringBoolRequest(mux goahttp.Muxer, decoder func(*http
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapStringBoolPayload(q)
+		payload = NewMethodQueryMapStringBoolPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-map-int-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-map-int-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapStringMapIntStringValidate endpoint.
 func DecodeMethodQueryMapStringMapIntStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (map[string]map[int]string, error) {
 	return func(r *http.Request) (map[string]map[int]string, error) {
+		var payload map[string]map[int]string
 		var (
 			q   map[string]map[int]string
 			err error
@@ -56,9 +57,9 @@ func DecodeMethodQueryMapStringMapIntStringValidateRequest(mux goahttp.Muxer, de
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryMapStringStringValidate endpoint.
 func DecodeMethodQueryMapStringStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapstringstringvalidate.MethodQueryMapStringStringValidatePayload, error) {
 	return func(r *http.Request) (*servicequerymapstringstringvalidate.MethodQueryMapStringStringValidatePayload, error) {
+		var payload *servicequerymapstringstringvalidate.MethodQueryMapStringStringValidatePayload
 		var (
 			q   map[string]string
 			err error
@@ -43,9 +44,9 @@ func DecodeMethodQueryMapStringStringValidateRequest(mux goahttp.Muxer, decoder 
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapStringStringValidatePayload(q)
+		payload = NewMethodQueryMapStringStringValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-map-string-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-map-string-string.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryMapStringString MethodQueryMapStringString endpoint.
 func DecodeMethodQueryMapStringStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerymapstringstring.MethodQueryMapStringStringPayload, error) {
 	return func(r *http.Request) (*servicequerymapstringstring.MethodQueryMapStringStringPayload, error) {
+		var payload *servicequerymapstringstring.MethodQueryMapStringStringPayload
 		var (
 			q   map[string]string
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryMapStringStringRequest(mux goahttp.Muxer, decoder func(*ht
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryMapStringStringPayload(q)
+		payload = NewMethodQueryMapStringStringPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-primitive-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-primitive-array-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryPrimitiveArrayBoolValidate endpoint.
 func DecodeMethodQueryPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]bool, error) {
 	return func(r *http.Request) ([]bool, error) {
+		var payload []bool
 		var (
 			q   []bool
 			err error
@@ -30,9 +31,9 @@ func DecodeMethodQueryPrimitiveArrayBoolValidateRequest(mux goahttp.Muxer, decod
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-primitive-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-primitive-array-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryPrimitiveArrayStringValidate endpoint.
 func DecodeMethodQueryPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) ([]string, error) {
 	return func(r *http.Request) ([]string, error) {
+		var payload []string
 		var (
 			q   []string
 			err error
@@ -20,9 +21,9 @@ func DecodeMethodQueryPrimitiveArrayStringValidateRequest(mux goahttp.Muxer, dec
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-primitive-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-primitive-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryPrimitiveBoolValidate endpoint.
 func DecodeMethodQueryPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (bool, error) {
 	return func(r *http.Request) (bool, error) {
+		var payload bool
 		var (
 			q   bool
 			err error
@@ -22,9 +23,9 @@ func DecodeMethodQueryPrimitiveBoolValidateRequest(mux goahttp.Muxer, decoder fu
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{true}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-primitive-map-bool-array-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-primitive-map-bool-array-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryPrimitiveMapBoolArrayBoolValidate endpoint.
 func DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (map[bool][]bool, error) {
 	return func(r *http.Request) (map[bool][]bool, error) {
+		var payload map[bool][]bool
 		var (
 			q   map[bool][]bool
 			err error
@@ -64,9 +65,9 @@ func DecodeMethodQueryPrimitiveMapBoolArrayBoolValidateRequest(mux goahttp.Muxer
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-primitive-map-string-array-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-primitive-map-string-array-string-validate.go.golden
@@ -4,6 +4,7 @@
 // MethodQueryPrimitiveMapStringArrayStringValidate endpoint.
 func DecodeMethodQueryPrimitiveMapStringArrayStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (map[string][]string, error) {
 	return func(r *http.Request) (map[string][]string, error) {
+		var payload map[string][]string
 		var (
 			q   map[string][]string
 			err error
@@ -45,9 +46,9 @@ func DecodeMethodQueryPrimitiveMapStringArrayStringValidateRequest(mux goahttp.M
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-primitive-map-string-bool-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-primitive-map-string-bool-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryPrimitiveMapStringBoolValidate endpoint.
 func DecodeMethodQueryPrimitiveMapStringBoolValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (map[string]bool, error) {
 	return func(r *http.Request) (map[string]bool, error) {
+		var payload map[string]bool
 		var (
 			q   map[string]bool
 			err error
@@ -50,9 +51,9 @@ func DecodeMethodQueryPrimitiveMapStringBoolValidateRequest(mux goahttp.Muxer, d
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-primitive-string-default.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-primitive-string-default.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryPrimitiveStringDefault endpoint.
 func DecodeMethodQueryPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
 	return func(r *http.Request) (string, error) {
+		var payload string
 		var (
 			q   string
 			err error
@@ -12,9 +13,9 @@ func DecodeMethodQueryPrimitiveStringDefaultRequest(mux goahttp.Muxer, decoder f
 			err = goa.MergeErrors(err, goa.MissingFieldError("q", "query string"))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-primitive-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-primitive-string-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryPrimitiveStringValidate endpoint.
 func DecodeMethodQueryPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (string, error) {
 	return func(r *http.Request) (string, error) {
+		var payload string
 		var (
 			q   string
 			err error
@@ -15,9 +16,9 @@ func DecodeMethodQueryPrimitiveStringValidateRequest(mux goahttp.Muxer, decoder 
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"val"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := q
+		payload = q
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-string-default-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-string-default-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryStringDefaultValidate endpoint.
 func DecodeMethodQueryStringDefaultValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerystringdefaultvalidate.MethodQueryStringDefaultValidatePayload, error) {
 	return func(r *http.Request) (*servicequerystringdefaultvalidate.MethodQueryStringDefaultValidatePayload, error) {
+		var payload *servicequerystringdefaultvalidate.MethodQueryStringDefaultValidatePayload
 		var (
 			q   string
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodQueryStringDefaultValidateRequest(mux goahttp.Muxer, decoder fu
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"def"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryStringDefaultValidatePayload(q)
+		payload = NewMethodQueryStringDefaultValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-string-default.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-string-default.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryStringDefault MethodQueryStringDefault endpoint.
 func DecodeMethodQueryStringDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerystringdefault.MethodQueryStringDefaultPayload, error) {
 	return func(r *http.Request) (*servicequerystringdefault.MethodQueryStringDefaultPayload, error) {
+		var payload *servicequerystringdefault.MethodQueryStringDefaultPayload
 		var (
 			q string
 		)
@@ -11,7 +12,7 @@ func DecodeMethodQueryStringDefaultRequest(mux goahttp.Muxer, decoder func(*http
 		} else {
 			q = "def"
 		}
-		payload := NewMethodQueryStringDefaultPayload(q)
+		payload = NewMethodQueryStringDefaultPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-string-extended-payload.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-string-extended-payload.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryStringExtendedPayload endpoint.
 func DecodeMethodQueryStringExtendedPayloadRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerystringextendedpayload.MethodQueryStringExtendedPayloadPayload, error) {
 	return func(r *http.Request) (*servicequerystringextendedpayload.MethodQueryStringExtendedPayloadPayload, error) {
+		var payload *servicequerystringextendedpayload.MethodQueryStringExtendedPayloadPayload
 		var (
 			q *string
 		)
@@ -10,7 +11,7 @@ func DecodeMethodQueryStringExtendedPayloadRequest(mux goahttp.Muxer, decoder fu
 		if qRaw != "" {
 			q = &qRaw
 		}
-		payload := NewMethodQueryStringExtendedPayloadPayload(q)
+		payload = NewMethodQueryStringExtendedPayloadPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-string-mapped.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-string-mapped.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryStringMapped MethodQueryStringMapped endpoint.
 func DecodeMethodQueryStringMappedRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerystringmapped.MethodQueryStringMappedPayload, error) {
 	return func(r *http.Request) (*servicequerystringmapped.MethodQueryStringMappedPayload, error) {
+		var payload *servicequerystringmapped.MethodQueryStringMappedPayload
 		var (
 			query *string
 		)
@@ -9,7 +10,7 @@ func DecodeMethodQueryStringMappedRequest(mux goahttp.Muxer, decoder func(*http.
 		if queryRaw != "" {
 			query = &queryRaw
 		}
-		payload := NewMethodQueryStringMappedPayload(query)
+		payload = NewMethodQueryStringMappedPayload(query)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-string-not-required-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-string-not-required-validate.go.golden
@@ -3,6 +3,7 @@
 // MethodQueryStringNotRequiredValidate endpoint.
 func DecodeMethodQueryStringNotRequiredValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerystringnotrequiredvalidate.MethodQueryStringNotRequiredValidatePayload, error) {
 	return func(r *http.Request) (*servicequerystringnotrequiredvalidate.MethodQueryStringNotRequiredValidatePayload, error) {
+		var payload *servicequerystringnotrequiredvalidate.MethodQueryStringNotRequiredValidatePayload
 		var (
 			q   *string
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodQueryStringNotRequiredValidateRequest(mux goahttp.Muxer, decode
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryStringNotRequiredValidatePayload(q)
+		payload = NewMethodQueryStringNotRequiredValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-string-slice-default.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-string-slice-default.go.golden
@@ -3,6 +3,7 @@
 // endpoint.
 func DecodeMethodQueryStringSliceDefaultRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerystringslicedefault.MethodQueryStringSliceDefaultPayload, error) {
 	return func(r *http.Request) (*servicequerystringslicedefault.MethodQueryStringSliceDefaultPayload, error) {
+		var payload *servicequerystringslicedefault.MethodQueryStringSliceDefaultPayload
 		var (
 			q []string
 		)
@@ -10,7 +11,7 @@ func DecodeMethodQueryStringSliceDefaultRequest(mux goahttp.Muxer, decoder func(
 		if q == nil {
 			q = []string{"hello", "goodbye"}
 		}
-		payload := NewMethodQueryStringSliceDefaultPayload(q)
+		payload = NewMethodQueryStringSliceDefaultPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-string-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-string-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryStringValidate MethodQueryStringValidate endpoint.
 func DecodeMethodQueryStringValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerystringvalidate.MethodQueryStringValidatePayload, error) {
 	return func(r *http.Request) (*servicequerystringvalidate.MethodQueryStringValidatePayload, error) {
+		var payload *servicequerystringvalidate.MethodQueryStringValidatePayload
 		var (
 			q   string
 			err error
@@ -14,9 +15,9 @@ func DecodeMethodQueryStringValidateRequest(mux goahttp.Muxer, decoder func(*htt
 			err = goa.MergeErrors(err, goa.InvalidEnumValueError("q", q, []any{"val"}))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryStringValidatePayload(q)
+		payload = NewMethodQueryStringValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-string.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-string.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryString MethodQueryString endpoint.
 func DecodeMethodQueryStringRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequerystring.MethodQueryStringPayload, error) {
 	return func(r *http.Request) (*servicequerystring.MethodQueryStringPayload, error) {
+		var payload *servicequerystring.MethodQueryStringPayload
 		var (
 			q *string
 		)
@@ -9,7 +10,7 @@ func DecodeMethodQueryStringRequest(mux goahttp.Muxer, decoder func(*http.Reques
 		if qRaw != "" {
 			q = &qRaw
 		}
-		payload := NewMethodQueryStringPayload(q)
+		payload = NewMethodQueryStringPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-uint-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-uint-validate.go.golden
@@ -2,6 +2,7 @@
 // the ServiceQueryUIntValidate MethodQueryUIntValidate endpoint.
 func DecodeMethodQueryUIntValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryuintvalidate.MethodQueryUIntValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryuintvalidate.MethodQueryUIntValidatePayload, error) {
+		var payload *servicequeryuintvalidate.MethodQueryUIntValidatePayload
 		var (
 			q   uint
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryUIntValidateRequest(mux goahttp.Muxer, decoder func(*http.
 			err = goa.MergeErrors(err, goa.InvalidRangeError("q", q, 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryUIntValidatePayload(q)
+		payload = NewMethodQueryUIntValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-uint.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-uint.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryUInt MethodQueryUInt endpoint.
 func DecodeMethodQueryUIntRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryuint.MethodQueryUIntPayload, error) {
 	return func(r *http.Request) (*servicequeryuint.MethodQueryUIntPayload, error) {
+		var payload *servicequeryuint.MethodQueryUIntPayload
 		var (
 			q   *uint
 			err error
@@ -18,9 +19,9 @@ func DecodeMethodQueryUIntRequest(mux goahttp.Muxer, decoder func(*http.Request)
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryUIntPayload(q)
+		payload = NewMethodQueryUIntPayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-uint32-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-uint32-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryUInt32Validate MethodQueryUInt32Validate endpoint.
 func DecodeMethodQueryUInt32ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryuint32validate.MethodQueryUInt32ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryuint32validate.MethodQueryUInt32ValidatePayload, error) {
+		var payload *servicequeryuint32validate.MethodQueryUInt32ValidatePayload
 		var (
 			q   uint32
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryUInt32ValidateRequest(mux goahttp.Muxer, decoder func(*htt
 			err = goa.MergeErrors(err, goa.InvalidRangeError("q", q, 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryUInt32ValidatePayload(q)
+		payload = NewMethodQueryUInt32ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-uint32.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-uint32.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryUInt32 MethodQueryUInt32 endpoint.
 func DecodeMethodQueryUInt32Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryuint32.MethodQueryUInt32Payload, error) {
 	return func(r *http.Request) (*servicequeryuint32.MethodQueryUInt32Payload, error) {
+		var payload *servicequeryuint32.MethodQueryUInt32Payload
 		var (
 			q   *uint32
 			err error
@@ -18,9 +19,9 @@ func DecodeMethodQueryUInt32Request(mux goahttp.Muxer, decoder func(*http.Reques
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryUInt32Payload(q)
+		payload = NewMethodQueryUInt32Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-uint64-validate.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-uint64-validate.go.golden
@@ -2,6 +2,7 @@
 // to the ServiceQueryUInt64Validate MethodQueryUInt64Validate endpoint.
 func DecodeMethodQueryUInt64ValidateRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryuint64validate.MethodQueryUInt64ValidatePayload, error) {
 	return func(r *http.Request) (*servicequeryuint64validate.MethodQueryUInt64ValidatePayload, error) {
+		var payload *servicequeryuint64validate.MethodQueryUInt64ValidatePayload
 		var (
 			q   uint64
 			err error
@@ -21,9 +22,9 @@ func DecodeMethodQueryUInt64ValidateRequest(mux goahttp.Muxer, decoder func(*htt
 			err = goa.MergeErrors(err, goa.InvalidRangeError("q", q, 1, true))
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryUInt64ValidatePayload(q)
+		payload = NewMethodQueryUInt64ValidatePayload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-query-uint64.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-query-uint64.go.golden
@@ -2,6 +2,7 @@
 // ServiceQueryUInt64 MethodQueryUInt64 endpoint.
 func DecodeMethodQueryUInt64Request(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicequeryuint64.MethodQueryUInt64Payload, error) {
 	return func(r *http.Request) (*servicequeryuint64.MethodQueryUInt64Payload, error) {
+		var payload *servicequeryuint64.MethodQueryUInt64Payload
 		var (
 			q   *uint64
 			err error
@@ -17,9 +18,9 @@ func DecodeMethodQueryUInt64Request(mux goahttp.Muxer, decoder func(*http.Reques
 			}
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodQueryUInt64Payload(q)
+		payload = NewMethodQueryUInt64Payload(q)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/golden/server_decode_decode-with-params-and-headers-dsl.go.golden
+++ b/http/codegen/testdata/golden/server_decode_decode-with-params-and-headers-dsl.go.golden
@@ -2,6 +2,7 @@
 // ServiceWithParamsAndHeadersBlock MethodA endpoint.
 func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.Decoder) func(*http.Request) (*servicewithparamsandheadersblock.MethodAPayload, error) {
 	return func(r *http.Request) (*servicewithparamsandheadersblock.MethodAPayload, error) {
+		var payload *servicewithparamsandheadersblock.MethodAPayload
 		var (
 			body MethodARequestBody
 			err  error
@@ -9,13 +10,13 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 		err = decoder(r).Decode(&body)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil, goa.MissingPayloadError()
+				return payload, goa.MissingPayloadError()
 			}
 			var gerr *goa.ServiceError
 			if errors.As(err, &gerr) {
-				return nil, gerr
+				return payload, gerr
 			}
-			return nil, goa.DecodePayloadError(err.Error())
+			return payload, goa.DecodePayloadError(err.Error())
 		}
 
 		var (
@@ -74,9 +75,9 @@ func DecodeMethodARequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp
 			optionalButRequiredHeader = float32(v)
 		}
 		if err != nil {
-			return nil, err
+			return payload, err
 		}
-		payload := NewMethodAPayload(&body, path, optional, optionalButRequiredParam, required, optionalButRequiredHeader)
+		payload = NewMethodAPayload(&body, path, optional, optionalButRequiredParam, required, optionalButRequiredHeader)
 
 		return payload, nil
 	}

--- a/http/codegen/testdata/payload_dsls.go
+++ b/http/codegen/testdata/payload_dsls.go
@@ -1512,6 +1512,20 @@ var PayloadPathPrimitiveStringValidateDSL = func() {
 	})
 }
 
+var PayloadPathPrimitiveStringFormatIPValidateDSL = func() {
+	Service("ServicePathPrimitiveStringFormatIPValidate", func() {
+		Method("MethodPathPrimitiveStringFormatIPValidate", func() {
+			Payload(String, func() {
+				Format(FormatIP)
+			})
+			HTTP(func() {
+				GET("/forecast/{ip}")
+				Param("ip")
+			})
+		})
+	})
+}
+
 var PayloadPathPrimitiveBoolValidateDSL = func() {
 	Service("ServicePathPrimitiveBoolValidate", func() {
 		Method("MethodPathPrimitiveBoolValidate", func() {


### PR DESCRIPTION
## Summary
- Fix HTTP request decoder generation to avoid emitting `return nil, err` in functions that return non-nilable primitive payloads (e.g. `string`, `bool`, numeric types).
- Generate a typed zero-value `payload` up front and return it on all early error paths; assign into it when constructing the payload.
- Add a golden-backed regression case for `Format(FormatIP)` validation on a primitive path payload (`/forecast/{ip}`) and assert decoders never emit `return nil,`.

## Rationale
A refactor tightened request decoder signatures from `(any, error)` to `(<payload>, error)` but left early-return branches returning `nil`. That compiles for pointer/slice/map payloads, but fails for primitives.

## Test plan
- `go test ./http/codegen -run TestDecode -update`
- `go test ./http/codegen -run TestDecode`
- `go test ./http/codegen/...`