### PR TITLE
fix(codegen): emit extended unions per package

### DIFF
--- a/codegen/service/service_data.go
+++ b/codegen/service/service_data.go
@@ -900,10 +900,10 @@ func (d *ServicesData) analyze(service *expr.ServiceExpr) *Data {
 	}
 
 	// Collect union sum-type definitions for the service.
-	unionByHash := make(map[string]*UnionTypeData)
+	unionByPackage := make(map[string]*UnionTypeData)
 	seen = make(map[string]struct{})
 	collectUnions := func(att *expr.AttributeExpr, loc *codegen.Location) {
-		collectUnionTypes(att, scope, loc, unionByHash, seen, false)
+		collectUnionTypes(att, scope, loc, unionByPackage, seen, false)
 	}
 	for _, t := range types {
 		collectUnions(&expr.AttributeExpr{Type: t.Type}, t.Loc)
@@ -925,12 +925,15 @@ func (d *ServicesData) analyze(service *expr.ServiceExpr) *Data {
 			collectUnions(e.AttributeExpr, codegen.UserTypeLocation(e.Type))
 		}
 	}
-	unions := make([]*UnionTypeData, 0, len(unionByHash))
-	for _, u := range unionByHash {
+	unions := make([]*UnionTypeData, 0, len(unionByPackage))
+	for _, u := range unionByPackage {
 		unions = append(unions, u)
 	}
 	sort.Slice(unions, func(i, j int) bool {
-		return unions[i].Name < unions[j].Name
+		if unions[i].Name != unions[j].Name {
+			return unions[i].Name < unions[j].Name
+		}
+		return unionPackageKey(unions[i].Loc, false) < unionPackageKey(unions[j].Loc, false)
 	})
 
 	desc := service.Description
@@ -1064,10 +1067,12 @@ func collectTypes(at *expr.AttributeExpr, scope *codegen.NameScope, seen map[str
 }
 
 // collectUnionTypes traverses the attribute to gather all union sum-type
-// definitions referenced by the service. It records each union by its hash to
-// avoid generating duplicate types. When view is true the provided location is
-// used for all nested user types so that unions are generated in the views
-// package and refer to view-local types (preventing import cycles).
+// definitions referenced by the service. It records each union by its hash and
+// generated package so Extend can copy one union into multiple packages while
+// duplicate uses within one package still share a definition. When view is true
+// the provided location is used for all nested user types so that unions are
+// generated in the views package and refer to view-local types (preventing
+// import cycles).
 func collectUnionTypes(att *expr.AttributeExpr, scope *codegen.NameScope, loc *codegen.Location, unions map[string]*UnionTypeData, seen map[string]struct{}, view bool) {
 	if att == nil || att.Type == expr.Empty {
 		return
@@ -1093,14 +1098,27 @@ func collectUnionTypes(att *expr.AttributeExpr, scope *codegen.NameScope, loc *c
 		collectUnionTypes(dt.KeyType, scope, loc, unions, seen, view)
 		collectUnionTypes(dt.ElemType, scope, loc, unions, seen, view)
 	case *expr.Union:
-		hash := dt.Hash()
-		if _, ok := unions[hash]; !ok {
-			unions[hash] = buildUnionTypeData(dt, scope, loc, view)
+		key := dt.Hash() + "\x00" + unionPackageKey(loc, view)
+		if _, ok := unions[key]; !ok {
+			unions[key] = buildUnionTypeData(dt, scope, loc, view)
 		}
 		for _, nat := range dt.Values {
 			collectUnionTypes(nat.Attribute, scope, loc, unions, seen, view)
 		}
 	}
+}
+
+// unionPackageKey identifies the generated package that owns a union. A nil
+// location is the current service package; viewed unions share the views
+// package regardless of locations inherited from service types.
+func unionPackageKey(loc *codegen.Location, view bool) string {
+	if view {
+		return "views"
+	}
+	if loc == nil {
+		return ""
+	}
+	return loc.RelImportPath
 }
 
 // buildUnionTypeData creates the data needed to generate a sum-type union

--- a/codegen/service/service_test.go
+++ b/codegen/service/service_test.go
@@ -214,3 +214,39 @@ func TestStructPkgPath_UnionJSONFieldBranchesGenerateAliases(t *testing.T) {
 	require.True(t, hasValuesAFile, "expected generated alias file in struct:pkg:path package: gen/types/values_a.go")
 	require.True(t, hasValuesBFile, "expected generated alias file in struct:pkg:path package: gen/types/values_b.go")
 }
+
+func TestStructPkgPath_ExtendedUnionGeneratedInEachOwningPackage(t *testing.T) {
+	root := codegen.RunDSL(t, testdata.PkgPathExtendedUnionDSL)
+	services := NewServicesData(root)
+	require.Len(t, root.Services, 1)
+
+	files := Files("goa.design/goa/example", root.Services[0], services, make(map[string][]string))
+	require.GreaterOrEqual(t, len(files), 2)
+
+	var serviceFile, sharedTypeFile *codegen.File
+	for _, f := range files {
+		switch {
+		case strings.HasSuffix(f.Path, filepath.Join("gen", "pkg_path_extended_union", "service.go")):
+			serviceFile = f
+		case strings.HasSuffix(f.Path, filepath.Join("gen", "types", "equipment_scope.go")):
+			sharedTypeFile = f
+		}
+	}
+	require.NotNil(t, serviceFile)
+	require.NotNil(t, sharedTypeFile)
+
+	render := func(file *codegen.File) string {
+		buf := new(bytes.Buffer)
+		for _, section := range file.SectionTemplates {
+			require.NoError(t, section.Write(buf))
+		}
+		code, err := format.Source(buf.Bytes())
+		require.NoError(t, err, buf.String())
+		return string(code)
+	}
+	serviceCode := render(serviceFile)
+	sharedTypeCode := render(sharedTypeFile)
+	require.Contains(t, serviceCode, "Scope Scope")
+	require.Contains(t, serviceCode, "type Scope struct")
+	require.Contains(t, sharedTypeCode, "type Scope struct")
+}

--- a/codegen/service/testdata/service_dsls.go
+++ b/codegen/service/testdata/service_dsls.go
@@ -179,6 +179,34 @@ var PkgPathUnionJSONFieldDSL = func() {
 	})
 }
 
+// PkgPathExtendedUnionDSL tests that extending a relocated type copies its
+// nested union into the package that owns the extending type.
+var PkgPathExtendedUnionDSL = func() {
+	var ScopeDescription = Type("ScopeDescription", String, func() {
+		Meta("struct:pkg:path", "types")
+	})
+	var EquipmentAliases = Type("EquipmentAliases", ArrayOf(String), func() {
+		Meta("struct:pkg:path", "types")
+	})
+	var EquipmentScope = Type("EquipmentScope", func() {
+		Meta("struct:pkg:path", "types")
+		Meta("type:generate:force")
+		OneOf("Scope", func() {
+			Attribute("Description", ScopeDescription)
+			Attribute("DeviceAliases", EquipmentAliases)
+		})
+	})
+	var ToolPayload = Type("ToolPayload", func() {
+		Extend(EquipmentScope)
+		Attribute("query", String)
+	})
+	Service("PkgPathExtendedUnion", func() {
+		Method("M", func() {
+			Payload(ToolPayload)
+		})
+	})
+}
+
 var WithDefaultDSL = func() {
 	Service("WithDefault", func() {
 		Method("A", func() {


### PR DESCRIPTION
## What changed

- Generate a nested union once per destination package instead of once per structural hash across the whole service.
- Preserve de-duplication when the same union is reused multiple times inside one package.
- Add a regression design that extends a `struct:pkg:path` type and verifies that both the shared package and the extending service package receive a compilable union definition.

## Why

`Extend` copies fields into the extending type. When a relocated type contained a `OneOf`, Goa saw the relocated union and the copied service-local union as structurally identical and emitted only one definition. The service payload still referenced its local union name, producing fields such as `Scope Scope` without a local `Scope` declaration.

The generated package is part of a union definition's identity: copied unions in different packages require separate definitions, while repeated uses in one package do not.

## Impact

Designs that extend a relocated type containing a nested union now generate compilable service packages. Existing designs whose unions are generated in only one package retain the same definitions and references.

## Validation

- `go test ./codegen/...`
- `make test`
- `make lint`
- Plain Goa reproduction with a relocated equipment-scope union
- goa-ai exported-tool reproduction using the same contract shape
- Downstream multi-service regeneration through a local Goa module replacement
