### PR TITLE
codegen/example: restore errors.Is for flag.ErrHelp regressed by #3734

### DIFF
--- a/codegen/example/templates/client_endpoint_init.go.tpl
+++ b/codegen/example/templates/client_endpoint_init.go.tpl
@@ -31,7 +31,7 @@
 		}
 	}
 	if err != nil {
-		if err == flag.ErrHelp {
+		if errors.Is(err, flag.ErrHelp) {
 			os.Exit(0)
 		}
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/codegen/example/testdata/client-no-server.golden
+++ b/codegen/example/testdata/client-no-server.golden
@@ -61,7 +61,7 @@ func main() {
 		}
 	}
 	if err != nil {
-		if err == flag.ErrHelp {
+		if errors.Is(err, flag.ErrHelp) {
 			os.Exit(0)
 		}
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/codegen/example/testdata/client-single-server-multiple-hosts-with-variables.golden
+++ b/codegen/example/testdata/client-single-server-multiple-hosts-with-variables.golden
@@ -80,7 +80,7 @@ func main() {
 		}
 	}
 	if err != nil {
-		if err == flag.ErrHelp {
+		if errors.Is(err, flag.ErrHelp) {
 			os.Exit(0)
 		}
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/codegen/example/testdata/client-single-server-multiple-hosts.golden
+++ b/codegen/example/testdata/client-single-server-multiple-hosts.golden
@@ -61,7 +61,7 @@ func main() {
 		}
 	}
 	if err != nil {
-		if err == flag.ErrHelp {
+		if errors.Is(err, flag.ErrHelp) {
 			os.Exit(0)
 		}
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/codegen/example/testdata/client-single-server-single-host-with-variables.golden
+++ b/codegen/example/testdata/client-single-server-single-host-with-variables.golden
@@ -77,7 +77,7 @@ func main() {
 		}
 	}
 	if err != nil {
-		if err == flag.ErrHelp {
+		if errors.Is(err, flag.ErrHelp) {
 			os.Exit(0)
 		}
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/codegen/example/testdata/client-single-server-single-host.golden
+++ b/codegen/example/testdata/client-single-server-single-host.golden
@@ -61,7 +61,7 @@ func main() {
 		}
 	}
 	if err != nil {
-		if err == flag.ErrHelp {
+		if errors.Is(err, flag.ErrHelp) {
 			os.Exit(0)
 		}
 		fmt.Fprintln(os.Stderr, err.Error())


### PR DESCRIPTION
## Summary

- restore `errors.Is(err, flag.ErrHelp)` in `codegen/example/templates/client_endpoint_init.go.tpl` (originally added by #3736)
- update the affected client golden files under `codegen/example/testdata/`

#3736 introduced `errors.Is(err, flag.ErrHelp)` so the generated example CLI passes `golangci-lint` with `errorlint` enabled. #3734 (Add JSON-RPC 2.0 Transport Support) was based on a state predating #3736 and inadvertently reintroduced `err == flag.ErrHelp` while adding the JSON-RPC scheme dispatch — see [merge commit `8931cbb`](https://github.com/goadesign/goa/commit/8931cbb).

`"errors"` is already in the import spec list in `codegen/example/example_client.go`, so no additional source change is needed.

## Test plan

- [x] `go test ./codegen/example/...`
- [x] `go test ./codegen/... ./http/codegen/...` (no regressions in adjacent codegen packages)
- [x] `make lint`

Related to #3736.