### PR TITLE
codegen: memoize GetMetaTypeImports to avoid redundant type-graph walks

### DIFF
--- a/codegen/import.go
+++ b/codegen/import.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"sync"
 
 	"goa.design/goa/v3/expr"
 	goa "goa.design/goa/v3/pkg"
@@ -119,9 +120,17 @@ func GetMetaType(att *expr.AttributeExpr) (typeName string, importS *ImportSpec)
 	return
 }
 
+// metaTypeImports caches GetMetaTypeImports results by attribute.
+var metaTypeImports sync.Map // map[*expr.AttributeExpr][]*ImportSpec
+
 // GetMetaTypeImports parses the attribute for all user defined imports
 func GetMetaTypeImports(att *expr.AttributeExpr) []*ImportSpec {
-	return safelyGetMetaTypeImports(att, nil)
+	if v, ok := metaTypeImports.Load(att); ok {
+		return v.([]*ImportSpec)
+	}
+	res := safelyGetMetaTypeImports(att, nil)
+	metaTypeImports.Store(att, res)
+	return res
 }
 
 // safelyGetMetaTypeImports parses attributes while keeping track of previous usertypes to avoid infinite recursion

--- a/codegen/import_test.go
+++ b/codegen/import_test.go
@@ -170,3 +170,42 @@ func TestGetMetaTypeImports(t *testing.T) {
 		})
 	}
 }
+
+// TestGetMetaTypeImportsAcrossDesigns verifies that results are cached by
+// attribute identity, not by type name: two designs that declare a type with
+// the same name but different struct:field:type imports must each resolve their
+// own imports.
+func TestGetMetaTypeImportsAcrossDesigns(t *testing.T) {
+	design := func(pkg string) func() {
+		return func() {
+			shared := dsl.Type("Shared", func() {
+				dsl.Attribute("a", dsl.String, func() {
+					dsl.Meta("struct:field:type", "Custom", pkg)
+				})
+			})
+			dsl.Service("svc", func() {
+				dsl.Method("m", func() {
+					dsl.Payload(shared)
+				})
+			})
+		}
+	}
+	paths := func(imports []*ImportSpec) []string {
+		got := make([]string, 0, len(imports))
+		for _, im := range imports {
+			got = append(got, im.Path)
+		}
+		sort.Strings(got)
+		return got
+	}
+	root1 := RunDSL(t, design("package/first"))
+	first := paths(GetMetaTypeImports(root1.Services[0].Methods[0].Payload))
+	root2 := RunDSL(t, design("package/second"))
+	second := paths(GetMetaTypeImports(root2.Services[0].Methods[0].Payload))
+	if want := []string{"package/first"}; !reflect.DeepEqual(want, first) {
+		t.Errorf("first design: want %+v, got %+v", want, first)
+	}
+	if want := []string{"package/second"}; !reflect.DeepEqual(want, second) {
+		t.Errorf("second design: want %+v, got %+v", want, second)
+	}
+}


### PR DESCRIPTION
## Summary

`GetMetaTypeImports` walks an attribute's entire type graph via
`safelyGetMetaTypeImports` to collect `struct:field:type` imports. The service
and transport generators resolve imports for the same method payloads and
results repeatedly, so on large designs this walk dominates generation time —
and on designs that use no `struct:field:type` metadata at all, it's pure
overhead that still walks every type.

This memoizes `GetMetaTypeImports` by attribute identity.

## Why this is safe

`safelyGetMetaTypeImports(att, nil)` returns the set of `struct:field:type`
imports reachable from `att` — a transitive-closure property that's independent
of traversal entry point (the `seen` map only prevents infinite recursion; it
never drops a reachable node). So a memoized result always equals a fresh
computation.

The cache is keyed on the `*expr.AttributeExpr` pointer rather than the type
name/ID, so entries can't collide across different designs generated in the same
process (e.g. the test suite). `sync.Map` keeps it safe if a caller ever resolves
imports concurrently; today all callers run in the serial generator phase.

## Output is unchanged

- `go test ./...` and the integration tests pass — the codegen golden-file tests
  cover the service, http, grpc and jsonrpc generators.
  A new test (`TestGetMetaTypeImportsAcrossDesigns`) pins the keying: two designs
  with a same-named type each resolve their own imports — it fails if the cache
  is keyed by type name instead of attribute identity.
- Regenerating `goadesign/examples` (`basic`) produces byte-identical output
  patched vs unpatched.
- A large production design (347 design files, 3671 generated files)
  regenerates byte-identical, with end-to-end `goa gen` dropping from ~39s to
  ~23s — the serial generator phase drops from 28.8s to 13.5s.

A focused micro-benchmark of the import resolution a generator pass performs
measured -63% time / -66% allocations. I left the benchmark out since the repo
has no existing benchmarks; happy to add it if you'd like one in-tree.
