### PR TITLE
Preserve gRPC client cancellation identity

### DIFF
--- a/grpc/codegen/idempotency_test.go
+++ b/grpc/codegen/idempotency_test.go
@@ -27,4 +27,9 @@ func TestIdempotentRPCCodegen(t *testing.T) {
 	clientCode := codegen.SectionsCode(t, clientFiles[0].Section("client-endpoint-init"))
 	assert.Contains(t, clientCode, `goa.RetryEndpoint(endpoint, "busy")`)
 	assert.Equal(t, 1, strings.Count(clientCode, "goa.RetryEndpoint("))
+	contextErrorIndex := strings.Index(clientCode, "goagrpc.ContextError(ctx, err)")
+	transportErrorIndex := strings.Index(clientCode, "goagrpc.NewTransportError(err)")
+	require.NotEqual(t, -1, contextErrorIndex)
+	require.NotEqual(t, -1, transportErrorIndex)
+	assert.Less(t, contextErrorIndex, transportErrorIndex)
 }

--- a/grpc/codegen/streaming_errors_test.go
+++ b/grpc/codegen/streaming_errors_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"goa.design/goa/v3/codegen"
 	. "goa.design/goa/v3/dsl"
 	"goa.design/goa/v3/grpc/codegen/testdata"
 )
@@ -78,6 +79,64 @@ func TestStreamingWithErrors(t *testing.T) {
 			c.testFunc(t, code)
 		})
 	}
+}
+
+func TestClientStreamingContextErrorCodegen(t *testing.T) {
+	root := RunGRPCDSL(t, testdata.BidirectionalStreamingRPCWithErrorsDSL)
+	services := CreateGRPCServices(root)
+	clientFiles := ClientFiles("", services)
+	require.NotEmpty(t, clientFiles)
+
+	recvCode := codegen.SectionsCode(t, clientFiles[0].Section("client-stream-recv"))
+	serviceErrorIndex := strings.Index(recvCode, "goagrpc.NewServiceError(message)")
+	contextErrorIndex := strings.Index(recvCode, "goagrpc.ContextError(s.ctx, err)")
+	require.NotEqual(t, -1, serviceErrorIndex)
+	require.NotEqual(t, -1, contextErrorIndex)
+	assert.Less(t, serviceErrorIndex, contextErrorIndex)
+
+	sendCode := codegen.SectionsCode(t, clientFiles[0].Section("client-stream-send"))
+	assert.NotContains(t, sendCode, "goagrpc.ContextError")
+
+	closeCode := codegen.SectionsCode(t, clientFiles[0].Section("client-stream-close"))
+	assert.NotContains(t, closeCode, "goagrpc.ContextError")
+
+	noResultRoot := RunGRPCDSL(t, testdata.ClientStreamingNoResultDSL)
+	noResultFiles := ClientFiles("", CreateGRPCServices(noResultRoot))
+	require.NotEmpty(t, noResultFiles)
+	closeAndRecvCode := codegen.SectionsCode(t, noResultFiles[0].Section("client-stream-close"))
+	assert.Contains(t, closeAndRecvCode, "s.stream.CloseAndRecv()")
+	assert.NotContains(t, closeAndRecvCode, "goagrpc.DecodeError(err)")
+	assert.NotContains(t, closeAndRecvCode, "goagrpc.NewServiceError(message)")
+	assert.Contains(t, closeAndRecvCode, "goagrpc.ContextError(s.ctx, err)")
+
+	closeErrorDSL := func() {
+		var StreamError = Type("StreamError", func() {
+			ErrorName(1, "name", String, "error name")
+			Field(2, "message", String, "error message")
+			Required("name", "message")
+		})
+		Service("ClientStreamErrorService", func() {
+			Method("Upload", func() {
+				StreamingPayload(String)
+				Error("stream_error", StreamError)
+				GRPC(func() {
+					Response("stream_error", CodeCanceled)
+				})
+			})
+		})
+	}
+	closeErrorRoot := RunGRPCDSL(t, closeErrorDSL)
+	closeErrorFiles := ClientFiles("", CreateGRPCServices(closeErrorRoot))
+	require.NotEmpty(t, closeErrorFiles)
+	closeErrorCode := codegen.SectionsCode(t, closeErrorFiles[0].Section("client-stream-close"))
+	typedErrorIndex := strings.Index(
+		closeErrorCode,
+		"case *client_stream_error_servicepb.UploadStreamErrorError:",
+	)
+	closeContextIndex := strings.Index(closeErrorCode, "goagrpc.ContextError(s.ctx, err)")
+	require.NotEqual(t, -1, typedErrorIndex)
+	require.NotEqual(t, -1, closeContextIndex)
+	assert.Less(t, typedErrorIndex, closeContextIndex)
 }
 
 // TestStreamingErrorsWithValidation verifies that custom errors with

--- a/grpc/codegen/templates/client_endpoint_init.go.tpl
+++ b/grpc/codegen/templates/client_endpoint_init.go.tpl
@@ -29,6 +29,9 @@ func (c *{{ .ClientStruct }}) {{ .Method.VarName }}() goa.Endpoint {
 			case *goapb.ErrorResponse:
 				return nil, goagrpc.NewServiceError(message)
 			default:
+				if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+					return nil, ctxErr
+				}
 				{{- if $retry }}
 				return nil, goagrpc.NewTransportError(err)
 				{{- else }}
@@ -37,13 +40,16 @@ func (c *{{ .ClientStruct }}) {{ .Method.VarName }}() goa.Endpoint {
 			}
 		{{- else }}
 			{{- if $retry }}
-			// Try to decode a Goa error response detail before preserving the transport error.
+			// Decode a Goa error detail before returning a matching context error or preserving the transport error.
 			{{- else }}
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			{{- end }}
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			{{- if $retry }}
 			return nil, goagrpc.NewTransportError(err)

--- a/grpc/codegen/templates/response_decoder.go.tpl
+++ b/grpc/codegen/templates/response_decoder.go.tpl
@@ -39,6 +39,7 @@ func Decode{{ .Method.VarName }}Response(ctx context.Context, v any, hdr, trlr m
 {{- if .ClientStream }}
 	return &{{ .ClientStream.VarName }}{
 		stream: v.({{ .ClientStream.Interface }}),
+		ctx: ctx,
 	{{- if .ViewedResultRef }}
 		view: view,
 	{{- end }}

--- a/grpc/codegen/templates/stream_close.go.tpl
+++ b/grpc/codegen/templates/stream_close.go.tpl
@@ -7,6 +7,36 @@ func (s *{{ .VarName }}) Close() error {
 {{- else }}
 	{{ comment "synchronize and report any server error" }}
 	_, err := s.stream.CloseAndRecv()
+	if err != nil {
+		{{- if .Endpoint.Errors }}
+		resp := goagrpc.DecodeError(err)
+		switch message := resp.(type) {
+		{{- range .Endpoint.Errors }}
+			{{- if .Response.ClientConvert }}
+		case {{ .Response.ClientConvert.SrcRef }}:
+			{{- if .Response.ClientConvert.Validation }}
+			if err := {{ .Response.ClientConvert.Validation.Name }}(message); err != nil {
+				return err
+			}
+			{{- end }}
+			return {{ .Response.ClientConvert.Init.Name }}({{ range .Response.ClientConvert.Init.Args }}{{ .Name }}, {{ end }})
+			{{- end }}
+		{{- end }}
+		case *goapb.ErrorResponse:
+			return goagrpc.NewServiceError(message)
+		default:
+			if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+				return ctxErr
+			}
+			return err
+		}
+		{{- else }}
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+		{{- end }}
+	}
 	return err
 {{- end }}
 {{- else }}

--- a/grpc/codegen/templates/stream_recv.go.tpl
+++ b/grpc/codegen/templates/stream_recv.go.tpl
@@ -38,9 +38,17 @@ func (s *{{ .VarName }}) {{ .RecvName }}() ({{ .RecvRef }}, error) {
 		case *goapb.ErrorResponse:
 			return res, goagrpc.NewServiceError(message)
 		default:
+			if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+				return res, ctxErr
+			}
 			return res, err
 		}
 	{{- else }}
+		{{- if eq .Type "client" }}
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
+		{{- end }}
 		return res, err
 	{{- end }}
 	}

--- a/grpc/codegen/templates/stream_struct_type.go.tpl
+++ b/grpc/codegen/templates/stream_struct_type.go.tpl
@@ -1,6 +1,9 @@
 {{ printf "%s implements the %s interface." .VarName .ServiceInterface | comment }}
 type {{ .VarName }} struct {
 	stream {{ .Interface }}
+{{- if eq .Type "client" }}
+	ctx context.Context
+{{- end }}
 {{- if and (eq .Type "server") .Endpoint.Request.LegacyDecode }}
 	// legacy indicates that the client speaks the legacy stream protocol
 	// which sends raw stream item frames instead of typed envelopes.

--- a/grpc/codegen/testdata/golden/client_endpoint_init_bidirectional-streaming-rpc-with-errors.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_bidirectional-streaming-rpc-with-errors.go.golden
@@ -15,6 +15,9 @@ func (c *Client) MethodBidirectionalStreamingRPCWithErrors() goa.Endpoint {
 			case *goapb.ErrorResponse:
 				return nil, goagrpc.NewServiceError(message)
 			default:
+				if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+					return nil, ctxErr
+				}
 				return nil, goa.Fault("%s", err.Error())
 			}
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_bidirectional-streaming-rpc-with-payload.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_bidirectional-streaming-rpc-with-payload.go.golden
@@ -10,10 +10,13 @@ func (c *Client) MethodBidirectionalStreamingRPCWithPayload() goa.Endpoint {
 			DecodeMethodBidirectionalStreamingRPCWithPayloadResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_bidirectional-streaming-rpc.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_bidirectional-streaming-rpc.go.golden
@@ -10,10 +10,13 @@ func (c *Client) MethodBidirectionalStreamingRPC() goa.Endpoint {
 			DecodeMethodBidirectionalStreamingRPCResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_client-streaming-rpc-no-result.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_client-streaming-rpc-no-result.go.golden
@@ -10,10 +10,13 @@ func (c *Client) MethodClientStreamingNoResult() goa.Endpoint {
 			DecodeMethodClientStreamingNoResultResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_client-streaming-rpc-with-payload.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_client-streaming-rpc-with-payload.go.golden
@@ -10,10 +10,13 @@ func (c *Client) MethodClientStreamingRPCWithPayload() goa.Endpoint {
 			DecodeMethodClientStreamingRPCWithPayloadResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_client-streaming-rpc.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_client-streaming-rpc.go.golden
@@ -8,10 +8,13 @@ func (c *Client) MethodClientStreamingRPC() goa.Endpoint {
 			DecodeMethodClientStreamingRPCResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_server-streaming-rpc.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_server-streaming-rpc.go.golden
@@ -8,10 +8,13 @@ func (c *Client) MethodServerStreamingRPC() goa.Endpoint {
 			DecodeMethodServerStreamingRPCResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpc-acronym.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpc-acronym.go.golden
@@ -8,10 +8,13 @@ func (c *Client) MethodUnaryRPCAcronymJWT() goa.Endpoint {
 			nil)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpc-no-payload.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpc-no-payload.go.golden
@@ -8,10 +8,13 @@ func (c *Client) MethodUnaryRPCNoPayload() goa.Endpoint {
 			DecodeMethodUnaryRPCNoPayloadResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpc-no-result.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpc-no-result.go.golden
@@ -8,10 +8,13 @@ func (c *Client) MethodUnaryRPCNoResult() goa.Endpoint {
 			nil)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpc-with-errors.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpc-with-errors.go.golden
@@ -25,6 +25,9 @@ func (c *Client) MethodUnaryRPCWithErrors() goa.Endpoint {
 			case *goapb.ErrorResponse:
 				return nil, goagrpc.NewServiceError(message)
 			default:
+				if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+					return nil, ctxErr
+				}
 				return nil, goa.Fault("%s", err.Error())
 			}
 		}

--- a/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpcs.go.golden
+++ b/grpc/codegen/testdata/golden/client_endpoint_init_unary-rpcs.go.golden
@@ -8,10 +8,13 @@ func (c *Client) MethodUnaryRPCA() goa.Endpoint {
 			DecodeMethodUnaryRPCAResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}
@@ -29,10 +32,13 @@ func (c *Client) MethodUnaryRPCB() goa.Endpoint {
 			DecodeMethodUnaryRPCBResponse)
 		res, err := inv.Invoke(ctx, v)
 		if err != nil {
-			// Try to decode a Goa error response detail before falling back to Fault.
+			// Decode a Goa error detail before returning a matching context error or falling back to Fault.
 			resp := goagrpc.DecodeError(err)
 			if eresp, ok := resp.(*goapb.ErrorResponse); ok {
 				return nil, goagrpc.NewServiceError(eresp)
+			}
+			if ctxErr := goagrpc.ContextError(ctx, err); ctxErr != nil {
+				return nil, ctxErr
 			}
 			return nil, goa.Fault("%s", err.Error())
 		}

--- a/grpc/codegen/testdata/golden/response_decoder_response-decoder-bidirectional-streaming.go.golden
+++ b/grpc/codegen/testdata/golden/response_decoder_response-decoder-bidirectional-streaming.go.golden
@@ -9,6 +9,7 @@ func DecodeMethodBidirectionalStreamingRPCResponse(ctx context.Context, v any, h
 	}
 	return &MethodBidirectionalStreamingRPCClientStream{
 		stream: v.(service_bidirectional_streaming_rpcpb.ServiceBidirectionalStreamingRPC_MethodBidirectionalStreamingRPCClient),
+		ctx:    ctx,
 		view:   view,
 	}, nil
 }

--- a/grpc/codegen/testdata/golden/response_decoder_response-decoder-client-streaming.go.golden
+++ b/grpc/codegen/testdata/golden/response_decoder_response-decoder-client-streaming.go.golden
@@ -3,5 +3,6 @@
 func DecodeMethodClientStreamingRPCResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	return &MethodClientStreamingRPCClientStream{
 		stream: v.(service_client_streaming_rpcpb.ServiceClientStreamingRPC_MethodClientStreamingRPCClient),
+		ctx:    ctx,
 	}, nil
 }

--- a/grpc/codegen/testdata/golden/response_decoder_response-decoder-server-streaming-result-with-views.go.golden
+++ b/grpc/codegen/testdata/golden/response_decoder_response-decoder-server-streaming-result-with-views.go.golden
@@ -9,6 +9,7 @@ func DecodeMethodServerStreamingUserTypeRPCResponse(ctx context.Context, v any, 
 	}
 	return &MethodServerStreamingUserTypeRPCClientStream{
 		stream: v.(service_server_streaming_user_type_rpcpb.ServiceServerStreamingUserTypeRPC_MethodServerStreamingUserTypeRPCClient),
+		ctx:    ctx,
 		view:   view,
 	}, nil
 }

--- a/grpc/codegen/testdata/golden/response_decoder_response-decoder-server-streaming.go.golden
+++ b/grpc/codegen/testdata/golden/response_decoder_response-decoder-server-streaming.go.golden
@@ -3,5 +3,6 @@
 func DecodeMethodServerStreamingUserTypeRPCResponse(ctx context.Context, v any, hdr, trlr metadata.MD) (any, error) {
 	return &MethodServerStreamingUserTypeRPCClientStream{
 		stream: v.(service_server_streaming_user_type_rpcpb.ServiceServerStreamingUserTypeRPC_MethodServerStreamingUserTypeRPCClient),
+		ctx:    ctx,
 	}, nil
 }

--- a/grpc/codegen/testdata/streaming_code.go
+++ b/grpc/codegen/testdata/streaming_code.go
@@ -35,6 +35,7 @@ var ServerStreamingClientStructCode = `// MethodServerStreamingUserTypeRPCClient
 // interface.
 type MethodServerStreamingUserTypeRPCClientStream struct {
 	stream service_server_streaming_user_type_rpcpb.ServiceServerStreamingUserTypeRPC_MethodServerStreamingUserTypeRPCClient
+	ctx    context.Context
 }
 `
 
@@ -45,6 +46,9 @@ func (s *MethodServerStreamingUserTypeRPCClientStream) Recv() (*serviceserverstr
 	var res *serviceserverstreamingusertyperpc.UserType
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	return NewMethodServerStreamingUserTypeRPCResponseUserType(v), nil
@@ -96,6 +100,7 @@ var ServerStreamingResultWithViewsClientStructCode = `// MethodServerStreamingUs
 // interface.
 type MethodServerStreamingUserTypeRPCClientStream struct {
 	stream service_server_streaming_user_type_rpcpb.ServiceServerStreamingUserTypeRPC_MethodServerStreamingUserTypeRPCClient
+	ctx    context.Context
 	view   string
 }
 `
@@ -107,6 +112,9 @@ func (s *MethodServerStreamingUserTypeRPCClientStream) Recv() (*serviceserverstr
 	var res *serviceserverstreamingusertyperpc.ResultType
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	proj := NewMethodServerStreamingUserTypeRPCResponseResultTypeView(v)
@@ -159,6 +167,9 @@ func (s *MethodServerStreamingResultTypeCollectionWithExplicitViewClientStream) 
 	var res serviceserverstreamingresulttypecollectionwithexplicitview.ResultTypeCollection
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	proj := NewResultTypeCollectionResultTypeCollection(v)
@@ -201,6 +212,9 @@ func (s *MethodServerStreamingRPCClientStream) Recv() (string, error) {
 	var res string
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	return NewMethodServerStreamingRPCResponseMethodServerStreamingRPCResponse(v), nil
@@ -237,6 +251,9 @@ func (s *MethodServerStreamingArrayClientStream) Recv() ([]int, error) {
 	var res []int
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	return NewMethodServerStreamingArrayResponseMethodServerStreamingArrayResponse(v), nil
@@ -273,6 +290,9 @@ func (s *MethodServerStreamingMapClientStream) Recv() (map[string]*serviceserver
 	var res map[string]*serviceserverstreamingmap.UserType
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	return NewMethodServerStreamingMapResponseMethodServerStreamingMapResponse(v), nil
@@ -293,6 +313,9 @@ func (s *MethodServerStreamingRPCClientStream) Recv() (*serviceserverstreamingrp
 	var res *serviceserverstreamingrpc.UserType
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	return NewMethodServerStreamingRPCResponseUserType(v), nil
@@ -312,6 +335,9 @@ func (s *OtherMethodServerStreamingRPCClientStream) Recv() (*serviceserverstream
 	var res *serviceserverstreamingrpc.UserType
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	return NewOtherMethodServerStreamingRPCResponseUserType(v), nil
@@ -372,6 +398,7 @@ var ClientStreamingClientStructCode = `// MethodClientStreamingRPCClientStream i
 // serviceclientstreamingrpc.MethodClientStreamingRPCClientStream interface.
 type MethodClientStreamingRPCClientStream struct {
 	stream service_client_streaming_rpcpb.ServiceClientStreamingRPC_MethodClientStreamingRPCClient
+	ctx    context.Context
 }
 `
 
@@ -398,6 +425,9 @@ func (s *MethodClientStreamingRPCClientStream) CloseAndRecv() (string, error) {
 	var res string
 	v, err := s.stream.CloseAndRecv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	return NewMethodClientStreamingRPCResponseMethodClientStreamingRPCResponse(v), nil
@@ -420,6 +450,12 @@ var ClientStreamingServerNoResultCloseCode = `func (s *MethodClientStreamingNoRe
 var ClientStreamingClientNoResultCloseCode = `func (s *MethodClientStreamingNoResultClientStream) Close() error {
 	// synchronize and report any server error
 	_, err := s.stream.CloseAndRecv()
+	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
 	return err
 }
 `
@@ -481,6 +517,7 @@ var BidirectionalStreamingClientStructCode = `// MethodBidirectionalStreamingRPC
 // interface.
 type MethodBidirectionalStreamingRPCClientStream struct {
 	stream service_bidirectional_streaming_rpcpb.ServiceBidirectionalStreamingRPC_MethodBidirectionalStreamingRPCClient
+	ctx    context.Context
 	view   string
 }
 `
@@ -508,6 +545,9 @@ func (s *MethodBidirectionalStreamingRPCClientStream) Recv() (*servicebidirectio
 	var res *servicebidirectionalstreamingrpc.ID
 	v, err := s.stream.Recv()
 	if err != nil {
+		if ctxErr := goagrpc.ContextError(s.ctx, err); ctxErr != nil {
+			return res, ctxErr
+		}
 		return res, err
 	}
 	proj := NewMethodBidirectionalStreamingRPCResponseIDView(v)

--- a/grpc/error.go
+++ b/grpc/error.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -29,6 +30,14 @@ type (
 		Timeout bool
 		// Is the error a server-side fault?
 		Fault bool
+	}
+
+	// contextError preserves both the gRPC status and the matching Go context
+	// error for callers that inspect either contract.
+	contextError struct {
+		transportErr    error
+		transportStatus *status.Status
+		ctxErr          error
 	}
 )
 
@@ -95,6 +104,27 @@ func NewTransportError(err error) *goa.ServiceError {
 	)
 }
 
+// ContextError returns a context error when the gRPC status code matches the
+// ended caller context. The returned error retains the transport text and
+// unwraps to ctx.Err(). It returns nil when the caller context remains active
+// or the status codes differ. Deadlines added internally by gRPC are not part
+// of the caller context.
+func ContextError(ctx context.Context, transportErr error) error {
+	ctxErr := ctx.Err()
+	if ctxErr == nil {
+		return nil
+	}
+	transportStatus, ok := status.FromError(transportErr)
+	if !ok || transportStatus.Code() != status.FromContextError(ctxErr).Code() {
+		return nil
+	}
+	return &contextError{
+		transportErr:    transportErr,
+		transportStatus: transportStatus,
+		ctxErr:          ctxErr,
+	}
+}
+
 // NewStatusError creates a gRPC status error with the error response
 // messages added to its details.
 func NewStatusError(code codes.Code, err error, details ...protoiface.MessageV1) error {
@@ -154,10 +184,9 @@ func EncodeError(err error) error {
 	return NewStatusError(codes.Unknown, err, NewErrorResponse(err))
 }
 
-// DecodeError returns the error message encoded in the status details if error
-// is a gRPC status error. It assumes that the error message is encoded as the
-// first item in the details. It returns nil if the error is not a gRPC status
-// error or if no detail is found.
+// DecodeError returns the protobuf error message encoded as the first gRPC
+// status detail. It returns nil when the error is not a gRPC status error, has
+// no details, or the peer sent a detail type unavailable to this process.
 func DecodeError(err error) proto.Message {
 	st, ok := status.FromError(err)
 	if !ok {
@@ -167,7 +196,11 @@ func DecodeError(err error) proto.Message {
 	if len(details) == 0 {
 		return nil
 	}
-	return details[0].(proto.Message)
+	detail, ok := details[0].(proto.Message)
+	if !ok {
+		return nil
+	}
+	return detail
 }
 
 // ErrInvalidType is the error returned when the wrong type is given to a
@@ -180,4 +213,21 @@ func ErrInvalidType(svc, m, expected string, actual any) error {
 // Error builds an error message.
 func (c *ClientError) Error() string {
 	return fmt.Sprintf("[%s %s]: %s", c.Service, c.Method, c.Message)
+}
+
+// Error retains the original gRPC diagnostic text.
+func (e *contextError) Error() string {
+	return e.transportErr.Error()
+}
+
+// GRPCStatus returns the original transport status without rewriting its
+// message or dropping status details.
+func (e *contextError) GRPCStatus() *status.Status {
+	return e.transportStatus
+}
+
+// Unwrap exposes the gRPC status and matching context error without discarding
+// either inspection contract.
+func (e *contextError) Unwrap() []error {
+	return []error{e.transportErr, e.ctxErr}
 }

--- a/grpc/error_test.go
+++ b/grpc/error_test.go
@@ -1,12 +1,18 @@
 package grpc
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	goapb "goa.design/goa/v3/grpc/pb"
 	goa "goa.design/goa/v3/pkg"
@@ -123,4 +129,83 @@ func TestNewTransportError(t *testing.T) {
 			assert.ErrorIs(t, err, cause)
 		})
 	}
+}
+
+func TestDecodeErrorUnknownDetail(t *testing.T) {
+	transportErr := status.FromProto(&statuspb.Status{
+		Code:    int32(codes.Unknown),
+		Message: "unknown remote detail",
+		Details: []*anypb.Any{{
+			TypeUrl: "type.googleapis.com/example.UnknownError",
+		}},
+	}).Err()
+
+	assert.NotPanics(t, func() {
+		assert.Nil(t, DecodeError(transportErr))
+	})
+}
+
+func TestContextError(t *testing.T) {
+	transportErr := errors.New("transport failed")
+
+	t.Run("active context has no context error", func(t *testing.T) {
+		require.NoError(t, ContextError(context.Background(), transportErr))
+	})
+
+	t.Run("matching canceled status preserves text and context error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		transportStatus, statusErr := status.New(codes.Canceled, "transport canceled").WithDetails(
+			&goapb.ErrorResponse{Name: "remote_canceled", Msg: "remote detail"},
+		)
+		require.NoError(t, statusErr)
+		transportErr := transportStatus.Err()
+		err := ContextError(ctx, transportErr)
+		require.ErrorContains(t, err, transportErr.Error())
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, codes.Canceled, status.Code(err))
+		require.Equal(t, transportStatus.Proto(), status.Convert(err).Proto())
+	})
+
+	t.Run("matching deadline status preserves text and context error", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Unix(0, 0))
+		defer cancel()
+
+		transportErr := status.Error(codes.DeadlineExceeded, "transport deadline")
+		err := ContextError(ctx, transportErr)
+		require.ErrorContains(t, err, transportErr.Error())
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	})
+
+	t.Run("independent transport failure remains separate", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.NoError(t, ContextError(ctx, status.Error(codes.Internal, "server failed")))
+	})
+
+	t.Run("mismatched context and transport statuses remain separate", func(t *testing.T) {
+		canceledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+		require.NoError(t, ContextError(
+			canceledCtx,
+			status.Error(codes.DeadlineExceeded, "transport deadline"),
+		))
+
+		deadlineCtx, deadlineCancel := context.WithDeadline(context.Background(), time.Unix(0, 0))
+		defer deadlineCancel()
+		require.NoError(t, ContextError(
+			deadlineCtx,
+			status.Error(codes.Canceled, "transport canceled"),
+		))
+	})
+
+	t.Run("non-gRPC context error remains separate", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.NoError(t, ContextError(ctx, context.Canceled))
+	})
 }


### PR DESCRIPTION
## Why generated clients needed a stronger error contract

A generated gRPC client currently converts an RPC failure into a Goa fault before checking whether the caller's context ended. Callers therefore cannot reliably use `errors.Is(err, context.Canceled)` or `errors.Is(err, context.DeadlineExceeded)`. Streaming clients have the same problem after the stream is created. A concurrent cancellation can also hide a declared service error if context classification runs first.

Remote status details expose a second boundary issue: grpc-go represents an unknown detail type as an `error`, while `DecodeError` previously asserted that the first detail was always a protobuf message. A peer could therefore panic the client with an unavailable detail type.

## Resulting client behavior

Generated unary clients now decode declared and generic Goa errors first. Only an undecoded transport error is compared with the caller context. When the status code and ended caller context agree, the returned error:

- matches `context.Canceled` or `context.DeadlineExceeded` through `errors.Is`;
- retains the original gRPC code, message, and status details through `GRPCStatus`;
- retains the original transport diagnostic text.

Generated stream wrappers retain the context used to create the stream and apply the same fallback classification in `Recv` and `CloseAndRecv`. `Send` remains unchanged because grpc-go may return `io.EOF` there and exposes the authoritative transport status through receive. Streams without declared errors preserve their existing raw transport-error behavior.

`DecodeError` now returns nil for missing or unknown remote detail types instead of panicking. Declared error decoding remains unchanged.

## Ownership and compatibility

The gRPC transport package owns translation between gRPC status errors and Go context errors; generated service clients continue to own declared-error conversion. This keeps application code from reinterpreting transport races.

This is an additive Go API and does not change the wire protocol or Goa DSL. Existing generated clients keep their current behavior until regenerated. Regenerated clients gain the error behavior above; no data migration or deployment ordering is required.

## Validation performed

- `make lint`
- `make test`
- focused generated-code assertions for unary, server-streaming, client-streaming, and bidirectional-streaming clients
- complete status protobuf comparison covering code, message, and details
- unknown remote status-detail regression test
- independent review with no remaining High, Medium, or Low findings

## Review guide

Start with `grpc/error.go` for the context/status identity contract. Then inspect `grpc/codegen/templates/client_endpoint_init.go.tpl`, `stream_recv.go.tpl`, and `stream_close.go.tpl` for error precedence and stream behavior. The generated golden files show the exact source applications receive after regeneration.