### PR TITLE
fix(preview): settle an explicit body attribute before a selected view

### DIFF
--- a/http/codegen/client_body_types_test.go
+++ b/http/codegen/client_body_types_test.go
@@ -46,6 +46,7 @@ func TestBodyTypeInit(t *testing.T) {
 		{"result-body-user-required", testdata.ResultBodyUserRequiredDSL, 3},
 		{"result-body-inline-object", testdata.ResultBodyInlineObjectDSL, 2},
 		{"result-explicit-body-primitive", testdata.ExplicitBodyPrimitiveResultMultipleViewsDSL, 1},
+		{"result-explicit-body-primitive-default-view", testdata.ExplicitBodyPrimitiveResultDefaultViewDSL, 1},
 		{"result-explicit-body-user-type", testdata.ExplicitBodyUserResultMultipleViewsDSL, 3},
 		{"result-explicit-body-object", testdata.ExplicitBodyUserResultObjectDSL, 3},
 		{"result-explicit-body-object-views", testdata.ExplicitBodyUserResultObjectMultipleViewDSL, 3},

--- a/http/codegen/service_data.go
+++ b/http/codegen/service_data.go
@@ -3000,11 +3000,14 @@ func (sds *ServicesData) buildResponses(e *expr.HTTPEndpointExpr, result *expr.A
 						}
 					}
 					switch {
+					case origin != "":
+						clientBodyData = sds.buildResponseBodyType(respBody, result, e, false, &vname, sd, nil, resultOwner, bodyOwner)
+						clientBodyView = &vname
 					case clientView != "":
 						clientRespBody = effectiveClientResponseBodyForView(respBody, clientView, e)
 						clientBodyData = sds.buildResponseBodyType(clientRespBody, result, e, false, &clientView, sd, nil, resultOwner, bodyOwner)
 						clientBodyView = &clientView
-					case origin != "" || explicitBody:
+					case explicitBody:
 						clientBodyData = sds.buildResponseBodyType(respBody, result, e, false, &vname, sd, nil, resultOwner, bodyOwner)
 						clientBodyView = &vname
 					default:

--- a/http/codegen/testdata/golden/client_body_type_init_result-explicit-body-primitive-default-view.go.golden
+++ b/http/codegen/testdata/golden/client_body_type_init_result-explicit-body-primitive-default-view.go.golden
@@ -1,0 +1,13 @@
+// NewMethodExplicitBodyPrimitiveResultDefaultViewResulttypedefaultviewOK
+// builds a "ServiceExplicitBodyPrimitiveResultDefaultView" service
+// "MethodExplicitBodyPrimitiveResultDefaultView" endpoint result from a HTTP
+// "OK" response.
+func NewMethodExplicitBodyPrimitiveResultDefaultViewResulttypedefaultviewOK(body string, b *string) *serviceexplicitbodyprimitiveresultdefaultviewviews.ResulttypedefaultviewView {
+	v := body
+	res := &serviceexplicitbodyprimitiveresultdefaultviewviews.ResulttypedefaultviewView{
+		A: &v,
+	}
+	res.B = b
+
+	return res
+}

--- a/http/codegen/testdata/result_dsls.go
+++ b/http/codegen/testdata/result_dsls.go
@@ -1076,6 +1076,30 @@ var EmptyBodyResultMultipleViewsDSL = func() {
 	})
 }
 
+// ExplicitBodyPrimitiveResultDefaultViewDSL sets the response body to one
+// attribute of a result type that declares no view. The body is an attribute of
+// the result, so no view projection applies to it.
+var ExplicitBodyPrimitiveResultDefaultViewDSL = func() {
+	var ResultType = ResultType("ResultTypeDefaultView", func() {
+		Attribute("a", String, func() {
+			MinLength(5)
+		})
+		Attribute("b", String)
+	})
+	Service("ServiceExplicitBodyPrimitiveResultDefaultView", func() {
+		Method("MethodExplicitBodyPrimitiveResultDefaultView", func() {
+			Result(ResultType)
+			HTTP(func() {
+				POST("/")
+				Response(StatusOK, func() {
+					Header("b:Location")
+					Body("a")
+				})
+			})
+		})
+	})
+}
+
 var ExplicitBodyPrimitiveResultMultipleViewsDSL = func() {
 	var ResultType = ResultType("ResultTypeMultipleViews", func() {
 		Attribute("a", String, func() {


### PR DESCRIPTION
close #3982

Two switches decide which view a response body belongs to, and they ordered their cases differently. Collection settles `Body("name")` first, while the consuming side checked the selected view first. A result type that declares no view sets both, so the transform was recorded under an empty view and looked up under the default one. The lookup returned a nil record that was dereferenced:

    panic: runtime error: invalid memory address or nil pointer dereference
           http/codegen/service_data.go:3216

Instrumenting both sides:

    [COLLECT] method=m status=200 tag=[] view=""
    [LOOKUP ] method=m status=200 tag=[] view="default" found=false

* Move only the `origin` case ahead of the selected view. An inline `Body(func() { ... })` sets `explicitBody` without `origin`, and collection settles that case after the selected view, so it stays where it is.
* Add a client body type test for a result type that declares no view.

The existing explicit body cases in `TestBodyTypeInit` all declare their views, which is the path where the order of the two switches does not matter, so none of them covered this. The generated client decoder for the design in #3982 is the same as the one produced by v3.30.0.
