### PR TITLE
fix(codegen): make SSE client streams satisfy the service stream interface

### DIFF
--- a/http/codegen/sse.go
+++ b/http/codegen/sse.go
@@ -28,10 +28,6 @@ type (
 		SendWithContextName string
 		// SendWithContextDesc is the description for the send function with context.
 		SendWithContextDesc string
-		// RecvName is the name of the client method to connect to the SSE endpoint.
-		RecvName string
-		// RecvDesc is the description for the client method.
-		RecvDesc string
 		// EventTypeRef is the fully qualified type ref for the event type.
 		EventTypeRef string
 		// EventTypeName is the name of the event type without package qualifier.
@@ -90,7 +86,6 @@ func initSSEData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData) {
 
 	sendDesc := fmt.Sprintf("%s streams instances of %q to the %q endpoint SSE connection.", md.ServerStream.SendName, eventType.Name, md.Name)
 	sendWithContextDesc := fmt.Sprintf("%s streams instances of %q to the %q endpoint SSE connection with context.", md.ServerStream.SendWithContextName, eventType.Name, md.Name)
-	recvDesc := fmt.Sprintf("%s connects to the %q SSE endpoint and streams events.", md.ServerStream.RecvName, md.Name)
 
 	// Convert attribute names to Go field names
 	var dataFieldVar, dataFieldTypeRef, idFieldVar, eventFieldVar, retryFieldVar string
@@ -123,8 +118,6 @@ func initSSEData(ed *EndpointData, e *expr.HTTPEndpointExpr, sd *ServiceData) {
 		SendDesc:            sendDesc,
 		SendWithContextName: md.ServerStream.SendWithContextName,
 		SendWithContextDesc: sendWithContextDesc,
-		RecvName:            md.ClientStream.RecvName,
-		RecvDesc:            recvDesc,
 		EventTypeRef:        eventType.Ref,
 		EventTypeName:       eventType.Name,
 		EventIsStruct:       eventType.IsStruct,

--- a/http/codegen/sse_client_test.go
+++ b/http/codegen/sse_client_test.go
@@ -1,0 +1,43 @@
+package codegen
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"goa.design/goa/v3/codegen"
+	"goa.design/goa/v3/codegen/testutil"
+	"goa.design/goa/v3/expr"
+	"goa.design/goa/v3/http/codegen/testdata"
+)
+
+func TestSSEClient(t *testing.T) {
+	cases := []struct {
+		Name string
+		DSL  func()
+	}{
+		{"string", testdata.SSEStringDSL},
+		{"int", testdata.SSEIntDSL},
+		{"bool", testdata.SSEBoolDSL},
+		{"object", testdata.SSEObjectDSL},
+		{"data-field", testdata.SSEDataFieldDSL},
+		{"data-id-field", testdata.SSEDataIDFieldDSL},
+		{"request-id", testdata.SSERequestIDDSL},
+		{"all-fields", testdata.SSEAllFieldsDSL},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			root := expr.RunDSL(t, c.DSL)
+			services := CreateHTTPServices(root)
+			fs := ClientFiles("", services)
+			require.Len(t, fs, 3)
+			sections := fs[1].SectionTemplates
+			require.Greater(t, len(sections), 1)
+			code := codegen.SectionCode(t, sections[1])
+			golden := filepath.Join("testdata", "golden", "sse-client-"+c.Name+".golden")
+			testutil.CompareOrUpdateGolden(t, code, golden)
+		})
+	}
+}

--- a/http/codegen/templates/client_endpoint_init.go.tpl
+++ b/http/codegen/templates/client_endpoint_init.go.tpl
@@ -4,9 +4,7 @@ func (c *{{ .ClientStruct }}) {{ .EndpointInit }}({{ if .MultipartRequestEncoder
 		{{- if .RequestEncoder }}
 		encodeRequest  = {{ .RequestEncoder }}({{ if .MultipartRequestEncoder }}{{ .MultipartRequestEncoder.InitName }}({{ .MultipartRequestEncoder.VarName }}){{ else }}c.encoder{{ end }})
 		{{- end }}
-		{{- if not (isSSEEndpoint .) }}
 		decodeResponse = {{ .ResponseDecoder }}(c.decoder, c.RestoreResponseBody)
-		{{- end }}
 	)
 	return func(ctx context.Context, v any) (any, error) {
 		req, err := c.{{ .RequestInit.Name }}(ctx, {{ range .RequestInit.ClientArgs }}{{ .Ref }}, {{ end }})
@@ -68,8 +66,8 @@ func (c *{{ .ClientStruct }}) {{ .EndpointInit }}({{ if .MultipartRequestEncoder
 		}
 		
 		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
-			return nil, fmt.Errorf("unexpected status from SSE endpoint: %d", resp.StatusCode)
+			// Decode designed errors (the decoder closes the response body).
+			return decodeResponse(resp)
 		}
 		
 		contentType := resp.Header.Get("Content-Type")

--- a/http/codegen/templates/client_sse.go.tpl
+++ b/http/codegen/templates/client_sse.go.tpl
@@ -1,7 +1,9 @@
 // {{ .Method.VarName }}ClientStream is the interface for reading Server-Sent Events.
 type {{ .Method.VarName }}ClientStream interface {
-    // Recv reads and returns the next event from the SSE stream.
-    Recv(context.Context) ({{ .SSE.EventTypeRef }}, error)
+    // {{ .Method.ClientStream.RecvName }} reads and returns the next event from the SSE stream.
+    {{ .Method.ClientStream.RecvName }}() ({{ .SSE.EventTypeRef }}, error)
+    // {{ .Method.ClientStream.RecvWithContextName }} reads and returns the next event from the SSE stream with context.
+    {{ .Method.ClientStream.RecvWithContextName }}(context.Context) ({{ .SSE.EventTypeRef }}, error)
     // Close closes the SSE stream and releases resources.
     Close() error
 }
@@ -20,6 +22,10 @@ type (
 // {{ .Method.VarName }}StreamImpl implements the {{ .Method.VarName }}ClientStream interface.
 var _ {{ .Method.VarName }}ClientStream = (*{{ .Method.VarName }}StreamImpl)(nil)
 
+// {{ .Method.VarName }}StreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ {{ .ServicePkgName }}.{{ .Method.ClientStream.Interface }} = (*{{ .Method.VarName }}StreamImpl)(nil)
+
 // New{{ .Method.VarName }}Stream creates a new {{ .Method.VarName }}ClientStream.
 func New{{ .Method.VarName }}Stream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) {{ .Method.VarName }}ClientStream {
         return &{{ .Method.VarName }}StreamImpl{
@@ -29,8 +35,13 @@ func New{{ .Method.VarName }}Stream(resp *http.Response, decoder func(*http.Resp
         }
 }
 
-// Recv reads and returns the next event from the SSE stream, respecting context cancellation.
-func (s *{{ .Method.VarName }}StreamImpl) Recv(ctx context.Context) (event {{ .SSE.EventTypeRef }}, err error) {
+// {{ .Method.ClientStream.RecvName }} reads and returns the next event from the SSE stream.
+func (s *{{ .Method.VarName }}StreamImpl) {{ .Method.ClientStream.RecvName }}() ({{ .SSE.EventTypeRef }}, error) {
+        return s.{{ .Method.ClientStream.RecvWithContextName }}(context.Background())
+}
+
+// {{ .Method.ClientStream.RecvWithContextName }} reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *{{ .Method.VarName }}StreamImpl) {{ .Method.ClientStream.RecvWithContextName }}(ctx context.Context) (event {{ .SSE.EventTypeRef }}, err error) {
         var byts []byte
         byts, err = s.readEvent(ctx)
         if err != nil {

--- a/http/codegen/testdata/golden/sse-client-all-fields.golden
+++ b/http/codegen/testdata/golden/sse-client-all-fields.golden
@@ -1,0 +1,247 @@
+// SSEAllFieldsMethodClientStream is the interface for reading Server-Sent Events.
+type SSEAllFieldsMethodClientStream interface {
+	// Recv reads and returns the next event from the SSE stream.
+	Recv() (*sseallfieldsservice.SSEAllFieldsMethodResult, error)
+	// RecvWithContext reads and returns the next event from the SSE stream with context.
+	RecvWithContext(context.Context) (*sseallfieldsservice.SSEAllFieldsMethodResult, error)
+	// Close closes the SSE stream and releases resources.
+	Close() error
+}
+
+type (
+	// SSEAllFieldsMethodStreamImpl implements the SSEAllFieldsMethodClientStream interface.
+	SSEAllFieldsMethodStreamImpl struct {
+		resp    *http.Response
+		decoder func(*http.Response) goahttp.Decoder
+		buffer  []byte // Buffer for unprocessed data
+		lock    sync.Mutex
+		closed  bool
+	}
+)
+
+// SSEAllFieldsMethodStreamImpl implements the SSEAllFieldsMethodClientStream interface.
+var _ SSEAllFieldsMethodClientStream = (*SSEAllFieldsMethodStreamImpl)(nil)
+
+// SSEAllFieldsMethodStreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ sseallfieldsservice.SSEAllFieldsMethodClientStream = (*SSEAllFieldsMethodStreamImpl)(nil)
+
+// NewSSEAllFieldsMethodStream creates a new SSEAllFieldsMethodClientStream.
+func NewSSEAllFieldsMethodStream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) SSEAllFieldsMethodClientStream {
+	return &SSEAllFieldsMethodStreamImpl{
+		resp:    resp,
+		decoder: decoder,
+		buffer:  make([]byte, 0, 4096), // Pre-allocate buffer
+	}
+}
+
+// Recv reads and returns the next event from the SSE stream.
+func (s *SSEAllFieldsMethodStreamImpl) Recv() (*sseallfieldsservice.SSEAllFieldsMethodResult, error) {
+	return s.RecvWithContext(context.Background())
+}
+
+// RecvWithContext reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *SSEAllFieldsMethodStreamImpl) RecvWithContext(ctx context.Context) (event *sseallfieldsservice.SSEAllFieldsMethodResult, err error) {
+	var byts []byte
+	byts, err = s.readEvent(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Clean up on EOF or context cancellation
+			s.Close()
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
+		return
+	}
+	return s.processEvent(byts)
+}
+
+// readEvent reads a single SSE event from the stream, respecting context
+// cancellation.  It first checks the internal buffer for a complete event
+// (delimited by double newlines). If no complete event is found, it reads from
+// the HTTP response body until it either finds an event boundary, reaches EOF,
+// or encounters an error. Any data after the event boundary is saved in the
+// buffer for the next call.
+func (s *SSEAllFieldsMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) {
+	const bufSize = 4096 // 4KB buffer size
+
+	// Check for event in existing buffer
+	event, ok := s.checkBuffer()
+	if ok {
+		return event, nil
+	}
+
+	// Initialize with any data from buffer
+	eventData := event
+	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
+	buf := make([]byte, bufSize)
+
+	// Read data in chunks until we find an event or hit EOF
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
+
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+
+		// Read next chunk
+		n, err := s.resp.Body.Read(buf)
+		s.lock.Unlock()
+
+		// Handle read errors
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Process data if we got any
+		if n > 0 {
+			// Look for event boundary in this chunk
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				eventData = append(eventData, b)
+
+				// Check for double newlines (event boundary)
+				if b == '\n' && wasNewline {
+					// Save any remaining data for next read
+					if i+1 < n {
+						s.lock.Lock()
+						s.buffer = append(s.buffer[:0], buf[i+1:n]...)
+						s.lock.Unlock()
+					}
+					return eventData, nil
+				}
+
+				// Update newline tracking
+				wasNewline = (b == '\n')
+			}
+		}
+
+		// Return partial data at EOF
+		if errors.Is(err, io.EOF) {
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+	}
+}
+
+// checkBuffer examines the internal buffer for a complete SSE event (delimited
+// by double newlines).  It returns two values: the event data (or all buffer
+// contents if no complete event is found), and a boolean indicating whether a
+// complete event was found. If a complete event is found, any remaining data
+// after the event is kept in the buffer for the next call.
+func (s *SSEAllFieldsMethodStreamImpl) checkBuffer() ([]byte, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Quick return if buffer is empty
+	if len(s.buffer) == 0 {
+		return nil, false
+	}
+
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event
+			eventEnd := i + 2 // Include both newlines
+			eventData := s.buffer[:eventEnd]
+
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
+
+			return eventData, true
+		}
+	}
+
+	// No complete event found, return buffer contents
+	eventData := s.buffer
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
+}
+
+// Close closes the SSE stream and releases any associated resources.
+func (s *SSEAllFieldsMethodStreamImpl) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// processEvent processes a raw SSE event into the expected type
+func (s *SSEAllFieldsMethodStreamImpl) processEvent(eventData []byte) (event *sseallfieldsservice.SSEAllFieldsMethodResult, err error) {
+	event = new(sseallfieldsservice.SSEAllFieldsMethodResult)
+	var dataLines []string
+	for _, line := range bytes.Split(eventData, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			dataLines = append(dataLines, s.trimHeader(len("data:"), line))
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("id:")) {
+			event.ID = s.trimHeader(len("id:"), line)
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("event:")) {
+			event.Event = s.trimHeader(len("event:"), line)
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("retry:")) {
+			// Note: retry value parsing depends on the field type; client currently expects integer-like types.
+			// We deliberately leave conversion to a future enhancement that includes the field type reference.
+			// For now this branch is kept for completeness; services using RetryField should be handled server-side.
+			continue
+		}
+	}
+	if len(dataLines) > 0 {
+		dataContent := strings.Join(dataLines, "\n")
+
+		// Use user-provided decoder for complex types
+		respBody := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(dataContent))),
+		}
+		err = s.decoder(respBody).Decode(&event.Data)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// trimHeader removes the header prefix and optional leading space
+func (s *SSEAllFieldsMethodStreamImpl) trimHeader(size int, data []byte) string {
+	if len(data) < size {
+		return string(data)
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	return string(data)
+}

--- a/http/codegen/testdata/golden/sse-client-bool.golden
+++ b/http/codegen/testdata/golden/sse-client-bool.golden
@@ -1,0 +1,232 @@
+// SSEBoolMethodClientStream is the interface for reading Server-Sent Events.
+type SSEBoolMethodClientStream interface {
+	// Recv reads and returns the next event from the SSE stream.
+	Recv() (bool, error)
+	// RecvWithContext reads and returns the next event from the SSE stream with context.
+	RecvWithContext(context.Context) (bool, error)
+	// Close closes the SSE stream and releases resources.
+	Close() error
+}
+
+type (
+	// SSEBoolMethodStreamImpl implements the SSEBoolMethodClientStream interface.
+	SSEBoolMethodStreamImpl struct {
+		resp    *http.Response
+		decoder func(*http.Response) goahttp.Decoder
+		buffer  []byte // Buffer for unprocessed data
+		lock    sync.Mutex
+		closed  bool
+	}
+)
+
+// SSEBoolMethodStreamImpl implements the SSEBoolMethodClientStream interface.
+var _ SSEBoolMethodClientStream = (*SSEBoolMethodStreamImpl)(nil)
+
+// SSEBoolMethodStreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ sseboolservice.SSEBoolMethodClientStream = (*SSEBoolMethodStreamImpl)(nil)
+
+// NewSSEBoolMethodStream creates a new SSEBoolMethodClientStream.
+func NewSSEBoolMethodStream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) SSEBoolMethodClientStream {
+	return &SSEBoolMethodStreamImpl{
+		resp:    resp,
+		decoder: decoder,
+		buffer:  make([]byte, 0, 4096), // Pre-allocate buffer
+	}
+}
+
+// Recv reads and returns the next event from the SSE stream.
+func (s *SSEBoolMethodStreamImpl) Recv() (bool, error) {
+	return s.RecvWithContext(context.Background())
+}
+
+// RecvWithContext reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *SSEBoolMethodStreamImpl) RecvWithContext(ctx context.Context) (event bool, err error) {
+	var byts []byte
+	byts, err = s.readEvent(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Clean up on EOF or context cancellation
+			s.Close()
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
+		return
+	}
+	return s.processEvent(byts)
+}
+
+// readEvent reads a single SSE event from the stream, respecting context
+// cancellation.  It first checks the internal buffer for a complete event
+// (delimited by double newlines). If no complete event is found, it reads from
+// the HTTP response body until it either finds an event boundary, reaches EOF,
+// or encounters an error. Any data after the event boundary is saved in the
+// buffer for the next call.
+func (s *SSEBoolMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) {
+	const bufSize = 4096 // 4KB buffer size
+
+	// Check for event in existing buffer
+	event, ok := s.checkBuffer()
+	if ok {
+		return event, nil
+	}
+
+	// Initialize with any data from buffer
+	eventData := event
+	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
+	buf := make([]byte, bufSize)
+
+	// Read data in chunks until we find an event or hit EOF
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
+
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+
+		// Read next chunk
+		n, err := s.resp.Body.Read(buf)
+		s.lock.Unlock()
+
+		// Handle read errors
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Process data if we got any
+		if n > 0 {
+			// Look for event boundary in this chunk
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				eventData = append(eventData, b)
+
+				// Check for double newlines (event boundary)
+				if b == '\n' && wasNewline {
+					// Save any remaining data for next read
+					if i+1 < n {
+						s.lock.Lock()
+						s.buffer = append(s.buffer[:0], buf[i+1:n]...)
+						s.lock.Unlock()
+					}
+					return eventData, nil
+				}
+
+				// Update newline tracking
+				wasNewline = (b == '\n')
+			}
+		}
+
+		// Return partial data at EOF
+		if errors.Is(err, io.EOF) {
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+	}
+}
+
+// checkBuffer examines the internal buffer for a complete SSE event (delimited
+// by double newlines).  It returns two values: the event data (or all buffer
+// contents if no complete event is found), and a boolean indicating whether a
+// complete event was found. If a complete event is found, any remaining data
+// after the event is kept in the buffer for the next call.
+func (s *SSEBoolMethodStreamImpl) checkBuffer() ([]byte, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Quick return if buffer is empty
+	if len(s.buffer) == 0 {
+		return nil, false
+	}
+
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event
+			eventEnd := i + 2 // Include both newlines
+			eventData := s.buffer[:eventEnd]
+
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
+
+			return eventData, true
+		}
+	}
+
+	// No complete event found, return buffer contents
+	eventData := s.buffer
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
+}
+
+// Close closes the SSE stream and releases any associated resources.
+func (s *SSEBoolMethodStreamImpl) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// processEvent processes a raw SSE event into the expected type
+func (s *SSEBoolMethodStreamImpl) processEvent(eventData []byte) (event bool, err error) {
+	var dataLines []string
+	for _, line := range bytes.Split(eventData, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			dataLines = append(dataLines, s.trimHeader(len("data:"), line))
+			continue
+		}
+	}
+	if len(dataLines) > 0 {
+		dataContent := strings.Join(dataLines, "\n")
+
+		// Use user-provided decoder for complex types
+		respBody := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(dataContent))),
+		}
+		err = s.decoder(respBody).Decode(&event)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// trimHeader removes the header prefix and optional leading space
+func (s *SSEBoolMethodStreamImpl) trimHeader(size int, data []byte) string {
+	if len(data) < size {
+		return string(data)
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	return string(data)
+}

--- a/http/codegen/testdata/golden/sse-client-data-field.golden
+++ b/http/codegen/testdata/golden/sse-client-data-field.golden
@@ -1,0 +1,225 @@
+// SSEDataFieldMethodClientStream is the interface for reading Server-Sent Events.
+type SSEDataFieldMethodClientStream interface {
+	// Recv reads and returns the next event from the SSE stream.
+	Recv() (*ssedatafieldservice.SSEDataFieldMethodResult, error)
+	// RecvWithContext reads and returns the next event from the SSE stream with context.
+	RecvWithContext(context.Context) (*ssedatafieldservice.SSEDataFieldMethodResult, error)
+	// Close closes the SSE stream and releases resources.
+	Close() error
+}
+
+type (
+	// SSEDataFieldMethodStreamImpl implements the SSEDataFieldMethodClientStream interface.
+	SSEDataFieldMethodStreamImpl struct {
+		resp    *http.Response
+		decoder func(*http.Response) goahttp.Decoder
+		buffer  []byte // Buffer for unprocessed data
+		lock    sync.Mutex
+		closed  bool
+	}
+)
+
+// SSEDataFieldMethodStreamImpl implements the SSEDataFieldMethodClientStream interface.
+var _ SSEDataFieldMethodClientStream = (*SSEDataFieldMethodStreamImpl)(nil)
+
+// SSEDataFieldMethodStreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ ssedatafieldservice.SSEDataFieldMethodClientStream = (*SSEDataFieldMethodStreamImpl)(nil)
+
+// NewSSEDataFieldMethodStream creates a new SSEDataFieldMethodClientStream.
+func NewSSEDataFieldMethodStream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) SSEDataFieldMethodClientStream {
+	return &SSEDataFieldMethodStreamImpl{
+		resp:    resp,
+		decoder: decoder,
+		buffer:  make([]byte, 0, 4096), // Pre-allocate buffer
+	}
+}
+
+// Recv reads and returns the next event from the SSE stream.
+func (s *SSEDataFieldMethodStreamImpl) Recv() (*ssedatafieldservice.SSEDataFieldMethodResult, error) {
+	return s.RecvWithContext(context.Background())
+}
+
+// RecvWithContext reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *SSEDataFieldMethodStreamImpl) RecvWithContext(ctx context.Context) (event *ssedatafieldservice.SSEDataFieldMethodResult, err error) {
+	var byts []byte
+	byts, err = s.readEvent(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Clean up on EOF or context cancellation
+			s.Close()
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
+		return
+	}
+	return s.processEvent(byts)
+}
+
+// readEvent reads a single SSE event from the stream, respecting context
+// cancellation.  It first checks the internal buffer for a complete event
+// (delimited by double newlines). If no complete event is found, it reads from
+// the HTTP response body until it either finds an event boundary, reaches EOF,
+// or encounters an error. Any data after the event boundary is saved in the
+// buffer for the next call.
+func (s *SSEDataFieldMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) {
+	const bufSize = 4096 // 4KB buffer size
+
+	// Check for event in existing buffer
+	event, ok := s.checkBuffer()
+	if ok {
+		return event, nil
+	}
+
+	// Initialize with any data from buffer
+	eventData := event
+	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
+	buf := make([]byte, bufSize)
+
+	// Read data in chunks until we find an event or hit EOF
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
+
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+
+		// Read next chunk
+		n, err := s.resp.Body.Read(buf)
+		s.lock.Unlock()
+
+		// Handle read errors
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Process data if we got any
+		if n > 0 {
+			// Look for event boundary in this chunk
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				eventData = append(eventData, b)
+
+				// Check for double newlines (event boundary)
+				if b == '\n' && wasNewline {
+					// Save any remaining data for next read
+					if i+1 < n {
+						s.lock.Lock()
+						s.buffer = append(s.buffer[:0], buf[i+1:n]...)
+						s.lock.Unlock()
+					}
+					return eventData, nil
+				}
+
+				// Update newline tracking
+				wasNewline = (b == '\n')
+			}
+		}
+
+		// Return partial data at EOF
+		if errors.Is(err, io.EOF) {
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+	}
+}
+
+// checkBuffer examines the internal buffer for a complete SSE event (delimited
+// by double newlines).  It returns two values: the event data (or all buffer
+// contents if no complete event is found), and a boolean indicating whether a
+// complete event was found. If a complete event is found, any remaining data
+// after the event is kept in the buffer for the next call.
+func (s *SSEDataFieldMethodStreamImpl) checkBuffer() ([]byte, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Quick return if buffer is empty
+	if len(s.buffer) == 0 {
+		return nil, false
+	}
+
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event
+			eventEnd := i + 2 // Include both newlines
+			eventData := s.buffer[:eventEnd]
+
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
+
+			return eventData, true
+		}
+	}
+
+	// No complete event found, return buffer contents
+	eventData := s.buffer
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
+}
+
+// Close closes the SSE stream and releases any associated resources.
+func (s *SSEDataFieldMethodStreamImpl) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// processEvent processes a raw SSE event into the expected type
+func (s *SSEDataFieldMethodStreamImpl) processEvent(eventData []byte) (event *ssedatafieldservice.SSEDataFieldMethodResult, err error) {
+	event = new(ssedatafieldservice.SSEDataFieldMethodResult)
+	var dataLines []string
+	for _, line := range bytes.Split(eventData, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			dataLines = append(dataLines, s.trimHeader(len("data:"), line))
+			continue
+		}
+	}
+	if len(dataLines) > 0 {
+		dataContent := strings.Join(dataLines, "\n")
+
+		event.Data = dataContent
+	}
+	return
+}
+
+// trimHeader removes the header prefix and optional leading space
+func (s *SSEDataFieldMethodStreamImpl) trimHeader(size int, data []byte) string {
+	if len(data) < size {
+		return string(data)
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	return string(data)
+}

--- a/http/codegen/testdata/golden/sse-client-data-id-field.golden
+++ b/http/codegen/testdata/golden/sse-client-data-id-field.golden
@@ -1,0 +1,229 @@
+// SSEDataIDFieldMethodClientStream is the interface for reading Server-Sent Events.
+type SSEDataIDFieldMethodClientStream interface {
+	// Recv reads and returns the next event from the SSE stream.
+	Recv() (*ssedataidfieldservice.SSEDataIDFieldMethodResult, error)
+	// RecvWithContext reads and returns the next event from the SSE stream with context.
+	RecvWithContext(context.Context) (*ssedataidfieldservice.SSEDataIDFieldMethodResult, error)
+	// Close closes the SSE stream and releases resources.
+	Close() error
+}
+
+type (
+	// SSEDataIDFieldMethodStreamImpl implements the SSEDataIDFieldMethodClientStream interface.
+	SSEDataIDFieldMethodStreamImpl struct {
+		resp    *http.Response
+		decoder func(*http.Response) goahttp.Decoder
+		buffer  []byte // Buffer for unprocessed data
+		lock    sync.Mutex
+		closed  bool
+	}
+)
+
+// SSEDataIDFieldMethodStreamImpl implements the SSEDataIDFieldMethodClientStream interface.
+var _ SSEDataIDFieldMethodClientStream = (*SSEDataIDFieldMethodStreamImpl)(nil)
+
+// SSEDataIDFieldMethodStreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ ssedataidfieldservice.SSEDataIDFieldMethodClientStream = (*SSEDataIDFieldMethodStreamImpl)(nil)
+
+// NewSSEDataIDFieldMethodStream creates a new SSEDataIDFieldMethodClientStream.
+func NewSSEDataIDFieldMethodStream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) SSEDataIDFieldMethodClientStream {
+	return &SSEDataIDFieldMethodStreamImpl{
+		resp:    resp,
+		decoder: decoder,
+		buffer:  make([]byte, 0, 4096), // Pre-allocate buffer
+	}
+}
+
+// Recv reads and returns the next event from the SSE stream.
+func (s *SSEDataIDFieldMethodStreamImpl) Recv() (*ssedataidfieldservice.SSEDataIDFieldMethodResult, error) {
+	return s.RecvWithContext(context.Background())
+}
+
+// RecvWithContext reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *SSEDataIDFieldMethodStreamImpl) RecvWithContext(ctx context.Context) (event *ssedataidfieldservice.SSEDataIDFieldMethodResult, err error) {
+	var byts []byte
+	byts, err = s.readEvent(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Clean up on EOF or context cancellation
+			s.Close()
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
+		return
+	}
+	return s.processEvent(byts)
+}
+
+// readEvent reads a single SSE event from the stream, respecting context
+// cancellation.  It first checks the internal buffer for a complete event
+// (delimited by double newlines). If no complete event is found, it reads from
+// the HTTP response body until it either finds an event boundary, reaches EOF,
+// or encounters an error. Any data after the event boundary is saved in the
+// buffer for the next call.
+func (s *SSEDataIDFieldMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) {
+	const bufSize = 4096 // 4KB buffer size
+
+	// Check for event in existing buffer
+	event, ok := s.checkBuffer()
+	if ok {
+		return event, nil
+	}
+
+	// Initialize with any data from buffer
+	eventData := event
+	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
+	buf := make([]byte, bufSize)
+
+	// Read data in chunks until we find an event or hit EOF
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
+
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+
+		// Read next chunk
+		n, err := s.resp.Body.Read(buf)
+		s.lock.Unlock()
+
+		// Handle read errors
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Process data if we got any
+		if n > 0 {
+			// Look for event boundary in this chunk
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				eventData = append(eventData, b)
+
+				// Check for double newlines (event boundary)
+				if b == '\n' && wasNewline {
+					// Save any remaining data for next read
+					if i+1 < n {
+						s.lock.Lock()
+						s.buffer = append(s.buffer[:0], buf[i+1:n]...)
+						s.lock.Unlock()
+					}
+					return eventData, nil
+				}
+
+				// Update newline tracking
+				wasNewline = (b == '\n')
+			}
+		}
+
+		// Return partial data at EOF
+		if errors.Is(err, io.EOF) {
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+	}
+}
+
+// checkBuffer examines the internal buffer for a complete SSE event (delimited
+// by double newlines).  It returns two values: the event data (or all buffer
+// contents if no complete event is found), and a boolean indicating whether a
+// complete event was found. If a complete event is found, any remaining data
+// after the event is kept in the buffer for the next call.
+func (s *SSEDataIDFieldMethodStreamImpl) checkBuffer() ([]byte, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Quick return if buffer is empty
+	if len(s.buffer) == 0 {
+		return nil, false
+	}
+
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event
+			eventEnd := i + 2 // Include both newlines
+			eventData := s.buffer[:eventEnd]
+
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
+
+			return eventData, true
+		}
+	}
+
+	// No complete event found, return buffer contents
+	eventData := s.buffer
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
+}
+
+// Close closes the SSE stream and releases any associated resources.
+func (s *SSEDataIDFieldMethodStreamImpl) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// processEvent processes a raw SSE event into the expected type
+func (s *SSEDataIDFieldMethodStreamImpl) processEvent(eventData []byte) (event *ssedataidfieldservice.SSEDataIDFieldMethodResult, err error) {
+	event = new(ssedataidfieldservice.SSEDataIDFieldMethodResult)
+	var dataLines []string
+	for _, line := range bytes.Split(eventData, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			dataLines = append(dataLines, s.trimHeader(len("data:"), line))
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("id:")) {
+			event.ID = s.trimHeader(len("id:"), line)
+			continue
+		}
+	}
+	if len(dataLines) > 0 {
+		dataContent := strings.Join(dataLines, "\n")
+
+		event.Data = dataContent
+	}
+	return
+}
+
+// trimHeader removes the header prefix and optional leading space
+func (s *SSEDataIDFieldMethodStreamImpl) trimHeader(size int, data []byte) string {
+	if len(data) < size {
+		return string(data)
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	return string(data)
+}

--- a/http/codegen/testdata/golden/sse-client-int.golden
+++ b/http/codegen/testdata/golden/sse-client-int.golden
@@ -1,0 +1,229 @@
+// SSEIntMethodClientStream is the interface for reading Server-Sent Events.
+type SSEIntMethodClientStream interface {
+	// Recv reads and returns the next event from the SSE stream.
+	Recv() (int, error)
+	// RecvWithContext reads and returns the next event from the SSE stream with context.
+	RecvWithContext(context.Context) (int, error)
+	// Close closes the SSE stream and releases resources.
+	Close() error
+}
+
+type (
+	// SSEIntMethodStreamImpl implements the SSEIntMethodClientStream interface.
+	SSEIntMethodStreamImpl struct {
+		resp    *http.Response
+		decoder func(*http.Response) goahttp.Decoder
+		buffer  []byte // Buffer for unprocessed data
+		lock    sync.Mutex
+		closed  bool
+	}
+)
+
+// SSEIntMethodStreamImpl implements the SSEIntMethodClientStream interface.
+var _ SSEIntMethodClientStream = (*SSEIntMethodStreamImpl)(nil)
+
+// SSEIntMethodStreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ sseintservice.SSEIntMethodClientStream = (*SSEIntMethodStreamImpl)(nil)
+
+// NewSSEIntMethodStream creates a new SSEIntMethodClientStream.
+func NewSSEIntMethodStream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) SSEIntMethodClientStream {
+	return &SSEIntMethodStreamImpl{
+		resp:    resp,
+		decoder: decoder,
+		buffer:  make([]byte, 0, 4096), // Pre-allocate buffer
+	}
+}
+
+// Recv reads and returns the next event from the SSE stream.
+func (s *SSEIntMethodStreamImpl) Recv() (int, error) {
+	return s.RecvWithContext(context.Background())
+}
+
+// RecvWithContext reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *SSEIntMethodStreamImpl) RecvWithContext(ctx context.Context) (event int, err error) {
+	var byts []byte
+	byts, err = s.readEvent(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Clean up on EOF or context cancellation
+			s.Close()
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
+		return
+	}
+	return s.processEvent(byts)
+}
+
+// readEvent reads a single SSE event from the stream, respecting context
+// cancellation.  It first checks the internal buffer for a complete event
+// (delimited by double newlines). If no complete event is found, it reads from
+// the HTTP response body until it either finds an event boundary, reaches EOF,
+// or encounters an error. Any data after the event boundary is saved in the
+// buffer for the next call.
+func (s *SSEIntMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) {
+	const bufSize = 4096 // 4KB buffer size
+
+	// Check for event in existing buffer
+	event, ok := s.checkBuffer()
+	if ok {
+		return event, nil
+	}
+
+	// Initialize with any data from buffer
+	eventData := event
+	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
+	buf := make([]byte, bufSize)
+
+	// Read data in chunks until we find an event or hit EOF
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
+
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+
+		// Read next chunk
+		n, err := s.resp.Body.Read(buf)
+		s.lock.Unlock()
+
+		// Handle read errors
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Process data if we got any
+		if n > 0 {
+			// Look for event boundary in this chunk
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				eventData = append(eventData, b)
+
+				// Check for double newlines (event boundary)
+				if b == '\n' && wasNewline {
+					// Save any remaining data for next read
+					if i+1 < n {
+						s.lock.Lock()
+						s.buffer = append(s.buffer[:0], buf[i+1:n]...)
+						s.lock.Unlock()
+					}
+					return eventData, nil
+				}
+
+				// Update newline tracking
+				wasNewline = (b == '\n')
+			}
+		}
+
+		// Return partial data at EOF
+		if errors.Is(err, io.EOF) {
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+	}
+}
+
+// checkBuffer examines the internal buffer for a complete SSE event (delimited
+// by double newlines).  It returns two values: the event data (or all buffer
+// contents if no complete event is found), and a boolean indicating whether a
+// complete event was found. If a complete event is found, any remaining data
+// after the event is kept in the buffer for the next call.
+func (s *SSEIntMethodStreamImpl) checkBuffer() ([]byte, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Quick return if buffer is empty
+	if len(s.buffer) == 0 {
+		return nil, false
+	}
+
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event
+			eventEnd := i + 2 // Include both newlines
+			eventData := s.buffer[:eventEnd]
+
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
+
+			return eventData, true
+		}
+	}
+
+	// No complete event found, return buffer contents
+	eventData := s.buffer
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
+}
+
+// Close closes the SSE stream and releases any associated resources.
+func (s *SSEIntMethodStreamImpl) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// processEvent processes a raw SSE event into the expected type
+func (s *SSEIntMethodStreamImpl) processEvent(eventData []byte) (event int, err error) {
+	var dataLines []string
+	for _, line := range bytes.Split(eventData, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			dataLines = append(dataLines, s.trimHeader(len("data:"), line))
+			continue
+		}
+	}
+	if len(dataLines) > 0 {
+		dataContent := strings.Join(dataLines, "\n")
+
+		var val int64
+		val, err = strconv.ParseInt(dataContent, 10, 0)
+		if err != nil {
+			return
+		}
+		event = int(val)
+	}
+	return
+}
+
+// trimHeader removes the header prefix and optional leading space
+func (s *SSEIntMethodStreamImpl) trimHeader(size int, data []byte) string {
+	if len(data) < size {
+		return string(data)
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	return string(data)
+}

--- a/http/codegen/testdata/golden/sse-client-object.golden
+++ b/http/codegen/testdata/golden/sse-client-object.golden
@@ -1,0 +1,232 @@
+// SSEObjectMethodClientStream is the interface for reading Server-Sent Events.
+type SSEObjectMethodClientStream interface {
+	// Recv reads and returns the next event from the SSE stream.
+	Recv() (*sseobjectservice.SSEObjectMethodResult, error)
+	// RecvWithContext reads and returns the next event from the SSE stream with context.
+	RecvWithContext(context.Context) (*sseobjectservice.SSEObjectMethodResult, error)
+	// Close closes the SSE stream and releases resources.
+	Close() error
+}
+
+type (
+	// SSEObjectMethodStreamImpl implements the SSEObjectMethodClientStream interface.
+	SSEObjectMethodStreamImpl struct {
+		resp    *http.Response
+		decoder func(*http.Response) goahttp.Decoder
+		buffer  []byte // Buffer for unprocessed data
+		lock    sync.Mutex
+		closed  bool
+	}
+)
+
+// SSEObjectMethodStreamImpl implements the SSEObjectMethodClientStream interface.
+var _ SSEObjectMethodClientStream = (*SSEObjectMethodStreamImpl)(nil)
+
+// SSEObjectMethodStreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ sseobjectservice.SSEObjectMethodClientStream = (*SSEObjectMethodStreamImpl)(nil)
+
+// NewSSEObjectMethodStream creates a new SSEObjectMethodClientStream.
+func NewSSEObjectMethodStream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) SSEObjectMethodClientStream {
+	return &SSEObjectMethodStreamImpl{
+		resp:    resp,
+		decoder: decoder,
+		buffer:  make([]byte, 0, 4096), // Pre-allocate buffer
+	}
+}
+
+// Recv reads and returns the next event from the SSE stream.
+func (s *SSEObjectMethodStreamImpl) Recv() (*sseobjectservice.SSEObjectMethodResult, error) {
+	return s.RecvWithContext(context.Background())
+}
+
+// RecvWithContext reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *SSEObjectMethodStreamImpl) RecvWithContext(ctx context.Context) (event *sseobjectservice.SSEObjectMethodResult, err error) {
+	var byts []byte
+	byts, err = s.readEvent(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Clean up on EOF or context cancellation
+			s.Close()
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
+		return
+	}
+	return s.processEvent(byts)
+}
+
+// readEvent reads a single SSE event from the stream, respecting context
+// cancellation.  It first checks the internal buffer for a complete event
+// (delimited by double newlines). If no complete event is found, it reads from
+// the HTTP response body until it either finds an event boundary, reaches EOF,
+// or encounters an error. Any data after the event boundary is saved in the
+// buffer for the next call.
+func (s *SSEObjectMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) {
+	const bufSize = 4096 // 4KB buffer size
+
+	// Check for event in existing buffer
+	event, ok := s.checkBuffer()
+	if ok {
+		return event, nil
+	}
+
+	// Initialize with any data from buffer
+	eventData := event
+	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
+	buf := make([]byte, bufSize)
+
+	// Read data in chunks until we find an event or hit EOF
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
+
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+
+		// Read next chunk
+		n, err := s.resp.Body.Read(buf)
+		s.lock.Unlock()
+
+		// Handle read errors
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Process data if we got any
+		if n > 0 {
+			// Look for event boundary in this chunk
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				eventData = append(eventData, b)
+
+				// Check for double newlines (event boundary)
+				if b == '\n' && wasNewline {
+					// Save any remaining data for next read
+					if i+1 < n {
+						s.lock.Lock()
+						s.buffer = append(s.buffer[:0], buf[i+1:n]...)
+						s.lock.Unlock()
+					}
+					return eventData, nil
+				}
+
+				// Update newline tracking
+				wasNewline = (b == '\n')
+			}
+		}
+
+		// Return partial data at EOF
+		if errors.Is(err, io.EOF) {
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+	}
+}
+
+// checkBuffer examines the internal buffer for a complete SSE event (delimited
+// by double newlines).  It returns two values: the event data (or all buffer
+// contents if no complete event is found), and a boolean indicating whether a
+// complete event was found. If a complete event is found, any remaining data
+// after the event is kept in the buffer for the next call.
+func (s *SSEObjectMethodStreamImpl) checkBuffer() ([]byte, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Quick return if buffer is empty
+	if len(s.buffer) == 0 {
+		return nil, false
+	}
+
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event
+			eventEnd := i + 2 // Include both newlines
+			eventData := s.buffer[:eventEnd]
+
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
+
+			return eventData, true
+		}
+	}
+
+	// No complete event found, return buffer contents
+	eventData := s.buffer
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
+}
+
+// Close closes the SSE stream and releases any associated resources.
+func (s *SSEObjectMethodStreamImpl) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// processEvent processes a raw SSE event into the expected type
+func (s *SSEObjectMethodStreamImpl) processEvent(eventData []byte) (event *sseobjectservice.SSEObjectMethodResult, err error) {
+	event = new(sseobjectservice.SSEObjectMethodResult)
+	var dataLines []string
+	for _, line := range bytes.Split(eventData, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			dataLines = append(dataLines, s.trimHeader(len("data:"), line))
+			continue
+		}
+	}
+	if len(dataLines) > 0 {
+		dataContent := strings.Join(dataLines, "\n")
+		// Decode JSON into the struct pointer directly
+		respBody := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(dataContent))),
+		}
+		err = s.decoder(respBody).Decode(event)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// trimHeader removes the header prefix and optional leading space
+func (s *SSEObjectMethodStreamImpl) trimHeader(size int, data []byte) string {
+	if len(data) < size {
+		return string(data)
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	return string(data)
+}

--- a/http/codegen/testdata/golden/sse-client-request-id.golden
+++ b/http/codegen/testdata/golden/sse-client-request-id.golden
@@ -1,0 +1,224 @@
+// SSERequestIDMethodClientStream is the interface for reading Server-Sent Events.
+type SSERequestIDMethodClientStream interface {
+	// Recv reads and returns the next event from the SSE stream.
+	Recv() (string, error)
+	// RecvWithContext reads and returns the next event from the SSE stream with context.
+	RecvWithContext(context.Context) (string, error)
+	// Close closes the SSE stream and releases resources.
+	Close() error
+}
+
+type (
+	// SSERequestIDMethodStreamImpl implements the SSERequestIDMethodClientStream interface.
+	SSERequestIDMethodStreamImpl struct {
+		resp    *http.Response
+		decoder func(*http.Response) goahttp.Decoder
+		buffer  []byte // Buffer for unprocessed data
+		lock    sync.Mutex
+		closed  bool
+	}
+)
+
+// SSERequestIDMethodStreamImpl implements the SSERequestIDMethodClientStream interface.
+var _ SSERequestIDMethodClientStream = (*SSERequestIDMethodStreamImpl)(nil)
+
+// SSERequestIDMethodStreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ sserequestidservice.SSERequestIDMethodClientStream = (*SSERequestIDMethodStreamImpl)(nil)
+
+// NewSSERequestIDMethodStream creates a new SSERequestIDMethodClientStream.
+func NewSSERequestIDMethodStream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) SSERequestIDMethodClientStream {
+	return &SSERequestIDMethodStreamImpl{
+		resp:    resp,
+		decoder: decoder,
+		buffer:  make([]byte, 0, 4096), // Pre-allocate buffer
+	}
+}
+
+// Recv reads and returns the next event from the SSE stream.
+func (s *SSERequestIDMethodStreamImpl) Recv() (string, error) {
+	return s.RecvWithContext(context.Background())
+}
+
+// RecvWithContext reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *SSERequestIDMethodStreamImpl) RecvWithContext(ctx context.Context) (event string, err error) {
+	var byts []byte
+	byts, err = s.readEvent(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Clean up on EOF or context cancellation
+			s.Close()
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
+		return
+	}
+	return s.processEvent(byts)
+}
+
+// readEvent reads a single SSE event from the stream, respecting context
+// cancellation.  It first checks the internal buffer for a complete event
+// (delimited by double newlines). If no complete event is found, it reads from
+// the HTTP response body until it either finds an event boundary, reaches EOF,
+// or encounters an error. Any data after the event boundary is saved in the
+// buffer for the next call.
+func (s *SSERequestIDMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) {
+	const bufSize = 4096 // 4KB buffer size
+
+	// Check for event in existing buffer
+	event, ok := s.checkBuffer()
+	if ok {
+		return event, nil
+	}
+
+	// Initialize with any data from buffer
+	eventData := event
+	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
+	buf := make([]byte, bufSize)
+
+	// Read data in chunks until we find an event or hit EOF
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
+
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+
+		// Read next chunk
+		n, err := s.resp.Body.Read(buf)
+		s.lock.Unlock()
+
+		// Handle read errors
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Process data if we got any
+		if n > 0 {
+			// Look for event boundary in this chunk
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				eventData = append(eventData, b)
+
+				// Check for double newlines (event boundary)
+				if b == '\n' && wasNewline {
+					// Save any remaining data for next read
+					if i+1 < n {
+						s.lock.Lock()
+						s.buffer = append(s.buffer[:0], buf[i+1:n]...)
+						s.lock.Unlock()
+					}
+					return eventData, nil
+				}
+
+				// Update newline tracking
+				wasNewline = (b == '\n')
+			}
+		}
+
+		// Return partial data at EOF
+		if errors.Is(err, io.EOF) {
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+	}
+}
+
+// checkBuffer examines the internal buffer for a complete SSE event (delimited
+// by double newlines).  It returns two values: the event data (or all buffer
+// contents if no complete event is found), and a boolean indicating whether a
+// complete event was found. If a complete event is found, any remaining data
+// after the event is kept in the buffer for the next call.
+func (s *SSERequestIDMethodStreamImpl) checkBuffer() ([]byte, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Quick return if buffer is empty
+	if len(s.buffer) == 0 {
+		return nil, false
+	}
+
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event
+			eventEnd := i + 2 // Include both newlines
+			eventData := s.buffer[:eventEnd]
+
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
+
+			return eventData, true
+		}
+	}
+
+	// No complete event found, return buffer contents
+	eventData := s.buffer
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
+}
+
+// Close closes the SSE stream and releases any associated resources.
+func (s *SSERequestIDMethodStreamImpl) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// processEvent processes a raw SSE event into the expected type
+func (s *SSERequestIDMethodStreamImpl) processEvent(eventData []byte) (event string, err error) {
+	var dataLines []string
+	for _, line := range bytes.Split(eventData, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			dataLines = append(dataLines, s.trimHeader(len("data:"), line))
+			continue
+		}
+	}
+	if len(dataLines) > 0 {
+		dataContent := strings.Join(dataLines, "\n")
+
+		event = dataContent
+	}
+	return
+}
+
+// trimHeader removes the header prefix and optional leading space
+func (s *SSERequestIDMethodStreamImpl) trimHeader(size int, data []byte) string {
+	if len(data) < size {
+		return string(data)
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	return string(data)
+}

--- a/http/codegen/testdata/golden/sse-client-string.golden
+++ b/http/codegen/testdata/golden/sse-client-string.golden
@@ -1,0 +1,224 @@
+// SSEStringMethodClientStream is the interface for reading Server-Sent Events.
+type SSEStringMethodClientStream interface {
+	// Recv reads and returns the next event from the SSE stream.
+	Recv() (string, error)
+	// RecvWithContext reads and returns the next event from the SSE stream with context.
+	RecvWithContext(context.Context) (string, error)
+	// Close closes the SSE stream and releases resources.
+	Close() error
+}
+
+type (
+	// SSEStringMethodStreamImpl implements the SSEStringMethodClientStream interface.
+	SSEStringMethodStreamImpl struct {
+		resp    *http.Response
+		decoder func(*http.Response) goahttp.Decoder
+		buffer  []byte // Buffer for unprocessed data
+		lock    sync.Mutex
+		closed  bool
+	}
+)
+
+// SSEStringMethodStreamImpl implements the SSEStringMethodClientStream interface.
+var _ SSEStringMethodClientStream = (*SSEStringMethodStreamImpl)(nil)
+
+// SSEStringMethodStreamImpl implements the service client stream
+// interface so the generated endpoint client can return it directly.
+var _ ssestringservice.SSEStringMethodClientStream = (*SSEStringMethodStreamImpl)(nil)
+
+// NewSSEStringMethodStream creates a new SSEStringMethodClientStream.
+func NewSSEStringMethodStream(resp *http.Response, decoder func(*http.Response) goahttp.Decoder) SSEStringMethodClientStream {
+	return &SSEStringMethodStreamImpl{
+		resp:    resp,
+		decoder: decoder,
+		buffer:  make([]byte, 0, 4096), // Pre-allocate buffer
+	}
+}
+
+// Recv reads and returns the next event from the SSE stream.
+func (s *SSEStringMethodStreamImpl) Recv() (string, error) {
+	return s.RecvWithContext(context.Background())
+}
+
+// RecvWithContext reads and returns the next event from the SSE stream, respecting context cancellation.
+func (s *SSEStringMethodStreamImpl) RecvWithContext(ctx context.Context) (event string, err error) {
+	var byts []byte
+	byts, err = s.readEvent(ctx)
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Clean up on EOF or context cancellation
+			s.Close()
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
+		return
+	}
+	return s.processEvent(byts)
+}
+
+// readEvent reads a single SSE event from the stream, respecting context
+// cancellation.  It first checks the internal buffer for a complete event
+// (delimited by double newlines). If no complete event is found, it reads from
+// the HTTP response body until it either finds an event boundary, reaches EOF,
+// or encounters an error. Any data after the event boundary is saved in the
+// buffer for the next call.
+func (s *SSEStringMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) {
+	const bufSize = 4096 // 4KB buffer size
+
+	// Check for event in existing buffer
+	event, ok := s.checkBuffer()
+	if ok {
+		return event, nil
+	}
+
+	// Initialize with any data from buffer
+	eventData := event
+	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
+	buf := make([]byte, bufSize)
+
+	// Read data in chunks until we find an event or hit EOF
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
+
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+
+		// Read next chunk
+		n, err := s.resp.Body.Read(buf)
+		s.lock.Unlock()
+
+		// Handle read errors
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		// Process data if we got any
+		if n > 0 {
+			// Look for event boundary in this chunk
+			for i := 0; i < n; i++ {
+				b := buf[i]
+				eventData = append(eventData, b)
+
+				// Check for double newlines (event boundary)
+				if b == '\n' && wasNewline {
+					// Save any remaining data for next read
+					if i+1 < n {
+						s.lock.Lock()
+						s.buffer = append(s.buffer[:0], buf[i+1:n]...)
+						s.lock.Unlock()
+					}
+					return eventData, nil
+				}
+
+				// Update newline tracking
+				wasNewline = (b == '\n')
+			}
+		}
+
+		// Return partial data at EOF
+		if errors.Is(err, io.EOF) {
+			if len(eventData) > 0 {
+				return eventData, nil
+			}
+			return nil, io.EOF
+		}
+	}
+}
+
+// checkBuffer examines the internal buffer for a complete SSE event (delimited
+// by double newlines).  It returns two values: the event data (or all buffer
+// contents if no complete event is found), and a boolean indicating whether a
+// complete event was found. If a complete event is found, any remaining data
+// after the event is kept in the buffer for the next call.
+func (s *SSEStringMethodStreamImpl) checkBuffer() ([]byte, bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Quick return if buffer is empty
+	if len(s.buffer) == 0 {
+		return nil, false
+	}
+
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event
+			eventEnd := i + 2 // Include both newlines
+			eventData := s.buffer[:eventEnd]
+
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
+
+			return eventData, true
+		}
+	}
+
+	// No complete event found, return buffer contents
+	eventData := s.buffer
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
+}
+
+// Close closes the SSE stream and releases any associated resources.
+func (s *SSEStringMethodStreamImpl) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// processEvent processes a raw SSE event into the expected type
+func (s *SSEStringMethodStreamImpl) processEvent(eventData []byte) (event string, err error) {
+	var dataLines []string
+	for _, line := range bytes.Split(eventData, []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			dataLines = append(dataLines, s.trimHeader(len("data:"), line))
+			continue
+		}
+	}
+	if len(dataLines) > 0 {
+		dataContent := strings.Join(dataLines, "\n")
+
+		event = dataContent
+	}
+	return
+}
+
+// trimHeader removes the header prefix and optional leading space
+func (s *SSEStringMethodStreamImpl) trimHeader(size int, data []byte) string {
+	if len(data) < size {
+		return string(data)
+	}
+	data = data[size:]
+	if len(data) > 0 && data[0] == ' ' {
+		data = data[1:]
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary

For an HTTP SSE endpoint, the service package declares the client stream contract as `Recv() (T, error)` plus `RecvWithContext(ctx) (T, error)` — the same shape WebSocket client streams implement. The HTTP SSE client template, however, emitted a stream with a single `Recv(context.Context)` method and a local interface of the same name. The generated service-level client type-asserts the endpoint result to the service interface:

```go
return ires.(StreamChatRunClientStream), nil
```

so every SSE method invoked through the service client panicked at runtime with `interface conversion: ... missing method Recv`. The path had no test coverage: SSE golden tests only exercised `ServerFiles`.

## Changes

- The generated SSE client stream now implements the service contract: `RecvWithContext(ctx)` carries the streaming logic and `Recv()` delegates with `context.Background()`, mirroring WebSocket client streams.
- A compile-time assertion (`var _ svcpkg.MethodClientStream = (*MethodStreamImpl)(nil)`) pins the transport stream to the service interface so this class of drift cannot ship silently again.
- New `TestSSEClient` golden tests cover the SSE client output for all existing SSE DSL fixtures.
- Removed the dead `SSEData.RecvName`/`RecvDesc` fields (set but never read).

## Compatibility

Regeneration changes SSE client code only; servers are unaffected. Callers that used the transport-level `Recv(ctx)` directly must switch to `RecvWithContext(ctx)` — that path was only reachable by bypassing the (panicking) service client, so no working integration breaks. JSON-RPC SSE uses its own templates and is unchanged.

## Testing

- `go test ./http/... ./codegen/...` passes.
- Verified end-to-end against a production multi-service design: regenerating and consuming an SSE endpoint through the generated service client streams events without panicking.