### PR TITLE
fix: increase JSON-RPC integration test server startup timeout

### DIFF
--- a/jsonrpc/integration_tests/harness/server.go
+++ b/jsonrpc/integration_tests/harness/server.go
@@ -209,8 +209,8 @@ func (s *Server) waitForReady(ctx context.Context) error {
 		return nil
 	case err := <-errChan:
 		return err
-	case <-time.After(10 * time.Second):
-		return fmt.Errorf("server failed to start within 10 seconds")
+	case <-time.After(60 * time.Second):
+		return fmt.Errorf("server failed to start within 60 seconds")
 	case <-ctx.Done():
 		return ctx.Err()
 	}


### PR DESCRIPTION
## Summary

- The JSON-RPC integration test has been failing on **all PRs** since ~Feb 23 (including dependabot bumps) on Go 1.24 / ubuntu runners
- Root cause: `go run .` must compile the generated 45-method test service from scratch in a temp directory; the hardcoded **10-second** startup timeout is too tight for current GitHub-hosted runner performance with Go 1.24
- Go 1.25 passes because it compiles faster; Go 1.24 consistently exceeds the 10s window
- Increases the timeout to **60 seconds** to accommodate cold compilations

Evidence of pre-existing failure (dependabot PR, no code changes):
https://github.com/goadesign/goa/actions/runs/22306046368

## Test plan

- [ ] CI passes on Go 1.24 ubuntu (currently broken)
- [ ] CI passes on Go 1.25 ubuntu (already passing)
- [ ] Windows jobs no longer get cancelled by fail-fast