### PR TITLE
fix: use context.WithoutCancel for graceful shutdown (gosec G118)

### DIFF
--- a/http/codegen/templates/server_end.go.tpl
+++ b/http/codegen/templates/server_end.go.tpl
@@ -23,12 +23,12 @@
 		log.Printf(ctx, "shutting down HTTP server at %q", u.Host)
 
 		{{ comment "Shutdown gracefully with a 30s timeout." }}
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 
-		err := srv.Shutdown(ctx)
+		err := srv.Shutdown(shutdownCtx)
 		if err != nil {
-			log.Printf(ctx, "failed to shutdown: %v", err)
+			log.Printf(shutdownCtx, "failed to shutdown: %v", err)
 		}
 	}()
 }

--- a/http/codegen/testdata/golden/server-no-server.golden
+++ b/http/codegen/testdata/golden/server-no-server.golden
@@ -67,12 +67,12 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		log.Printf(ctx, "shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 
-		err := srv.Shutdown(ctx)
+		err := srv.Shutdown(shutdownCtx)
 		if err != nil {
-			log.Printf(ctx, "failed to shutdown: %v", err)
+			log.Printf(shutdownCtx, "failed to shutdown: %v", err)
 		}
 	}()
 }

--- a/http/codegen/testdata/golden/server-server-hosting-multiple-services.golden
+++ b/http/codegen/testdata/golden/server-server-hosting-multiple-services.golden
@@ -73,12 +73,12 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		log.Printf(ctx, "shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 
-		err := srv.Shutdown(ctx)
+		err := srv.Shutdown(shutdownCtx)
 		if err != nil {
-			log.Printf(ctx, "failed to shutdown: %v", err)
+			log.Printf(shutdownCtx, "failed to shutdown: %v", err)
 		}
 	}()
 }

--- a/http/codegen/testdata/golden/server-server-hosting-service-subset.golden
+++ b/http/codegen/testdata/golden/server-server-hosting-service-subset.golden
@@ -67,12 +67,12 @@ func handleHTTPServer(ctx context.Context, u *url.URL, serviceEndpoints *service
 		log.Printf(ctx, "shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 
-		err := srv.Shutdown(ctx)
+		err := srv.Shutdown(shutdownCtx)
 		if err != nil {
-			log.Printf(ctx, "failed to shutdown: %v", err)
+			log.Printf(shutdownCtx, "failed to shutdown: %v", err)
 		}
 	}()
 }

--- a/http/codegen/testdata/golden/server-server-hosting-service-with-file-server.golden
+++ b/http/codegen/testdata/golden/server-server-hosting-service-with-file-server.golden
@@ -67,12 +67,12 @@ func handleHTTPServer(ctx context.Context, u *url.URL, wg *sync.WaitGroup, errc 
 		log.Printf(ctx, "shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 
-		err := srv.Shutdown(ctx)
+		err := srv.Shutdown(shutdownCtx)
 		if err != nil {
-			log.Printf(ctx, "failed to shutdown: %v", err)
+			log.Printf(shutdownCtx, "failed to shutdown: %v", err)
 		}
 	}()
 }

--- a/http/codegen/testdata/golden/server-streaming.golden
+++ b/http/codegen/testdata/golden/server-streaming.golden
@@ -74,12 +74,12 @@ func handleHTTPServer(ctx context.Context, u *url.URL, streamingServiceAEndpoint
 		log.Printf(ctx, "shutting down HTTP server at %q", u.Host)
 
 		// Shutdown gracefully with a 30s timeout.
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 
-		err := srv.Shutdown(ctx)
+		err := srv.Shutdown(shutdownCtx)
 		if err != nil {
-			log.Printf(ctx, "failed to shutdown: %v", err)
+			log.Printf(shutdownCtx, "failed to shutdown: %v", err)
 		}
 	}()
 }


### PR DESCRIPTION
## Summary

- update the server codegen template (`http/codegen/templates/server_end.go.tpl`) so the generated server file (`cmd/<svc>/http.go`) passes `golangci-lint` with `gosec` G118 (which flags implicit `context.Background()` / `context.TODO()` calls inside goroutines)
- rename the local `ctx` to `shutdownCtx` to remove the shadowing of the outer context (the `log.Printf` calls below it picked up the wrong variable)
- update the affected server golden files under `http/codegen/testdata/golden/`

Today the generated server does `context.WithTimeout(context.Background(), 30*time.Second)` inside the shutdown goroutine, which gosec G118 flags by default. It also drops any logger / trace span / request-scoped value attached to the outer `ctx`.

`context.WithoutCancel(ctx)` keeps those values while stripping cancellation. Graceful shutdown only runs after the outer `ctx` is already canceled, so `context.WithTimeout(ctx, ...)` would inherit that cancellation and fire immediately — `WithoutCancel` avoids this while preserving the logger / trace span attached to the original context.

`go.mod` already requires Go 1.25 (≥ 1.21), so `context.WithoutCancel` is unconditionally available.

Continues the same golangci-lint cleanup series as #3927 and #3928 (with earlier precedents in #3541 / #3542 / #3548 / #3736).

## Test plan

- [x] `go test ./http/codegen/...`
- [x] `make test`
- [x] `make lint`