### PR TITLE
fix(codegen): preserve streaming payload validation

### DIFF
--- a/expr/http_body_types.go
+++ b/expr/http_body_types.go
@@ -216,6 +216,14 @@ func httpStreamingBody(e *HTTPEndpointExpr) *AttributeExpr {
 	}
 	const suffix = "StreamingBody"
 	dupped := DupAtt(att)
+	// Method attributes that reference user types keep validation on the
+	// referenced type. Promote it to the computed body so HTTP type generation
+	// and transport conversion use the same field requiredness.
+	if dupped.Validation == nil {
+		if ut, ok := dupped.Type.(UserType); ok {
+			dupped.Validation = ut.Attribute().Validation
+		}
+	}
 	RemovePkgPath(dupped)
 	appendSuffix(dupped.Type, suffix)
 	ut := &UserTypeExpr{
@@ -226,7 +234,7 @@ func httpStreamingBody(e *HTTPEndpointExpr) *AttributeExpr {
 
 	return &AttributeExpr{
 		Type:         ut,
-		Validation:   att.Validation,
+		Validation:   dupped.Validation,
 		UserExamples: att.UserExamples,
 	}
 }

--- a/expr/http_body_types_test.go
+++ b/expr/http_body_types_test.go
@@ -1,0 +1,71 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPStreamingBodyValidation(t *testing.T) {
+	cases := []struct {
+		Name             string
+		StreamingPayload *AttributeExpr
+		Required         []string
+		NestedUserType   bool
+	}{
+		{
+			Name: "inline object",
+			StreamingPayload: &AttributeExpr{
+				Type: &Object{
+					&NamedAttributeExpr{Name: "required", Attribute: &AttributeExpr{Type: String}},
+					&NamedAttributeExpr{Name: "optional", Attribute: &AttributeExpr{Type: String}},
+				},
+				Validation: &ValidationExpr{Required: []string{"required"}},
+			},
+			Required: []string{"required"},
+		},
+		{
+			Name: "named user type",
+			StreamingPayload: &AttributeExpr{
+				Type: &UserTypeExpr{
+					AttributeExpr: &AttributeExpr{
+						Type: &Object{
+							&NamedAttributeExpr{Name: "required", Attribute: &AttributeExpr{Type: String}},
+							&NamedAttributeExpr{Name: "optional", Attribute: &AttributeExpr{Type: String}},
+						},
+						Validation: &ValidationExpr{Required: []string{"required"}},
+					},
+					TypeName: "StreamingCommand",
+					UID:      "StreamingCommand",
+				},
+			},
+			Required:       []string{"required"},
+			NestedUserType: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			service := &ServiceExpr{Name: "Service"}
+			method := &MethodExpr{
+				Name:             "Method",
+				Service:          service,
+				Stream:           BidirectionalStreamKind,
+				StreamingPayload: c.StreamingPayload,
+			}
+			endpoint := &HTTPEndpointExpr{
+				MethodExpr: method,
+				Service:    &HTTPServiceExpr{ServiceExpr: service},
+			}
+
+			body := httpStreamingBody(endpoint)
+			assert.Equal(t, c.Required, body.Validation.Required)
+			assert.True(t, NewMappedAttributeExpr(body).IsRequired("required"))
+			assert.False(t, NewMappedAttributeExpr(body).IsRequired("optional"))
+			_, nested := body.Type.(UserType).Attribute().Type.(UserType)
+			assert.Equal(t, c.NestedUserType, nested)
+
+			body.Validation.AddRequired("body-only")
+			assert.False(t, c.StreamingPayload.IsRequired("body-only"))
+		})
+	}
+}

--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -85,6 +85,7 @@ func TestClientTypes(t *testing.T) {
 		{"client-query-custom-name", testdata.PayloadQueryCustomNameDSL},
 		{"client-header-custom-name", testdata.PayloadHeaderCustomNameDSL},
 		{"client-cookie-custom-name", testdata.PayloadCookieCustomNameDSL},
+		{"client-streaming-payload-required-fields", testdata.StreamingPayloadRequiredFieldsDSL},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/server_types_test.go
+++ b/http/codegen/server_types_test.go
@@ -36,6 +36,7 @@ func TestServerTypes(t *testing.T) {
 		{"server-header-custom-name", testdata.PayloadHeaderCustomNameDSL},
 		{"server-cookie-custom-name", testdata.PayloadCookieCustomNameDSL},
 		{"server-payload-with-validated-alias", testdata.PayloadWithValidatedAliasDSL},
+		{"server-streaming-payload-required-fields", testdata.StreamingPayloadRequiredFieldsDSL},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/http/codegen/testdata/golden/client_types_client-streaming-payload-required-fields.go.golden
+++ b/http/codegen/testdata/golden/client_types_client-streaming-payload-required-fields.go.golden
@@ -1,0 +1,40 @@
+// ClientStreamStreamingBody is the type of the
+// "StreamingPayloadRequiredFieldsService" service "ClientStream" endpoint HTTP
+// request body.
+type ClientStreamStreamingBody StreamingRequestStreamingBody
+
+// BidirectionalStreamStreamingBody is the type of the
+// "StreamingPayloadRequiredFieldsService" service "BidirectionalStream"
+// endpoint HTTP request body.
+type BidirectionalStreamStreamingBody StreamingRequestStreamingBody
+
+// StreamingRequestStreamingBody is used to define fields on request body types.
+type StreamingRequestStreamingBody struct {
+	Required     string  `form:"required" json:"required" xml:"required"`
+	Optional     *string `form:"optional,omitempty" json:"optional,omitempty" xml:"optional,omitempty"`
+	BaseRequired string  `form:"baseRequired" json:"baseRequired" xml:"baseRequired"`
+}
+
+// NewClientStreamStreamingBody builds the HTTP request body from the payload
+// of the "ClientStream" endpoint of the
+// "StreamingPayloadRequiredFieldsService" service.
+func NewClientStreamStreamingBody(p *streamingpayloadrequiredfieldsservice.StreamingRequest) *ClientStreamStreamingBody {
+	body := &ClientStreamStreamingBody{
+		Required:     p.Required,
+		Optional:     p.Optional,
+		BaseRequired: p.BaseRequired,
+	}
+	return body
+}
+
+// NewBidirectionalStreamStreamingBody builds the HTTP request body from the
+// payload of the "BidirectionalStream" endpoint of the
+// "StreamingPayloadRequiredFieldsService" service.
+func NewBidirectionalStreamStreamingBody(p *streamingpayloadrequiredfieldsservice.StreamingRequest) *BidirectionalStreamStreamingBody {
+	body := &BidirectionalStreamStreamingBody{
+		Required:     p.Required,
+		Optional:     p.Optional,
+		BaseRequired: p.BaseRequired,
+	}
+	return body
+}

--- a/http/codegen/testdata/golden/server_types_server-streaming-payload-required-fields.go.golden
+++ b/http/codegen/testdata/golden/server_types_server-streaming-payload-required-fields.go.golden
@@ -1,0 +1,77 @@
+// ClientStreamStreamingBody is the type of the
+// "StreamingPayloadRequiredFieldsService" service "ClientStream" endpoint HTTP
+// request body.
+type ClientStreamStreamingBody StreamingRequestStreamingBody
+
+// BidirectionalStreamStreamingBody is the type of the
+// "StreamingPayloadRequiredFieldsService" service "BidirectionalStream"
+// endpoint HTTP request body.
+type BidirectionalStreamStreamingBody StreamingRequestStreamingBody
+
+// StreamingRequestStreamingBody is used to define fields on request body types.
+type StreamingRequestStreamingBody struct {
+	Required     *string `form:"required,omitempty" json:"required,omitempty" xml:"required,omitempty"`
+	Optional     *string `form:"optional,omitempty" json:"optional,omitempty" xml:"optional,omitempty"`
+	BaseRequired *string `form:"baseRequired,omitempty" json:"baseRequired,omitempty" xml:"baseRequired,omitempty"`
+}
+
+// NewClientStreamStreamingBody builds a StreamingPayloadRequiredFieldsService
+// service ClientStream endpoint payload.
+func NewClientStreamStreamingBody(body *ClientStreamStreamingBody) *streamingpayloadrequiredfieldsservice.StreamingRequest {
+	v := &streamingpayloadrequiredfieldsservice.StreamingRequest{
+		Required:     *body.Required,
+		Optional:     body.Optional,
+		BaseRequired: *body.BaseRequired,
+	}
+
+	return v
+}
+
+// NewBidirectionalStreamStreamingBody builds a
+// StreamingPayloadRequiredFieldsService service BidirectionalStream endpoint
+// payload.
+func NewBidirectionalStreamStreamingBody(body *BidirectionalStreamStreamingBody) *streamingpayloadrequiredfieldsservice.StreamingRequest {
+	v := &streamingpayloadrequiredfieldsservice.StreamingRequest{
+		Required:     *body.Required,
+		Optional:     body.Optional,
+		BaseRequired: *body.BaseRequired,
+	}
+
+	return v
+}
+
+// ValidateClientStreamStreamingBody runs the validations defined on
+// ClientStreamStreamingBody
+func ValidateClientStreamStreamingBody(body *ClientStreamStreamingBody) (err error) {
+	if body.Required == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("required", "body"))
+	}
+	if body.BaseRequired == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("baseRequired", "body"))
+	}
+	return
+}
+
+// ValidateBidirectionalStreamStreamingBody runs the validations defined on
+// BidirectionalStreamStreamingBody
+func ValidateBidirectionalStreamStreamingBody(body *BidirectionalStreamStreamingBody) (err error) {
+	if body.Required == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("required", "body"))
+	}
+	if body.BaseRequired == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("baseRequired", "body"))
+	}
+	return
+}
+
+// ValidateStreamingRequestStreamingBody runs the validations defined on
+// StreamingRequestStreamingBody
+func ValidateStreamingRequestStreamingBody(body *StreamingRequestStreamingBody) (err error) {
+	if body.Required == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("required", "body"))
+	}
+	if body.BaseRequired == nil {
+		err = goa.MergeErrors(err, goa.MissingFieldError("baseRequired", "body"))
+	}
+	return
+}

--- a/http/codegen/testdata/streaming_dsls.go
+++ b/http/codegen/testdata/streaming_dsls.go
@@ -337,6 +337,39 @@ var StreamingPayloadDSL = func() {
 	})
 }
 
+var StreamingPayloadRequiredFieldsDSL = func() {
+	var Base = Type("StreamingBase", func() {
+		Attribute("baseRequired", String)
+		Required("baseRequired")
+	})
+	var Request = Type("StreamingRequest", func() {
+		Extend(Base)
+		Attribute("required", String)
+		Attribute("optional", String)
+		Required("required")
+	})
+	Service("StreamingPayloadRequiredFieldsService", func() {
+		Method("ClientStream", func() {
+			Payload(func() {})
+			StreamingPayload(Request)
+			Result(String)
+			HTTP(func() {
+				GET("/client")
+				Response(StatusOK)
+			})
+		})
+		Method("BidirectionalStream", func() {
+			Payload(func() {})
+			StreamingPayload(Request)
+			StreamingResult(String)
+			HTTP(func() {
+				GET("/bidirectional")
+				Response(StatusOK)
+			})
+		})
+	})
+}
+
 var StreamingPayloadNoPayloadDSL = func() {
 	var Request = Type("Request", func() {
 		Attribute("x", String)


### PR DESCRIPTION
## Summary

HTTP WebSocket streaming payloads now carry validation from named Goa types into their computed transport body. Generated client body declarations and constructors therefore agree on whether each field is required.

Fixes #3965.

## Problem and ownership

A method attribute that references a named type keeps `Required` and other validation on that type. `httpStreamingBody` duplicated the method attribute and wrapped it in an endpoint-specific body type, but left validation on the nested named type.

HTTP body declarations reached the nested validation and generated required primitive fields as values. Client conversion inspected the outer body, treated the same fields as optional, and generated pointer assignments into those value fields. The generated client did not compile.

The computed HTTP body owns this transport contract. The fix promotes validation from the duplicated named type onto that body before code generation. It does not change shared transformer rules.

## Contract and compatibility

- Required client streaming fields remain values and constructors assign values.
- Optional client streaming fields remain pointers.
- Server decode fields remain pointers so omitted required fields can be detected before conversion.
- Local and inherited required fields receive the same treatment.
- Client-only and bidirectional WebSocket streams behave consistently.
- JSON/XML/form wire names and optionality are unchanged.
- Existing exported generated body type names and nesting are unchanged.
- Inline streaming payload behavior is unchanged.

## Verification

- `go test ./expr -run '^TestHTTPStreamingBodyValidation$' -count=1`
- `go test ./http/codegen -run '^(TestClientTypes|TestServerTypes|TestClientStreaming|TestServerStreaming)$' -count=1`
- Regenerated and compiled the standalone design from #3965 with the local generator: `go build ./...`
- `make test`
- `make lint`

## Review guide

The key invariant is in `httpStreamingBody`: validation must be copied from the already detached named type, preserving generator purity while making body declaration and conversion consume the same requiredness. The client and server goldens demonstrate the intended pointer behavior at both transport boundaries.