### PR TITLE
perf: reduce codegen import churn

### DIFF
--- a/codegen/generator/example.go
+++ b/codegen/generator/example.go
@@ -23,6 +23,9 @@ func Example(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 
 		// Create service data
 		services := service.NewServicesData(r)
+		for _, s := range r.Services {
+			service.SetUserTypeImports(genpkg, services.Get(s.Name))
+		}
 
 		// example service implementation
 		if fs := service.ExampleServiceFiles(genpkg, r, services); len(fs) != 0 {
@@ -78,13 +81,7 @@ func Example(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 		}
 
 		// Add imports defined via struct:field:type
-		for _, f := range files {
-			if len(f.SectionTemplates) > 0 {
-				for _, s := range r.Services {
-					service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s, services.Get(s.Name))
-				}
-			}
-		}
+		addServicesMetaTypeImports(files, services, r.Services)
 	}
 	return files, nil
 }

--- a/codegen/generator/service.go
+++ b/codegen/generator/service.go
@@ -22,19 +22,25 @@ func Service(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 		services := service.NewServicesData(r)
 
 		for _, s := range r.Services {
+			d := services.Get(s.Name)
+			service.SetUserTypeImports(genpkg, d)
+
 			// Make sure service is first so name scope is
 			// properly initialized.
-			files = append(files, service.Files(genpkg, s, services, userTypePkgs)...)
-			files = append(files, service.EndpointFile(genpkg, s, services), service.ClientFile(genpkg, s, services))
-			if f := service.ViewsFile(genpkg, s, services); f != nil {
-				files = append(files, f)
+			svcFiles := service.Files(genpkg, s, services, userTypePkgs)
+			addServiceImports(svcFiles, d)
+			files = append(files, svcFiles...)
+
+			endpointFiles := []*codegen.File{
+				service.EndpointFile(genpkg, s, services),
+				service.ClientFile(genpkg, s, services),
 			}
-			for _, f := range files {
-				if len(f.SectionTemplates) > 0 {
-					d := services.Get(s.Name)
-					service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s, d)
-					service.AddUserTypeImports(genpkg, f.SectionTemplates[0], d)
-				}
+			addServiceImports(endpointFiles, d)
+			files = append(files, endpointFiles...)
+
+			if f := service.ViewsFile(genpkg, s, services); f != nil {
+				addServiceImports([]*codegen.File{f}, d)
+				files = append(files, f)
 			}
 			convFiles, err := service.ConvertFiles(r, s, services)
 			if err != nil {
@@ -44,4 +50,35 @@ func Service(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 		}
 	}
 	return files, nil
+}
+
+func addServiceImports(files []*codegen.File, d *service.Data) {
+	for _, f := range files {
+		if len(f.SectionTemplates) == 0 {
+			continue
+		}
+		service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], d)
+		service.AddUserTypeImports(f.SectionTemplates[0], d)
+	}
+}
+
+func addServicesImports(files []*codegen.File, services *service.ServicesData, svcs []*expr.ServiceExpr) {
+	for _, s := range svcs {
+		addServiceImports(files, services.Get(s.Name))
+	}
+}
+
+func addMetaTypeImports(files []*codegen.File, d *service.Data) {
+	for _, f := range files {
+		if len(f.SectionTemplates) == 0 {
+			continue
+		}
+		service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], d)
+	}
+}
+
+func addServicesMetaTypeImports(files []*codegen.File, services *service.ServicesData, svcs []*expr.ServiceExpr) {
+	for _, s := range svcs {
+		addMetaTypeImports(files, services.Get(s.Name))
+	}
 }

--- a/codegen/generator/transport.go
+++ b/codegen/generator/transport.go
@@ -22,6 +22,9 @@ func Transport(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 
 		// Create service data
 		services := service.NewServicesData(r)
+		for _, s := range r.Services {
+			service.SetUserTypeImports(genpkg, services.Get(s.Name))
+		}
 
 		// HTTP
 		httpServices := httpcodegen.NewServicesData(services, r.API.HTTP)
@@ -52,15 +55,7 @@ func Transport(genpkg string, roots []eval.Root) ([]*codegen.File, error) {
 		files = append(files, jsonrpccodegen.SSEServerFiles(genpkg, jsonrpcServices)...)
 
 		// Add service data meta type imports
-		for _, f := range files {
-			if len(f.SectionTemplates) > 0 {
-				for _, s := range r.Services {
-					d := services.Get(s.Name)
-					service.AddServiceDataMetaTypeImports(f.SectionTemplates[0], s, d)
-					service.AddUserTypeImports(genpkg, f.SectionTemplates[0], d)
-				}
-			}
-		}
+		addServicesImports(files, services, r.Services)
 	}
 	return files, nil
 }

--- a/codegen/header.go
+++ b/codegen/header.go
@@ -41,10 +41,20 @@ func AddImport(section *SectionTemplate, imprts ...*ImportSpec) {
 		return
 	}
 	var specs []*ImportSpec
-	if data, ok := section.Data.(map[string]any); ok {
-		if imports, ok := data["Imports"]; ok {
-			specs = imports.([]*ImportSpec)
-		}
-		data["Imports"] = append(specs, imprts...)
+	data := section.Data.(map[string]any)
+	if imports, ok := data["Imports"]; ok {
+		specs = imports.([]*ImportSpec)
 	}
+	seen := make(map[ImportSpec]struct{}, len(specs)+len(imprts))
+	for _, spec := range specs {
+		seen[*spec] = struct{}{}
+	}
+	for _, spec := range imprts {
+		if _, ok := seen[*spec]; ok {
+			continue
+		}
+		seen[*spec] = struct{}{}
+		specs = append(specs, spec)
+	}
+	data["Imports"] = specs
 }

--- a/codegen/service/service.go
+++ b/codegen/service/service.go
@@ -290,27 +290,48 @@ func dedupeByResult(ms []*MethodData) []*MethodData {
 	return out
 }
 
-// AddServiceDataMetaTypeImports Adds all imports defined by struct:field:type from the service expr and the service data
-func AddServiceDataMetaTypeImports(header *codegen.SectionTemplate, svcExpr *expr.ServiceExpr, svcData *Data) {
-	codegen.AddServiceMetaTypeImports(header, svcExpr)
-	for _, ut := range svcData.userTypes {
-		codegen.AddImport(header, codegen.GetMetaTypeImports(ut.Type.Attribute())...)
-	}
-	for _, et := range svcData.errorTypes {
-		codegen.AddImport(header, codegen.GetMetaTypeImports(et.Type.Attribute())...)
-	}
-	for _, t := range svcData.viewedResultTypes {
-		codegen.AddImport(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
-	}
-	for _, t := range svcData.projectedTypes {
-		codegen.AddImport(header, codegen.GetMetaTypeImports(t.Type.Attribute())...)
-	}
+// SetUserTypeImports sets the import paths for user types declared in custom
+// packages with the Meta key "struct:pkg:path".
+func SetUserTypeImports(genpkg string, d *Data) {
+	d.UserTypeImports = userTypeImports(genpkg, d)
 }
 
-// AddUserTypeImports sets the import paths for the user types defined in the
-// service.  User types may be declared in multiple packages when defined with
-// the Meta key "struct:pkg:path".
-func AddUserTypeImports(genpkg string, header *codegen.SectionTemplate, d *Data) {
+// AddServiceDataMetaTypeImports adds all imports defined by struct:field:type
+// metadata for the service data.
+func AddServiceDataMetaTypeImports(header *codegen.SectionTemplate, d *Data) {
+	codegen.AddImport(header, d.metaTypeImports...)
+}
+
+// AddUserTypeImports adds the imports for user types declared in custom
+// packages with the Meta key "struct:pkg:path".
+func AddUserTypeImports(header *codegen.SectionTemplate, d *Data) {
+	codegen.AddImport(header, d.UserTypeImports...)
+}
+
+func metaTypeImports(svcExpr *expr.ServiceExpr, svcData *Data) []*codegen.ImportSpec {
+	seen := make(map[codegen.ImportSpec]struct{})
+	var imports []*codegen.ImportSpec
+	for _, m := range svcExpr.Methods {
+		imports = appendUniqueImport(imports, seen, codegen.GetMetaTypeImports(m.Payload)...)
+		imports = appendUniqueImport(imports, seen, codegen.GetMetaTypeImports(m.StreamingPayload)...)
+		imports = appendUniqueImport(imports, seen, codegen.GetMetaTypeImports(m.Result)...)
+	}
+	for _, ut := range svcData.userTypes {
+		imports = appendUniqueImport(imports, seen, codegen.GetMetaTypeImports(ut.Type.Attribute())...)
+	}
+	for _, et := range svcData.errorTypes {
+		imports = appendUniqueImport(imports, seen, codegen.GetMetaTypeImports(et.Type.Attribute())...)
+	}
+	for _, t := range svcData.viewedResultTypes {
+		imports = appendUniqueImport(imports, seen, codegen.GetMetaTypeImports(t.Type.Attribute())...)
+	}
+	for _, t := range svcData.projectedTypes {
+		imports = appendUniqueImport(imports, seen, codegen.GetMetaTypeImports(t.Type.Attribute())...)
+	}
+	return imports
+}
+
+func userTypeImports(genpkg string, d *Data) []*codegen.ImportSpec {
 	importsByPath := make(map[string]*codegen.ImportSpec)
 
 	initLoc := func(loc *codegen.Location) {
@@ -337,10 +358,22 @@ func AddUserTypeImports(genpkg string, header *codegen.SectionTemplate, d *Data)
 		initLoc(et.Loc)
 	}
 
+	imports := make([]*codegen.ImportSpec, 0, len(importsByPath))
 	for _, imp := range importsByPath { // Order does not matter, imports are sorted during formatting.
-		codegen.AddImport(header, imp)
-		d.UserTypeImports = append(d.UserTypeImports, imp)
+		imports = append(imports, imp)
 	}
+	return imports
+}
+
+func appendUniqueImport(imports []*codegen.ImportSpec, seen map[codegen.ImportSpec]struct{}, specs ...*codegen.ImportSpec) []*codegen.ImportSpec {
+	for _, spec := range specs {
+		if _, ok := seen[*spec]; ok {
+			continue
+		}
+		seen[*spec] = struct{}{}
+		imports = append(imports, spec)
+	}
+	return imports
 }
 
 func errorName(et *UserTypeData) string {

--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -95,6 +95,9 @@ type (
 		unions []*UnionTypeData
 		// viewedResultTypes lists all the viewed method result types.
 		viewedResultTypes []*ViewedResultTypeData
+		// metaTypeImports lists the imports derived from struct:field:type
+		// metadata for the service.
+		metaTypeImports []*codegen.ImportSpec
 	}
 
 	// MethodData describes a single service method.
@@ -958,6 +961,7 @@ func (d *ServicesData) analyze(service *expr.ServiceExpr) *Data {
 		viewedResultTypes:  viewedRTs,
 		unions:             unions,
 	}
+	data.metaTypeImports = metaTypeImports(service, data)
 
 	d.Services[service.Name] = data
 


### PR DESCRIPTION
## Summary
This speeds up code generation for large designs by reducing import churn during file rendering.

Previously, service-derived imports were recomputed and appended across broad sets of generated files, then the formatter/import cleanup path had to remove many duplicates and unused imports. This PR makes service import data a cached property of `service.Data` and applies those imports only to the generated file batches that need them.

The generated output format stays on the existing import cleanup pipeline, so this keeps output stable while avoiding a large amount of repeated work.

In a large downstream design, the full generation script dropped from roughly 46s with the pinned release to 10.85s with this branch, a little over a 4x wall-clock improvement. A direct `goa gen --debug` run on the same design completed in about 12s.

## Breaking change
This changes exported codegen helper signatures used by Goa plugins or other code that imports `goa.design/goa/v3/codegen/service`.

Changed APIs:
- `service.AddServiceDataMetaTypeImports(header, svcExpr, data)` is now `service.AddServiceDataMetaTypeImports(header, data)`.
- `service.AddUserTypeImports(genpkg, header, data)` is now `service.AddUserTypeImports(header, data)`.
- New helper: `service.SetUserTypeImports(genpkg, data)` computes user type imports once before they are added to headers.

## Upgrade guide
If your plugin calls `AddServiceDataMetaTypeImports`, remove the service expression argument:

```go
service.AddServiceDataMetaTypeImports(header, data)
```

If your plugin calls `AddUserTypeImports`, compute the imports once after creating `service.ServicesData`, then pass only the header and service data when adding imports:

```go
services := service.NewServicesData(root)
for _, svc := range root.Services {
    data := services.Get(svc.Name)
    service.SetUserTypeImports(genpkg, data)
    service.AddUserTypeImports(header, data)
}
```

The conceptual change is that `service.Data` now owns the derived import sets. Callers should not recompute them while walking generated files.

## Test plan
- `make test`
- `go test ./...` in `~/go/src/goa.design/plugins` with local Goa in a workspace
- `make test` in `~/go/src/goa.design/plugins` with local Goa in a workspace
- Downstream large design generation with local Goa completed in 10.85s via `./scripts/gen goa`