### PR TITLE
fix: use absolute generator directory

### DIFF
--- a/cmd/goa/gen.go
+++ b/cmd/goa/gen.go
@@ -106,13 +106,13 @@ func NewGenerator(cmd, path, output string, debug bool) *Generator {
 func (g *Generator) Write(_ bool) error {
 	var tmpDir string
 	{
-		wd := "."
-		if cwd, err := os.Getwd(); err != nil {
-			wd = cwd
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get current directory: %w", err)
 		}
 		tmp, err := os.MkdirTemp(wd, "goa")
 		if err != nil {
-			return err
+			return fmt.Errorf("create generator directory: %w", err)
 		}
 		tmpDir = tmp
 	}
@@ -165,7 +165,7 @@ func (g *Generator) Compile(debug bool) error {
 	// We first need to go get the generated package to make sure that all
 	// dependencies are added to go.sum prior to compiling.
 	startLoad := time.Now()
-	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, fmt.Sprintf(".%c%s", filepath.Separator, g.tmpDir))
+	pkgs, err := packages.Load(&packages.Config{Mode: packages.NeedName}, g.tmpDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/goa/main_test.go
+++ b/cmd/goa/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -73,5 +74,23 @@ func TestCmdLine(t *testing.T) {
 		if debug != c.ExpectedDebug {
 			t.Errorf("%s: Expected debug to be %v but got %v", k, c.ExpectedDebug, debug)
 		}
+	}
+}
+
+func TestGeneratorWriteCreatesAbsoluteTemporaryDirectory(t *testing.T) {
+	generator := &Generator{
+		Command:       "gen",
+		DesignPath:    "example.com/design",
+		Output:        t.TempDir(),
+		DesignVersion: 3,
+		bin:           "goa",
+	}
+	t.Cleanup(generator.Remove)
+
+	if err := generator.Write(false); err != nil {
+		t.Errorf("Write() error = %v", err)
+	}
+	if !filepath.IsAbs(generator.tmpDir) {
+		t.Errorf("Write() temporary directory = %q, want absolute path", generator.tmpDir)
 	}
 }


### PR DESCRIPTION
## What changed

Goa now creates the temporary generator directory with an absolute path and passes that path directly to the Go package loader.

## Why

The launcher previously created a relative `goa…` directory and then constructed its package argument by prefixing `./`. The two assumptions only worked together accidentally; once the working directory differed, Goa could compile the generator but fail to run it reliably.

## Impact

Successful generation behavior and generated output are unchanged. `goa gen` and `goa example` no longer depend on a relative temporary path.

## Validation

- `go test ./cmd/goa`
- Installed the fixed CLI and successfully generated Aura with `goa gen … --debug`