### PR TITLE
Honor NoSecurity in OpenAPI

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -1345,7 +1345,7 @@ func (d *ServicesData) buildMethodData(m *expr.MethodExpr, scope *codegen.NameSc
 		}
 	}
 
-	for _, req := range m.Requirements {
+	for _, req := range expr.EffectiveSecurityRequirements(m.Requirements) {
 		var rs SchemesData
 		for _, s := range req.Schemes {
 			sch := BuildSchemeData(s, m)

--- a/expr/grpc_endpoint.go
+++ b/expr/grpc_endpoint.go
@@ -289,9 +289,10 @@ func (e *GRPCEndpointExpr) Finalize() {
 
 		// Initialize any security attributes in request metadata unless it is
 		// specified explicitly in the request message via the DSL.
-		if reqLen := len(e.MethodExpr.Requirements); reqLen > 0 {
+		requirements := EffectiveSecurityRequirements(e.MethodExpr.Requirements)
+		if reqLen := len(requirements); reqLen > 0 {
 			e.Requirements = make([]*SecurityExpr, 0, reqLen)
-			for _, req := range e.MethodExpr.Requirements {
+			for _, req := range requirements {
 				dupReq := DupRequirement(req)
 				for _, sch := range dupReq.Schemes {
 					var field string

--- a/expr/http_body_types.go
+++ b/expr/http_body_types.go
@@ -73,14 +73,15 @@ func UnionToObject(att *AttributeExpr) *AttributeExpr {
 // password attributes).
 func defaultRequestHeaderAttributes(e *HTTPEndpointExpr) map[string]bool {
 	var requirements []*SecurityExpr
-	if e.MethodExpr.Requirements != nil {
+	switch {
+	case HasNoSecurity(e.MethodExpr.Requirements):
+		return nil
+	case len(e.MethodExpr.Requirements) > 0:
 		requirements = e.MethodExpr.Requirements
-	}
-	if e.Service.ServiceExpr.Requirements != nil {
-		requirements = append(requirements, e.Service.ServiceExpr.Requirements...)
-	}
-	if Root.API.Requirements != nil {
-		requirements = append(requirements, Root.API.Requirements...)
+	case len(e.Service.ServiceExpr.Requirements) > 0:
+		requirements = e.Service.ServiceExpr.Requirements
+	case len(Root.API.Requirements) > 0:
+		requirements = Root.API.Requirements
 	}
 	if len(requirements) == 0 {
 		return nil

--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -759,9 +759,10 @@ func (e *HTTPEndpointExpr) Finalize() {
 	}
 
 	// Compute security scheme attribute name and corresponding HTTP location
-	if reqLen := len(e.MethodExpr.Requirements); reqLen > 0 {
+	requirements := EffectiveSecurityRequirements(e.MethodExpr.Requirements)
+	if reqLen := len(requirements); reqLen > 0 {
 		e.Requirements = make([]*SecurityExpr, 0, reqLen)
-		for _, req := range e.MethodExpr.Requirements {
+		for _, req := range requirements {
 			dupReq := DupRequirement(req)
 			for _, sch := range dupReq.Schemes {
 				var field string

--- a/expr/method.go
+++ b/expr/method.go
@@ -32,8 +32,6 @@ type (
 		// schemes. Incoming requests must validate at least one
 		// requirement to be authorized.
 		Requirements []*SecurityExpr
-		// NoSecurity records whether the method explicitly disables security.
-		NoSecurity bool
 		// ClientInterceptors is the list of client interceptors.
 		ClientInterceptors []*InterceptorExpr
 		// ServerInterceptors is the list of server interceptors.
@@ -403,20 +401,8 @@ func (m *MethodExpr) Finalize() {
 	}
 
 	// Inherit security requirements
-	noreq := false
-loop:
-	for _, r := range m.Requirements {
-		// Handle special case of no security
-		for _, s := range r.Schemes {
-			if s.Kind == NoKind {
-				noreq = true
-				break loop
-			}
-		}
-	}
-	if noreq {
-		m.NoSecurity = true
-		m.Requirements = nil
+	if HasNoSecurity(m.Requirements) {
+		m.Requirements = []*SecurityExpr{{Schemes: []*SchemeExpr{{Kind: NoKind}}}}
 		return
 	}
 	if len(m.Requirements) == 0 {

--- a/expr/method.go
+++ b/expr/method.go
@@ -32,6 +32,8 @@ type (
 		// schemes. Incoming requests must validate at least one
 		// requirement to be authorized.
 		Requirements []*SecurityExpr
+		// NoSecurity records whether the method explicitly disables security.
+		NoSecurity bool
 		// ClientInterceptors is the list of client interceptors.
 		ClientInterceptors []*InterceptorExpr
 		// ServerInterceptors is the list of server interceptors.
@@ -413,6 +415,7 @@ loop:
 		}
 	}
 	if noreq {
+		m.NoSecurity = true
 		m.Requirements = nil
 		return
 	}

--- a/expr/method_test.go
+++ b/expr/method_test.go
@@ -113,6 +113,39 @@ func TestMethodExprFinalizeInheritsBearerFormat(t *testing.T) {
 	}
 }
 
+func TestMethodExprFinalizePreservesNoSecurityMarker(t *testing.T) {
+	root := expr.Root
+	t.Cleanup(func() {
+		expr.Root = root
+	})
+
+	expr.Root = &expr.RootExpr{
+		API: &expr.APIExpr{
+			Requirements: []*expr.SecurityExpr{{
+				Schemes: []*expr.SchemeExpr{{
+					Kind:       expr.JWTKind,
+					SchemeName: "jwt",
+				}},
+			}},
+		},
+	}
+	method := &expr.MethodExpr{
+		Name: "Health",
+		Requirements: []*expr.SecurityExpr{{
+			Schemes: []*expr.SchemeExpr{{Kind: expr.NoKind}},
+		}},
+		Service: &expr.ServiceExpr{Name: "Service"},
+	}
+
+	method.Finalize()
+
+	require.True(t, expr.HasNoSecurity(method.Requirements))
+	require.Len(t, method.Requirements, 1)
+	require.Len(t, method.Requirements[0].Schemes, 1)
+	require.Equal(t, expr.NoKind, method.Requirements[0].Schemes[0].Kind)
+	require.Nil(t, expr.EffectiveSecurityRequirements(method.Requirements))
+}
+
 func TestMethodExprError(t *testing.T) {
 	var (
 		errorFoo = &expr.ErrorExpr{

--- a/expr/security.go
+++ b/expr/security.go
@@ -145,6 +145,28 @@ func DupScheme(sch *SchemeExpr) *SchemeExpr {
 	return &dup
 }
 
+// HasNoSecurity returns true if the security requirements explicitly disable
+// security.
+func HasNoSecurity(reqs []*SecurityExpr) bool {
+	for _, req := range reqs {
+		for _, scheme := range req.Schemes {
+			if scheme.Kind == NoKind {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// EffectiveSecurityRequirements returns the security requirements that should
+// be enforced. It returns nil when reqs explicitly disable security.
+func EffectiveSecurityRequirements(reqs []*SecurityExpr) []*SecurityExpr {
+	if HasNoSecurity(reqs) {
+		return nil
+	}
+	return reqs
+}
+
 // Type returns the type of the scheme.
 func (s *SchemeExpr) Type() string {
 	switch s.Kind {

--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -642,6 +642,7 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 			Deprecated:   deprecated,
 			Extensions:   openapi.ExtensionsFromExpr(endpoint.MethodExpr.Meta),
 			Security:     requirements,
+			NoSecurity:   endpoint.MethodExpr.NoSecurity,
 		}
 
 		if key == "" {

--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -601,7 +601,10 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 
 		description := endpoint.Description()
 
-		requirements := make([]map[string][]string, len(endpoint.Requirements))
+		var requirements SecurityRequirements
+		if len(endpoint.Requirements) > 0 {
+			requirements = make(SecurityRequirements, len(endpoint.Requirements))
+		}
 		for i, req := range endpoint.Requirements {
 			requirement := make(map[string][]string)
 			for _, s := range req.Schemes {
@@ -627,6 +630,9 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 			}
 			requirements[i] = requirement
 		}
+		if expr.HasNoSecurity(endpoint.MethodExpr.Requirements) {
+			requirements = SecurityRequirements{}
+		}
 		_, deprecated := endpoint.MethodExpr.Meta.Last("openapi:deprecated")
 		operation := &Operation{
 			Tags:         tagNames,
@@ -642,7 +648,6 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 			Deprecated:   deprecated,
 			Extensions:   openapi.ExtensionsFromExpr(endpoint.MethodExpr.Meta),
 			Security:     requirements,
-			NoSecurity:   endpoint.MethodExpr.NoSecurity,
 		}
 
 		if key == "" {

--- a/http/codegen/openapi/v2/builder_test.go
+++ b/http/codegen/openapi/v2/builder_test.go
@@ -95,6 +95,87 @@ func TestNoSecurityOverridesAPISecurity(t *testing.T) {
 	}
 }
 
+func TestNoSecurityOverridesServiceSecurity(t *testing.T) {
+	root := codegen.RunDSL(t, noSecurityOverridesServiceSecurityDSL)
+	spec, err := NewV2(root, root.API.Servers[0].Hosts[0])
+	require.NoError(t, err)
+
+	cases := map[string]struct {
+		marshal   func(any) ([]byte, error)
+		unmarshal func([]byte, any) error
+	}{
+		"json": {
+			marshal:   json.Marshal,
+			unmarshal: json.Unmarshal,
+		},
+		"yaml": {
+			marshal:   yaml.Marshal,
+			unmarshal: yaml.Unmarshal,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data, err := tc.marshal(spec)
+			require.NoError(t, err)
+
+			var actual struct {
+				Paths map[string]map[string]struct {
+					Security []map[string][]string `json:"security" yaml:"security"`
+				} `json:"paths" yaml:"paths"`
+			}
+			require.NoError(t, tc.unmarshal(data, &actual))
+
+			require.NotEmpty(t, actual.Paths["/service-secure"]["get"].Security, "secure operation has no security requirements")
+			security := actual.Paths["/service-public"]["get"].Security
+			require.NotNil(t, security, "NoSecurity operation omitted the operation security override")
+			require.Empty(t, security, "NoSecurity operation security expected empty override")
+		})
+	}
+}
+
+func TestOperationSecurityMarshal(t *testing.T) {
+	securityCases := map[string]struct {
+		operation Operation
+		expected  map[string]any
+	}{
+		"nil security is omitted": {
+			operation: Operation{},
+			expected:  map[string]any{},
+		},
+		"empty security is emitted": {
+			operation: Operation{Security: SecurityRequirements{}},
+			expected:  map[string]any{"security": []any{}},
+		},
+	}
+	cases := map[string]struct {
+		marshal   func(any) ([]byte, error)
+		unmarshal func([]byte, any) error
+	}{
+		"json": {
+			marshal:   json.Marshal,
+			unmarshal: json.Unmarshal,
+		},
+		"yaml": {
+			marshal:   yaml.Marshal,
+			unmarshal: yaml.Unmarshal,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			for securityName, securityTC := range securityCases {
+				t.Run(securityName, func(t *testing.T) {
+					data, err := tc.marshal(securityTC.operation)
+					require.NoError(t, err)
+
+					var actual map[string]any
+					require.NoError(t, tc.unmarshal(data, &actual))
+					require.Equal(t, securityTC.expected, actual)
+				})
+			}
+		})
+	}
+}
+
 var noSecurityOverridesAPISecurityDSL = func() {
 	var JWTAuth = dsl.JWTSecurity("jwt")
 
@@ -116,6 +197,31 @@ var noSecurityOverridesAPISecurityDSL = func() {
 			dsl.NoSecurity()
 			dsl.HTTP(func() {
 				dsl.GET("/public")
+			})
+		})
+	})
+}
+
+var noSecurityOverridesServiceSecurityDSL = func() {
+	var JWTAuth = dsl.JWTSecurity("jwt")
+
+	dsl.API("test", func() {})
+
+	dsl.Service("test", func() {
+		dsl.Security(JWTAuth)
+		dsl.Method("service-secure", func() {
+			dsl.Payload(func() {
+				dsl.Token("token", dsl.String)
+				dsl.Required("token")
+			})
+			dsl.HTTP(func() {
+				dsl.GET("/service-secure")
+			})
+		})
+		dsl.Method("service-public", func() {
+			dsl.NoSecurity()
+			dsl.HTTP(func() {
+				dsl.GET("/service-public")
 			})
 		})
 	})

--- a/http/codegen/openapi/v2/builder_test.go
+++ b/http/codegen/openapi/v2/builder_test.go
@@ -1,9 +1,14 @@
 package openapiv2
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"goa.design/goa/v3/codegen"
+	dsl "goa.design/goa/v3/dsl"
 	"goa.design/goa/v3/expr"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBuildPathFromFileServer(t *testing.T) {
@@ -50,6 +55,70 @@ func TestBuildPathFromFileServer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNoSecurityOverridesAPISecurity(t *testing.T) {
+	root := codegen.RunDSL(t, noSecurityOverridesAPISecurityDSL)
+	spec, err := NewV2(root, root.API.Servers[0].Hosts[0])
+	require.NoError(t, err)
+
+	cases := map[string]struct {
+		marshal   func(any) ([]byte, error)
+		unmarshal func([]byte, any) error
+	}{
+		"json": {
+			marshal:   json.Marshal,
+			unmarshal: json.Unmarshal,
+		},
+		"yaml": {
+			marshal:   yaml.Marshal,
+			unmarshal: yaml.Unmarshal,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data, err := tc.marshal(spec)
+			require.NoError(t, err)
+
+			var actual struct {
+				Paths map[string]map[string]struct {
+					Security []map[string][]string `json:"security" yaml:"security"`
+				} `json:"paths" yaml:"paths"`
+			}
+			require.NoError(t, tc.unmarshal(data, &actual))
+
+			require.NotEmpty(t, actual.Paths["/secure"]["get"].Security, "secure operation has no security requirements")
+			security := actual.Paths["/public"]["get"].Security
+			require.NotNil(t, security, "NoSecurity operation omitted the operation security override")
+			require.Empty(t, security, "NoSecurity operation security expected empty override")
+		})
+	}
+}
+
+var noSecurityOverridesAPISecurityDSL = func() {
+	var JWTAuth = dsl.JWTSecurity("jwt")
+
+	dsl.API("test", func() {
+		dsl.Security(JWTAuth)
+	})
+
+	dsl.Service("test", func() {
+		dsl.Method("secure", func() {
+			dsl.Payload(func() {
+				dsl.Token("token", dsl.String)
+				dsl.Required("token")
+			})
+			dsl.HTTP(func() {
+				dsl.GET("/secure")
+			})
+		})
+		dsl.Method("public", func() {
+			dsl.NoSecurity()
+			dsl.HTTP(func() {
+				dsl.GET("/public")
+			})
+		})
+	})
 }
 
 func TestBuildPathFromExpr(t *testing.T) {

--- a/http/codegen/openapi/v2/openapi.go
+++ b/http/codegen/openapi/v2/openapi.go
@@ -95,6 +95,8 @@ type (
 		Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 		// Security is a declaration of which security schemes are applied for this operation.
 		Security []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
+		// NoSecurity indicates that the operation explicitly disables security.
+		NoSecurity bool `json:"-" yaml:"-"`
 		// Extensions defines the swagger extensions.
 		Extensions map[string]any `json:"-" yaml:"-"`
 	}
@@ -284,7 +286,7 @@ func (p Path) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON returns the JSON encoding of o.
 func (o Operation) MarshalJSON() ([]byte, error) {
-	return openapi.MarshalJSON(_Operation(o), o.Extensions)
+	return openapi.MarshalJSON(_Operation(o), operationExtensions(o))
 }
 
 // MarshalJSON returns the JSON encoding of p.
@@ -314,7 +316,19 @@ func (p Path) MarshalYAML() (any, error) {
 
 // MarshalYAML returns value which marshaled in place of the original value
 func (o Operation) MarshalYAML() (any, error) {
-	return openapi.MarshalYAML(_Operation(o), o.Extensions)
+	return openapi.MarshalYAML(_Operation(o), operationExtensions(o))
+}
+
+func operationExtensions(o Operation) map[string]any {
+	if !o.NoSecurity {
+		return o.Extensions
+	}
+	extensions := make(map[string]any, len(o.Extensions)+1)
+	for key, value := range o.Extensions {
+		extensions[key] = value
+	}
+	extensions["security"] = []map[string][]string{}
+	return extensions
 }
 
 // MarshalYAML returns value which marshaled in place of the original value

--- a/http/codegen/openapi/v2/openapi.go
+++ b/http/codegen/openapi/v2/openapi.go
@@ -94,12 +94,13 @@ type (
 		// Deprecated declares this operation to be deprecated.
 		Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 		// Security is a declaration of which security schemes are applied for this operation.
-		Security []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
-		// NoSecurity indicates that the operation explicitly disables security.
-		NoSecurity bool `json:"-" yaml:"-"`
+		Security SecurityRequirements `json:"security,omitzero" yaml:"security,omitempty"`
 		// Extensions defines the swagger extensions.
 		Extensions map[string]any `json:"-" yaml:"-"`
 	}
+
+	// SecurityRequirements lists alternative security requirements.
+	SecurityRequirements []map[string][]string
 
 	// Parameter describes a single operation parameter.
 	Parameter struct {
@@ -286,7 +287,7 @@ func (p Path) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON returns the JSON encoding of o.
 func (o Operation) MarshalJSON() ([]byte, error) {
-	return openapi.MarshalJSON(_Operation(o), operationExtensions(o))
+	return openapi.MarshalJSON(_Operation(o), o.Extensions)
 }
 
 // MarshalJSON returns the JSON encoding of p.
@@ -316,19 +317,12 @@ func (p Path) MarshalYAML() (any, error) {
 
 // MarshalYAML returns value which marshaled in place of the original value
 func (o Operation) MarshalYAML() (any, error) {
-	return openapi.MarshalYAML(_Operation(o), operationExtensions(o))
+	return openapi.MarshalYAML(_Operation(o), o.Extensions)
 }
 
-func operationExtensions(o Operation) map[string]any {
-	if !o.NoSecurity {
-		return o.Extensions
-	}
-	extensions := make(map[string]any, len(o.Extensions)+1)
-	for key, value := range o.Extensions {
-		extensions[key] = value
-	}
-	extensions["security"] = []map[string][]string{}
-	return extensions
+// IsZero reports whether s should be omitted from OpenAPI output.
+func (s SecurityRequirements) IsZero() bool {
+	return s == nil
 }
 
 // MarshalYAML returns value which marshaled in place of the original value

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -340,6 +340,7 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 		RequestBody:  requestBody,
 		Responses:    responses,
 		Security:     buildSecurityRequirements(e.Requirements),
+		NoSecurity:   e.MethodExpr.NoSecurity,
 		Deprecated:   deprecated,
 		ExternalDocs: openapi.DocsFromExpr(m.Docs, m.Meta),
 		Extensions:   openapi.ExtensionsFromExpr(m.Meta),

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -331,6 +331,10 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 
 	// An endpoint may be marked as deprecated. if the openapi:deprecated tag is present, we populate it to true
 	_, deprecated := e.Meta.Last("openapi:deprecated")
+	security := buildSecurityRequirements(e.Requirements)
+	if expr.HasNoSecurity(e.MethodExpr.Requirements) {
+		security = SecurityRequirements{}
+	}
 	return &Operation{
 		Tags:         tagNames,
 		Summary:      summary,
@@ -339,8 +343,7 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 		Parameters:   params,
 		RequestBody:  requestBody,
 		Responses:    responses,
-		Security:     buildSecurityRequirements(e.Requirements),
-		NoSecurity:   e.MethodExpr.NoSecurity,
+		Security:     security,
 		Deprecated:   deprecated,
 		ExternalDocs: openapi.DocsFromExpr(m.Docs, m.Meta),
 		Extensions:   openapi.ExtensionsFromExpr(m.Meta),
@@ -535,8 +538,14 @@ func buildServers(servers []*expr.ServerExpr) []*Server {
 
 // buildSecurityRequirements builds the OpenAPI security requirements for the
 // given security expressions.
-func buildSecurityRequirements(reqs []*expr.SecurityExpr) []map[string][]string {
-	srs := make([]map[string][]string, len(reqs))
+func buildSecurityRequirements(reqs []*expr.SecurityExpr) SecurityRequirements {
+	if expr.HasNoSecurity(reqs) {
+		return SecurityRequirements{}
+	}
+	if len(reqs) == 0 {
+		return nil
+	}
+	srs := make(SecurityRequirements, len(reqs))
 	for i, req := range reqs {
 		sr := make(map[string][]string, len(req.Schemes))
 		for _, sch := range req.Schemes {

--- a/http/codegen/openapi/v3/builder_test.go
+++ b/http/codegen/openapi/v3/builder_test.go
@@ -129,6 +129,89 @@ func TestNoSecurityOverridesAPISecurity(t *testing.T) {
 	}
 }
 
+func TestNoSecurityOverridesServiceSecurity(t *testing.T) {
+	root := codegen.RunDSL(t, noSecurityOverridesServiceSecurityDSL)
+	spec := New(root)
+
+	cases := map[string]struct {
+		marshal   func(any) ([]byte, error)
+		unmarshal func([]byte, any) error
+	}{
+		"json": {
+			marshal:   json.Marshal,
+			unmarshal: json.Unmarshal,
+		},
+		"yaml": {
+			marshal:   yaml.Marshal,
+			unmarshal: yaml.Unmarshal,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data, err := tc.marshal(spec)
+			require.NoError(t, err)
+
+			var actual struct {
+				Paths map[string]map[string]struct {
+					Security []map[string][]string `json:"security" yaml:"security"`
+				} `json:"paths" yaml:"paths"`
+			}
+			require.NoError(t, tc.unmarshal(data, &actual))
+
+			require.NotEmpty(t, actual.Paths["/service-secure"]["get"].Security, "secure operation has no security requirements")
+			security := actual.Paths["/service-public"]["get"].Security
+			require.NotNil(t, security, "NoSecurity operation omitted the operation security override")
+			require.Empty(t, security, "NoSecurity operation security expected empty override")
+		})
+	}
+}
+
+func TestOperationSecurityMarshal(t *testing.T) {
+	securityCases := map[string]struct {
+		operation Operation
+		expected  map[string]any
+	}{
+		"nil security is omitted": {
+			operation: Operation{Responses: map[string]*ResponseRef{}},
+			expected:  map[string]any{"responses": map[string]any{}},
+		},
+		"empty security is emitted": {
+			operation: Operation{
+				Responses: map[string]*ResponseRef{},
+				Security:  SecurityRequirements{},
+			},
+			expected: map[string]any{"responses": map[string]any{}, "security": []any{}},
+		},
+	}
+	cases := map[string]struct {
+		marshal   func(any) ([]byte, error)
+		unmarshal func([]byte, any) error
+	}{
+		"json": {
+			marshal:   json.Marshal,
+			unmarshal: json.Unmarshal,
+		},
+		"yaml": {
+			marshal:   yaml.Marshal,
+			unmarshal: yaml.Unmarshal,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			for securityName, securityTC := range securityCases {
+				t.Run(securityName, func(t *testing.T) {
+					data, err := tc.marshal(securityTC.operation)
+					require.NoError(t, err)
+
+					var actual map[string]any
+					require.NoError(t, tc.unmarshal(data, &actual))
+					require.Equal(t, securityTC.expected, actual)
+				})
+			}
+		})
+	}
+}
+
 type param struct {
 	Name        string
 	In          string
@@ -521,6 +604,31 @@ var noSecurityOverridesAPISecurityDSL = func() {
 			dsl.NoSecurity()
 			dsl.HTTP(func() {
 				dsl.GET("/public")
+			})
+		})
+	})
+}
+
+var noSecurityOverridesServiceSecurityDSL = func() {
+	var JWTAuth = dsl.JWTSecurity("jwt")
+
+	dsl.API("test", func() {})
+
+	dsl.Service("test", func() {
+		dsl.Security(JWTAuth)
+		dsl.Method("service-secure", func() {
+			dsl.Payload(func() {
+				dsl.Token("token", dsl.String)
+				dsl.Required("token")
+			})
+			dsl.HTTP(func() {
+				dsl.GET("/service-secure")
+			})
+		})
+		dsl.Method("service-public", func() {
+			dsl.NoSecurity()
+			dsl.HTTP(func() {
+				dsl.GET("/service-public")
 			})
 		})
 	})

--- a/http/codegen/openapi/v3/builder_test.go
+++ b/http/codegen/openapi/v3/builder_test.go
@@ -1,13 +1,17 @@
 package openapiv3
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"goa.design/goa/v3/codegen"
+	dsl "goa.design/goa/v3/dsl"
 	"goa.design/goa/v3/expr"
 	"goa.design/goa/v3/http/codegen/openapi"
 	"goa.design/goa/v3/http/codegen/openapi/v3/testdata/dsls"
+	"gopkg.in/yaml.v3"
 )
 
 func TestBuildInfo(t *testing.T) {
@@ -84,6 +88,43 @@ func TestBuildInfo(t *testing.T) {
 			if info.Version != c.Version {
 				t.Errorf("got API version %q, expected %q", info.Version, c.Version)
 			}
+		})
+	}
+}
+
+func TestNoSecurityOverridesAPISecurity(t *testing.T) {
+	root := codegen.RunDSL(t, noSecurityOverridesAPISecurityDSL)
+	spec := New(root)
+
+	cases := map[string]struct {
+		marshal   func(any) ([]byte, error)
+		unmarshal func([]byte, any) error
+	}{
+		"json": {
+			marshal:   json.Marshal,
+			unmarshal: json.Unmarshal,
+		},
+		"yaml": {
+			marshal:   yaml.Marshal,
+			unmarshal: yaml.Unmarshal,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			data, err := tc.marshal(spec)
+			require.NoError(t, err)
+
+			var actual struct {
+				Paths map[string]map[string]struct {
+					Security []map[string][]string `json:"security" yaml:"security"`
+				} `json:"paths" yaml:"paths"`
+			}
+			require.NoError(t, tc.unmarshal(data, &actual))
+
+			require.NotEmpty(t, actual.Paths["/secure"]["get"].Security, "secure operation has no security requirements")
+			security := actual.Paths["/public"]["get"].Security
+			require.NotNil(t, security, "NoSecurity operation omitted the operation security override")
+			require.Empty(t, security, "NoSecurity operation security expected empty override")
 		})
 	}
 }
@@ -457,4 +498,30 @@ func matchesHeader(t *testing.T, h *HeaderRef, types map[string]*openapi.Schema,
 		In:              "header",
 	}}
 	matchesParameterHeader(t, par, types, expected, "header")
+}
+
+var noSecurityOverridesAPISecurityDSL = func() {
+	var JWTAuth = dsl.JWTSecurity("jwt")
+
+	dsl.API("test", func() {
+		dsl.Security(JWTAuth)
+	})
+
+	dsl.Service("test", func() {
+		dsl.Method("secure", func() {
+			dsl.Payload(func() {
+				dsl.Token("token", dsl.String)
+				dsl.Required("token")
+			})
+			dsl.HTTP(func() {
+				dsl.GET("/secure")
+			})
+		})
+		dsl.Method("public", func() {
+			dsl.NoSecurity()
+			dsl.HTTP(func() {
+				dsl.GET("/public")
+			})
+		})
+	})
 }

--- a/http/codegen/openapi/v3/openapi.go
+++ b/http/codegen/openapi/v3/openapi.go
@@ -101,19 +101,21 @@ type (
 	// Operation represents an OpenAPI Operation object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#operationObject
 	Operation struct {
-		Tags         []string                `json:"tags,omitempty" yaml:"tags,omitempty"`
-		Summary      string                  `json:"summary,omitempty" yaml:"summary,omitempty"`
-		Description  string                  `json:"description,omitempty" yaml:"description,omitempty"`
-		OperationID  string                  `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-		Parameters   []*ParameterRef         `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-		RequestBody  *RequestBodyRef         `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-		Responses    map[string]*ResponseRef `json:"responses" yaml:"responses"` // Required
-		Callbacks    map[string]*CallbackRef `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
-		Deprecated   bool                    `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-		Security     []map[string][]string   `json:"security,omitempty" yaml:"security,omitempty"`
-		Servers      []*Server               `json:"servers,omitempty" yaml:"servers,omitempty"`
-		ExternalDocs *openapi.ExternalDocs   `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
-		Extensions   map[string]any          `json:"-" yaml:"-"`
+		Tags        []string                `json:"tags,omitempty" yaml:"tags,omitempty"`
+		Summary     string                  `json:"summary,omitempty" yaml:"summary,omitempty"`
+		Description string                  `json:"description,omitempty" yaml:"description,omitempty"`
+		OperationID string                  `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+		Parameters  []*ParameterRef         `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+		RequestBody *RequestBodyRef         `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+		Responses   map[string]*ResponseRef `json:"responses" yaml:"responses"` // Required
+		Callbacks   map[string]*CallbackRef `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
+		Deprecated  bool                    `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+		Security    []map[string][]string   `json:"security,omitempty" yaml:"security,omitempty"`
+		// NoSecurity indicates that the operation explicitly disables security.
+		NoSecurity   bool                  `json:"-" yaml:"-"`
+		Servers      []*Server             `json:"servers,omitempty" yaml:"servers,omitempty"`
+		ExternalDocs *openapi.ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+		Extensions   map[string]any        `json:"-" yaml:"-"`
 	}
 
 	// Parameter represents an OpenAPI Parameter object as defined in
@@ -280,7 +282,7 @@ func (p PathItem) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON returns the JSON encoding of o.
 func (o Operation) MarshalJSON() ([]byte, error) {
-	return openapi.MarshalJSON(_Operation(o), o.Extensions)
+	return openapi.MarshalJSON(_Operation(o), operationExtensions(o))
 }
 
 // MarshalJSON returns the JSON encoding of p.
@@ -310,7 +312,19 @@ func (p PathItem) MarshalYAML() (any, error) {
 
 // MarshalYAML returns value which marshaled in place of the original value
 func (o Operation) MarshalYAML() (any, error) {
-	return openapi.MarshalYAML(_Operation(o), o.Extensions)
+	return openapi.MarshalYAML(_Operation(o), operationExtensions(o))
+}
+
+func operationExtensions(o Operation) map[string]any {
+	if !o.NoSecurity {
+		return o.Extensions
+	}
+	extensions := make(map[string]any, len(o.Extensions)+1)
+	for key, value := range o.Extensions {
+		extensions[key] = value
+	}
+	extensions["security"] = []map[string][]string{}
+	return extensions
 }
 
 // MarshalYAML returns value which marshaled in place of the original value

--- a/http/codegen/openapi/v3/openapi.go
+++ b/http/codegen/openapi/v3/openapi.go
@@ -101,22 +101,23 @@ type (
 	// Operation represents an OpenAPI Operation object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#operationObject
 	Operation struct {
-		Tags        []string                `json:"tags,omitempty" yaml:"tags,omitempty"`
-		Summary     string                  `json:"summary,omitempty" yaml:"summary,omitempty"`
-		Description string                  `json:"description,omitempty" yaml:"description,omitempty"`
-		OperationID string                  `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-		Parameters  []*ParameterRef         `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-		RequestBody *RequestBodyRef         `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-		Responses   map[string]*ResponseRef `json:"responses" yaml:"responses"` // Required
-		Callbacks   map[string]*CallbackRef `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
-		Deprecated  bool                    `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-		Security    []map[string][]string   `json:"security,omitempty" yaml:"security,omitempty"`
-		// NoSecurity indicates that the operation explicitly disables security.
-		NoSecurity   bool                  `json:"-" yaml:"-"`
-		Servers      []*Server             `json:"servers,omitempty" yaml:"servers,omitempty"`
-		ExternalDocs *openapi.ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
-		Extensions   map[string]any        `json:"-" yaml:"-"`
+		Tags         []string                `json:"tags,omitempty" yaml:"tags,omitempty"`
+		Summary      string                  `json:"summary,omitempty" yaml:"summary,omitempty"`
+		Description  string                  `json:"description,omitempty" yaml:"description,omitempty"`
+		OperationID  string                  `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+		Parameters   []*ParameterRef         `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+		RequestBody  *RequestBodyRef         `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+		Responses    map[string]*ResponseRef `json:"responses" yaml:"responses"` // Required
+		Callbacks    map[string]*CallbackRef `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
+		Deprecated   bool                    `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+		Security     SecurityRequirements    `json:"security,omitzero" yaml:"security,omitempty"`
+		Servers      []*Server               `json:"servers,omitempty" yaml:"servers,omitempty"`
+		ExternalDocs *openapi.ExternalDocs   `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+		Extensions   map[string]any          `json:"-" yaml:"-"`
 	}
+
+	// SecurityRequirements lists alternative security requirements.
+	SecurityRequirements []map[string][]string
 
 	// Parameter represents an OpenAPI Parameter object as defined in
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#parameterObject
@@ -282,7 +283,7 @@ func (p PathItem) MarshalJSON() ([]byte, error) {
 
 // MarshalJSON returns the JSON encoding of o.
 func (o Operation) MarshalJSON() ([]byte, error) {
-	return openapi.MarshalJSON(_Operation(o), operationExtensions(o))
+	return openapi.MarshalJSON(_Operation(o), o.Extensions)
 }
 
 // MarshalJSON returns the JSON encoding of p.
@@ -312,19 +313,12 @@ func (p PathItem) MarshalYAML() (any, error) {
 
 // MarshalYAML returns value which marshaled in place of the original value
 func (o Operation) MarshalYAML() (any, error) {
-	return openapi.MarshalYAML(_Operation(o), operationExtensions(o))
+	return openapi.MarshalYAML(_Operation(o), o.Extensions)
 }
 
-func operationExtensions(o Operation) map[string]any {
-	if !o.NoSecurity {
-		return o.Extensions
-	}
-	extensions := make(map[string]any, len(o.Extensions)+1)
-	for key, value := range o.Extensions {
-		extensions[key] = value
-	}
-	extensions["security"] = []map[string][]string{}
-	return extensions
+// IsZero reports whether s should be omitted from OpenAPI output.
+func (s SecurityRequirements) IsZero() bool {
+	return s == nil
 }
 
 // MarshalYAML returns value which marshaled in place of the original value


### PR DESCRIPTION
Preserve explicit NoSecurity declarations after method finalization so the OpenAPI generators can distinguish them from methods that simply have no local security requirement.

For example, an API can define `Security(JWTAuth)` globally while a health or status method calls `NoSecurity()`. That method must emit an operation-level security: [] entry so generated OpenAPI v2 and v3 documents do not make clients inherit the global JWT requirement for that public endpoint.