### PR TITLE
fix(codegen): preserve invalid optional unions

### DIFF
--- a/codegen/go_transform.go
+++ b/codegen/go_transform.go
@@ -365,12 +365,10 @@ func transformObject(source, target *expr.AttributeExpr, sourceVar, targetVar st
 			}
 			if code != "" && checkNil {
 				cond := fmt.Sprintf("if %s != nil {\n", srcVar)
-				if expr.IsUnion(srcc.Type) {
-					if ta.SourceCtx.IsFieldPointer(n, srcMatt.AttributeExpr) {
-						cond = fmt.Sprintf("if %s != nil && %s.Kind() != \"\" {\n", srcVar, srcVar)
-					} else {
-						cond = fmt.Sprintf("if %s.Kind() != \"\" {\n", srcVar)
-					}
+				// A pointer-backed union uses nil as its sole absence value. Preserve a
+				// non-nil zero union so validation rejects its missing discriminator.
+				if expr.IsUnion(srcc.Type) && !ta.SourceCtx.IsFieldPointer(n, srcMatt.AttributeExpr) {
+					cond = fmt.Sprintf("if %s.Kind() != \"\" {\n", srcVar)
 				}
 				code = fmt.Sprintf("%s\t%s}", cond, code)
 				if expr.IsArray(srcc.Type) && srcMatt.IsRequired(n) {

--- a/codegen/go_transform_test.go
+++ b/codegen/go_transform_test.go
@@ -215,7 +215,8 @@ func TestGoTransformOptionalUnionField(t *testing.T) {
 
 	code, _, err := GoTransform(attribute, attribute, "source", "target", ctx, ctx, "", true)
 	require.NoError(t, err)
-	require.Contains(t, code, `if source.Scope != nil && source.Scope.Kind() != "" {`)
+	require.Contains(t, code, `if source.Scope != nil {`)
+	require.NotContains(t, code, `source.Scope.Kind() != ""`)
 	require.Contains(t, code, "var scopeValue Scope")
 	require.Contains(t, code, "target.Scope = &scopeValue")
 }

--- a/codegen/service/testdata/golden/service_service-result-with-one-of-type.go.golden
+++ b/codegen/service/testdata/golden/service_service-result-with-one-of-type.go.golden
@@ -214,7 +214,7 @@ func NewViewedResultOneof(res *ResultOneof, view string) *resultwithoneoftypevie
 // ResultOneof.
 func newResultOneof(vres *resultwithoneoftypeviews.ResultOneofView) *ResultOneof {
 	res := &ResultOneof{}
-	if vres.Result != nil && vres.Result.Kind() != "" {
+	if vres.Result != nil {
 		var resultValue Result
 		switch string(vres.Result.Kind()) {
 		case "t":
@@ -239,7 +239,7 @@ func newResultOneof(vres *resultwithoneoftypeviews.ResultOneofView) *ResultOneof
 // ResultOneofView using the "default" view.
 func newResultOneofView(res *ResultOneof) *resultwithoneoftypeviews.ResultOneofView {
 	vres := &resultwithoneoftypeviews.ResultOneofView{}
-	if res.Result != nil && res.Result.Kind() != "" {
+	if res.Result != nil {
 		var resultValue resultwithoneoftypeviews.Result
 		switch string(res.Result.Kind()) {
 		case "t":

--- a/grpc/codegen/protobuf_transform_test.go
+++ b/grpc/codegen/protobuf_transform_test.go
@@ -159,7 +159,8 @@ func TestProtoBufTransform(t *testing.T) {
 			{"pkg-override-to-pkg-override", pkgOverride, pkgOverride, false, svcCtx},
 		},
 	}
-	for name, cases := range tc {
+	for _, name := range []string{"to-protobuf-type", "to-service-type"} {
+		cases := tc[name]
 		t.Run(name, func(t *testing.T) {
 			for _, c := range cases {
 				t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/testdata/golden/server_payload_types_body-union.go.golden
+++ b/http/codegen/testdata/golden/server_payload_types_body-union.go.golden
@@ -2,7 +2,7 @@
 // endpoint payload.
 func NewMethodBodyUnionUnion(body *MethodBodyUnionRequestBody) *servicebodyunion.Union {
 	v := &servicebodyunion.Union{}
-	if body.Values != nil && body.Values.Kind() != "" {
+	if body.Values != nil {
 		var valuesValue servicebodyunion.Values
 		switch string(body.Values.Kind()) {
 		case "String":


### PR DESCRIPTION
## What changed

- treat `nil` as the only omitted representation for pointer-backed union fields
- preserve non-nil unions with a missing discriminator so generated validation rejects them
- make the shared gRPC transform test order deterministic without changing its generated output

## Why

Optional union fields are pointers: `nil` means the field is absent, while a non-nil value must select a branch. The conversion generator also checked for a selected branch and silently dropped malformed non-nil values, creating a second implicit absence representation.

## Compatibility

Valid selected unions and omitted nil unions generate exactly the same code and wire values as before. A malformed non-nil union with no selected branch is no longer erased during conversion; it reaches the generated validator or marshaler and is rejected.

## Verification

- `make lint`
- `GOFLAGS=-count=1 make test`
- repeated the order-sensitive gRPC transform test three times