### PR TITLE
Name primitive alias types in OpenAPI 3.2 components

### DIFF
--- a/http/codegen/openapi/v3/files_test.go
+++ b/http/codegen/openapi/v3/files_test.go
@@ -58,6 +58,8 @@ func TestFiles(t *testing.T) {
 		{"endpoint", testdata.ExtensionDSL},
 		{"endpoint-swagger", testdata.ExtensionSwaggerDSL},
 		{"type-extension", testdata.TypeExtensionDSL},
+		// Alias types stay inline in 3.0 documents (named in 3.2 only).
+		{"alias-type", testdata.AliasTypeDSL},
 		{"skip-response-body-encode-decode", testdata.SkipResponseBodyEncodeDecodeDSL},
 		// TestValidations
 		{"string", testdata.StringValidationDSL},
@@ -131,6 +133,7 @@ func TestFilesV32(t *testing.T) {
 		{"sse-all-fields", testdata.SSEAllFieldsDSL},
 		{"sse-mixed-results", testdata.MixedResultsDSL},
 		{"websocket", testdata.StreamingResultDSL},
+		{"alias-type", testdata.AliasTypeDSL},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/openapi/v3/testdata/golden/alias-type_file0.golden
+++ b/http/codegen/openapi/v3/testdata/golden/alias-type_file0.golden
@@ -1,0 +1,116 @@
+{
+  "components": {
+    "schemas": {
+      "Setup": {
+        "description": "Request body for testEndpoint.",
+        "example": {
+          "completed": [
+            "where",
+            "where",
+            "where",
+            "where"
+          ],
+          "current": "where"
+        },
+        "properties": {
+          "completed": {
+            "example": [
+              "where",
+              "where"
+            ],
+            "items": {
+              "description": "Setup stage.",
+              "enum": [
+                "who",
+                "when",
+                "where",
+                "what"
+              ],
+              "example": "what",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "current": {
+            "description": "Setup stage.",
+            "enum": [
+              "who",
+              "when",
+              "where",
+              "what"
+            ],
+            "example": "who",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "Goa API",
+    "version": "0.0.1"
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/": {
+      "post": {
+        "operationId": "testService#testEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "completed": [
+                  "where",
+                  "where"
+                ],
+                "current": "where"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/Setup"
+              }
+            }
+          },
+          "description": "Request body for testEndpoint.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "completed": [
+                    "when",
+                    "when",
+                    "when",
+                    "when"
+                  ],
+                  "current": "when"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Setup"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "testEndpoint testService",
+        "tags": [
+          "testService"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Default server for test api",
+      "url": "http://localhost:80"
+    }
+  ],
+  "tags": [
+    {
+      "name": "testService"
+    }
+  ]
+}

--- a/http/codegen/openapi/v3/testdata/golden/alias-type_file1.golden
+++ b/http/codegen/openapi/v3/testdata/golden/alias-type_file1.golden
@@ -1,0 +1,78 @@
+openapi: 3.0.3
+info:
+    title: Goa API
+    version: 0.0.1
+servers:
+    - url: http://localhost:80
+      description: Default server for test api
+paths:
+    /:
+        post:
+            tags:
+                - testService
+            summary: testEndpoint testService
+            operationId: testService#testEndpoint
+            requestBody:
+                description: Request body for testEndpoint.
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Setup'
+                        example:
+                            completed:
+                                - where
+                                - where
+                            current: where
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Setup'
+                            example:
+                                completed:
+                                    - when
+                                    - when
+                                    - when
+                                    - when
+                                current: when
+components:
+    schemas:
+        Setup:
+            type: object
+            properties:
+                completed:
+                    type: array
+                    items:
+                        type: string
+                        description: Setup stage.
+                        example: what
+                        enum:
+                            - who
+                            - when
+                            - where
+                            - what
+                    example:
+                        - where
+                        - where
+                current:
+                    type: string
+                    description: Setup stage.
+                    example: who
+                    enum:
+                        - who
+                        - when
+                        - where
+                        - what
+            description: Request body for testEndpoint.
+            example:
+                completed:
+                    - where
+                    - where
+                    - where
+                    - where
+                current: where
+tags:
+    - name: testService

--- a/http/codegen/openapi/v3/testdata/golden/v3.2/alias-type_file0.golden
+++ b/http/codegen/openapi/v3/testdata/golden/v3.2/alias-type_file0.golden
@@ -1,0 +1,113 @@
+{
+  "components": {
+    "schemas": {
+      "Setup": {
+        "description": "Request body for testEndpoint.",
+        "example": {
+          "completed": [
+            "who",
+            "who",
+            "who",
+            "who"
+          ],
+          "current": "who"
+        },
+        "properties": {
+          "completed": {
+            "example": [
+              "who",
+              "who"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Stage"
+            },
+            "type": "array"
+          },
+          "current": {
+            "$ref": "#/components/schemas/Stage"
+          }
+        },
+        "type": "object"
+      },
+      "Stage": {
+        "description": "Setup stage.",
+        "enum": [
+          "who",
+          "when",
+          "where",
+          "what"
+        ],
+        "example": "who",
+        "type": "string"
+      }
+    }
+  },
+  "info": {
+    "title": "Goa API",
+    "version": "0.0.1"
+  },
+  "openapi": "3.2.0",
+  "paths": {
+    "/": {
+      "post": {
+        "operationId": "testService#testEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "completed": [
+                  "who",
+                  "who",
+                  "who",
+                  "who"
+                ],
+                "current": "who"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/Setup"
+              }
+            }
+          },
+          "description": "Request body for testEndpoint.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "completed": [
+                    "where",
+                    "where",
+                    "where"
+                  ],
+                  "current": "where"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/Setup"
+                }
+              }
+            },
+            "description": "OK response."
+          }
+        },
+        "summary": "testEndpoint testService",
+        "tags": [
+          "testService"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "description": "Default server for test api",
+      "name": "test api",
+      "url": "http://localhost:80"
+    }
+  ],
+  "tags": [
+    {
+      "name": "testService"
+    }
+  ]
+}

--- a/http/codegen/openapi/v3/testdata/golden/v3.2/alias-type_file1.golden
+++ b/http/codegen/openapi/v3/testdata/golden/v3.2/alias-type_file1.golden
@@ -1,0 +1,75 @@
+openapi: 3.2.0
+info:
+    title: Goa API
+    version: 0.0.1
+servers:
+    - url: http://localhost:80
+      name: test api
+      description: Default server for test api
+paths:
+    /:
+        post:
+            tags:
+                - testService
+            summary: testEndpoint testService
+            operationId: testService#testEndpoint
+            requestBody:
+                description: Request body for testEndpoint.
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/Setup'
+                        example:
+                            completed:
+                                - who
+                                - who
+                                - who
+                                - who
+                            current: who
+            responses:
+                "200":
+                    description: OK response.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Setup'
+                            example:
+                                completed:
+                                    - where
+                                    - where
+                                    - where
+                                current: where
+components:
+    schemas:
+        Setup:
+            type: object
+            properties:
+                completed:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Stage'
+                    example:
+                        - who
+                        - who
+                current:
+                    $ref: '#/components/schemas/Stage'
+            description: Request body for testEndpoint.
+            example:
+                completed:
+                    - who
+                    - who
+                    - who
+                    - who
+                current: who
+        Stage:
+            type: string
+            description: Setup stage.
+            example: who
+            enum:
+                - who
+                - when
+                - where
+                - what
+tags:
+    - name: testService

--- a/http/codegen/openapi/v3/types.go
+++ b/http/codegen/openapi/v3/types.go
@@ -42,6 +42,12 @@ type (
 		// type names indexed by hashes
 		hashes map[uint64][]string
 		rand   *expr.ExampleGenerator
+		// nameAliases generates named component schemas for primitive alias
+		// types instead of inlining them. Only set when the schemas map feeds
+		// the document components (OpenAPI 3.2 documents): schemafiers whose
+		// schemas are discarded (parameters, headers) must keep inlining
+		// aliases as their references would dangle.
+		nameAliases bool
 	}
 )
 
@@ -69,6 +75,7 @@ func newSchemafier(rand *expr.ExampleGenerator) *schemafier {
 func buildBodyTypes(api *expr.APIExpr, types []expr.UserType, resultTypes []*expr.ResultTypeExpr, ver openapi.Version) (map[string]map[string]*EndpointBodies, map[string]*openapi.Schema) {
 	bodies := make(map[string]map[string]*EndpointBodies)
 	sf := newSchemafier(api.ExampleGenerator)
+	sf.nameAliases = ver == openapi.Version32
 	services := openAPIGeneratedServices(api)
 
 	// Generates the types referenced from the endpoints.
@@ -293,7 +300,7 @@ func (sf *schemafier) schemafy(attr *expr.AttributeExpr, noref ...bool) *openapi
 		s.Properties[valueKey] = valueSchema
 		s.Required = append(s.Required, typeKey, valueKey)
 	case expr.UserType:
-		if expr.IsAlias(t) {
+		if expr.IsAlias(t) && !sf.nameAliases {
 			return sf.schemafy(t.Attribute())
 		}
 		h := sf.hashAttribute(attr, fnv.New64())

--- a/http/codegen/testdata/openapi_dsls.go
+++ b/http/codegen/testdata/openapi_dsls.go
@@ -1179,3 +1179,23 @@ var TypeExtensionDSL = func() {
 		})
 	})
 }
+
+var AliasTypeDSL = func() {
+	var Stage = Type("Stage", String, func() {
+		Description("Setup stage.")
+		Enum("who", "when", "where", "what")
+	})
+	var Setup = Type("Setup", func() {
+		Attribute("current", Stage)
+		Attribute("completed", ArrayOf(Stage))
+	})
+	Service("testService", func() {
+		Method("testEndpoint", func() {
+			Payload(Setup)
+			Result(Setup)
+			HTTP(func() {
+				POST("/")
+			})
+		})
+	})
+}


### PR DESCRIPTION
## Why

The v3 schemafier inlines primitive alias types (e.g. `Type("Stage", String, func() { Enum("who", "when", ...) })`) at every reference site. Two costs:

1. The design type name disappears from the document — consumers can't tell two identical anonymous enums are the same concept.
2. SDK generators emit one duplicated anonymous enum per reference site. Against a real-world design (Aura), Speakeasy generated `routinedraft2.ts` … `routinedraft10.ts` each containing a copy of the same stage enum, where the Swagger 2.0 pipeline used to produce a single named `RoutineSetupStage`.

## What

OpenAPI **3.2 documents** render primitive alias types as named component schemas (`#/components/schemas/Stage`) referenced where used — restoring parity with what the 2.0 generator's definitions provided, with one canonical name per design type.

**3.0.3 documents are byte-identical** — the change is gated to the new version, which has no compatibility constraints yet.

Scoping detail: only the schemafier that feeds `components.schemas` names aliases. The parameter/header schemafiers keep inlining because their schema maps are discarded — a `$ref` from a parameter would dangle.

## Testing

New `alias-type` golden case in both suites: 3.0 locks the inline rendering, 3.2 locks the named component. All pre-existing goldens pass without regeneration. `make lint && make test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)