### PR TITLE
Avoid SSE produces in Swagger v2

### DIFF
--- a/http/codegen/openapi/v2/builder.go
+++ b/http/codegen/openapi/v2/builder.go
@@ -521,8 +521,7 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 
 		responses := make(map[string]*Response, len(endpoint.Responses))
 		for _, r := range endpoint.Responses {
-			switch {
-			case endpoint.UsesWebSocket():
+			if endpoint.UsesWebSocket() {
 				// A WebSocket endpoint allows at most one successful response
 				// definition. So it is okay to change the first successful
 				// response to a HTTP 101 response for OpenAPI docs.
@@ -530,9 +529,6 @@ func buildPathFromExpr(s *V2, root *expr.RootExpr, h *expr.HostExpr, route *expr
 					r = r.Dup()
 					r.StatusCode = expr.StatusSwitchingProtocols
 				}
-			case endpoint.UsesSSE():
-				r = r.Dup()
-				r.ContentType = "text/event-stream"
 			}
 			resp := responseSpecFromExpr(s, root, r, endpoint.Service.Name())
 			responses[strconv.Itoa(r.StatusCode)] = resp

--- a/http/codegen/openapi/v2/builder_test.go
+++ b/http/codegen/openapi/v2/builder_test.go
@@ -141,7 +141,6 @@ func TestStreamingResponseStatusCodes(t *testing.T) {
 	sseResponses := spec.Paths["/sse"].(*Path).Get.Responses
 	require.Contains(t, sseResponses, "200")
 	require.NotContains(t, sseResponses, "101")
-	require.Contains(t, spec.Paths["/sse"].(*Path).Get.Produces, "text/event-stream")
 	require.NotContains(t, spec.Paths["/sse"].(*Path).Get.Schemes, "ws")
 	require.NotContains(t, spec.Paths["/sse"].(*Path).Get.Schemes, "wss")
 


### PR DESCRIPTION
## Summary
- keep the SSE status-code fix in Swagger/OpenAPI v2
- avoid setting operation-level produces to text/event-stream for SSE endpoints in v2
- keep the v2 regression focused on 200 status and non-WebSocket schemes

## Root Cause
Swagger 2 only represents response media types through operation-level produces. Setting SSE success responses to text/event-stream there makes converted OpenAPI 3 specs treat every response on the operation, including normal error responses, as event-stream payloads.

OpenAPI v3 still documents successful SSE responses as text/event-stream where the content type is response-scoped.

## Validation
- go test ./http/codegen/openapi/v2 ./http/codegen/openapi/v3
- make test
- make lint
- go test ./http/codegen/openapi/v2