### PR TITLE
ci: drop Go 1.24 from matrix (go.mod requires Go 1.25)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: ['1.24', '1.25']
+        go: ['1.25']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ### Go Code Style
 
-- **Go 1.24+**. Format with `go fmt ./...`.
+- **Go 1.25+**. Format with `go fmt ./...`.
 - **Imports**: Group stdlib separate from external. Let gofmt manage ordering.
 - **Files**: Use `lower_snake_case.go`. Keep ≤1000 lines; split proactively.
 - **Naming**: Packages are lowercase and short. Exported identifiers need GoDoc. Avoid stutter.


### PR DESCRIPTION
## Summary

- drop `'1.24'` from the `ci` job's Go version matrix in `.github/workflows/test.yml`
- bump `AGENTS.md` Go style guideline from `Go 1.24+` to `Go 1.25+` to match

Prepare v3.27.0 ([420dd780](https://github.com/goadesign/goa/commit/420dd780)) bumped `go.mod` from `go 1.24.0` to `go 1.25.0` and removed the `toolchain` directive, making Go 1.25 the new minimum. The CI matrix in `test.yml` and the `Go Code Style` line in `AGENTS.md` were not updated in the same change, so every PR opened against `v3` since then has been failing on `ci (1.24, ubuntu-latest)` with:

```
# goa.design/goa/v3/jsonrpc
go: no such tool "covdata"
# goa.design/goa/v3/middleware/xray/xraytest
go: no such tool "covdata"
# goa.design/goa/v3/security
go: no such tool "covdata"
```

Go 1.24's toolchain cannot build a module that declares `go 1.25`, so the `go test ./... --coverprofile=cover.out` step fails for packages that contain no test files (where the build falls back to the coverage-instrumentation path that needs the `covdata` tool).

Examples: #3929, #3930 — both fail on 1.24 and pass on 1.25 despite having no coverage-related changes, confirming the failure is toolchain-gated rather than test-logic-specific.

The `Upload test coverage for deep source` step already gates on `matrix.go == '1.25'`, so dropping 1.24 has no side effect there.

## Test plan

- [x] confirm `go.mod` declares `go 1.25.0`
- [x] confirm the artifact upload step is gated on Go 1.25 and is unaffected
- [ ] CI on this PR runs only on Go 1.25 and goes green (verified after push)