### PR TITLE
http/codegen: wrap cli.ParseEndpoint error in generated CLI

### DIFF
--- a/http/codegen/templates/cli_end.go.tpl
+++ b/http/codegen/templates/cli_end.go.tpl
@@ -1,4 +1,4 @@
-return cli.ParseEndpoint(
+endpoint, payload, err := cli.ParseEndpoint(
 		scheme,
 		host,
 		doer,
@@ -26,4 +26,8 @@ return cli.ParseEndpoint(
 	{{- end }}
 {{- end }}
 	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	return endpoint, payload, nil
 }

--- a/http/codegen/testdata/golden/client-no-server.golden
+++ b/http/codegen/testdata/golden/client-no-server.golden
@@ -9,7 +9,7 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		}
 	}
 
-	return cli.ParseEndpoint(
+	endpoint, payload, err := cli.ParseEndpoint(
 		scheme,
 		host,
 		doer,
@@ -17,6 +17,10 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		goahttp.ResponseDecoder,
 		debug,
 	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	return endpoint, payload, nil
 }
 
 func httpUsageCommands() []string {

--- a/http/codegen/testdata/golden/client-server-hosting-multiple-services.golden
+++ b/http/codegen/testdata/golden/client-server-hosting-multiple-services.golden
@@ -9,7 +9,7 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		}
 	}
 
-	return cli.ParseEndpoint(
+	endpoint, payload, err := cli.ParseEndpoint(
 		scheme,
 		host,
 		doer,
@@ -17,6 +17,10 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		goahttp.ResponseDecoder,
 		debug,
 	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	return endpoint, payload, nil
 }
 
 func httpUsageCommands() []string {

--- a/http/codegen/testdata/golden/client-server-hosting-service-subset.golden
+++ b/http/codegen/testdata/golden/client-server-hosting-service-subset.golden
@@ -9,7 +9,7 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		}
 	}
 
-	return cli.ParseEndpoint(
+	endpoint, payload, err := cli.ParseEndpoint(
 		scheme,
 		host,
 		doer,
@@ -17,6 +17,10 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		goahttp.ResponseDecoder,
 		debug,
 	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	return endpoint, payload, nil
 }
 
 func httpUsageCommands() []string {

--- a/http/codegen/testdata/golden/client-streaming-multiple-services.golden
+++ b/http/codegen/testdata/golden/client-streaming-multiple-services.golden
@@ -16,7 +16,7 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		dialer = websocket.DefaultDialer
 	}
 
-	return cli.ParseEndpoint(
+	endpoint, payload, err := cli.ParseEndpoint(
 		scheme,
 		host,
 		doer,
@@ -27,6 +27,10 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		nil,
 		nil,
 	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	return endpoint, payload, nil
 }
 
 func httpUsageCommands() []string {

--- a/http/codegen/testdata/golden/client-streaming.golden
+++ b/http/codegen/testdata/golden/client-streaming.golden
@@ -16,7 +16,7 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		dialer = websocket.DefaultDialer
 	}
 
-	return cli.ParseEndpoint(
+	endpoint, payload, err := cli.ParseEndpoint(
 		scheme,
 		host,
 		doer,
@@ -26,6 +26,10 @@ func doHTTP(scheme, host string, timeout int, debug bool) (goa.Endpoint, any, er
 		dialer,
 		nil,
 	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+	return endpoint, payload, nil
 }
 
 func httpUsageCommands() []string {


### PR DESCRIPTION
## Summary

- wrap the `cli.ParseEndpoint` return value in `http/codegen/templates/cli_end.go.tpl` with `fmt.Errorf("parse endpoint: %w", err)` so the generated example CLI passes `golangci-lint` with `wrapcheck` enabled
- update the affected client golden files under `http/codegen/testdata/golden/`

Today the generated `cmd/<svc>-cli/main.go` does `return cli.ParseEndpoint(...)`, which returns an error from another package without wrapping it. `wrapcheck` flags this on every fresh `goa example` output and downstream projects have to either disable the linter or post-process the generated file.

`"fmt"` is already in the import spec list in `http/codegen/example_cli.go`, so no additional source change is needed; goimports retains it now that the template references `fmt.Errorf`.

Follows the spirit of #3541 / #3542 / #3548 / #3736 / #3927 (golangci-lint cleanup on generated code).

## Test plan

- [x] `go test ./http/codegen/...`
- [x] `make test`
- [x] `make lint`