### PR TITLE
Fix OpenAPI empty parameter values

### DIFF
--- a/http/codegen/openapi/v3/parameters.go
+++ b/http/codegen/openapi/v3/parameters.go
@@ -63,7 +63,7 @@ func paramFor(att *expr.AttributeExpr, name, in string, required bool, rand *exp
 		Name:            name,
 		In:              in,
 		Description:     att.Description,
-		AllowEmptyValue: in != "path",
+		AllowEmptyValue: in == "query",
 		Required:        required,
 		Schema:          newSchemafier(rand).schemafy(att),
 		Extensions:      openapi.ExtensionsFromExpr(att.Meta),

--- a/http/codegen/openapi/v3/parameters_test.go
+++ b/http/codegen/openapi/v3/parameters_test.go
@@ -1,0 +1,36 @@
+package openapiv3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"goa.design/goa/v3/expr"
+)
+
+func TestParamForAllowEmptyValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     bool
+	}{
+		{name: "query", location: "query", want: true},
+		{name: "path", location: "path", want: false},
+		{name: "header", location: "header", want: false},
+		{name: "cookie", location: "cookie", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			param := paramFor(
+				&expr.AttributeExpr{Type: expr.String},
+				"value",
+				test.location,
+				false,
+				expr.NewRandom(test.name),
+			)
+
+			require.Equal(t, test.want, param.AllowEmptyValue)
+		})
+	}
+}

--- a/http/codegen/openapi/v3/testdata/golden/headers_file0.golden
+++ b/http/codegen/openapi/v3/testdata/golden/headers_file0.golden
@@ -11,7 +11,6 @@
         "operationId": "test service#test endpoint",
         "parameters": [
           {
-            "allowEmptyValue": true,
             "example": 8568805688952666000,
             "in": "header",
             "name": "foo",
@@ -22,7 +21,6 @@
             }
           },
           {
-            "allowEmptyValue": true,
             "example": 8380651525843656000,
             "in": "header",
             "name": "bar",

--- a/http/codegen/openapi/v3/testdata/golden/headers_file1.golden
+++ b/http/codegen/openapi/v3/testdata/golden/headers_file1.golden
@@ -15,7 +15,6 @@ paths:
             parameters:
                 - name: foo
                   in: header
-                  allowEmptyValue: true
                   schema:
                     type: integer
                     example: 5490475434297746524
@@ -23,7 +22,6 @@ paths:
                   example: 8568805688952666114
                 - name: bar
                   in: header
-                  allowEmptyValue: true
                   schema:
                     type: integer
                     example: 1475422799873681639

--- a/http/codegen/openapi/v3/testdata/golden/v3.2/sse-all-fields_file0.golden
+++ b/http/codegen/openapi/v3/testdata/golden/v3.2/sse-all-fields_file0.golden
@@ -65,7 +65,6 @@
         "operationId": "SSEAllFieldsService#SSEAllFieldsMethod",
         "parameters": [
           {
-            "allowEmptyValue": true,
             "example": "Non sed saepe voluptatem.",
             "in": "header",
             "name": "Last-Event-ID",

--- a/http/codegen/openapi/v3/testdata/golden/v3.2/sse-all-fields_file1.golden
+++ b/http/codegen/openapi/v3/testdata/golden/v3.2/sse-all-fields_file1.golden
@@ -16,7 +16,6 @@ paths:
             parameters:
                 - name: Last-Event-ID
                   in: header
-                  allowEmptyValue: true
                   schema:
                     type: string
                     example: Natus magni voluptates consequatur suscipit.

--- a/http/codegen/openapi/v3/testdata/golden/v3.2/sse-request-id_file0.golden
+++ b/http/codegen/openapi/v3/testdata/golden/v3.2/sse-request-id_file0.golden
@@ -27,7 +27,6 @@
         "operationId": "SSERequestIDService#SSERequestIDMethod",
         "parameters": [
           {
-            "allowEmptyValue": true,
             "example": "Non sed saepe voluptatem.",
             "in": "header",
             "name": "Last-Event-ID",

--- a/http/codegen/openapi/v3/testdata/golden/v3.2/sse-request-id_file1.golden
+++ b/http/codegen/openapi/v3/testdata/golden/v3.2/sse-request-id_file1.golden
@@ -16,7 +16,6 @@ paths:
             parameters:
                 - name: Last-Event-ID
                   in: header
-                  allowEmptyValue: true
                   schema:
                     type: string
                     example: Natus magni voluptates consequatur suscipit.

--- a/http/codegen/openapi/v3/types_test.go
+++ b/http/codegen/openapi/v3/types_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/dsl"
 	"goa.design/goa/v3/expr"
 	"goa.design/goa/v3/http/codegen/openapi"
 	"goa.design/goa/v3/http/codegen/openapi/v3/testdata/dsls"
@@ -523,6 +524,61 @@ func TestTypesOnlyDifferByEnum(t *testing.T) {
 		jsoned, _ := json.Marshal(derefed)
 		t.Errorf("shared referenced type (%s) was: %v", name, string(jsoned))
 		return
+	}
+}
+
+func TestBuildBodyTypesPreservesPrimitiveAliasComponents(t *testing.T) {
+	root := codegen.RunDSL(t, func() {
+		unauthorized := dsl.Type("Unauthorized", dsl.String, func() {
+			dsl.Description("Authentication is required.")
+		})
+		forbidden := dsl.Type("Forbidden", dsl.String, func() {
+			dsl.Description("Access is forbidden.")
+		})
+
+		dsl.Service("auth", func() {
+			dsl.Method("show", func() {
+				dsl.Error("unauthorized", unauthorized)
+				dsl.Error("forbidden", forbidden)
+				dsl.HTTP(func() {
+					dsl.GET("/")
+					dsl.Response("unauthorized", dsl.StatusUnauthorized)
+					dsl.Response("forbidden", dsl.StatusForbidden)
+				})
+			})
+		})
+	})
+
+	bodies, types := buildBodyTypes(root.API, root.Types, root.ResultTypes, openapi.Version32)
+	tests := []struct {
+		name        string
+		status      int
+		description string
+	}{
+		{name: "Unauthorized", status: 401, description: "Authentication is required."},
+		{name: "Forbidden", status: 403, description: "Access is forbidden."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			responses := bodies["auth"]["show"].ResponseBodies[test.status]
+			if len(responses) != 1 {
+				t.Errorf("got %d response schemas, expected 1", len(responses))
+				return
+			}
+			wantRef := "#/components/schemas/" + test.name
+			if responses[0].Ref != wantRef {
+				t.Errorf("got response ref %q, expected %q", responses[0].Ref, wantRef)
+			}
+			schema, ok := types[test.name]
+			if !ok {
+				t.Errorf("missing component schema %q", test.name)
+				return
+			}
+			if schema.Description != test.description {
+				t.Errorf("got description %q, expected %q", schema.Description, test.description)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What changed

- emit `allowEmptyValue` only for query parameters
- omit the field from generated header and cookie parameters
- add regression coverage for all parameter locations
- add coverage ensuring distinct primitive aliases keep their own OpenAPI 3.2 components and descriptions

## Why

OpenAPI permits `allowEmptyValue` only on query parameters. Goa emitted it for every non-path parameter, producing invalid header and cookie parameter objects under strict OpenAPI validation.

The primitive-alias regression also confirms the previously reported alias merging issue is fixed in the current generator.

## Validation

- `make test`
- `go test ./http/codegen/...`