### PR TITLE
Prefix interceptor var with service to avoid collision

### DIFF
--- a/codegen/cli/cli.go
+++ b/codegen/cli/cli.go
@@ -167,7 +167,7 @@ func BuildCommandData(data *service.Data) *CommandData {
 	var interceptors *InterceptorData
 	if len(data.ClientInterceptors) > 0 {
 		interceptors = &InterceptorData{
-			VarName: "inter",
+			VarName: codegen.Goify(data.Name, false) + "Inter",
 			PkgName: data.PkgName,
 		}
 	}
@@ -226,7 +226,7 @@ func BuildSubcommandData(data *service.Data, m *service.MethodData, buildFunctio
 	var interceptors *InterceptorData
 	if len(m.ClientInterceptors) > 0 {
 		interceptors = &InterceptorData{
-			VarName: "inter",
+			VarName: codegen.Goify(data.Name, false) + "Inter",
 			PkgName: data.PkgName,
 		}
 	}

--- a/grpc/codegen/testdata/endpoint-endpoint-with-interceptors.golden
+++ b/grpc/codegen/testdata/endpoint-endpoint-with-interceptors.golden
@@ -35,7 +35,7 @@ func UsageExamples() string {
 // line.
 func ParseEndpoint(
 	cc *grpc.ClientConn,
-	inter servicewithinterceptors.ClientInterceptors,
+	serviceWithInterceptorsInter servicewithinterceptors.ClientInterceptors,
 	opts ...grpc.CallOption,
 ) (goa.Endpoint, any, error) {
 	var (
@@ -118,11 +118,11 @@ func ParseEndpoint(
 			switch epn {
 			case "method-a":
 				endpoint = c.MethodA()
-				endpoint = servicewithinterceptors.WrapMethodAClientEndpoint(endpoint, inter)
+				endpoint = servicewithinterceptors.WrapMethodAClientEndpoint(endpoint, serviceWithInterceptorsInter)
 				data, err = servicewithinterceptorsc.BuildMethodAPayload(*serviceWithInterceptorsMethodAMessageFlag)
 			case "method-b":
 				endpoint = c.MethodB()
-				endpoint = servicewithinterceptors.WrapMethodBClientEndpoint(endpoint, inter)
+				endpoint = servicewithinterceptors.WrapMethodBClientEndpoint(endpoint, serviceWithInterceptorsInter)
 				data, err = servicewithinterceptorsc.BuildMethodBPayload(*serviceWithInterceptorsMethodBMessageFlag)
 			}
 		}


### PR DESCRIPTION
When multiple service designs contain the Interceptor DSL, the grpc CLI code generated contains an error with re-declaring same variable names.
```
Error: gen/grpc/cli/<service>/cli.go:48:2: inter redeclared in this block
Error: 	gen/grpc/cli/<service>/cli.go:47:2: other declaration of inter
```
Incorrect ParseEndpoint code with duplicate `inter` vars.
```
// ParseEndpoint returns the endpoint and payload as specified on the command
// line.
func ParseEndpoint(
	cc *grpc.ClientConn,
	inter <service_A>.ClientInterceptors,
	inter <service_B>.ClientInterceptors,
	opts ...grpc.CallOption,
) (goa.Endpoint, any, error) {
```

This fix will prefix the `inter` var with the service name to prevent collision.