### PR TITLE
fix(dsl): honor TypeName in OneOf

### DIFF
--- a/dsl/oneof_test.go
+++ b/dsl/oneof_test.go
@@ -126,3 +126,41 @@ func TestOneOfCustomKeysSameKeyError(t *testing.T) {
 		t.Fatal("expected DSL error for same type and value keys, got none")
 	}
 }
+
+func TestOneOfTypeName(t *testing.T) {
+	eval.Context = &eval.DSLContext{}
+
+	ut := &expr.UserTypeExpr{
+		AttributeExpr: &expr.AttributeExpr{
+			Type: &expr.Object{},
+		},
+		TypeName: "TestType",
+	}
+
+	eval.Execute(func() {
+		OneOf("scope", func() {
+			TypeName("EquipmentScopeSelection")
+			Attribute("description", String)
+			Attribute("aliases", ArrayOf(String))
+		})
+	}, ut)
+
+	if eval.Context.Errors != nil {
+		t.Errorf("unexpected DSL errors: %v", eval.Context.Errors)
+	}
+	obj := ut.Attribute().Type.(*expr.Object)
+	scope := obj.Attribute("scope")
+	if scope == nil {
+		t.Fatal("scope attribute not found")
+	}
+	union, ok := scope.Type.(*expr.Union)
+	if !ok {
+		t.Fatalf("expected Union type, got %T", scope.Type)
+	}
+	if union.Name() != "EquipmentScopeSelection" {
+		t.Errorf("expected union name %q, got %q", "EquipmentScopeSelection", union.Name())
+	}
+	if obj.Attribute("EquipmentScopeSelection") != nil {
+		t.Error("TypeName changed the scope attribute name")
+	}
+}

--- a/dsl/result_type.go
+++ b/dsl/result_type.go
@@ -128,13 +128,19 @@ func ResultType(identifier string, args ...any) *expr.ResultTypeExpr {
 // This function makes it possible to override that and provide a custom name.
 // name must be a valid Go identifier.
 //
-// TypeName must appear in a Type or ResultType expression.
+// TypeName must appear in a Type, ResultType, or OneOf expression. In a OneOf
+// expression it changes the generated Go union name without changing the
+// attribute name used by transports.
 func TypeName(name string) {
 	switch e := eval.Current().(type) {
 	case expr.UserType:
 		e.Rename(name)
 	case *expr.AttributeExpr:
-		e.AddMeta("struct:type:name", name)
+		if union, ok := e.Type.(*expr.Union); ok {
+			union.TypeName = name
+		} else {
+			e.AddMeta("struct:type:name", name)
+		}
 	default:
 		eval.IncompatibleDSL()
 	}


### PR DESCRIPTION
## Summary

- make `TypeName` rename the union when used inside `OneOf`
- keep the enclosing attribute and transport field name unchanged
- preserve existing `TypeName` behavior for ordinary attributes and declared types

## Problem

`TypeName` accepted a `OneOf` expression but stored the requested name only as attribute metadata. References generated through attribute-aware paths used the custom name, while the public union definition still used the `OneOf` field name. The resulting generated code referenced a union type that was never declared.

## Contract

```go
OneOf("scope", func() {
    TypeName("EquipmentScopeSelection")
    Attribute("description", String)
    Attribute("aliases", ArrayOf(String))
})
```

The transport property remains `scope`; the generated Go union is `EquipmentScopeSelection`. Designs that do not call `TypeName` are unchanged.

## Verification

- `go test ./dsl ./codegen/service`
- `make test`
- `make lint`