### PR TITLE
fix(codegen): SSE client discards truncated frames and returns io.EOF

### DIFF
--- a/http/codegen/templates/client_sse.go.tpl
+++ b/http/codegen/templates/client_sse.go.tpl
@@ -46,11 +46,9 @@ func (s *{{ .Method.VarName }}StreamImpl) {{ .Method.ClientStream.RecvWithContex
         byts, err = s.readEvent(ctx)
         if err != nil {
                 if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-                        // Clean up on EOF or context cancellation
+                        // Clean up on EOF or context cancellation. io.EOF
+                        // propagates to the caller to signal end of stream.
                         s.Close()
-                        if errors.Is(err, io.EOF) {
-                                err = nil
-                        }
                 }
                 return
         }
@@ -77,28 +75,24 @@ func (s *{{ .Method.VarName }}StreamImpl) readEvent(ctx context.Context) ([]byte
         wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
         buf := make([]byte, bufSize)
 
-        // Read data in chunks until we find an event or hit EOF
-        for {
-                // Check if context is done
-                select {
-                case <-ctx.Done():
-                        if len(eventData) > 0 {
-                                return eventData, nil
-                        }
-                        return nil, ctx.Err()
-                default:
-                        // Continue processing
-                }
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
+	for {
+		// Check if context is done
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+			// Continue processing
+		}
 
-                // Check if stream is closed
-                s.lock.Lock()
-                if s.closed {
-                        s.lock.Unlock()
-                        if len(eventData) > 0 {
-                                return eventData, nil
-                        }
-                        return nil, io.EOF
-                }
+		// Check if stream is closed
+		s.lock.Lock()
+		if s.closed {
+			s.lock.Unlock()
+			return nil, io.EOF
+		}
 
                 // Read next chunk
                 n, err := s.resp.Body.Read(buf)
@@ -132,13 +126,11 @@ func (s *{{ .Method.VarName }}StreamImpl) readEvent(ctx context.Context) ([]byte
                         }
                 }
 
-                // Return partial data at EOF
-                if errors.Is(err, io.EOF) {
-                        if len(eventData) > 0 {
-                                return eventData, nil
-                        }
-                        return nil, io.EOF
-                }
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
+		if errors.Is(err, io.EOF) {
+			return nil, io.EOF
+		}
         }
 }
 

--- a/http/codegen/templates/client_sse.go.tpl
+++ b/http/codegen/templates/client_sse.go.tpl
@@ -148,28 +148,34 @@ func (s *{{ .Method.VarName }}StreamImpl) checkBuffer() ([]byte, bool) {
                 return nil, false
         }
 
-        // Look for double newline in buffer
-        for i := 0; i < len(s.buffer)-1; i++ {
-                if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-                        // Found complete event
-                        eventEnd := i + 2 // Include both newlines
-                        eventData := s.buffer[:eventEnd]
+	// Look for double newline in buffer
+	for i := 0; i < len(s.buffer)-1; i++ {
+		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
+			eventEnd := i + 2 // Include both newlines
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
-                        // Save remaining data for next time
-                        if eventEnd < len(s.buffer) {
-                                s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
-                        } else {
-                                s.buffer = s.buffer[:0]
-                        }
+			// Save remaining data for next time
+			if eventEnd < len(s.buffer) {
+				s.buffer = append(s.buffer[:0], s.buffer[eventEnd:]...)
+			} else {
+				s.buffer = s.buffer[:0]
+			}
 
-                        return eventData, true
-                }
-        }
+			return eventData, true
+		}
+	}
 
-        // No complete event found, return buffer contents
-        eventData := s.buffer
-        s.buffer = s.buffer[:0] // Clear buffer but keep capacity
-        return eventData, false
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
+	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
+	return eventData, false
 }
 
 // Close closes the SSE stream and releases any associated resources.

--- a/http/codegen/testdata/golden/sse-client-all-fields.golden
+++ b/http/codegen/testdata/golden/sse-client-all-fields.golden
@@ -46,11 +46,9 @@ func (s *SSEAllFieldsMethodStreamImpl) RecvWithContext(ctx context.Context) (eve
 	byts, err = s.readEvent(ctx)
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Clean up on EOF or context cancellation
+			// Clean up on EOF or context cancellation. io.EOF
+			// propagates to the caller to signal end of stream.
 			s.Close()
-			if errors.Is(err, io.EOF) {
-				err = nil
-			}
 		}
 		return
 	}
@@ -77,14 +75,13 @@ func (s *SSEAllFieldsMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
 	buf := make([]byte, bufSize)
 
-	// Read data in chunks until we find an event or hit EOF
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
 	for {
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, ctx.Err()
 		default:
 			// Continue processing
@@ -94,9 +91,6 @@ func (s *SSEAllFieldsMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 		s.lock.Lock()
 		if s.closed {
 			s.lock.Unlock()
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 
@@ -132,11 +126,9 @@ func (s *SSEAllFieldsMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 			}
 		}
 
-		// Return partial data at EOF
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
 		if errors.Is(err, io.EOF) {
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 	}

--- a/http/codegen/testdata/golden/sse-client-all-fields.golden
+++ b/http/codegen/testdata/golden/sse-client-all-fields.golden
@@ -151,9 +151,12 @@ func (s *SSEAllFieldsMethodStreamImpl) checkBuffer() ([]byte, bool) {
 	// Look for double newline in buffer
 	for i := 0; i < len(s.buffer)-1; i++ {
 		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-			// Found complete event
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
 			eventEnd := i + 2 // Include both newlines
-			eventData := s.buffer[:eventEnd]
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
 			// Save remaining data for next time
 			if eventEnd < len(s.buffer) {
@@ -166,8 +169,11 @@ func (s *SSEAllFieldsMethodStreamImpl) checkBuffer() ([]byte, bool) {
 		}
 	}
 
-	// No complete event found, return buffer contents
-	eventData := s.buffer
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
 	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
 	return eventData, false
 }

--- a/http/codegen/testdata/golden/sse-client-bool.golden
+++ b/http/codegen/testdata/golden/sse-client-bool.golden
@@ -46,11 +46,9 @@ func (s *SSEBoolMethodStreamImpl) RecvWithContext(ctx context.Context) (event bo
 	byts, err = s.readEvent(ctx)
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Clean up on EOF or context cancellation
+			// Clean up on EOF or context cancellation. io.EOF
+			// propagates to the caller to signal end of stream.
 			s.Close()
-			if errors.Is(err, io.EOF) {
-				err = nil
-			}
 		}
 		return
 	}
@@ -77,14 +75,13 @@ func (s *SSEBoolMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error)
 	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
 	buf := make([]byte, bufSize)
 
-	// Read data in chunks until we find an event or hit EOF
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
 	for {
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, ctx.Err()
 		default:
 			// Continue processing
@@ -94,9 +91,6 @@ func (s *SSEBoolMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error)
 		s.lock.Lock()
 		if s.closed {
 			s.lock.Unlock()
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 
@@ -132,11 +126,9 @@ func (s *SSEBoolMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error)
 			}
 		}
 
-		// Return partial data at EOF
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
 		if errors.Is(err, io.EOF) {
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 	}

--- a/http/codegen/testdata/golden/sse-client-bool.golden
+++ b/http/codegen/testdata/golden/sse-client-bool.golden
@@ -151,9 +151,12 @@ func (s *SSEBoolMethodStreamImpl) checkBuffer() ([]byte, bool) {
 	// Look for double newline in buffer
 	for i := 0; i < len(s.buffer)-1; i++ {
 		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-			// Found complete event
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
 			eventEnd := i + 2 // Include both newlines
-			eventData := s.buffer[:eventEnd]
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
 			// Save remaining data for next time
 			if eventEnd < len(s.buffer) {
@@ -166,8 +169,11 @@ func (s *SSEBoolMethodStreamImpl) checkBuffer() ([]byte, bool) {
 		}
 	}
 
-	// No complete event found, return buffer contents
-	eventData := s.buffer
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
 	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
 	return eventData, false
 }

--- a/http/codegen/testdata/golden/sse-client-data-field.golden
+++ b/http/codegen/testdata/golden/sse-client-data-field.golden
@@ -46,11 +46,9 @@ func (s *SSEDataFieldMethodStreamImpl) RecvWithContext(ctx context.Context) (eve
 	byts, err = s.readEvent(ctx)
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Clean up on EOF or context cancellation
+			// Clean up on EOF or context cancellation. io.EOF
+			// propagates to the caller to signal end of stream.
 			s.Close()
-			if errors.Is(err, io.EOF) {
-				err = nil
-			}
 		}
 		return
 	}
@@ -77,14 +75,13 @@ func (s *SSEDataFieldMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
 	buf := make([]byte, bufSize)
 
-	// Read data in chunks until we find an event or hit EOF
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
 	for {
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, ctx.Err()
 		default:
 			// Continue processing
@@ -94,9 +91,6 @@ func (s *SSEDataFieldMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 		s.lock.Lock()
 		if s.closed {
 			s.lock.Unlock()
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 
@@ -132,11 +126,9 @@ func (s *SSEDataFieldMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 			}
 		}
 
-		// Return partial data at EOF
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
 		if errors.Is(err, io.EOF) {
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 	}

--- a/http/codegen/testdata/golden/sse-client-data-field.golden
+++ b/http/codegen/testdata/golden/sse-client-data-field.golden
@@ -151,9 +151,12 @@ func (s *SSEDataFieldMethodStreamImpl) checkBuffer() ([]byte, bool) {
 	// Look for double newline in buffer
 	for i := 0; i < len(s.buffer)-1; i++ {
 		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-			// Found complete event
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
 			eventEnd := i + 2 // Include both newlines
-			eventData := s.buffer[:eventEnd]
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
 			// Save remaining data for next time
 			if eventEnd < len(s.buffer) {
@@ -166,8 +169,11 @@ func (s *SSEDataFieldMethodStreamImpl) checkBuffer() ([]byte, bool) {
 		}
 	}
 
-	// No complete event found, return buffer contents
-	eventData := s.buffer
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
 	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
 	return eventData, false
 }

--- a/http/codegen/testdata/golden/sse-client-data-id-field.golden
+++ b/http/codegen/testdata/golden/sse-client-data-id-field.golden
@@ -46,11 +46,9 @@ func (s *SSEDataIDFieldMethodStreamImpl) RecvWithContext(ctx context.Context) (e
 	byts, err = s.readEvent(ctx)
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Clean up on EOF or context cancellation
+			// Clean up on EOF or context cancellation. io.EOF
+			// propagates to the caller to signal end of stream.
 			s.Close()
-			if errors.Is(err, io.EOF) {
-				err = nil
-			}
 		}
 		return
 	}
@@ -77,14 +75,13 @@ func (s *SSEDataIDFieldMethodStreamImpl) readEvent(ctx context.Context) ([]byte,
 	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
 	buf := make([]byte, bufSize)
 
-	// Read data in chunks until we find an event or hit EOF
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
 	for {
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, ctx.Err()
 		default:
 			// Continue processing
@@ -94,9 +91,6 @@ func (s *SSEDataIDFieldMethodStreamImpl) readEvent(ctx context.Context) ([]byte,
 		s.lock.Lock()
 		if s.closed {
 			s.lock.Unlock()
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 
@@ -132,11 +126,9 @@ func (s *SSEDataIDFieldMethodStreamImpl) readEvent(ctx context.Context) ([]byte,
 			}
 		}
 
-		// Return partial data at EOF
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
 		if errors.Is(err, io.EOF) {
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 	}

--- a/http/codegen/testdata/golden/sse-client-data-id-field.golden
+++ b/http/codegen/testdata/golden/sse-client-data-id-field.golden
@@ -151,9 +151,12 @@ func (s *SSEDataIDFieldMethodStreamImpl) checkBuffer() ([]byte, bool) {
 	// Look for double newline in buffer
 	for i := 0; i < len(s.buffer)-1; i++ {
 		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-			// Found complete event
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
 			eventEnd := i + 2 // Include both newlines
-			eventData := s.buffer[:eventEnd]
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
 			// Save remaining data for next time
 			if eventEnd < len(s.buffer) {
@@ -166,8 +169,11 @@ func (s *SSEDataIDFieldMethodStreamImpl) checkBuffer() ([]byte, bool) {
 		}
 	}
 
-	// No complete event found, return buffer contents
-	eventData := s.buffer
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
 	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
 	return eventData, false
 }

--- a/http/codegen/testdata/golden/sse-client-int.golden
+++ b/http/codegen/testdata/golden/sse-client-int.golden
@@ -151,9 +151,12 @@ func (s *SSEIntMethodStreamImpl) checkBuffer() ([]byte, bool) {
 	// Look for double newline in buffer
 	for i := 0; i < len(s.buffer)-1; i++ {
 		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-			// Found complete event
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
 			eventEnd := i + 2 // Include both newlines
-			eventData := s.buffer[:eventEnd]
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
 			// Save remaining data for next time
 			if eventEnd < len(s.buffer) {
@@ -166,8 +169,11 @@ func (s *SSEIntMethodStreamImpl) checkBuffer() ([]byte, bool) {
 		}
 	}
 
-	// No complete event found, return buffer contents
-	eventData := s.buffer
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
 	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
 	return eventData, false
 }

--- a/http/codegen/testdata/golden/sse-client-int.golden
+++ b/http/codegen/testdata/golden/sse-client-int.golden
@@ -46,11 +46,9 @@ func (s *SSEIntMethodStreamImpl) RecvWithContext(ctx context.Context) (event int
 	byts, err = s.readEvent(ctx)
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Clean up on EOF or context cancellation
+			// Clean up on EOF or context cancellation. io.EOF
+			// propagates to the caller to signal end of stream.
 			s.Close()
-			if errors.Is(err, io.EOF) {
-				err = nil
-			}
 		}
 		return
 	}
@@ -77,14 +75,13 @@ func (s *SSEIntMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) 
 	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
 	buf := make([]byte, bufSize)
 
-	// Read data in chunks until we find an event or hit EOF
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
 	for {
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, ctx.Err()
 		default:
 			// Continue processing
@@ -94,9 +91,6 @@ func (s *SSEIntMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) 
 		s.lock.Lock()
 		if s.closed {
 			s.lock.Unlock()
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 
@@ -132,11 +126,9 @@ func (s *SSEIntMethodStreamImpl) readEvent(ctx context.Context) ([]byte, error) 
 			}
 		}
 
-		// Return partial data at EOF
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
 		if errors.Is(err, io.EOF) {
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 	}

--- a/http/codegen/testdata/golden/sse-client-object.golden
+++ b/http/codegen/testdata/golden/sse-client-object.golden
@@ -151,9 +151,12 @@ func (s *SSEObjectMethodStreamImpl) checkBuffer() ([]byte, bool) {
 	// Look for double newline in buffer
 	for i := 0; i < len(s.buffer)-1; i++ {
 		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-			// Found complete event
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
 			eventEnd := i + 2 // Include both newlines
-			eventData := s.buffer[:eventEnd]
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
 			// Save remaining data for next time
 			if eventEnd < len(s.buffer) {
@@ -166,8 +169,11 @@ func (s *SSEObjectMethodStreamImpl) checkBuffer() ([]byte, bool) {
 		}
 	}
 
-	// No complete event found, return buffer contents
-	eventData := s.buffer
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
 	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
 	return eventData, false
 }

--- a/http/codegen/testdata/golden/sse-client-object.golden
+++ b/http/codegen/testdata/golden/sse-client-object.golden
@@ -46,11 +46,9 @@ func (s *SSEObjectMethodStreamImpl) RecvWithContext(ctx context.Context) (event 
 	byts, err = s.readEvent(ctx)
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Clean up on EOF or context cancellation
+			// Clean up on EOF or context cancellation. io.EOF
+			// propagates to the caller to signal end of stream.
 			s.Close()
-			if errors.Is(err, io.EOF) {
-				err = nil
-			}
 		}
 		return
 	}
@@ -77,14 +75,13 @@ func (s *SSEObjectMethodStreamImpl) readEvent(ctx context.Context) ([]byte, erro
 	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
 	buf := make([]byte, bufSize)
 
-	// Read data in chunks until we find an event or hit EOF
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
 	for {
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, ctx.Err()
 		default:
 			// Continue processing
@@ -94,9 +91,6 @@ func (s *SSEObjectMethodStreamImpl) readEvent(ctx context.Context) ([]byte, erro
 		s.lock.Lock()
 		if s.closed {
 			s.lock.Unlock()
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 
@@ -132,11 +126,9 @@ func (s *SSEObjectMethodStreamImpl) readEvent(ctx context.Context) ([]byte, erro
 			}
 		}
 
-		// Return partial data at EOF
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
 		if errors.Is(err, io.EOF) {
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 	}

--- a/http/codegen/testdata/golden/sse-client-request-id.golden
+++ b/http/codegen/testdata/golden/sse-client-request-id.golden
@@ -151,9 +151,12 @@ func (s *SSERequestIDMethodStreamImpl) checkBuffer() ([]byte, bool) {
 	// Look for double newline in buffer
 	for i := 0; i < len(s.buffer)-1; i++ {
 		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-			// Found complete event
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
 			eventEnd := i + 2 // Include both newlines
-			eventData := s.buffer[:eventEnd]
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
 			// Save remaining data for next time
 			if eventEnd < len(s.buffer) {
@@ -166,8 +169,11 @@ func (s *SSERequestIDMethodStreamImpl) checkBuffer() ([]byte, bool) {
 		}
 	}
 
-	// No complete event found, return buffer contents
-	eventData := s.buffer
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
 	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
 	return eventData, false
 }

--- a/http/codegen/testdata/golden/sse-client-request-id.golden
+++ b/http/codegen/testdata/golden/sse-client-request-id.golden
@@ -46,11 +46,9 @@ func (s *SSERequestIDMethodStreamImpl) RecvWithContext(ctx context.Context) (eve
 	byts, err = s.readEvent(ctx)
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Clean up on EOF or context cancellation
+			// Clean up on EOF or context cancellation. io.EOF
+			// propagates to the caller to signal end of stream.
 			s.Close()
-			if errors.Is(err, io.EOF) {
-				err = nil
-			}
 		}
 		return
 	}
@@ -77,14 +75,13 @@ func (s *SSERequestIDMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
 	buf := make([]byte, bufSize)
 
-	// Read data in chunks until we find an event or hit EOF
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
 	for {
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, ctx.Err()
 		default:
 			// Continue processing
@@ -94,9 +91,6 @@ func (s *SSERequestIDMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 		s.lock.Lock()
 		if s.closed {
 			s.lock.Unlock()
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 
@@ -132,11 +126,9 @@ func (s *SSERequestIDMethodStreamImpl) readEvent(ctx context.Context) ([]byte, e
 			}
 		}
 
-		// Return partial data at EOF
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
 		if errors.Is(err, io.EOF) {
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 	}

--- a/http/codegen/testdata/golden/sse-client-string.golden
+++ b/http/codegen/testdata/golden/sse-client-string.golden
@@ -46,11 +46,9 @@ func (s *SSEStringMethodStreamImpl) RecvWithContext(ctx context.Context) (event 
 	byts, err = s.readEvent(ctx)
 	if err != nil {
 		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			// Clean up on EOF or context cancellation
+			// Clean up on EOF or context cancellation. io.EOF
+			// propagates to the caller to signal end of stream.
 			s.Close()
-			if errors.Is(err, io.EOF) {
-				err = nil
-			}
 		}
 		return
 	}
@@ -77,14 +75,13 @@ func (s *SSEStringMethodStreamImpl) readEvent(ctx context.Context) ([]byte, erro
 	wasNewline := len(eventData) > 0 && eventData[len(eventData)-1] == '\n'
 	buf := make([]byte, bufSize)
 
-	// Read data in chunks until we find an event or hit EOF
+	// Read data in chunks until we find an event or hit EOF. A stream that
+	// ends mid-event (before the blank-line delimiter) discards the partial
+	// frame, per the SSE specification.
 	for {
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, ctx.Err()
 		default:
 			// Continue processing
@@ -94,9 +91,6 @@ func (s *SSEStringMethodStreamImpl) readEvent(ctx context.Context) ([]byte, erro
 		s.lock.Lock()
 		if s.closed {
 			s.lock.Unlock()
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 
@@ -132,11 +126,9 @@ func (s *SSEStringMethodStreamImpl) readEvent(ctx context.Context) ([]byte, erro
 			}
 		}
 
-		// Return partial data at EOF
+		// Discard any partial frame at EOF: an event that ends before its
+		// blank-line delimiter was truncated by the transport.
 		if errors.Is(err, io.EOF) {
-			if len(eventData) > 0 {
-				return eventData, nil
-			}
 			return nil, io.EOF
 		}
 	}

--- a/http/codegen/testdata/golden/sse-client-string.golden
+++ b/http/codegen/testdata/golden/sse-client-string.golden
@@ -151,9 +151,12 @@ func (s *SSEStringMethodStreamImpl) checkBuffer() ([]byte, bool) {
 	// Look for double newline in buffer
 	for i := 0; i < len(s.buffer)-1; i++ {
 		if s.buffer[i] == '\n' && s.buffer[i+1] == '\n' {
-			// Found complete event
+			// Found complete event. Copy it out: compacting the buffer
+			// below would otherwise overwrite the returned bytes, since
+			// both slices share the same backing array.
 			eventEnd := i + 2 // Include both newlines
-			eventData := s.buffer[:eventEnd]
+			eventData := make([]byte, eventEnd)
+			copy(eventData, s.buffer[:eventEnd])
 
 			// Save remaining data for next time
 			if eventEnd < len(s.buffer) {
@@ -166,8 +169,11 @@ func (s *SSEStringMethodStreamImpl) checkBuffer() ([]byte, bool) {
 		}
 	}
 
-	// No complete event found, return buffer contents
-	eventData := s.buffer
+	// No complete event found, return a copy of the buffer contents: the
+	// caller keeps accumulating into the returned slice while readEvent
+	// refills s.buffer, so they must not share a backing array.
+	eventData := make([]byte, len(s.buffer))
+	copy(eventData, s.buffer)
 	s.buffer = s.buffer[:0] // Clear buffer but keep capacity
 	return eventData, false
 }


### PR DESCRIPTION
## Summary

Follow-up to #3963, found by running a production evaluation harness over a generated SSE client.

Two remaining defects in the generated HTTP SSE client stream:

- **Truncated frames were surfaced as events.** When the stream ended mid-event — EOF, stream close, or context cancellation before the blank-line delimiter — `readEvent` returned the partial frame. An event whose `id:` line was cut at the boundary decoded into an event carrying a truncated ID and no payload, which callers then replayed as a resume cursor. The SSE specification requires discarding an incomplete event at end of stream (browser `EventSource` does the same). Partial frames are now discarded.
- **Clean EOF returned `(nil, nil)`.** Callers had to guard every `Recv` against a nil event to avoid a nil dereference at normal end of stream. End of stream now propagates as `io.EOF`, matching WebSocket client streams and standard `io` semantics.

## Compatibility

Regeneration changes SSE client code only. Callers that treated a nil event as end of stream must switch to checking `io.EOF`.

## Testing

- `go test ./http/... ./codegen/...` passes with updated client goldens.
- Verified against a production multi-service design: stream reattachment with the last received event ID no longer replays truncated cursors, and long-running SSE consumption survives repeated bounded-stream reconnects.