### PR TITLE
fix(codegen): guard required pointer unions during validation

### DIFF
--- a/codegen/validation.go
+++ b/codegen/validation.go
@@ -273,7 +273,11 @@ func validateAttribute(ctx *AttributeContext, att *expr.AttributeExpr, put expr.
 		}
 		if expr.IsUnion(att.Type) {
 			_, sumType := ctx.Scope.(*AttributeScope)
-			if req || sumType && !ctx.IsUnionPointer(false) {
+			if sumType {
+				if !ctx.IsUnionPointer(req) {
+					return code
+				}
+			} else if req {
 				return code
 			}
 			cond := fmt.Sprintf("if %s != nil {\n", target)

--- a/codegen/validation_union_context_test.go
+++ b/codegen/validation_union_context_test.go
@@ -59,8 +59,16 @@ func TestUnionValidationUsesGeneratedFieldRepresentation(t *testing.T) {
 	transportCtx.UnionPointer = true
 	transportCode := ValidationCode(attribute, nil, transportCtx, true, false, false, "target")
 	require.Contains(t, transportCode, "if target.Required == nil {")
+	require.Contains(t, transportCode, "if target.Required != nil {")
 	require.Contains(t, transportCode, "if target.Optional != nil {")
 	require.NotContains(t, transportCode, `if target.Required.Kind() == "" {`)
+
+	marshalCtx := NewAttributeContext(false, false, true, "", scope)
+	marshalCtx.UnionPointer = true
+	marshalCode := ValidationCode(attribute, nil, marshalCtx, true, false, false, "target")
+	require.Contains(t, marshalCode, `if target.Required.Kind() == "" {`)
+	require.NotContains(t, marshalCode, "if target.Required != nil {")
+	require.Contains(t, marshalCode, "if target.Optional != nil {")
 }
 
 // requiredObjectUnionDSL defines a OneOf with required-only object branches so


### PR DESCRIPTION
## What changed

Generated validation now checks whether a sum-type union field is pointer-backed before validating its selected branch. When a required JSON transport field is absent, validation returns the existing missing-field error without dereferencing the nil field.

Value-backed service fields, marshal-side required fields, optional pointer fields, and interface-based union validation keep their existing behavior.

## Why

HTTP-style transport structs use pointers to distinguish an omitted required field from a present value. Required union validation reported the omission and then called `Kind` on the nil pointer. The validator must use the same field representation that the type generator selected.

## Verification

- `make test`
- `make lint`
- focused coverage for service values, pointer-backed decode fields, value-backed marshal fields, optional unions, and interface unions