### PR TITLE
codegen: stabilize union type naming across object order

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -1073,7 +1073,7 @@ func collectUnionTypes(att *expr.AttributeExpr, scope *codegen.NameScope, loc *c
 		seen[dt.ID()] = struct{}{}
 		collectUnionTypes(dt.Attribute(), scope, codegen.UserTypeLocation(dt), unions, seen)
 	case *expr.Object:
-		for _, nat := range *dt {
+		for _, nat := range sortedNamedAttributes(*dt) {
 			collectUnionTypes(nat.Attribute, scope, loc, unions, seen)
 		}
 	case *expr.Array:
@@ -1152,7 +1152,7 @@ func collectViewUnionTypes(att *expr.AttributeExpr, scope *codegen.NameScope, lo
 		seen[dt.ID()] = struct{}{}
 		collectViewUnionTypes(dt.Attribute(), scope, loc, unions, seen)
 	case *expr.Object:
-		for _, nat := range *dt {
+		for _, nat := range sortedNamedAttributes(*dt) {
 			collectViewUnionTypes(nat.Attribute, scope, loc, unions, seen)
 		}
 	case *expr.Array:
@@ -1206,6 +1206,21 @@ func buildViewUnionTypeData(u *expr.Union, scope *codegen.NameScope, loc *codege
 		TypeKey:  u.GetTypeKey(),
 		ValueKey: u.GetValueKey(),
 	}
+}
+
+// sortedNamedAttributes returns object fields sorted by attribute name.
+// Union naming uses NameScope uniqueness, so callers that discover unions while
+// traversing objects must use a deterministic field order to avoid oscillating
+// generated identifiers across runs.
+func sortedNamedAttributes(attrs []*expr.NamedAttributeExpr) []*expr.NamedAttributeExpr {
+	if len(attrs) < 2 {
+		return attrs
+	}
+	sorted := slices.Clone(attrs)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+	return sorted
 }
 
 // primitiveAliasGoType resolves the native Go type for a primitive alias branch.

--- a/codegen/service/service_data_union_order_test.go
+++ b/codegen/service/service_data_union_order_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/expr"
+)
+
+func TestCollectUnionTypesDeterministicAcrossObjectOrder(t *testing.T) {
+	sourceFromSignals := makeUnionForOrderTest("source",
+		"physical_point",
+		"synthetic_series",
+	)
+	sourceFromInputs := makeUnionForOrderTest("source",
+		"time_series",
+		"energy_rates",
+	)
+
+	forward := &expr.AttributeExpr{
+		Type: &expr.Object{
+			{
+				Name: "alpha",
+				Attribute: &expr.AttributeExpr{
+					Type: sourceFromSignals,
+				},
+			},
+			{
+				Name: "beta",
+				Attribute: &expr.AttributeExpr{
+					Type: sourceFromInputs,
+				},
+			},
+		},
+	}
+	reverse := &expr.AttributeExpr{
+		Type: &expr.Object{
+			{
+				Name: "beta",
+				Attribute: &expr.AttributeExpr{
+					Type: sourceFromInputs,
+				},
+			},
+			{
+				Name: "alpha",
+				Attribute: &expr.AttributeExpr{
+					Type: sourceFromSignals,
+				},
+			},
+		},
+	}
+
+	loc := &codegen.Location{
+		RelImportPath: "gen/service",
+	}
+	forwardNames := collectServiceUnionTypeNames(forward, loc)
+	reverseNames := collectServiceUnionTypeNames(reverse, loc)
+
+	require.Len(t, forwardNames, 2)
+	require.Equal(t, forwardNames, reverseNames)
+}
+
+func collectServiceUnionTypeNames(att *expr.AttributeExpr, loc *codegen.Location) map[string]string {
+	scope := codegen.NewNameScope()
+	seen := make(map[string]struct{})
+	unionByHash := make(map[string]*UnionTypeData)
+	collectUnionTypes(att, scope, loc, unionByHash, seen)
+
+	names := make(map[string]string, len(unionByHash))
+	for hash, data := range unionByHash {
+		names[hash] = data.Name
+	}
+	return names
+}
+
+func makeUnionForOrderTest(typeName string, variants ...string) *expr.Union {
+	values := make([]*expr.NamedAttributeExpr, len(variants))
+	for i, variant := range variants {
+		values[i] = &expr.NamedAttributeExpr{
+			Name: variant,
+			Attribute: &expr.AttributeExpr{
+				Type: expr.String,
+			},
+		}
+	}
+	return &expr.Union{
+		TypeName: typeName,
+		Values:   values,
+	}
+}

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -2722,7 +2722,7 @@ func collectHTTPUnionTypes(att *expr.AttributeExpr, scope *codegen.NameScope, un
 		seen[dt.ID()] = struct{}{}
 		collectHTTPUnionTypes(dt.Attribute(), scope, unions, seen)
 	case *expr.Object:
-		for _, nat := range *dt {
+		for _, nat := range sortedNamedAttributes(*dt) {
 			collectHTTPUnionTypes(nat.Attribute, scope, unions, seen)
 		}
 	case *expr.Array:
@@ -2767,6 +2767,21 @@ func buildHTTPUnionTypeData(u *expr.Union, scope *codegen.NameScope) *service.Un
 		TypeKey:  u.GetTypeKey(),
 		ValueKey: u.GetValueKey(),
 	}
+}
+
+// sortedNamedAttributes returns object fields sorted by attribute name.
+// Union naming uses NameScope uniqueness, so callers that discover unions while
+// traversing objects must use a deterministic field order to avoid oscillating
+// generated identifiers across runs.
+func sortedNamedAttributes(attrs []*expr.NamedAttributeExpr) []*expr.NamedAttributeExpr {
+	if len(attrs) < 2 {
+		return attrs
+	}
+	sorted := slices.Clone(attrs)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Name < sorted[j].Name
+	})
+	return sorted
 }
 
 func (sds *ServicesData) attributeTypeData(ut expr.UserType, req, ptr, server bool, rd *ServiceData) *TypeData {

--- a/http/codegen/service_data_union_order_test.go
+++ b/http/codegen/service_data_union_order_test.go
@@ -1,0 +1,90 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	cg "goa.design/goa/v3/codegen"
+	svc "goa.design/goa/v3/codegen/service"
+	"goa.design/goa/v3/expr"
+)
+
+func TestCollectHTTPUnionTypesDeterministicAcrossObjectOrder(t *testing.T) {
+	sourceFromSignals := makeUnionForOrderTest("source",
+		"physical_point",
+		"synthetic_series",
+	)
+	sourceFromInputs := makeUnionForOrderTest("source",
+		"time_series",
+		"energy_rates",
+	)
+
+	forward := &expr.AttributeExpr{
+		Type: &expr.Object{
+			{
+				Name: "alpha",
+				Attribute: &expr.AttributeExpr{
+					Type: sourceFromSignals,
+				},
+			},
+			{
+				Name: "beta",
+				Attribute: &expr.AttributeExpr{
+					Type: sourceFromInputs,
+				},
+			},
+		},
+	}
+	reverse := &expr.AttributeExpr{
+		Type: &expr.Object{
+			{
+				Name: "beta",
+				Attribute: &expr.AttributeExpr{
+					Type: sourceFromInputs,
+				},
+			},
+			{
+				Name: "alpha",
+				Attribute: &expr.AttributeExpr{
+					Type: sourceFromSignals,
+				},
+			},
+		},
+	}
+
+	forwardNames := collectHTTPUnionTypeNames(forward)
+	reverseNames := collectHTTPUnionTypeNames(reverse)
+
+	require.Len(t, forwardNames, 2)
+	require.Equal(t, forwardNames, reverseNames)
+}
+
+func collectHTTPUnionTypeNames(att *expr.AttributeExpr) map[string]string {
+	scope := cg.NewNameScope()
+	seen := make(map[string]struct{})
+	unionByHash := make(map[string]*svc.UnionTypeData)
+	collectHTTPUnionTypes(att, scope, unionByHash, seen)
+
+	names := make(map[string]string, len(unionByHash))
+	for hash, data := range unionByHash {
+		names[hash] = data.Name
+	}
+	return names
+}
+
+func makeUnionForOrderTest(typeName string, variants ...string) *expr.Union {
+	values := make([]*expr.NamedAttributeExpr, len(variants))
+	for i, variant := range variants {
+		values[i] = &expr.NamedAttributeExpr{
+			Name: variant,
+			Attribute: &expr.AttributeExpr{
+				Type: expr.String,
+			},
+		}
+	}
+	return &expr.Union{
+		TypeName: typeName,
+		Values:   values,
+	}
+}


### PR DESCRIPTION
## Summary
- Make union type collection deterministic in both service and HTTP codegen by sorting object attributes before traversal.
- Prevent NameScope-assigned union identifiers (e.g. `Source3`/`Source4`) from oscillating when equivalent object fields are declared in different orders.
- Add regression tests in both packages to prove union naming remains stable across reversed object field orders.

## Test plan
- [x] `go test ./http/codegen ./codegen/service`
- [x] Built local Goa CLI from source: `go build -o /tmp/goa-local ./cmd/goa`
- [x] Verified end-to-end determinism by running local `goa gen` 4 times against a downstream design that exercises overlapping `OneOf("source")` unions and confirming the generated union/type files remain byte-identical across runs