### PR TITLE
Fix SSE OpenAPI streaming responses

### DIFF
--- a/expr/http_endpoint.go
+++ b/expr/http_endpoint.go
@@ -130,6 +130,18 @@ func (e *HTTPEndpointExpr) IsJSONRPC() bool {
 	return ok
 }
 
+// UsesSSE returns true if the endpoint streams result events over Server-Sent
+// Events.
+func (e *HTTPEndpointExpr) UsesSSE() bool {
+	return e.SSE != nil && (e.MethodExpr.IsResultStreaming() || e.MethodExpr.HasMixedResults())
+}
+
+// UsesWebSocket returns true if the endpoint streams payloads or results over a
+// WebSocket connection.
+func (e *HTTPEndpointExpr) UsesWebSocket() bool {
+	return e.MethodExpr.IsStreaming() && e.SSE == nil
+}
+
 // HasAbsoluteRoutes returns true if all the endpoint routes are absolute.
 func (e *HTTPEndpointExpr) HasAbsoluteRoutes() bool {
 	for _, r := range e.Routes {
@@ -354,7 +366,7 @@ func (e *HTTPEndpointExpr) Prepare() {
 
 	// Make sure JSON-RPC HTTP verb is set to GET if the endpoint is a
 	// WebSocket endpoint
-	if e.MethodExpr.IsStreaming() && e.SSE == nil && len(e.Routes) > 0 {
+	if e.UsesWebSocket() && len(e.Routes) > 0 {
 		e.Routes[0].Method = "GET"
 	}
 
@@ -451,7 +463,7 @@ func (e *HTTPEndpointExpr) Validate() error {
 	// JSON-RPC validation
 	if e.IsJSONRPC() {
 		// JSON-RPC WebSocket endpoints with server streaming cannot have both Payload and StreamingPayload
-		if e.MethodExpr.Stream == ServerStreamKind && e.SSE == nil {
+		if e.UsesWebSocket() && e.MethodExpr.Stream == ServerStreamKind {
 			if e.MethodExpr.Payload.Type != Empty && e.MethodExpr.StreamingPayload.Type != Empty {
 				verr.Add(e, "JSON-RPC WebSocket server streaming method %q cannot define both Payload and StreamingPayload. Use Payload for the request data", e.MethodExpr.Name)
 			}
@@ -730,7 +742,7 @@ func (e *HTTPEndpointExpr) Validate() error {
 		// Exception: JSON-RPC WebSocket endpoints can have payloads as they are sent
 		// as JSON-RPC messages after the WebSocket connection is established
 		_, isJSONRPC := e.MethodExpr.Meta["jsonrpc"]
-		if e.SSE == nil && !isJSONRPC { // Only apply this validation to non-SSE, non-JSON-RPC streaming endpoints
+		if e.UsesWebSocket() && !isJSONRPC {
 			verr.Add(e, "HTTP endpoint request body must be empty when the endpoint uses streaming. Payload attributes must be mapped to headers and/or params.")
 		}
 	}
@@ -748,7 +760,7 @@ func (e *HTTPEndpointExpr) Finalize() {
 	// move the payload to streaming payload. This is because the payload is sent as
 	// JSON-RPC messages after the WebSocket connection is established, making it
 	// effectively a streaming payload from the transport perspective.
-	if _, isJSONRPC := e.MethodExpr.Meta["jsonrpc"]; isJSONRPC && e.MethodExpr.Stream == ServerStreamKind && e.SSE == nil {
+	if _, isJSONRPC := e.MethodExpr.Meta["jsonrpc"]; isJSONRPC && e.UsesWebSocket() && e.MethodExpr.Stream == ServerStreamKind {
 		if e.MethodExpr.Payload.Type != Empty && e.MethodExpr.StreamingPayload.Type == Empty {
 			// Move payload to streaming payload
 			e.MethodExpr.StreamingPayload = e.MethodExpr.Payload
@@ -1037,7 +1049,7 @@ func (r *RouteExpr) Validate() *eval.ValidationErrors {
 
 	// For WebSocket streaming endpoints, only GET is supported
 	// SSE endpoints can use both GET and POST (JSON-RPC SSE uses POST)
-	if r.Endpoint.MethodExpr.IsStreaming() && len(r.Endpoint.Responses) > 0 && r.Endpoint.SSE == nil {
+	if r.Endpoint.UsesWebSocket() && len(r.Endpoint.Responses) > 0 {
 		if r.Method != "GET" {
 			verr.Add(r, "WebSocket endpoint supports only \"GET\" method. Got %q.", r.Method)
 		}

--- a/expr/http_service.go
+++ b/expr/http_service.go
@@ -289,13 +289,11 @@ func (svc *HTTPServiceExpr) validateTransports(verr *eval.ValidationErrors) {
 
 	// Analyze endpoints
 	for _, e := range svc.HTTPEndpoints {
-		usesWebSocket := e.MethodExpr.IsStreaming() && e.SSE == nil
-
 		if e.IsJSONRPC() {
-			if usesWebSocket {
+			if e.UsesWebSocket() {
 				hasJSONRPCWebSocket = true
 			}
-		} else if usesWebSocket {
+		} else if e.UsesWebSocket() {
 			hasPureHTTPWebSocket = true
 		}
 	}
@@ -373,7 +371,7 @@ func (svc *HTTPServiceExpr) prepareJSONRPCRoutes() {
 
 		// If using WebSocket, force GET
 		for _, e := range svc.HTTPEndpoints {
-			if e.IsJSONRPC() && e.MethodExpr.IsStreaming() && e.SSE == nil {
+			if e.IsJSONRPC() && e.UsesWebSocket() {
 				method = "GET" // WebSocket requires GET
 				break
 			}
@@ -404,13 +402,12 @@ func (svc *HTTPServiceExpr) validateJSONRPCTransportConsistency(verr *eval.Valid
 
 	for _, e := range svc.HTTPEndpoints {
 		if e.IsJSONRPC() {
-			if e.MethodExpr.IsStreaming() {
-				if e.SSE != nil {
-					hasSSE = true
-				} else {
-					hasWebSocket = true
-				}
-			} else {
+			switch {
+			case e.UsesWebSocket():
+				hasWebSocket = true
+			case e.UsesSSE():
+				hasSSE = true
+			default:
 				hasRegular = true
 			}
 		}
@@ -429,7 +426,7 @@ func (svc *HTTPServiceExpr) validateJSONRPCRoutes(verr *eval.ValidationErrors) {
 		if e.IsJSONRPC() {
 			for _, r := range e.Routes {
 				// WebSocket requires GET
-				if e.MethodExpr.IsStreaming() && e.SSE == nil {
+				if e.UsesWebSocket() {
 					if r.Method != "GET" {
 						verr.Add(r, "JSON-RPC WebSocket endpoint must use GET method, got %q", r.Method)
 					}

--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -521,14 +521,18 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 
 		responses := make(map[string]*Response, len(endpoint.Responses))
 		for _, r := range endpoint.Responses {
-			if endpoint.MethodExpr.IsStreaming() {
-				// A streaming endpoint allows at most one successful response
+			switch {
+			case endpoint.UsesWebSocket():
+				// A WebSocket endpoint allows at most one successful response
 				// definition. So it is okay to change the first successful
-				// response to a HTTP 101 response for openapi docs.
+				// response to a HTTP 101 response for OpenAPI docs.
 				if _, ok := responses[strconv.Itoa(expr.StatusSwitchingProtocols)]; !ok {
 					r = r.Dup()
 					r.StatusCode = expr.StatusSwitchingProtocols
 				}
+			case endpoint.UsesSSE():
+				r = r.Dup()
+				r.ContentType = "text/event-stream"
 			}
 			resp := responseSpecFromExpr(s, root, r, endpoint.Service.Name())
 			responses[strconv.Itoa(r.StatusCode)] = resp
@@ -585,8 +589,8 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 			}
 		}
 
-		// replace http with ws for streaming endpoints
-		if endpoint.MethodExpr.IsStreaming() {
+		// replace HTTP with WebSocket schemes for WebSocket endpoints
+		if endpoint.UsesWebSocket() {
 			for i := len(schemes) - 1; i >= 0; i-- {
 				if schemes[i] == "http" {
 					news := append([]string{"ws"}, schemes[i+1:]...)

--- a/http/codegen/openapi/v2/builder_test.go
+++ b/http/codegen/openapi/v2/builder_test.go
@@ -133,6 +133,24 @@ func TestNoSecurityOverridesServiceSecurity(t *testing.T) {
 	}
 }
 
+func TestStreamingResponseStatusCodes(t *testing.T) {
+	root := codegen.RunDSL(t, streamingResponseStatusDSL)
+	spec, err := NewV2(root, root.API.Servers[0].Hosts[0])
+	require.NoError(t, err)
+
+	sseResponses := spec.Paths["/sse"].(*Path).Get.Responses
+	require.Contains(t, sseResponses, "200")
+	require.NotContains(t, sseResponses, "101")
+	require.Contains(t, spec.Paths["/sse"].(*Path).Get.Produces, "text/event-stream")
+	require.NotContains(t, spec.Paths["/sse"].(*Path).Get.Schemes, "ws")
+	require.NotContains(t, spec.Paths["/sse"].(*Path).Get.Schemes, "wss")
+
+	websocketResponses := spec.Paths["/websocket"].(*Path).Get.Responses
+	require.Contains(t, websocketResponses, "101")
+	require.NotContains(t, websocketResponses, "200")
+	require.Contains(t, spec.Paths["/websocket"].(*Path).Get.Schemes, "ws")
+}
+
 func TestOperationSecurityMarshal(t *testing.T) {
 	securityCases := map[string]struct {
 		operation Operation
@@ -222,6 +240,24 @@ var noSecurityOverridesServiceSecurityDSL = func() {
 			dsl.NoSecurity()
 			dsl.HTTP(func() {
 				dsl.GET("/service-public")
+			})
+		})
+	})
+}
+
+var streamingResponseStatusDSL = func() {
+	dsl.Service("streaming", func() {
+		dsl.Method("sse", func() {
+			dsl.StreamingResult(dsl.String)
+			dsl.HTTP(func() {
+				dsl.GET("/sse")
+				dsl.ServerSentEvents()
+			})
+		})
+		dsl.Method("websocket", func() {
+			dsl.StreamingResult(dsl.String)
+			dsl.HTTP(func() {
+				dsl.GET("/websocket")
 			})
 		})
 	})

--- a/http/codegen/openapi/v3/builder.go
+++ b/http/codegen/openapi/v3/builder.go
@@ -278,10 +278,11 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 	// responses
 	responses := make(map[string]*ResponseRef, len(e.Responses))
 	for _, r := range e.Responses {
-		if e.MethodExpr.IsStreaming() {
-			// A streaming endpoint allows at most one successful response
+		switch {
+		case e.UsesWebSocket():
+			// A WebSocket endpoint allows at most one successful response
 			// definition. So it is okay to change the first successful
-			// response to a HTTP 101 response for openapi docs.
+			// response to a HTTP 101 response for OpenAPI docs.
 			if _, ok := responses[strconv.Itoa(expr.StatusSwitchingProtocols)]; !ok {
 				b := bodies.ResponseBodies[r.StatusCode]
 				delete(bodies.ResponseBodies, r.StatusCode)
@@ -289,6 +290,9 @@ func buildOperation(key string, r *expr.RouteExpr, bodies *EndpointBodies, rand 
 				r.StatusCode = expr.StatusSwitchingProtocols
 				bodies.ResponseBodies[r.StatusCode] = b
 			}
+		case e.UsesSSE():
+			r = r.Dup()
+			r.ContentType = "text/event-stream"
 		}
 		resp := responseFromExpr(r, bodies.ResponseBodies, rand)
 		responses[strconv.Itoa(r.StatusCode)] = &ResponseRef{Value: resp}

--- a/http/codegen/openapi/v3/builder_test.go
+++ b/http/codegen/openapi/v3/builder_test.go
@@ -166,6 +166,21 @@ func TestNoSecurityOverridesServiceSecurity(t *testing.T) {
 	}
 }
 
+func TestStreamingResponseStatusCodes(t *testing.T) {
+	root := codegen.RunDSL(t, streamingResponseStatusDSL)
+	spec := New(root)
+
+	sseResponses := spec.Paths["/sse"].Get.Responses
+	require.Contains(t, sseResponses, "200")
+	require.NotContains(t, sseResponses, "101")
+	require.Contains(t, sseResponses["200"].Value.Content, "text/event-stream")
+	require.NotContains(t, sseResponses["200"].Value.Content, "application/json")
+
+	websocketResponses := spec.Paths["/websocket"].Get.Responses
+	require.Contains(t, websocketResponses, "101")
+	require.NotContains(t, websocketResponses, "200")
+}
+
 func TestOperationSecurityMarshal(t *testing.T) {
 	securityCases := map[string]struct {
 		operation Operation
@@ -629,6 +644,24 @@ var noSecurityOverridesServiceSecurityDSL = func() {
 			dsl.NoSecurity()
 			dsl.HTTP(func() {
 				dsl.GET("/service-public")
+			})
+		})
+	})
+}
+
+var streamingResponseStatusDSL = func() {
+	dsl.Service("streaming", func() {
+		dsl.Method("sse", func() {
+			dsl.StreamingResult(dsl.String)
+			dsl.HTTP(func() {
+				dsl.GET("/sse")
+				dsl.ServerSentEvents()
+			})
+		})
+		dsl.Method("websocket", func() {
+			dsl.StreamingResult(dsl.String)
+			dsl.HTTP(func() {
+				dsl.GET("/websocket")
 			})
 		})
 	})

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -837,7 +837,7 @@ func (sds *ServicesData) analyze(httpSvc *expr.HTTPServiceExpr) *ServiceData {
 			"Args":         args,
 			"PathInit":     routes[0].PathInit,
 			"Verb":         routes[0].Verb,
-			"IsWebSocket":  httpEndpoint.MethodExpr.IsStreaming() && httpEndpoint.SSE == nil,
+			"IsWebSocket":  httpEndpoint.UsesWebSocket(),
 		}
 		if httpEndpoint.SkipRequestBodyEncodeDecode {
 			data["RequestStruct"] = pkg + "." + method.RequestStruct

--- a/http/codegen/sse.go
+++ b/http/codegen/sse.go
@@ -64,7 +64,7 @@ type (
 
 // initSSEData initializes the SSE related data in ed.
 func initSSEData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData) {
-	if e.SSE == nil {
+	if !e.UsesSSE() {
 		return
 	}
 

--- a/http/codegen/sse_server_test.go
+++ b/http/codegen/sse_server_test.go
@@ -40,3 +40,16 @@ func TestSSE(t *testing.T) {
 		})
 	}
 }
+
+func TestSSETransportDefaultsToStatusOK(t *testing.T) {
+	root := RunHTTPDSL(t, testdata.SSEStringDSL)
+	services := CreateHTTPServices(root)
+	fs := ServerFiles("", services)
+	require.Len(t, fs, 3)
+
+	sections := fs[1].SectionTemplates
+	require.Greater(t, len(sections), 1)
+	code := codegen.SectionCode(t, sections[1])
+	require.Contains(t, code, "s.w.WriteHeader(http.StatusOK)")
+	require.NotContains(t, code, "http.StatusSwitchingProtocols")
+}

--- a/http/codegen/websocket.go
+++ b/http/codegen/websocket.go
@@ -75,7 +75,7 @@ type (
 
 // initWebSocketData initializes the WebSocket related data in ed.
 func (sds *ServicesData) initWebSocketData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData) {
-	if e.SSE != nil {
+	if !e.UsesWebSocket() {
 		return
 	}
 	var (


### PR DESCRIPTION
## Summary
- classify HTTP streaming endpoints by transport with HTTPEndpointExpr helpers
- keep WebSocket OpenAPI responses on 101 Switching Protocols
- document SSE success responses as 200 with text/event-stream and keep v2 schemes on HTTP
- add regression coverage for OpenAPI v2/v3 and generated SSE server status

## Root Cause
OpenAPI generation treated every streaming endpoint as a WebSocket endpoint. That rewrote SSE success responses to 101 Switching Protocols even though the generated SSE transport writes HTTP 200 and text/event-stream.

## Validation
- go test ./expr ./http/codegen ./http/codegen/openapi/v2 ./http/codegen/openapi/v3
- make lint
- make test
- cd cmd/goa && go install .