### PR TITLE
Document Goa release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,13 @@ make test          # Run tests
 cd cmd/goa && go install .  # Install CLI locally
 ```
 
+### Releases
+
+- For every Goa release or version bump, follow
+  [`.cursor/skills/goa-release/SKILL.md`](.cursor/skills/goa-release/SKILL.md).
+- Do not edit `pkg/version.go` or the README version badge by hand during the standard release
+  workflow; `make release` owns those changes.
+
 ### Code Generation Behavior
 
 - After modifying goa source, `goa gen` and `goa example` automatically compile and use your changes—no manual rebuild needed.


### PR DESCRIPTION
## What changed

- reference the repository's Goa release skill from `AGENTS.md`
- clarify that the standard release flow must not edit `pkg/version.go` or the README badge manually

## Why

This keeps future release work on the repository-defined workflow, where `Makefile` selects the target version and `make release` owns the generated version and badge changes.