### PR TITLE
Support cookie-backed API key security inference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ No commented-out code—delete dead code.
 
 - **Use NameScope helpers** for type references: `GoTypeRef`, `GoFullTypeRef`, `GoTypeName`. Never concatenate strings for types.
 - Let Goa decide pointer/value semantics. Do not force `pointer=true` except in transport validation.
+- **Keep helper visibility minimal**: If logic is shared only inside one codegen area, keep it package-private or move it under an `internal` package. Do not export helpers from a parent package just to share them across sibling generators.
+- **Avoid pass-through wrappers**: When two helper functions differ only by forwarding arguments or hard-coding `nil`, collapse them into a single implementation instead of adding an extra layer.
 
 ### Documentation
 

--- a/codegen/sections_test.go
+++ b/codegen/sections_test.go
@@ -71,11 +71,23 @@ import (
 package testpackage
 
 `
-		imprt            = []*ImportSpec{{Path: "test"}}
-		imports          = append(imprt, &ImportSpec{Path: "other"})
-		pathImport       = []*ImportSpec{{Path: "import/with/slashes"}}
-		pathImports      = append(pathImport, &ImportSpec{Path: "other/import/with/slashes"})
-		pathNamedImport  = []*ImportSpec{{Name: "myname", Path: "import/with/slashes"}}
+		imprt = func() []*ImportSpec {
+			imports := make([]*ImportSpec, 0, 2)
+			imports = append(imports, &ImportSpec{Path: "test"})
+			return imports
+		}()
+		imports    = append(imprt, &ImportSpec{Path: "other"})
+		pathImport = func() []*ImportSpec {
+			imports := make([]*ImportSpec, 0, 2)
+			imports = append(imports, &ImportSpec{Path: "import/with/slashes"})
+			return imports
+		}()
+		pathImports     = append(pathImport, &ImportSpec{Path: "other/import/with/slashes"})
+		pathNamedImport = func() []*ImportSpec {
+			imports := make([]*ImportSpec, 0, 2)
+			imports = append(imports, &ImportSpec{Name: "myname", Path: "import/with/slashes"})
+			return imports
+		}()
 		pathNamedImports = append(pathNamedImport, &ImportSpec{Name: "myothername", Path: "other/import/with/slashes"})
 	)
 	cases := map[string]struct {

--- a/expr/helpers.go
+++ b/expr/helpers.go
@@ -12,8 +12,8 @@ func Title(s string) string {
 }
 
 // findKey finds the given key in the endpoint expression and returns the
-// transport element name and the position (header, query, or body for HTTP or
-// message, metadata for gRPC endpoint).
+// transport element name and the position (header, query, cookie, or body for
+// HTTP or message, metadata for gRPC endpoint).
 func findKey(exp eval.Expression, keyAtt string) (string, string) {
 	switch e := exp.(type) {
 	case *HTTPEndpointExpr:
@@ -21,6 +21,8 @@ func findKey(exp eval.Expression, keyAtt string) (string, string) {
 			return n, "query"
 		} else if n, exists := e.Headers.FindKey(keyAtt); exists {
 			return n, "header"
+		} else if n, exists := e.Cookies.FindKey(keyAtt); exists {
+			return n, "cookie"
 		} else if e.Body == nil {
 			return "", "header"
 		}

--- a/http/codegen/cookie_security_test.go
+++ b/http/codegen/cookie_security_test.go
@@ -1,0 +1,156 @@
+package codegen
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+	"text/template"
+
+	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/dsl"
+	"goa.design/goa/v3/expr"
+	"goa.design/goa/v3/http/codegen/openapi"
+	openapiv2 "goa.design/goa/v3/http/codegen/openapi/v2"
+	openapiv3 "goa.design/goa/v3/http/codegen/openapi/v3"
+)
+
+func TestCookieAPIKeySecurity(t *testing.T) {
+	t.Run("endpoint requirement uses cookie transport", func(t *testing.T) {
+		root := RunHTTPDSL(t, cookieAPIKeySecurityDSL)
+		endpoint := root.API.HTTP.Services[0].HTTPEndpoints[0]
+		require.Len(t, endpoint.Requirements, 1)
+		require.Len(t, endpoint.Requirements[0].Schemes, 1)
+
+		scheme := endpoint.Requirements[0].Schemes[0]
+		require.Equal(t, "cookie", scheme.In)
+		require.Equal(t, "__Host-ak_session", scheme.Name)
+
+		headers := expr.AsObject(endpoint.Headers.Type)
+		require.Zero(t, len(*headers), "cookie-backed api key must not synthesize an Authorization header")
+	})
+
+	t.Run("openapi uses cookie security scheme", func(t *testing.T) {
+		root := RunHTTPDSL(t, cookieAPIKeySecurityDSL)
+		openapi.Definitions = make(map[string]*openapi.Schema)
+
+		v2JSON := renderOpenAPIJSON(t, openapiv2.Files, root)
+		var swagger openapi2.T
+		require.NoError(t, swagger.UnmarshalJSON(v2JSON))
+		require.Len(t, swagger.SecurityDefinitions, 1)
+		require.Len(t, swagger.Paths, 1)
+		require.Contains(t, swagger.Paths, "/auth/profile")
+		require.NotNil(t, swagger.Paths["/auth/profile"].Get.Security)
+		require.Len(t, *swagger.Paths["/auth/profile"].Get.Security, 1)
+		for name, def := range swagger.SecurityDefinitions {
+			require.Equal(t, "apiKey", def.Type, name)
+			require.Equal(t, "cookie", def.In, name)
+			require.Equal(t, "__Host-ak_session", def.Name, name)
+			require.Contains(t, (*swagger.Paths["/auth/profile"].Get.Security)[0], name)
+		}
+
+		openapi.Definitions = make(map[string]*openapi.Schema)
+		v3JSON := renderOpenAPIJSON(t, openapiv3.Files, root)
+		loader := openapi3.NewLoader()
+		doc, err := loader.LoadFromData(v3JSON)
+		require.NoError(t, err)
+		require.NoError(t, doc.Validate(context.Background()))
+		require.Len(t, doc.Components.SecuritySchemes, 1)
+		require.NotNil(t, doc.Paths.Find("/auth/profile"))
+		require.NotNil(t, doc.Paths.Find("/auth/profile").Get.Security)
+		require.Len(t, *doc.Paths.Find("/auth/profile").Get.Security, 1)
+		for name, ref := range doc.Components.SecuritySchemes {
+			require.NotNil(t, ref.Value, name)
+			require.Equal(t, "apiKey", ref.Value.Type, name)
+			require.Equal(t, "cookie", ref.Value.In, name)
+			require.Equal(t, "__Host-ak_session", ref.Value.Name, name)
+			require.Contains(t, (*doc.Paths.Find("/auth/profile").Get.Security)[0], name)
+		}
+	})
+
+	t.Run("http codegen does not duplicate cookie-backed auth fields", func(t *testing.T) {
+		root := RunHTTPDSL(t, cookieAPIKeySecurityDSL)
+		services := CreateHTTPServices(root)
+
+		serverTypes := serverType("gen", root.API.HTTP.Services[0], services)
+		var serverTypesBuf bytes.Buffer
+		for _, section := range serverTypes.SectionTemplates[1:] {
+			require.NoError(t, section.Write(&serverTypesBuf))
+		}
+		serverTypesCode := codegen.FormatTestCode(t, "package foo\n"+serverTypesBuf.String())
+		require.Contains(t, serverTypesCode, "func NewProfilePayload(browserSession string)")
+		require.NotContains(t, serverTypesCode, "browserSession *string, browserSession *string")
+		require.NotContains(t, serverTypesCode, "browserSession string, browserSession string")
+
+		serverFiles := ServerFiles("", services)
+		require.Len(t, serverFiles, 2)
+		serverDecode := codegen.SectionCode(t, serverFiles[1].SectionTemplates[2])
+		require.Contains(t, serverDecode, `r.Cookie("__Host-ak_session")`)
+		require.NotContains(t, serverDecode, "Authorization")
+		require.NotContains(t, serverDecode, "browserSession *string, browserSession *string")
+		require.NotContains(t, serverDecode, "browserSession string, browserSession string")
+
+		clientFiles := ClientFiles("", services)
+		require.Len(t, clientFiles, 2)
+		clientEncode := codegen.SectionCode(t, clientFiles[1].SectionTemplates[2])
+		require.Contains(t, clientEncode, `req.AddCookie(&http.Cookie{`)
+		require.Contains(t, clientEncode, `Name:  "__Host-ak_session"`)
+		require.NotContains(t, clientEncode, "Authorization")
+	})
+}
+
+func renderOpenAPIJSON(
+	t *testing.T,
+	build func(*expr.RootExpr) ([]*codegen.File, error),
+	root *expr.RootExpr,
+) []byte {
+	t.Helper()
+
+	files, err := build(root)
+	require.NoError(t, err)
+	for _, f := range files {
+		if filepath.Ext(f.Path) != ".json" {
+			continue
+		}
+		require.Len(t, f.SectionTemplates, 1)
+		section := f.SectionTemplates[0]
+		require.NotEmpty(t, section.Source)
+		require.NotNil(t, section.Data)
+
+		var buf bytes.Buffer
+		tmpl := template.Must(template.New("openapi").Funcs(section.FuncMap).Parse(section.Source))
+		require.NoError(t, tmpl.Execute(&buf, section.Data))
+		return buf.Bytes()
+	}
+
+	t.Fatalf("no JSON OpenAPI file generated")
+	return nil
+}
+
+var cookieAPIKeySecurityDSL = func() {
+	var browserSessionCookie = dsl.APIKeySecurity("browser_session_cookie", func() {
+		dsl.Description("Browser session cookie")
+	})
+
+	dsl.Service("cookieSecurity", func() {
+		dsl.Method("profile", func() {
+			dsl.Security(browserSessionCookie)
+			dsl.Payload(func() {
+				dsl.APIKey("browser_session_cookie", "browser_session", dsl.String, func() {
+					dsl.Description("Opaque browser session cookie")
+				})
+				dsl.Required("browser_session")
+			})
+			dsl.Result(dsl.Empty)
+			dsl.HTTP(func() {
+				dsl.GET("/auth/profile")
+				dsl.Cookie("browser_session:__Host-ak_session")
+				dsl.Response(dsl.StatusOK)
+			})
+		})
+	})
+}

--- a/http/codegen/openapi/internal/security.go
+++ b/http/codegen/openapi/internal/security.go
@@ -1,4 +1,4 @@
-package openapi
+package internal
 
 import (
 	"strings"

--- a/http/codegen/openapi/security.go
+++ b/http/codegen/openapi/security.go
@@ -1,0 +1,33 @@
+package openapi
+
+import (
+	"strings"
+
+	"goa.design/goa/v3/expr"
+)
+
+// IsSecurityParameter returns true if the given HTTP transport element is used
+// by one of the endpoint security schemes and should therefore not be emitted
+// again as a regular OpenAPI parameter.
+func IsSecurityParameter(endpoint *expr.HTTPEndpointExpr, in, name string) bool {
+	if endpoint == nil {
+		return false
+	}
+	for _, req := range endpoint.Requirements {
+		for _, scheme := range req.Schemes {
+			if scheme.In != in {
+				continue
+			}
+			if in == "header" {
+				if strings.EqualFold(scheme.Name, name) {
+					return true
+				}
+				continue
+			}
+			if scheme.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -12,6 +12,7 @@ import (
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/expr"
 	"goa.design/goa/v3/http/codegen/openapi"
+	openapiinternal "goa.design/goa/v3/http/codegen/openapi/internal"
 )
 
 // NewV2 returns the OpenAPI v2 specification for the given API.
@@ -35,7 +36,7 @@ func NewV2(root *expr.RootExpr, h *expr.HostExpr) (*V2, error) {
 	if hasAbsoluteRoutes(root) {
 		basePath = ""
 	}
-	params := paramsFromExpr(root.API.HTTP.Params, basePath)
+	params := paramsFromExpr(nil, root.API.HTTP.Params, basePath)
 	var paramMap map[string]*Parameter
 	if len(params) > 0 {
 		paramMap = make(map[string]*Parameter, len(params))
@@ -269,11 +270,7 @@ func summaryFromMeta(name string, meta expr.MetaExpr) string {
 	return name
 }
 
-func paramsFromExpr(params *expr.MappedAttributeExpr, path string) []*Parameter {
-	return paramsFromExprForEndpoint(nil, params, path)
-}
-
-func paramsFromExprForEndpoint(endpoint *expr.HTTPEndpointExpr, params *expr.MappedAttributeExpr, path string) []*Parameter {
+func paramsFromExpr(endpoint *expr.HTTPEndpointExpr, params *expr.MappedAttributeExpr, path string) []*Parameter {
 	if params == nil {
 		return nil
 	}
@@ -287,7 +284,7 @@ func paramsFromExprForEndpoint(endpoint *expr.HTTPEndpointExpr, params *expr.Map
 			in = "path"
 			required = true
 		}
-		if endpoint != nil && in != "path" && openapi.IsSecurityParameter(endpoint, in, pn) {
+		if endpoint != nil && in != "path" && openapiinternal.IsSecurityParameter(endpoint, in, pn) {
 			return nil
 		}
 		param := paramFor(at, pn, in, required)
@@ -301,7 +298,7 @@ func paramsFromHeaders(endpoint *expr.HTTPEndpointExpr) []*Parameter {
 	var params []*Parameter
 
 	expr.WalkMappedAttr(endpoint.Headers, func(name, elem string, att *expr.AttributeExpr) error { // nolint: errcheck
-		if openapi.IsSecurityParameter(endpoint, "header", elem) {
+		if openapiinternal.IsSecurityParameter(endpoint, "header", elem) {
 			return nil
 		}
 		required := endpoint.Headers.IsRequiredNoDefault(name)
@@ -499,7 +496,7 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 		// Remove any wildcards that is defined in path as a workaround to
 		// https://github.com/OAI/OpenAPI-Specification/issues/291
 		key = expr.HTTPWildcardRegex.ReplaceAllString(key, "/{$1}")
-		params := paramsFromExprForEndpoint(endpoint, endpoint.Params, key)
+		params := paramsFromExpr(endpoint, endpoint.Params, key)
 		params = append(params, paramsFromHeaders(endpoint)...)
 		var produces []string
 

--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -270,6 +270,10 @@ func summaryFromMeta(name string, meta expr.MetaExpr) string {
 }
 
 func paramsFromExpr(params *expr.MappedAttributeExpr, path string) []*Parameter {
+	return paramsFromExprForEndpoint(nil, params, path)
+}
+
+func paramsFromExprForEndpoint(endpoint *expr.HTTPEndpointExpr, params *expr.MappedAttributeExpr, path string) []*Parameter {
 	if params == nil {
 		return nil
 	}
@@ -283,6 +287,9 @@ func paramsFromExpr(params *expr.MappedAttributeExpr, path string) []*Parameter 
 			in = "path"
 			required = true
 		}
+		if endpoint != nil && in != "path" && openapi.IsSecurityParameter(endpoint, in, pn) {
+			return nil
+		}
 		param := paramFor(at, pn, in, required)
 		res = append(res, param)
 		return nil
@@ -294,23 +301,13 @@ func paramsFromHeaders(endpoint *expr.HTTPEndpointExpr) []*Parameter {
 	var params []*Parameter
 
 	expr.WalkMappedAttr(endpoint.Headers, func(name, elem string, att *expr.AttributeExpr) error { // nolint: errcheck
+		if openapi.IsSecurityParameter(endpoint, "header", elem) {
+			return nil
+		}
 		required := endpoint.Headers.IsRequiredNoDefault(name)
 		params = append(params, paramFor(att, elem, "header", required))
 		return nil
 	})
-
-	// Add basic auth to headers
-	if att := expr.TaggedAttribute(endpoint.MethodExpr.Payload, "security:username"); att != "" {
-		// Basic Auth is always encoded in the Authorization header
-		// https://golang.org/pkg/net/http/#Request.SetBasicAuth
-		params = append(params, &Parameter{
-			In:          "header",
-			Name:        "Authorization",
-			Required:    endpoint.MethodExpr.Payload.IsRequired(att),
-			Description: "Basic Auth security using Basic scheme (https://tools.ietf.org/html/rfc7617)",
-			Type:        "string",
-		})
-	}
 
 	return params
 }
@@ -502,7 +499,7 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 		// Remove any wildcards that is defined in path as a workaround to
 		// https://github.com/OAI/OpenAPI-Specification/issues/291
 		key = expr.HTTPWildcardRegex.ReplaceAllString(key, "/{$1}")
-		params := paramsFromExpr(endpoint.Params, key)
+		params := paramsFromExprForEndpoint(endpoint, endpoint.Params, key)
 		params = append(params, paramsFromHeaders(endpoint)...)
 		var produces []string
 

--- a/http/codegen/openapi/v2/testdata/TestSections/security_file0.golden
+++ b/http/codegen/openapi/v2/testdata/TestSections/security_file0.golden
@@ -14,33 +14,6 @@
       "get": {
         "description": "\n**Required security scopes for basic**:\n  * `api:read`\n\n**Required security scopes for jwt**:\n  * `api:read`\n\n**Required security scopes for api_key**:\n  * `api:read`",
         "operationId": "testService#testEndpointA",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "k",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "header",
-            "name": "Token",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "header",
-            "name": "X-Authorization",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Basic Auth security using Basic scheme (https://tools.ietf.org/html/rfc7617)",
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "type": "string"
-          }
-        ],
         "responses": {
           "204": {
             "description": "No Content response."
@@ -66,20 +39,6 @@
       },
       "post": {
         "operationId": "testService#testEndpointB",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "auth",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "header",
-            "name": "Authorization",
-            "required": true,
-            "type": "string"
-          }
-        ],
         "responses": {
           "204": {
             "description": "No Content response."

--- a/http/codegen/openapi/v2/testdata/TestSections/security_file1.golden
+++ b/http/codegen/openapi/v2/testdata/TestSections/security_file1.golden
@@ -27,24 +27,6 @@ paths:
                 **Required security scopes for api_key**:
                   * `api:read`
             operationId: testService#testEndpointA
-            parameters:
-                - name: k
-                  in: query
-                  required: true
-                  type: string
-                - name: Token
-                  in: header
-                  required: true
-                  type: string
-                - name: X-Authorization
-                  in: header
-                  required: true
-                  type: string
-                - name: Authorization
-                  in: header
-                  description: Basic Auth security using Basic scheme (https://tools.ietf.org/html/rfc7617)
-                  required: true
-                  type: string
             responses:
                 "204":
                     description: No Content response.
@@ -61,15 +43,6 @@ paths:
                 - testService
             summary: testEndpointB testService
             operationId: testService#testEndpointB
-            parameters:
-                - name: auth
-                  in: query
-                  required: true
-                  type: string
-                - name: Authorization
-                  in: header
-                  required: true
-                  type: string
             responses:
                 "204":
                     description: No Content response.

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -250,7 +250,7 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 	// parameters
 	var params []*ParameterRef
 	{
-		ps := paramsFromPath(e.Params, key, rand)
+		ps := paramsFromPath(e, key, rand)
 		ps = append(ps, paramsFromHeadersAndCookies(e, rand)...)
 		if e.MapQueryParams != nil {
 			name := *e.MapQueryParams

--- a/http/codegen/openapi/v3/parameters.go
+++ b/http/codegen/openapi/v3/parameters.go
@@ -6,6 +6,7 @@ import (
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/expr"
 	"goa.design/goa/v3/http/codegen/openapi"
+	openapiinternal "goa.design/goa/v3/http/codegen/openapi/internal"
 )
 
 // paramsFromPath computes the OpenAPI spec parameters for the given endpoint
@@ -22,7 +23,7 @@ func paramsFromPath(endpoint *expr.HTTPEndpointExpr, path string, rand *expr.Exa
 			in = "path"
 			required = true
 		}
-		if in != "path" && openapi.IsSecurityParameter(endpoint, in, pn) {
+		if in != "path" && openapiinternal.IsSecurityParameter(endpoint, in, pn) {
 			return nil
 		}
 		res = append(res, paramFor(at, pn, in, required, rand))
@@ -37,7 +38,7 @@ func paramsFromHeadersAndCookies(endpoint *expr.HTTPEndpointExpr, rand *expr.Exa
 	var params []*Parameter
 
 	expr.WalkMappedAttr(endpoint.Headers, func(name, elem string, att *expr.AttributeExpr) error { // nolint: errcheck
-		if openapi.IsSecurityParameter(endpoint, "header", elem) {
+		if openapiinternal.IsSecurityParameter(endpoint, "header", elem) {
 			return nil
 		}
 		required := endpoint.Headers.IsRequiredNoDefault(name)
@@ -45,7 +46,7 @@ func paramsFromHeadersAndCookies(endpoint *expr.HTTPEndpointExpr, rand *expr.Exa
 		return nil
 	})
 	expr.WalkMappedAttr(endpoint.Cookies, func(name, elem string, att *expr.AttributeExpr) error { // nolint: errcheck
-		if openapi.IsSecurityParameter(endpoint, "cookie", elem) {
+		if openapiinternal.IsSecurityParameter(endpoint, "cookie", elem) {
 			return nil
 		}
 		required := endpoint.Cookies.IsRequiredNoDefault(name)

--- a/http/codegen/openapi/v3/parameters.go
+++ b/http/codegen/openapi/v3/parameters.go
@@ -2,18 +2,18 @@ package openapiv3
 
 import (
 	"slices"
-	"strings"
 
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/expr"
 	"goa.design/goa/v3/http/codegen/openapi"
 )
 
-// paramsFromPath computes the OpenAPI spec parameters for the given API,
-// service or endpoint HTTP path and query parameters.
-func paramsFromPath(params *expr.MappedAttributeExpr, path string, rand *expr.ExampleGenerator) []*Parameter {
+// paramsFromPath computes the OpenAPI spec parameters for the given endpoint
+// HTTP path and query parameters.
+func paramsFromPath(endpoint *expr.HTTPEndpointExpr, path string, rand *expr.ExampleGenerator) []*Parameter {
 	var (
 		res       []*Parameter
+		params    = endpoint.Params
 		wildcards = expr.ExtractHTTPWildcards(path)
 	)
 	codegen.WalkMappedAttr(params, func(n, pn string, required bool, at *expr.AttributeExpr) error { // nolint: errcheck
@@ -21,6 +21,9 @@ func paramsFromPath(params *expr.MappedAttributeExpr, path string, rand *expr.Ex
 		if slices.Contains(wildcards, n) {
 			in = "path"
 			required = true
+		}
+		if in != "path" && openapi.IsSecurityParameter(endpoint, in, pn) {
+			return nil
 		}
 		res = append(res, paramFor(at, pn, in, required, rand))
 		return nil
@@ -34,10 +37,7 @@ func paramsFromHeadersAndCookies(endpoint *expr.HTTPEndpointExpr, rand *expr.Exa
 	var params []*Parameter
 
 	expr.WalkMappedAttr(endpoint.Headers, func(name, elem string, att *expr.AttributeExpr) error { // nolint: errcheck
-		if strings.ToLower(elem) == "authorization" {
-			// Headers named "Authorization" are ignored by OpenAPI v3.
-			// Instead it uses the security and securitySchemes sections to
-			// define authorization.
+		if openapi.IsSecurityParameter(endpoint, "header", elem) {
 			return nil
 		}
 		required := endpoint.Headers.IsRequiredNoDefault(name)
@@ -45,6 +45,9 @@ func paramsFromHeadersAndCookies(endpoint *expr.HTTPEndpointExpr, rand *expr.Exa
 		return nil
 	})
 	expr.WalkMappedAttr(endpoint.Cookies, func(name, elem string, att *expr.AttributeExpr) error { // nolint: errcheck
+		if openapi.IsSecurityParameter(endpoint, "cookie", elem) {
+			return nil
+		}
 		required := endpoint.Cookies.IsRequiredNoDefault(name)
 		params = append(params, paramFor(att, elem, "cookie", required, rand))
 		return nil

--- a/http/codegen/openapi/v3/testdata/golden/security_file0.golden
+++ b/http/codegen/openapi/v3/testdata/golden/security_file0.golden
@@ -64,41 +64,6 @@
     "/": {
       "get": {
         "operationId": "testService#testEndpointA",
-        "parameters": [
-          {
-            "allowEmptyValue": true,
-            "example": "Doloribus qui quia.",
-            "in": "query",
-            "name": "k",
-            "required": true,
-            "schema": {
-              "example": "Quia molestias.",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": true,
-            "example": "Itaque inventore optio.",
-            "in": "header",
-            "name": "Token",
-            "required": true,
-            "schema": {
-              "example": "Et tempora et quae.",
-              "type": "string"
-            }
-          },
-          {
-            "allowEmptyValue": true,
-            "example": "Iste perspiciatis.",
-            "in": "header",
-            "name": "X-Authorization",
-            "required": true,
-            "schema": {
-              "example": "Ullam aut.",
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "204": {
             "description": "No Content response."
@@ -123,19 +88,6 @@
       },
       "post": {
         "operationId": "testService#testEndpointB",
-        "parameters": [
-          {
-            "allowEmptyValue": true,
-            "example": "Neque nisi quibusdam nisi sint sunt.",
-            "in": "query",
-            "name": "auth",
-            "required": true,
-            "schema": {
-              "example": "Harum et.",
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "204": {
             "description": "No Content response."

--- a/http/codegen/openapi/v3/testdata/golden/security_file1.golden
+++ b/http/codegen/openapi/v3/testdata/golden/security_file1.golden
@@ -12,31 +12,6 @@ paths:
                 - testService
             summary: testEndpointA testService
             operationId: testService#testEndpointA
-            parameters:
-                - name: k
-                  in: query
-                  allowEmptyValue: true
-                  required: true
-                  schema:
-                    type: string
-                    example: Quia molestias.
-                  example: Doloribus qui quia.
-                - name: Token
-                  in: header
-                  allowEmptyValue: true
-                  required: true
-                  schema:
-                    type: string
-                    example: Et tempora et quae.
-                  example: Itaque inventore optio.
-                - name: X-Authorization
-                  in: header
-                  allowEmptyValue: true
-                  required: true
-                  schema:
-                    type: string
-                    example: Ullam aut.
-                  example: Iste perspiciatis.
             responses:
                 "204":
                     description: No Content response.
@@ -52,15 +27,6 @@ paths:
                 - testService
             summary: testEndpointB testService
             operationId: testService#testEndpointB
-            parameters:
-                - name: auth
-                  in: query
-                  allowEmptyValue: true
-                  required: true
-                  schema:
-                    type: string
-                    example: Harum et.
-                  example: Neque nisi quibusdam nisi sint sunt.
             responses:
                 "204":
                     description: No Content response.

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -760,7 +760,7 @@ func (sds *ServicesData) analyze(httpSvc *expr.HTTPServiceExpr) *ServiceData {
 		payload := sds.buildPayloadData(httpEndpoint, sd)
 
 		var (
-			reqs  service.RequirementsData
+			reqs  = make(service.RequirementsData, 0, len(httpEndpoint.Requirements))
 			hsch  service.SchemesData
 			bosch service.SchemesData
 			qsch  service.SchemesData


### PR DESCRIPTION
## Summary
- make HTTP security key inference consider request cookies in addition to params, headers, and body
- add a regression test covering cookie-backed API key inference, OpenAPI v2/v3 output, and generated HTTP transport code

## Testing
- go test ./expr ./http/codegen/...

Fixes #3909