### PR TITLE
fix(preview): reuse the generated collection type for suffixed identifiers

### DIFF
--- a/dsl/collection_of_test.go
+++ b/dsl/collection_of_test.go
@@ -1,0 +1,41 @@
+package dsl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"goa.design/goa/v3/expr"
+)
+
+// TestCollectionOfReusesGeneratedType verifies that CollectionOf reuses the
+// generated collection type when it is called more than once for the same
+// result type. The lookup is made with a canonical identifier, so a result type
+// whose identifier carries a suffix such as "+json" must still match. Creating a
+// second type makes two declarations ask for one generated Go name.
+func TestCollectionOfReusesGeneratedType(t *testing.T) {
+	var first, second *expr.ResultTypeExpr
+	expr.RunDSL(t, func() {
+		rt := ResultType("application/vnd.item+json", func() {
+			Attributes(func() {
+				Attribute("id", expr.Int)
+				Required("id")
+			})
+		})
+		Service("svc", func() {
+			Method("first", func() {
+				first = CollectionOf(rt)
+				Result(first)
+				HTTP(func() { GET("/first") })
+			})
+			Method("second", func() {
+				second = CollectionOf(rt)
+				Result(second)
+				HTTP(func() { GET("/second") })
+			})
+		})
+	})
+
+	assert.Same(t, first, second)
+	assert.Len(t, *expr.GeneratedResultTypes, 1)
+}

--- a/expr/result_types_root.go
+++ b/expr/result_types_root.go
@@ -15,10 +15,13 @@ type (
 var GeneratedResultTypes = new(ResultTypesRoot)
 
 // GeneratedResultType returns the generated result type expression with the given
-// id, nil if there isn't one.
+// id, nil if there isn't one. Identifiers are compared canonically so that a
+// lookup by canonical identifier finds a type recorded with its authored
+// suffix, such as "+json".
 func GeneratedResultType(id string) *ResultTypeExpr {
+	canonical := CanonicalIdentifier(id)
 	for _, rt := range *GeneratedResultTypes {
-		if rt.Identifier == id {
+		if CanonicalIdentifier(rt.Identifier) == canonical {
 			return rt
 		}
 	}

--- a/expr/result_types_root_test.go
+++ b/expr/result_types_root_test.go
@@ -1,0 +1,27 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGeneratedResultTypeMatchesCanonicalIdentifier verifies that a lookup by
+// canonical identifier finds a generated result type recorded with its authored
+// media type suffix. CollectionOf looks its cache up with a canonical
+// identifier, so a suffixed identifier must not create a second type.
+func TestGeneratedResultTypeMatchesCanonicalIdentifier(t *testing.T) {
+	ResetDSL(t)
+
+	suffixed := "application/vnd.item+json; type=collection"
+	collection := NewResultTypeExpr("ItemCollection", suffixed, func() {})
+	GeneratedResultTypes.Append(collection)
+
+	canonical := CanonicalIdentifier(suffixed)
+	require.NotEqual(t, suffixed, canonical, "the identifier must lose its suffix to exercise the lookup")
+
+	assert.Same(t, collection, GeneratedResultType(canonical))
+	assert.Same(t, collection, GeneratedResultType(suffixed))
+	assert.Nil(t, GeneratedResultType("application/vnd.other; type=collection"))
+}


### PR DESCRIPTION
close #3977 

`CollectionOf` looks its cache up with a canonical identifier while generated result types are recorded with their authored identifier. A result type whose identifier carries a suffix such as `+json` therefore never matched, and every call created another collection type. Two declarations then asked for one generated Go name and generation stopped:

    declare user type "ItemCollection": generated package "gen/item" cannot
    declare exact type "ItemCollection": already declared by exact type

The design declares no duplicate: the second type is created inside `CollectionOf`.

* Compare canonical identifiers on both sides of the lookup. The two callers pass a canonical and a raw identifier respectively, so the comparison belongs in the lookup itself.
* Add an `expr` test for the lookup and a `dsl` test that calls `CollectionOf` twice for one result type.

For the design in #3977, `gen/reservation/service.go` is byte-identical to the file generated by v3.30.0.
