### PR TITLE
Fix OpenAPI generate metadata example panic

### DIFF
--- a/expr/example.go
+++ b/expr/example.go
@@ -29,15 +29,7 @@ func (a *AttributeExpr) Example(r *ExampleGenerator) any {
 		return nil
 	}
 
-	value, ok := a.Meta.Last("openapi:generate")
-	if !ok {
-		value, ok = a.Meta.Last("swagger:generate")
-	}
-	if ok && value == "false" {
-		return nil
-	}
-
-	value, ok = a.Meta.Last("openapi:example")
+	value, ok := a.Meta.Last("openapi:example")
 	if !ok {
 		value, ok = a.Meta.Last("swagger:example")
 	}

--- a/expr/example_test.go
+++ b/expr/example_test.go
@@ -65,6 +65,7 @@ func TestExample(t *testing.T) {
 		{"invalid-example-type", testdata.InvalidExampleTypeDSL, nil, "service \"InvalidExampleType\" method \"Method\": payload - example value map[int]int{1:1} is incompatible with type map"},
 		{"empty-example", testdata.EmptyExampleDSL, nil, "too few arguments given to Example in attribute"},
 		{"hiding-example", testdata.HidingExampleDSL, nil, ""},
+		{"openapi-generate-false-array-example", testdata.OpenAPIGenerateFalseArrayExampleDSL, map[string]any{"items": []map[string]any{{"name": "example"}}}, ""},
 		{"overriding-hidden-examples", testdata.OverridingHiddenExamplesDSL, "example", ""},
 	}
 	r := expr.NewRandom("test")

--- a/expr/testdata/example_test_dsls.go
+++ b/expr/testdata/example_test_dsls.go
@@ -106,6 +106,27 @@ var HidingExampleDSL = func() {
 	})
 }
 
+var OpenAPIGenerateFalseArrayExampleDSL = func() {
+	var Hidden = Type("Hidden", func() {
+		Meta("openapi:generate", "false")
+		Attribute("name", String, func() {
+			Example("example")
+		})
+		Required("name")
+	})
+	Service("OpenAPIGenerateFalseArrayExample", func() {
+		Method("Method", func() {
+			Payload(func() {
+				Attribute("items", ArrayOf(Hidden), func() {
+					MinLength(1)
+					MaxLength(1)
+				})
+				Required("items")
+			})
+		})
+	})
+}
+
 var OverridingHiddenExamplesDSL = func() {
 	Service("OverridingHiddenExamples", func() {
 		Meta("openapi:example", "false")

--- a/http/codegen/openapi/json_schema.go
+++ b/http/codegen/openapi/json_schema.go
@@ -3,6 +3,7 @@ package openapi
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"goa.design/goa/v3/codegen"
@@ -448,6 +449,20 @@ func ToStringMap(val any) any {
 	}
 }
 
+// Example returns an example value projected to the OpenAPI-visible shape of at.
+func Example(at *expr.AttributeExpr, r *expr.ExampleGenerator) any {
+	return ProjectExample(at, at.Example(r))
+}
+
+// ProjectExample removes values for fields that are hidden from the OpenAPI
+// schema by metadata while keeping examples usable by service codegen.
+func ProjectExample(at *expr.AttributeExpr, val any) any {
+	if val == nil {
+		return nil
+	}
+	return projectExample(at.Type, val)
+}
+
 // MarshalJSON returns the JSON encoding of s.
 func (s *Schema) MarshalJSON() ([]byte, error) {
 	return MarshalJSON((*_Schema)(s), s.Extensions)
@@ -506,7 +521,7 @@ func buildAttributeSchema(api *expr.APIExpr, s *Schema, at *expr.AttributeExpr) 
 	}
 	s.DefaultValue = ToStringMap(at.DefaultValue)
 	s.Description = at.Description
-	s.Example = at.Example(api.ExampleGenerator)
+	s.Example = Example(at, api.ExampleGenerator)
 	s.Extensions = ExtensionsFromExpr(at.Meta)
 	if ap := AdditionalPropertiesFromExpr(at.Meta); ap != nil {
 		s.AdditionalProperties = ap
@@ -626,4 +641,100 @@ func AdditionalPropertiesFromExpr(meta expr.MetaExpr) any {
 		return false
 	}
 	return nil
+}
+
+func projectExample(t expr.DataType, val any) any {
+	switch actual := t.(type) {
+	case *expr.UserTypeExpr:
+		return ProjectExample(actual.Attribute(), val)
+	case *expr.ResultTypeExpr:
+		return ProjectExample(actual.Attribute(), val)
+	case *expr.Object:
+		return projectObjectExample(actual, val)
+	case *expr.Array:
+		return projectArrayExample(actual, val)
+	case *expr.Map:
+		return projectMapExample(actual, val)
+	default:
+		return ToStringMap(val)
+	}
+}
+
+func projectObjectExample(obj *expr.Object, val any) any {
+	values, ok := exampleMap(val)
+	if !ok {
+		return ToStringMap(val)
+	}
+	projected := make(map[string]any)
+	for _, nat := range *obj {
+		if !MustGenerate(nat.Attribute.Meta) {
+			continue
+		}
+		if v, ok := values[nat.Name]; ok {
+			if projectedValue := ProjectExample(nat.Attribute, v); projectedValue != nil {
+				projected[nat.Name] = projectedValue
+			}
+		}
+	}
+	return projected
+}
+
+func projectArrayExample(array *expr.Array, val any) any {
+	values, ok := exampleSlice(val)
+	if !ok {
+		return ToStringMap(val)
+	}
+	projected := make([]any, len(values))
+	for i, v := range values {
+		projected[i] = ProjectExample(array.ElemType, v)
+	}
+	return projected
+}
+
+func projectMapExample(m *expr.Map, val any) any {
+	values, ok := exampleMap(val)
+	if !ok {
+		return ToStringMap(val)
+	}
+	projected := make(map[string]any, len(values))
+	for k, v := range values {
+		if projectedValue := ProjectExample(m.ElemType, v); projectedValue != nil {
+			projected[k] = projectedValue
+		}
+	}
+	return projected
+}
+
+func exampleMap(val any) (map[string]any, bool) {
+	switch actual := val.(type) {
+	case map[string]any:
+		return actual, true
+	case map[any]any:
+		m := make(map[string]any, len(actual))
+		for k, v := range actual {
+			m[ToString(k)] = v
+		}
+		return m, true
+	}
+	rv := reflect.ValueOf(val)
+	if rv.Kind() != reflect.Map || rv.Type().Key().Kind() != reflect.String {
+		return nil, false
+	}
+	m := make(map[string]any, rv.Len())
+	for _, k := range rv.MapKeys() {
+		m[k.String()] = rv.MapIndex(k).Interface()
+	}
+	return m, true
+}
+
+func exampleSlice(val any) ([]any, bool) {
+	rv := reflect.ValueOf(val)
+	if rv.Kind() != reflect.Array && rv.Kind() != reflect.Slice {
+		return nil, false
+	}
+	values := make([]any, rv.Len())
+	for i := range values {
+		values[i] = rv.Index(i).Interface()
+	}
+	return values, true
 }

--- a/http/codegen/openapi/v3/example.go
+++ b/http/codegen/openapi/v3/example.go
@@ -2,6 +2,7 @@ package openapiv3
 
 import (
 	"goa.design/goa/v3/expr"
+	"goa.design/goa/v3/http/codegen/openapi"
 )
 
 type (
@@ -23,15 +24,15 @@ func initExamples(obj exampler, attr *expr.AttributeExpr, r *expr.ExampleGenerat
 			example := &Example{
 				Summary:     ex.Summary,
 				Description: ex.Description,
-				Value:       ex.Value,
+				Value:       openapi.ProjectExample(attr, ex.Value),
 			}
 			refs[ex.Summary] = &ExampleRef{Value: example}
 		}
 		obj.setExamples(refs)
 		return
 	case len(examples) > 0:
-		obj.setExample(examples[0].Value)
+		obj.setExample(openapi.ProjectExample(attr, examples[0].Value))
 	default:
-		obj.setExample(attr.Example(r))
+		obj.setExample(openapi.Example(attr, r))
 	}
 }

--- a/http/codegen/openapi/v3/response.go
+++ b/http/codegen/openapi/v3/response.go
@@ -20,7 +20,7 @@ func headersFromAttr(attr *expr.MappedAttributeExpr, rand *expr.ExampleGenerator
 			Description: attr.Description,
 			Required:    attr.IsRequiredNoDefault(name),
 			Schema:      newSchemafier(rand).schemafy(attr),
-			Example:     attr.Example(rand),
+			Example:     openapi.Example(attr, rand),
 			Extensions:  openapi.ExtensionsFromExpr(attr.Meta),
 		}
 		initExamples(header, attr, rand)

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -280,7 +280,7 @@ func (sf *schemafier) schemafy(attr *expr.AttributeExpr, noref ...bool) *openapi
 
 	// Default value, example, extensions
 	s.DefaultValue = toStringMap(attr.DefaultValue)
-	s.Example = attr.Example(sf.rand)
+	s.Example = openapi.Example(attr, sf.rand)
 	s.Extensions = openapi.ExtensionsFromExpr(attr.Meta)
 
 	// Validations


### PR DESCRIPTION
## Summary
- Stop treating `openapi:generate=false` / `swagger:generate=false` as generic example suppression metadata.
- Add OpenAPI-specific example projection so OpenAPI examples still omit fields hidden from the generated schema.
- Add a regression DSL for an array of a user type marked `openapi:generate=false`, matching the service codegen panic path.

## Validation
- `go test ./expr ./codegen/service ./http/codegen/openapi/v2 ./http/codegen/openapi/v3`
- `make test`
- `make lint`
- `cd cmd/goa && go install .`