### PR TITLE
 Fix race in http.ErrorEncoder

### DIFF
--- a/http/encoding.go
+++ b/http/encoding.go
@@ -260,11 +260,11 @@ func ResponseDecoder(resp *http.Response) Decoder {
 // encoded as a permanent internal server error. This behavior as well as the
 // shape of the response can be overridden by providing a non-nil formatter.
 func ErrorEncoder(encoder func(context.Context, http.ResponseWriter) Encoder, formatter func(ctx context.Context, err error) Statuser) func(context.Context, http.ResponseWriter, error) error {
+	if formatter == nil {
+		formatter = NewErrorResponse
+	}
 	return func(ctx context.Context, w http.ResponseWriter, err error) error {
 		enc := encoder(ctx, w)
-		if formatter == nil {
-			formatter = NewErrorResponse
-		}
 		resp := formatter(ctx, err)
 		w.WriteHeader(resp.StatusCode())
 		return enc.Encode(resp)

--- a/http/encoding_test.go
+++ b/http/encoding_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -126,6 +127,28 @@ func TestUnsupportedDecoder(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code)
+}
+
+func TestErrorEncoderNilFormatterRace(t *testing.T) {
+	// Reproduce the data race that occurs when ErrorEncoder is called with a
+	// nil formatter: the returned encoder is invoked concurrently and each
+	// goroutine writes to the captured formatter variable. Run with -race.
+	encoder := ErrorEncoder(ResponseEncoder, nil)
+	err := errors.New("boom")
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			// Each goroutine uses its own ResponseWriter to avoid unrelated
+			// races and isolate the race on the captured formatter.
+			w := httptest.NewRecorder()
+			require.NoError(t, encoder(context.Background(), w, err))
+		}()
+	}
+	wg.Wait()
 }
 
 func TestResponseEncoder(t *testing.T) {


### PR DESCRIPTION
Moves the nil `formatter` handler outside of the closure, so the returned encoder is safe concurrently when `nil` is passed in.